### PR TITLE
fix(session): stop leaving an empty messages.jsonl in every session

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -813,17 +813,37 @@ class Session:
             return False
 
     async def is_materialized(self) -> bool:
-        """Check whether the session's authoritative live-message file exists."""
-        try:
-            await self._viking_fs.stat(
-                f"{self._session_uri}/messages.jsonl",
-                ctx=self.ctx,
-            )
-            return True
-        except Exception as exc:
-            if not _is_storage_not_found(exc):
-                raise
-            return False
+        """Check whether this session has ever held real content.
+
+        #3820 made messages.jsonl the materialization boundary so that a
+        half-created session root is not used for session-aware recall. A
+        committed session no longer keeps that file -- everything moved into
+        history/ -- so the archive directory is the second half of the same
+        boundary. A root with neither has never held a message.
+        """
+        for leaf in ("messages.jsonl", "history"):
+            try:
+                await self._viking_fs.stat(
+                    f"{self._session_uri}/{leaf}",
+                    ctx=self.ctx,
+                )
+                return True
+            except Exception as exc:
+                if not _is_storage_not_found(exc):
+                    raise
+        return False
+
+    async def _remove_live_messages(self, lease_ref: Optional[Any] = None) -> None:
+        """Drop the live message file; absence and emptiness mean the same thing.
+
+        VikingFS.rm is documented idempotent, so a session that never wrote a
+        live file needs no separate guard here.
+        """
+        await self._viking_fs.rm(
+            f"{self._session_uri}/messages.jsonl",
+            ctx=self.ctx,
+            lease_ref=lease_ref,
+        )
 
     async def ensure_exists(self) -> None:
         """Materialize session root and messages file if missing."""
@@ -1945,7 +1965,15 @@ class Session:
             session_path, timeout_secs=_SESSION_PHASE1_LOCK_TIMEOUT_SECONDS
         )
         try:
-            self._messages = await self._read_live_messages_strict()
+            try:
+                self._messages = await self._read_live_messages_strict()
+            except Exception as exc:
+                # A previous commit that archived everything removes the live
+                # file, so a second commit with nothing new must read as empty
+                # rather than as a storage failure.
+                if not _is_storage_not_found(exc):
+                    raise
+                self._messages = []
             try:
                 meta_content = await self._viking_fs.read_file(
                     f"{self._session_uri}/.meta.json",
@@ -5277,14 +5305,23 @@ class Session:
         overview = self._generate_overview(turn_count)
 
         lines = [m.to_jsonl() for m in messages]
-        content = "\n".join(lines) + "\n" if lines else ""
 
-        await viking_fs.write_file(
-            uri=f"{self._session_uri}/messages.jsonl",
-            content=content,
-            ctx=self.ctx,
-            lease_ref=lease_ref,
-        )
+        if lines:
+            await viking_fs.write_file(
+                uri=f"{self._session_uri}/messages.jsonl",
+                content="\n".join(lines) + "\n",
+                ctx=self.ctx,
+                lease_ref=lease_ref,
+            )
+        else:
+            # A commit that archives everything used to leave a 0-byte
+            # messages.jsonl in every session directory. Remove the file
+            # instead: "no live messages" and "an empty list of live messages"
+            # are the same state, and the empty file is the single most
+            # complained-about piece of session-directory clutter.
+            # is_materialized() still separates a committed session from a
+            # half-created root by falling back to the archive directory.
+            await self._remove_live_messages(lease_ref=lease_ref)
         await viking_fs.write_file(
             uri=f"{self._session_uri}/.abstract.md",
             content=render_abstract_overview(

--- a/tests/session/test_no_empty_live_messages.py
+++ b/tests/session/test_no_empty_live_messages.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""A fully archived session must not leave an empty messages.jsonl behind.
+
+Committing with keep_recent_count=0 moves every message into
+history/archive_NNN and used to rewrite the live file as an empty string, so
+each session directory kept a 0-byte messages.jsonl forever. #3820 made that
+file the materialization boundary for session-aware recall, so removing it has
+to keep a committed session distinguishable from a half-created root.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from openviking.session.session import Session
+
+
+class _FakeFS:
+    """Records writes and removals, and answers stat from what exists."""
+
+    def __init__(self, present=()):
+        self.present = set(present)
+        self.removed: list[str] = []
+        self.written: dict[str, str] = {}
+
+    async def write_file(self, uri, content, ctx=None, lease_ref=None):
+        self.written[uri] = content
+        self.present.add(uri)
+
+    async def rm(self, uri, ctx=None, lease_ref=None, **kwargs):
+        self.removed.append(uri)
+        self.present.discard(uri)
+
+    async def stat(self, uri, ctx=None):
+        if uri not in self.present:
+            raise FileNotFoundError(uri)
+        return {"uri": uri}
+
+
+def _session(fs) -> Session:
+    session = Session.__new__(Session)
+    session._viking_fs = fs
+    session._session_uri = "viking://user/alice/sessions/s1"
+    session.ctx = None
+    session._messages = []
+    session._stats = SimpleNamespace(total_turns=0)
+    session._compression = SimpleNamespace(compression_index=1)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_writing_no_messages_removes_the_live_file():
+    """The empty-file case is a removal, not a zero-byte write."""
+    uri = "viking://user/alice/sessions/s1/messages.jsonl"
+    fs = _FakeFS(present=[uri])
+
+    await Session._write_to_agfs_async(_session(fs), [])
+
+    assert fs.removed == [uri]
+    assert uri not in fs.written
+
+
+@pytest.mark.asyncio
+async def test_a_committed_session_is_still_materialized():
+    """#3820's boundary must survive: history/ is the second half of it."""
+    root = "viking://user/alice/sessions/s1"
+    fs = _FakeFS(present=[f"{root}/history"])
+
+    assert await Session.is_materialized(_session(fs)) is True
+
+
+@pytest.mark.asyncio
+async def test_a_live_session_is_still_materialized():
+    root = "viking://user/alice/sessions/s1"
+    fs = _FakeFS(present=[f"{root}/messages.jsonl"])
+
+    assert await Session.is_materialized(_session(fs)) is True
+
+
+@pytest.mark.asyncio
+async def test_a_half_created_root_is_not_materialized():
+    """The case #3820 was written for: a root with neither file."""
+    fs = _FakeFS(present=[])
+
+    assert await Session.is_materialized(_session(fs)) is False
+
+
+@pytest.mark.asyncio
+async def test_a_storage_failure_is_not_swallowed_as_not_materialized():
+    """Only not-found means 'absent'; anything else must surface."""
+
+    class _BrokenFS(_FakeFS):
+        async def stat(self, uri, ctx=None):
+            raise RuntimeError("vector store unreachable")
+
+    with pytest.raises(RuntimeError):
+        await Session.is_materialized(_session(_BrokenFS()))


### PR DESCRIPTION
Draft — the `is_materialized()` change touches the boundary #3820 deliberately drew, so I want that looked at before this merges.

## Problem

Committing with `keep_recent_count=0` moves every message into `history/archive_NNN` and then rewrites the live file as an empty string (`session.py`, `_write_to_agfs_async`). Every session directory therefore keeps a **0-byte `messages.jsonl` forever**.

This is the single most complained-about piece of session-directory clutter — it has come up from more than one person internally and in the user group. A directory listing full of files containing nothing is hard to read and hard to explain.

## Change

Remove the file rather than writing zero bytes. "No live messages" and "an empty list of live messages" are the same state, and `VikingFS.rm` is documented idempotent, so a session that never wrote a live file needs no separate guard.

## The part that needs review

[#3820](https://github.com/volcengine/OpenViking/pull/3820) made `messages.jsonl` **the materialization boundary**: `is_materialized()` exists so a half-created session root is not used for session-aware recall (`retrieve/context_assembler/pipeline.py:44` returns `None` when it is false).

Deleting the file naively would make every *committed* session look half-created and silently drop it out of context assembly. That would be a real regression, and it is the reason this is not a one-line change.

So `is_materialized()` now accepts either `messages.jsonl` **or** `history/`:

- live session → has `messages.jsonl` → materialized
- committed session → has `history/` → materialized
- half-created root → has neither → not materialized, exactly as #3820 intended

The boundary #3820 drew is preserved; it just has two halves now that the live file is no longer permanent.

Also guarded the commit path's strict live read: once the file can be absent, a second commit with nothing new must read as empty rather than raising.

## Scope

This fixes it for **all** sessions, not only MCP ones. An earlier attempt ([#4582](https://github.com/volcengine/OpenViking/pull/4582), closed) went at the `remember` tool instead; that was the wrong layer — the empty file is written by the generic commit path, so every session had it.

## Tests

`tests/session/test_no_empty_live_messages.py`, 5 cases: the empty write becomes a removal; a committed session (history only) is still materialized; a live session still is; a half-created root still is not — the #3820 regression case; and a storage failure is not swallowed as "not materialized".

`tests/session`, `tests/service`, `tests/server`, `tests/retrieve` show an identical failure set with and without the change — 177 failed / 790 errors before and after, 1182 → 1187 passed. Those pre-existing failures are this machine lacking a compiled `ov` binary and a server config, so **I could not exercise a real commit end to end**; the new tests use a fake filesystem. Worth a reviewer with a working environment confirming the archive path.