### PR TITLE
fix(memory): keep dynamic URI values in one path segment

### DIFF
--- a/openviking/session/memory/utils/uri.py
+++ b/openviking/session/memory/utils/uri.py
@@ -17,6 +17,7 @@ from openviking.session.memory.utils.template_utils import TemplateUtils
 _PORTABLE_SEGMENT_MARKER = "~ov~"
 _PORTABLE_SEGMENT_HASH_LENGTH = 16
 _WINDOWS_INVALID_CHARS = frozenset('<>:"\\|?*')
+_TRUSTED_PATH_SEGMENT_TEMPLATE = re.compile(r"^\{\{\s*user_space\s*\}\}$")
 _WINDOWS_RESERVED_STEMS = frozenset(
     {
         "CON",
@@ -100,23 +101,42 @@ def _portable_uri_segment(segment: str) -> str:
     return f"{stem}{suffix}{extension}"
 
 
-def _make_uri_path_segments_portable(uri: str) -> str:
-    """Make every rendered memory URI segment portable on supported filesystems.
+def _render_portable_uri_template(
+    template: str,
+    context: Dict[str, Any],
+    extract_context: Any,
+) -> str:
+    """Render template-defined path segments without treating field data as hierarchy.
 
-    Clean segments remain byte-identical. A non-portable segment keeps a readable
-    safe prefix and receives a deterministic digest of its original value, so
-    values such as ``Desktop``, ``Desktop ``, and ``Desktop.`` stay distinct.
+    ``user_space`` is an internal path fragment that may contain the explicit
+    ``peers/<peer_id>`` namespace. Other expressions render into exactly one path
+    segment. A slash in dynamic data aliases an underscore because both spellings
+    identify the same memory name.
     """
     scheme_separator = "://"
-    if scheme_separator in uri:
-        scheme, _, path = uri.partition(scheme_separator)
+    if scheme_separator in template:
+        scheme, _, path_template = template.partition(scheme_separator)
         prefix = f"{scheme}{scheme_separator}"
     else:
-        prefix, path = "", uri
+        prefix, path_template = "", template
 
-    if not path:
-        return uri
-    return prefix + "/".join(_portable_uri_segment(segment) for segment in path.split("/"))
+    if not path_template:
+        return prefix
+
+    segments = []
+    for segment_template in path_template.split("/"):
+        rendered = TemplateUtils.render(
+            segment_template,
+            context,
+            extract_context=extract_context,
+            debug_undefined=True,
+            strip=False,
+        )
+        if _TRUSTED_PATH_SEGMENT_TEMPLATE.fullmatch(segment_template):
+            segments.extend(rendered.split("/"))
+        else:
+            segments.append(rendered.replace("/", "_"))
+    return prefix + "/".join(_portable_uri_segment(segment) for segment in segments)
 
 
 def render_template(
@@ -175,18 +195,15 @@ def generate_uri(
         uri_template = f"{dir_template.rstrip('/')}/{filename_template.lstrip('/')}"
     else:
         uri_template = dir_template or filename_template
-    context = {"user_space": user_space}
-    # Add all fields to context (uri_fields with actual values)
-    context.update(fields)
+    context = dict(fields)
+    context["user_space"] = user_space
     template_vars = set(re.findall(r"\{\{\s*(\w+)\s*\}\}", uri_template))
     for var in template_vars:
         if var not in context:
             raise ValueError(f"Missing template variable: {var}")
         if context[var] is None:
             raise ValueError(f"Template variable '{var}' has None value")
-    # Render using unified render_template method (same as content_template)
-    uri = render_template(uri_template, context, extract_context)
-    return _make_uri_path_segments_portable(uri)
+    return _render_portable_uri_template(uri_template, context, extract_context)
 
 
 def validate_uri_template(memory_type: MemoryTypeSchema) -> bool:

--- a/tests/session/memory/test_memory_utils.py
+++ b/tests/session/memory/test_memory_utils.py
@@ -140,30 +140,22 @@ class TestUriGeneration:
         with pytest.raises(ValueError, match="has None value"):
             generate_uri(memory_type, {"topic": None})
 
-    def test_generate_uri_makes_windows_unsafe_directory_segment_collision_resistant(self):
-        """The exact #4308 shape is portable without changing the LLM field."""
+    def test_generate_uri_normalizes_dynamic_slash_without_new_hierarchy(self):
         memory_type = MemoryTypeSchema(
             memory_type="events",
-            description="Event memory",
             directory="viking://user/{{ user_space }}/memories/events",
             filename_template="2026/07/30/{{ event_name }}.md",
-            fields=[
-                MemoryField(
-                    name="event_name",
-                    field_type=FieldType.STRING,
-                    merge_op=MergeOp.IMMUTABLE,
-                )
-            ],
         )
-        fields = {"event_name": "Desktop /new report"}
+        fields = {"event_name": "alpha/beta"}
 
         uri = generate_uri(memory_type, fields, user_space="default")
 
-        assert uri == (
-            "viking://user/default/memories/events/2026/07/30/"
-            "Desktop~ov~02970756851a43cf/new report.md"
+        assert (
+            uri
+            == generate_uri(memory_type, {"event_name": "alpha_beta"}, user_space="default")
+            == "viking://user/default/memories/events/2026/07/30/alpha_beta.md"
         )
-        assert fields == {"event_name": "Desktop /new report"}
+        assert fields == {"event_name": "alpha/beta"}
 
     def test_generate_uri_keeps_colliding_windows_names_distinct(self):
         memory_type = MemoryTypeSchema(

--- a/tests/session/memory/test_streaming_memory_updater.py
+++ b/tests/session/memory/test_streaming_memory_updater.py
@@ -987,9 +987,7 @@ def test_enforce_merge_group_reapplies_portable_uri_without_changing_memory_name
     )
 
     assert op.memory_fields["note_name"] == "Desktop /new"
-    assert op.uris == [
-        "viking://user/u/peers/conv-42/memories/notes/Desktop~ov~02970756851a43cf/new.md"
-    ]
+    assert op.uris == ["viking://user/u/peers/conv-42/memories/notes/Desktop _new.md"]
 
 
 def test_enforce_merge_group_self_scope_removes_peer_id():


### PR DESCRIPTION
## Description

Fixes dynamic values containing `/` being interpreted as additional URI hierarchy when rendered into memory URI templates.

Template-defined separators continue to define directory structure, while `/` inside dynamic field values is normalized to `_` and remains within a single readable path component.

For example:

```text
Before: .../events/2026/09/02/alpha/beta.md
After:  .../events/2026/09/02/alpha_beta.md
```

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4551

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Render template-defined URI path components separately so dynamic data cannot introduce unintended hierarchy.
- Normalize `/` in dynamic path-component values to `_`, intentionally treating slash and underscore spellings as the same memory identity.
- Preserve trusted `user_space` hierarchy for peer memories.
- Retain the existing portability handling for other unsupported filenames.
- Add regression coverage for slash normalization and peer-memory URI regeneration.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing relevant unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation performed:

```text
107 passed
ruff check: passed
git diff --check: passed
```

A manual session commit containing `alpha/beta` generated:

```text
viking://user/jiajie/memories/events/2026/09/02/alpha_beta生产发布正式获批.md
```

No additional `alpha/` directory or `~ov~` hash suffix was created.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published