### PR TITLE
perf(admin): batch account directory initialization

### DIFF
--- a/openviking/core/directories.py
+++ b/openviking/core/directories.py
@@ -7,8 +7,9 @@ OpenViking uses a virtual filesystem where all directories are data records.
 This module defines the preset directory structure that is created on initialization.
 """
 
+import asyncio
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence
 
 from openviking.core.context import Context, Vectorize
 from openviking.core.namespace import (
@@ -19,6 +20,7 @@ from openviking.core.namespace import (
 )
 from openviking.server.identity import RequestContext
 from openviking.storage.queuefs.embedding_msg_converter import EmbeddingMsgConverter
+from openviking.storage.vector_ids import vector_record_id
 
 if TYPE_CHECKING:
     from openviking.storage import VikingDBManager
@@ -35,6 +37,15 @@ class DirectoryDefinition:
     abstract: str  # L0 summary
     overview: str  # L1 description
     children: List["DirectoryDefinition"] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _DirectoryTarget:
+    uri: str
+    parent_uri: Optional[str]
+    definition: DirectoryDefinition
+    scope: str
+    ctx: RequestContext
 
 
 # Preset directory tree - each scope has a root DirectoryDefinition
@@ -161,6 +172,37 @@ class DirectoryInitializer:
 
         return get_viking_fs()
 
+    async def initialize_account_workspace(self, ctx: RequestContext) -> tuple[int, int]:
+        """Initialize account and first-user preset directories as one batch."""
+        account_target = self._account_directory_target(ctx)
+        user_root, user_children = self._user_directory_targets(ctx)
+
+        root_targets = (account_target, user_root)
+        root_results = await asyncio.gather(
+            self._ensure_agfs_directory(account_target),
+            self._ensure_agfs_directory(user_root),
+            return_exceptions=True,
+        )
+        created_targets, root_error = self._partition_directory_results(root_targets, root_results)
+        if root_error is not None:
+            await self._ensure_directory_l0_l1_vectors(created_targets)
+            raise root_error
+
+        child_results = await asyncio.gather(
+            *(self._ensure_agfs_directory(target) for target in user_children),
+            return_exceptions=True,
+        )
+        created_children, child_error = self._partition_directory_results(
+            user_children, child_results
+        )
+        created_targets.extend(created_children)
+        await self._ensure_directory_l0_l1_vectors(created_targets)
+        if child_error is not None:
+            raise child_error
+        return int(root_results[0] is True), int(root_results[1] is True) + sum(
+            result is True for result in child_results
+        )
+
     async def initialize_account_directories(self, ctx: RequestContext) -> int:
         """Initialize account-shared scope roots.
 
@@ -168,22 +210,10 @@ class DirectoryInitializer:
         Its concrete metadata belongs to ``viking://user/{user_id}`` and is
         created by ``initialize_user_directories``.
         """
-        count = 0
-        scope_roots = {
-            "resources": PRESET_DIRECTORIES["resources"],
-        }
-        for scope, defn in scope_roots.items():
-            root_uri = f"viking://{scope}"
-            created = await self._ensure_directory(
-                uri=root_uri,
-                parent_uri=None,
-                defn=defn,
-                scope=scope,
-                ctx=ctx,
-            )
-            if created:
-                count += 1
-        return count
+        target = self._account_directory_target(ctx)
+        created = await self._ensure_agfs_directory(target)
+        await self._ensure_directory_l0_l1_vectors([target] if created else [])
+        return int(created)
 
     async def initialize_user_directories(self, ctx: RequestContext) -> int:
         """Initialize the current user's root and first-level entry directories.
@@ -194,109 +224,141 @@ class DirectoryInitializer:
         """
         if "user" not in PRESET_DIRECTORIES:
             return 0
-        user_space_root = canonical_user_root(ctx)
+        user_root, user_children = self._user_directory_targets(ctx)
+        root_created = await self._ensure_agfs_directory(user_root)
+        child_results = await asyncio.gather(
+            *(self._ensure_agfs_directory(target) for target in user_children),
+            return_exceptions=True,
+        )
+        created_targets = [user_root] if root_created else []
+        created_children, child_error = self._partition_directory_results(
+            user_children, child_results
+        )
+        created_targets.extend(created_children)
+        await self._ensure_directory_l0_l1_vectors(created_targets)
+        if child_error is not None:
+            raise child_error
+        return int(root_created) + sum(result is True for result in child_results)
+
+    @staticmethod
+    def _account_directory_target(ctx: RequestContext) -> _DirectoryTarget:
+        return _DirectoryTarget(
+            uri="viking://resources",
+            parent_uri=None,
+            definition=PRESET_DIRECTORIES["resources"],
+            scope="resources",
+            ctx=ctx,
+        )
+
+    @staticmethod
+    def _user_directory_targets(
+        ctx: RequestContext,
+    ) -> tuple[_DirectoryTarget, list[_DirectoryTarget]]:
         # Preset initialization is a server-controlled write to the current
-        # user's own root and first-level directories.  Actor-peer view must
+        # user's own root and first-level directories. Actor-peer view must
         # still protect peer subtrees during normal filesystem mutations, but
         # it must not prevent a fresh user from creating the container that
         # owns those subtrees in the first place.
         initialization_ctx = replace(ctx, actor_peer_id=None)
         user_tree = PRESET_DIRECTORIES["user"]
-        parent_uri = "viking://user"
-        count = 0
-        if await self._ensure_directory(
-            uri=user_space_root,
-            parent_uri=parent_uri,
-            defn=user_tree,
+        user_root_uri = canonical_user_root(initialization_ctx)
+        root = _DirectoryTarget(
+            uri=user_root_uri,
+            parent_uri="viking://user",
+            definition=user_tree,
             scope="user",
             ctx=initialization_ctx,
-        ):
-            count += 1
-
-        for child in user_tree.children:
-            child_uri = f"{user_space_root}/{child.path}"
-            if await self._ensure_directory(
-                uri=child_uri,
-                parent_uri=user_space_root,
-                defn=child,
+        )
+        children = [
+            _DirectoryTarget(
+                uri=f"{user_root_uri}/{child.path}",
+                parent_uri=user_root_uri,
+                definition=child,
                 scope="user",
                 ctx=initialization_ctx,
-            ):
-                count += 1
+            )
+            for child in user_tree.children
+        ]
+        return root, children
 
-        return count
+    @staticmethod
+    def _partition_directory_results(
+        targets: Sequence[_DirectoryTarget],
+        results: Sequence[bool | BaseException],
+    ) -> tuple[list[_DirectoryTarget], Optional[BaseException]]:
+        """Keep successful concurrent writes while preserving the first failure."""
+        created_targets = []
+        first_error = None
+        for target, result in zip(targets, results, strict=True):
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+            if isinstance(result, BaseException):
+                if first_error is None:
+                    first_error = result
+            elif result:
+                created_targets.append(target)
+        return created_targets, first_error
 
-    async def _ensure_directory(
-        self,
-        uri: str,
-        parent_uri: Optional[str],
-        defn: DirectoryDefinition,
-        scope: str,
-        ctx: RequestContext,
-    ) -> bool:
-        """Ensure directory exists, return whether newly created."""
+    async def _ensure_agfs_directory(self, target: _DirectoryTarget) -> bool:
+        """Ensure one directory exists in AGFS and report whether it was created."""
         from openviking_cli.utils.logger import get_logger
 
         logger = get_logger(__name__)
-        created = False
-        agfs_created = False
-        # 1. Ensure files exist in AGFS
-        if not await self._check_agfs_files_exist(uri, ctx=ctx):
-            logger.debug(f"[VikingFS] Creating directory: {uri} for scope {scope}")
-            await self._create_agfs_structure(uri, defn.abstract, defn.overview, ctx=ctx)
-            created = True
-            agfs_created = True
-        else:
-            logger.debug(f"[VikingFS] Directory {uri} already exists")
+        if await self._check_agfs_files_exist(target.uri, ctx=target.ctx):
+            logger.debug(f"[VikingFS] Directory {target.uri} already exists")
+            return False
+        logger.debug(f"[VikingFS] Creating directory: {target.uri} for scope {target.scope}")
+        await self._create_agfs_structure(
+            target.uri,
+            target.definition.abstract,
+            target.definition.overview,
+            ctx=target.ctx,
+        )
+        return True
 
-        # 2. Seed directory L0/L1 vectors only during fresh initialization.
-        owner_space = self._owner_space_for_scope(scope=scope, ctx=ctx)
-        if agfs_created and not is_session_uri(uri):
-            await self._ensure_directory_l0_l1_vectors(
-                uri=uri,
-                parent_uri=parent_uri,
-                defn=defn,
-                owner_space=owner_space,
-                ctx=ctx,
+    async def _ensure_directory_l0_l1_vectors(self, targets: list[_DirectoryTarget]) -> None:
+        """Seed missing L0/L1 records after one batch existence read."""
+        vector_targets = [
+            (target, level, vector_text)
+            for target in targets
+            if not is_session_uri(target.uri)
+            for level, vector_text in (
+                (0, target.definition.abstract),
+                (1, target.definition.overview),
             )
-        return created
+        ]
+        if not vector_targets:
+            return
 
-    async def _ensure_directory_l0_l1_vectors(
-        self,
-        uri: str,
-        parent_uri: Optional[str],
-        defn: DirectoryDefinition,
-        owner_space: str,
-        ctx: RequestContext,
-    ) -> None:
-        """Ensure L0/L1 vector records exist for a preset directory."""
-        for level, vector_text in (
-            (0, defn.abstract),
-            (1, defn.overview),
-        ):
-            existing = await self.vikingdb.get_context_by_uri(
-                uri=uri,
-                level=level,
-                limit=1,
-                ctx=ctx,
-            )
-            if existing:
+        record_ids = [
+            vector_record_id(target.ctx.account_id, target.uri, level)
+            for target, level, _vector_text in vector_targets
+        ]
+        existing = await self.vikingdb.get(record_ids, ctx=vector_targets[0][0].ctx)
+        existing_ids = {record.get("id") for record in existing if record.get("id")}
+
+        messages = []
+        for record_id, (target, level, vector_text) in zip(record_ids, vector_targets, strict=True):
+            if record_id in existing_ids:
                 continue
             context = Context(
-                uri=uri,
-                parent_uri=parent_uri,
+                uri=target.uri,
+                parent_uri=target.parent_uri,
                 is_leaf=False,
-                context_type=context_type_for_uri(uri),
-                abstract=defn.abstract,
+                context_type=context_type_for_uri(target.uri),
+                abstract=target.definition.abstract,
                 level=level,
-                user=ctx.user,
-                account_id=ctx.account_id,
-                owner_space=owner_space,
+                user=target.ctx.user,
+                account_id=target.ctx.account_id,
+                owner_space=self._owner_space_for_scope(scope=target.scope, ctx=target.ctx),
             )
             context.set_vectorize(Vectorize(text=vector_text))
             emb_msg = EmbeddingMsgConverter.from_context(context)
             if emb_msg:
-                await self.vikingdb.enqueue_embedding_msg(emb_msg)
+                messages.append(emb_msg)
+        await asyncio.gather(
+            *(self.vikingdb.enqueue_embedding_msg(message) for message in messages)
+        )
 
     @staticmethod
     def _owner_space_for_scope(scope: str, ctx: RequestContext) -> str:
@@ -312,34 +374,6 @@ class DirectoryInitializer:
             return True
         except (FileNotFoundError, NotFoundError):
             return False
-
-    async def _initialize_children(
-        self,
-        scope: str,
-        children: List[DirectoryDefinition],
-        parent_uri: str,
-        ctx: RequestContext,
-    ) -> int:
-        """Recursively initialize subdirectories."""
-        count = 0
-
-        for defn in children:
-            uri = f"{parent_uri}/{defn.path}"
-
-            created = await self._ensure_directory(
-                uri=uri,
-                parent_uri=parent_uri,
-                defn=defn,
-                scope=scope,
-                ctx=ctx,
-            )
-            if created:
-                count += 1
-
-            if defn.children:
-                count += await self._initialize_children(scope, defn.children, uri, ctx=ctx)
-
-        return count
 
     async def _create_agfs_structure(
         self, uri: str, abstract: str, overview: str, ctx: RequestContext

--- a/openviking/server/routers/admin.py
+++ b/openviking/server/routers/admin.py
@@ -309,8 +309,7 @@ async def create_account(
         body.admin_user_id,
         seed=body.seed,
     )
-    await service.initialize_account_directories(account_ctx)
-    await service.initialize_user_directories(account_ctx)
+    await service.initialize_account_workspace(account_ctx)
     await _write_initial_user_config(service, account_ctx, body.user_config)
     result = {
         "account_id": body.account_id,

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -385,8 +385,9 @@ class OpenVikingService:
         )
         self._directory_initializer = directory_initializer
         default_ctx = RequestContext(user=self._user, role=Role.ROOT)
-        account_count = await directory_initializer.initialize_account_directories(default_ctx)
-        user_count = await directory_initializer.initialize_user_directories(default_ctx)
+        account_count, user_count = await directory_initializer.initialize_account_workspace(
+            default_ctx
+        )
         logger.info(
             "Initialized preset directories account=%d user=%d",
             account_count,
@@ -661,6 +662,13 @@ class OpenVikingService:
         if not self._directory_initializer:
             return 0
         return await self._directory_initializer.initialize_account_directories(ctx)
+
+    async def initialize_account_workspace(self, ctx: RequestContext) -> tuple[int, int]:
+        """Initialize account and first-user preset directories in one batch."""
+        self._ensure_initialized()
+        if not self._directory_initializer:
+            return 0, 0
+        return await self._directory_initializer.initialize_account_workspace(ctx)
 
     async def initialize_user_directories(self, ctx: RequestContext) -> int:
         """Initialize current user's directory tree."""

--- a/tests/server/test_admin_api.py
+++ b/tests/server/test_admin_api.py
@@ -119,6 +119,9 @@ class _FakeService:
     async def initialize_user_directories(self, ctx):
         return None
 
+    async def initialize_account_workspace(self, ctx):
+        return None
+
 
 def _build_lightweight_admin_test_app() -> FastAPI:
     from openviking.server.auth.plugins import ApiKeyAuthPlugin

--- a/tests/unit/test_directory_initializer.py
+++ b/tests/unit/test_directory_initializer.py
@@ -1,7 +1,11 @@
 import pytest
 
 from openviking.core.directories import PRESET_DIRECTORIES, DirectoryInitializer
-from openviking.core.namespace import canonical_user_root, may_include_hidden_actor_peers
+from openviking.core.namespace import (
+    canonical_user_root,
+    is_session_uri,
+    may_include_hidden_actor_peers,
+)
 from openviking.server.identity import RequestContext, Role
 from openviking_cli.session.user_id import UserIdentifier
 
@@ -9,8 +13,10 @@ from openviking_cli.session.user_id import UserIdentifier
 class _FakeVikingDB:
     def __init__(self):
         self.embedding_messages = []
+        self.get_calls = []
 
-    async def get_context_by_uri(self, **_kwargs):
+    async def get(self, ids, ctx):
+        self.get_calls.append((ids, ctx))
         return []
 
     async def enqueue_embedding_msg(self, message):
@@ -37,27 +43,34 @@ class _FakeVikingFS:
 
 
 @pytest.mark.asyncio
-async def test_initialize_user_directories_creates_root_and_first_level_only():
+async def test_initialize_account_workspace_batches_preset_directories():
     vikingdb = _FakeVikingDB()
     viking_fs = _FakeVikingFS()
     initializer = DirectoryInitializer(vikingdb, viking_fs=viking_fs)
     ctx = RequestContext(user=UserIdentifier("acme", "alice"), role=Role.ADMIN)
 
-    count = await initializer.initialize_user_directories(ctx)
+    account_count, user_count = await initializer.initialize_account_workspace(ctx)
 
     user_root = canonical_user_root(ctx)
-    expected_uris = {
+    expected_user_uris = {
         user_root,
         *(f"{user_root}/{child.path}" for child in PRESET_DIRECTORIES["user"].children),
     }
-    assert count == len(expected_uris)
+    expected_uris = {"viking://resources", *expected_user_uris}
+    assert account_count == 1
+    assert user_count == len(expected_user_uris)
     assert set(viking_fs.contexts) == expected_uris
     assert f"{user_root}/memories/preferences" not in viking_fs.contexts
+    assert len(vikingdb.get_calls) == 1
+    vectorized_uris = {uri for uri in expected_uris if not is_session_uri(uri)}
+    assert len(vikingdb.get_calls[0][0]) == 2 * len(vectorized_uris)
+    assert len(vikingdb.embedding_messages) == 2 * len(vectorized_uris)
 
-    second_count = await initializer.initialize_user_directories(ctx)
+    second_account_count, second_user_count = await initializer.initialize_account_workspace(ctx)
 
-    assert second_count == 0
+    assert (second_account_count, second_user_count) == (0, 0)
     assert set(viking_fs.contexts) == expected_uris
+    assert len(vikingdb.get_calls) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

优化 `POST /api/v1/admin/accounts` 创建账户时的预置目录初始化耗时，保持现有同步接口和响应语义不变。

Before：账户资源目录、首个用户根目录及 6 个一级目录逐个初始化；每个需要向量化的目录分别查询 L0/L1 是否存在，共产生 14 次向量查询，随后逐条写入 embedding queue。

After：账户资源目录与用户根目录并发初始化，用户一级目录在根目录完成后并发初始化；所有新目录的 L0/L1 使用确定性 ID 一次批量读取，缺失的 embedding 消息并发入队。并发中的部分目录失败时，已成功目录仍会完成向量入队，然后保留原错误返回。

同一输入示例：

```http
POST /api/v1/admin/accounts
{"account_id":"acme-demo","admin_user_id":"alice"}
```

修改前后都同步返回 `200` 和相同的 `account_id`、`admin_user_id`、`user_key`；变化仅在内部初始化方式。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made

- 增加账户资源与首个用户目录的一体化初始化入口，按父子依赖分层并发执行 AGFS I/O。
- 用确定性向量记录 ID 将 14 次逐目录查询收敛为 1 次批量 `get`，并发持久化独立 embedding 消息。
- 改写现有目录初始化契约测试，覆盖批量读取、目录范围和重复初始化幂等性。

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Executed:

- `uv run --frozen --extra test pytest --no-cov -q tests/unit/test_directory_initializer.py` (2 passed)
- `uv run --frozen --extra test pytest --no-cov -q tests/server/test_admin_api.py::test_create_user_paths_accept_initial_user_config` (1 passed)
- `uv run --frozen ruff check ...`
- `uv run --frozen python -m compileall -q ...`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

本 PR 不把账户创建改为异步任务，不修改 API/SDK 契约，也不改账户注册表的存储方式。
