### PR TITLE
fix(mcp): reuse one resident session for remember

### DIFF
--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -705,6 +705,14 @@ async def tree(
 
 # -- remember --------------------------------------------------------------
 
+# One resident session per user instead of one per call. A session directory
+# survives its commit -- the live messages.jsonl is rewritten empty and the
+# content moves to history/archive_NNN -- so a fresh session id per call left a
+# permanently near-empty directory behind for every remembered fact. Sessions
+# are already scoped to viking://user/<user_id>/sessions/, so a fixed id is
+# per-user without any additional keying.
+MEMORY_STORE_SESSION_ID = "mcp-store"
+
 
 class StoreMessage(BaseModel):
     role: Literal["user", "assistant"] = Field(description="Message role")
@@ -714,13 +722,11 @@ class StoreMessage(BaseModel):
 @mcp.tool()
 async def remember(messages: list[StoreMessage]) -> str:
     """Store information into OpenViking long-term memory. Use when the user says 'remember this', shares preferences, important facts, or decisions worth persisting."""
-    import uuid
-
     from openviking.message.part import TextPart
 
     service = get_service()
     ctx = _get_ctx()
-    session_id = f"mcp-store-{uuid.uuid4().hex[:12]}"
+    session_id = MEMORY_STORE_SESSION_ID
     session = await service.sessions.get(session_id, ctx, auto_create=True)
     for msg in messages:
         if msg.content:

--- a/tests/server/test_mcp_remember_session_reuse.py
+++ b/tests/server/test_mcp_remember_session_reuse.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""`remember` must reuse one resident session instead of one per call.
+
+A session directory survives its own commit: the live ``messages.jsonl`` is
+rewritten empty and the content moves to ``history/archive_NNN``. Minting a
+fresh session id per call therefore left a permanently near-empty directory
+behind for every remembered fact.
+
+These tests stub the service and the identity contextvar directly so they do
+not need a server configuration file.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import openviking.server.mcp_endpoint as mcp_endpoint
+from openviking.server.identity import RequestContext, Role
+from openviking.server.mcp_endpoint import StoreMessage, remember
+from openviking_cli.session.user_id import UserIdentifier
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str]] = []
+
+    async def add_message_async(self, role, parts, peer_id=None, created_at=None):
+        self.messages.append((role, parts[0].text))
+
+
+@pytest.fixture
+def fake_service(monkeypatch):
+    """A service whose session store records every id it is asked for."""
+    sessions: dict[str, _FakeSession] = {}
+    requested: list[str] = []
+    committed: list[str] = []
+
+    async def _get(session_id, ctx, *args, **kwargs):
+        requested.append(session_id)
+        return sessions.setdefault(session_id, _FakeSession())
+
+    async def _commit(session_id, ctx, *args, **kwargs):
+        committed.append(session_id)
+        return {}
+
+    service = SimpleNamespace(
+        sessions=SimpleNamespace(get=_get, commit_async=_commit),
+    )
+    monkeypatch.setattr(mcp_endpoint, "get_service", lambda: service)
+
+    ctx = RequestContext(
+        user=UserIdentifier("acct", "alice"),
+        role=Role.USER,
+    )
+    token = mcp_endpoint._mcp_ctx.set(ctx)
+    yield SimpleNamespace(
+        sessions=sessions, requested=requested, committed=committed
+    )
+    mcp_endpoint._mcp_ctx.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_every_call_reuses_the_same_session(fake_service):
+    """Two remembered facts must not create two session directories."""
+    await remember(messages=[StoreMessage(role="user", content="first fact")])
+    await remember(messages=[StoreMessage(role="user", content="second fact")])
+
+    assert fake_service.requested == [
+        mcp_endpoint.MEMORY_STORE_SESSION_ID,
+        mcp_endpoint.MEMORY_STORE_SESSION_ID,
+    ]
+    assert len(fake_service.sessions) == 1
+
+
+@pytest.mark.asyncio
+async def test_the_session_id_is_stable_and_not_random(fake_service):
+    """A uuid-suffixed id is what created the directory-per-fact problem."""
+    await remember(messages=[StoreMessage(role="user", content="a fact")])
+
+    (session_id,) = fake_service.requested
+    assert session_id == "mcp-store"
+
+
+@pytest.mark.asyncio
+async def test_commit_targets_the_session_that_was_written_to(fake_service):
+    """Committing a different id would strand the messages uncommitted."""
+    await remember(messages=[StoreMessage(role="user", content="a fact")])
+
+    assert fake_service.committed == fake_service.requested
+
+
+@pytest.mark.asyncio
+async def test_content_still_reaches_the_session(fake_service):
+    """Reusing the session must not change what gets stored."""
+    await remember(
+        messages=[
+            StoreMessage(role="user", content="remember this"),
+            StoreMessage(role="assistant", content="noted"),
+            StoreMessage(role="user", content=""),
+        ]
+    )
+
+    session = fake_service.sessions[mcp_endpoint.MEMORY_STORE_SESSION_ID]
+    assert session.messages == [("user", "remember this"), ("assistant", "noted")]


### PR DESCRIPTION
Draft — the behaviour question in "Open question" below should be settled before this merges.

## Problem

Every `remember` call minted a fresh `mcp-store-<uuid>` session (`mcp_endpoint.py:715-733`).

A session directory **survives its own commit**. `remember` commits without `keep_recent_count`, so it takes the default `0`: every message moves into `history/archive_001/`, and `session.py:5279-5287` then rewrites the live `messages.jsonl` as an empty string. The directory stays, along with `.meta.json`, `.abstract.md` and `.overview.md`.

Net effect: **one permanently near-empty directory per remembered fact.** That is the reported "lots of empty directories, hard to read, and we bill per file" experience.

## Change

Use one resident session id per user. Sessions are already scoped to `viking://user/<user_id>/sessions/`, so a fixed id is per-user without any extra keying — no account, peer, or agent component needed.

The diff is one constant and one assignment.

## Relationship to #4029

[#4029](https://github.com/volcengine/OpenViking/issues/4029) proposes an opt-in retention/GC sweep for session directories and commit archives. This PR **does not replace it** — archives still accumulate inside the resident session and still need a retention policy.

What it does is remove the largest class of garbage at the source, so the GC is no longer the only thing standing between a busy deployment and unbounded directory count. Cleaning up files that never needed to exist is the wrong place to spend a background scanner.

## Open question

`remember` still commits on every call, so a busy user accumulates `history/archive_NNN` inside the one resident session. Committing less eagerly would cut that too, but it changes when extraction runs and therefore when a memory becomes searchable. I have deliberately not touched that — it is a latency contract, not a cleanup detail. Worth deciding whether it belongs here or in #4029's retention work.

Also worth a look: concurrent `remember` calls now share a session, so one call's commit can sweep in another's just-added messages. That is harmless for extraction (all of it is material to extract, and it produces fewer archives), but it is a real behaviour change from the isolated-session-per-call model and should be a conscious choice rather than a side effect.

## Tests

`tests/server/test_mcp_remember_session_reuse.py`, 4 cases: two calls reuse one session, the id is stable rather than random, the commit targets the session that was written to, and content still reaches the session with empty messages skipped.

They stub the service and the identity contextvar directly, so unlike the rest of `tests/server/test_mcp_endpoint.py` they run without a server configuration file.

Verified they fail without the fix (3 of 4 fail when the uuid id is restored). `tests/server`, `tests/session` and `tests/service` show an identical failure set with and without the change — 177 failed / 790 errors before and after, 1124 → 1128 passed. Those pre-existing failures are this machine lacking a compiled `ov` binary and a server config.