### PR TITLE
fix(web-studio): refresh context tree after external deletion

### DIFF
--- a/web-studio/src/routes/playground/route.test.tsx
+++ b/web-studio/src/routes/playground/route.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ComponentType, PropsWithChildren } from 'react'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import { Route } from './route'
+
+const mocks = vi.hoisted(() => ({
+  fetchFsStat: vi.fn(),
+  invalidateList: vi.fn(),
+  navigate: vi.fn(),
+  refreshLabel: 'refresh',
+  search: {} as { file?: string; uri?: string },
+}))
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    createFileRoute: () => (options: Record<string, unknown>) => ({
+      ...options,
+      fullPath: '/playground',
+      options,
+      useSearch: () => mocks.search,
+    }),
+    useNavigate: () => mocks.navigate,
+  }
+})
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('#/hooks/use-app-connection', () => ({
+  useAppConnection: () => ({ identityScopeKey: 'test' }),
+}))
+
+vi.mock('#/routes/resources/-hooks/viking-fm', () => ({
+  useInvalidateVikingFs: () => ({ invalidateList: mocks.invalidateList }),
+  useVikingFsList: () => ({ data: { entries: [] }, isFetching: false }),
+}))
+
+vi.mock('#/routes/resources/-lib/api', () => ({
+  fetchFsStat: mocks.fetchFsStat,
+}))
+
+vi.mock('#/routes/resources/-hooks/use-resource-upload', () => ({
+  ResourceUploadProvider: ({ children }: PropsWithChildren) => children,
+  useResourceUpload: () => ({
+    activeTaskCount: 0,
+    hasActiveTasks: false,
+    isRefreshingTasks: false,
+    refreshTasks: vi.fn(),
+    tasks: [],
+  }),
+}))
+
+vi.mock('#/routes/resources/-components/lazy-file-preview', () => ({
+  LazyFilePreview: ({ file }: { file: { uri: string } | null }) => (
+    <div data-testid="preview">{file?.uri}</div>
+  ),
+}))
+
+vi.mock('./-components/context-explorer', () => ({
+  ContextExplorerHeader: ({ onRefresh }: { onRefresh: () => void }) => (
+    <button type="button" aria-label={mocks.refreshLabel} onClick={onRefresh} />
+  ),
+  ContextTree: () => null,
+  PanelTab: () => null,
+  PlaygroundResizeHandle: () => null,
+}))
+
+vi.mock('./-components/agent-panel', () => ({ AgentPanel: () => null }))
+vi.mock('./-components/terminal-panel', () => ({ TerminalPanel: () => null }))
+vi.mock('#/routes/resources/-components/find-palette', () => ({
+  FindPalette: () => null,
+}))
+
+const PlaygroundRoute = Route.options.component as ComponentType & {
+  preload?: () => Promise<void>
+}
+const firstFile = 'viking://user/default/memories/first.md'
+const secondFile = 'viking://user/default/memories/second.md'
+const parentDirectory = 'viking://user/default/memories/'
+
+describe('playground context tree refresh', () => {
+  beforeAll(async () => {
+    await PlaygroundRoute.preload?.()
+  })
+
+  afterEach(cleanup)
+
+  beforeEach(() => {
+    mocks.search = { file: firstFile, uri: parentDirectory }
+    mocks.fetchFsStat.mockReset()
+    mocks.invalidateList.mockReset().mockResolvedValue(undefined)
+    mocks.navigate.mockReset()
+  })
+
+  it('clears a deleted selected file from the preview and URL search', async () => {
+    mocks.fetchFsStat.mockRejectedValue({ statusCode: 404 })
+    render(<PlaygroundRoute />)
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: mocks.refreshLabel }),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('preview').textContent).toBe('')
+    })
+    expect(mocks.invalidateList.mock.calls[0]).toEqual([])
+    expect(mocks.fetchFsStat).toHaveBeenCalledWith(firstFile, {
+      throwOnError: true,
+    })
+    const navigation = mocks.navigate.mock.calls[0][0]
+    expect(
+      navigation.search({ file: firstFile, uri: parentDirectory }),
+    ).toEqual({ uri: parentDirectory })
+  })
+
+  it('does not clear a newer selection when the old file stat finishes late', async () => {
+    let rejectStat: (error: unknown) => void = () => undefined
+    mocks.fetchFsStat.mockReturnValue(
+      new Promise((_, reject) => {
+        rejectStat = reject
+      }),
+    )
+    const { rerender } = render(<PlaygroundRoute />)
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: mocks.refreshLabel }),
+    )
+    await waitFor(() => {
+      expect(mocks.fetchFsStat).toHaveBeenCalledOnce()
+    })
+
+    mocks.search = { file: secondFile, uri: parentDirectory }
+    rerender(<PlaygroundRoute />)
+    await waitFor(() => {
+      expect(screen.getByTestId('preview').textContent).toBe(secondFile)
+    })
+
+    await act(async () => {
+      rejectStat({ statusCode: 404 })
+    })
+
+    expect(screen.getByTestId('preview').textContent).toBe(secondFile)
+    expect(mocks.navigate).not.toHaveBeenCalled()
+  })
+})

--- a/web-studio/src/routes/playground/route.tsx
+++ b/web-studio/src/routes/playground/route.tsx
@@ -121,6 +121,8 @@ function PlaygroundWorkbench() {
       ? createEntryFromUri(search.file, false)
       : createEntryFromUri(initialCurrentUri, true),
   )
+  const selectedFileRef = useRef(selectedFile)
+  selectedFileRef.current = selectedFile
   const [expandedKeys, setExpandedKeys] = useState<Set<string>>(() =>
     mergeExpanded(
       new Set(readPlaygroundExpandedUris(identityScopeKey)),
@@ -400,6 +402,26 @@ function PlaygroundWorkbench() {
     [syncSearch],
   )
 
+  const handleRefreshContextTree = useCallback(async () => {
+    const refreshedFile = selectedFileRef.current
+    await invalidateList()
+    if (!refreshedFile || refreshedFile.isDir) return
+
+    try {
+      await fetchFsStat(refreshedFile.uri, { throwOnError: true })
+      return
+    } catch (error) {
+      if ((error as { statusCode?: number }).statusCode !== 404) return
+    }
+    if (selectedFileRef.current?.uri !== refreshedFile.uri) return
+
+    setSelectedFile(null)
+    syncSearch({
+      file: undefined,
+      uri: normalizeDirUri(parentUri(refreshedFile.uri)),
+    })
+  }, [invalidateList, syncSearch])
+
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
@@ -544,10 +566,7 @@ function PlaygroundWorkbench() {
             onAddResource={() => setUploadDialogOpen(true)}
             onOpenProcessingTasks={handleOpenProcessingTasks}
             onOpenSearch={handleOpenSearch}
-            onRefresh={() => {
-              void invalidateList(currentUri)
-              void listQuery.refetch()
-            }}
+            onRefresh={() => void handleRefreshContextTree()}
           />
           <div className="min-h-0 flex-1">
             <ContextTree


### PR DESCRIPTION
## Description

Fix the Web Studio playground context tree refresh so files deleted outside the UI disappear from expanded directories and stale selected-file state is cleared.

Before this change, the refresh button invalidated only the current directory and immediately refetched it again. Expanded child directories could remain stale, while a deleted selected file stayed in the preview and in the `file` URL parameter.

The playground route owns this refresh flow. It now invalidates all active directory-list queries, checks the selected file after refresh, and clears the preview and URL only when that file returns 404. A latest-selection guard prevents a slow response for an older file from clearing a newer user selection.

No compatibility or migration impact is expected.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Invalidate every active filesystem list query when refreshing the context tree.
- Clear a deleted selected file from the preview and URL while preserving non-404 failures.
- Ignore stale deletion results after the user selects another file.
- Add focused route tests for deletion cleanup and the reachable selection race.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Commands run:

- `npm test` (58 files, 263 tests passed)
- `npm run build`
- `npx eslint src/routes/playground/route.tsx src/routes/playground/route.test.tsx`
- `npx prettier --check src/routes/playground/route.tsx src/routes/playground/route.test.tsx`
- `git diff --check`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The bug was reproduced on Windows with the Web Studio UI backed by a local HTTP filesystem fixture and a real temporary file. After deleting that file outside the UI and clicking refresh, the expanded directory entries were refetched, the file disappeared, the preview moved to its parent directory, and the stale `file` URL parameter was removed.

Documentation and dependent-change checklist items are not applicable to this focused behavioral fix.
