### PR TITLE
fix(parse): preserve filenames in understanding uploads

### DIFF
--- a/openviking/parse/parser_router.py
+++ b/openviking/parse/parser_router.py
@@ -150,7 +150,10 @@ class ParserRouter:
     async def submit(self, source: Union[str, Path, LocalResource], **kwargs) -> str:
         source_path = self._extract_source_path(source)
         if Path(source_path).is_file():
-            return await self._get_understanding_api().submit_file(source_path)
+            return await self._get_understanding_api().submit_file(
+                source_path,
+                file_name=kwargs.get("source_name") or self._extract_source_name(source),
+            )
         if not self.should_use_understanding_api(str(source_path)):
             raise ValueError("source is not routed to UnderstandingAPI")
         return await self._get_understanding_api().submit_url(str(source_path), **kwargs)
@@ -158,7 +161,17 @@ class ParserRouter:
     async def upload_file(self, source: Union[str, Path, LocalResource]) -> str:
         """Upload a local source file and return only the external Files API file_id."""
         source_path = self._extract_source_path(source)
-        return await self._get_understanding_api().upload_file(source_path)
+        return await self._get_understanding_api().upload_file(
+            source_path,
+            file_name=self._extract_source_name(source),
+        )
+
+    @staticmethod
+    def _extract_source_name(source: Union[str, Path, LocalResource]) -> str | None:
+        if not isinstance(source, LocalResource):
+            return None
+        source_name = source.meta.get("resolved_name") or source.meta.get("original_filename")
+        return str(source_name) if source_name else None
 
     def _extract_source_path(self, source: Union[str, Path, LocalResource]) -> Union[str, Path]:
         """Extract a filesystem path from the source."""

--- a/openviking/parse/understanding_api.py
+++ b/openviking/parse/understanding_api.py
@@ -170,8 +170,10 @@ class UnderstandingAPI(BaseParser):
         source_name = kwargs.get("source_name")
         if isinstance(source_name, str) and source_name:
             task_meta["source_name"] = source_name
+        upload_file_name = None
         if local_path is not None:
-            task_meta["file_name"] = local_path.name
+            upload_file_name = self._resolve_upload_file_name(local_path, source_name)
+            task_meta["file_name"] = upload_file_name
 
         try:
             if prepared_response_id:
@@ -180,7 +182,10 @@ class UnderstandingAPI(BaseParser):
                 task_meta["file_id"] = prepared_file_id
                 response_obj = await self._create_response_for_file(file_id=prepared_file_id)
             elif url is None and local_path is not None:
-                file_obj = await self._create_file(local_path=local_path)
+                file_obj = await self._create_file(
+                    local_path=local_path,
+                    file_name=upload_file_name,
+                )
                 file_id_value = file_obj.get("id")
                 if not file_id_value:
                     raise RuntimeError(
@@ -276,21 +281,31 @@ class UnderstandingAPI(BaseParser):
         logger.info("[UnderstandingAPI] done")
         return result
 
-    async def upload_file(self, source: Union[str, Path]) -> str:
+    async def upload_file(
+        self,
+        source: Union[str, Path],
+        *,
+        file_name: Optional[str] = None,
+    ) -> str:
         """Upload a local file and return a durable Files API file_id."""
         local_path = Path(source)
         if not local_path.is_file():
             raise ValueError("UnderstandingAPI file upload requires an existing local file")
 
-        file_obj = await self._create_file(local_path=local_path)
+        file_obj = await self._create_file(local_path=local_path, file_name=file_name)
         file_id = file_obj.get("id")
         if not file_id:
             raise RuntimeError(f"files api missing file_id: {self._safe_error_summary(file_obj)}")
         return str(file_id)
 
-    async def submit_file(self, source: Union[str, Path]) -> str:
+    async def submit_file(
+        self,
+        source: Union[str, Path],
+        *,
+        file_name: Optional[str] = None,
+    ) -> str:
         """Upload a local file and submit it without retaining the local artifact."""
-        file_id = await self.upload_file(source)
+        file_id = await self.upload_file(source, file_name=file_name)
         response_obj = await self._create_response_for_file(file_id=str(file_id))
         response_id = response_obj.get("id")
         if not response_id:
@@ -429,7 +444,20 @@ class UnderstandingAPI(BaseParser):
         self._raise_if_error(body, context=context)
         return body
 
-    async def _create_file(self, *, local_path: Path) -> Dict[str, Any]:
+    @staticmethod
+    def _resolve_upload_file_name(local_path: Path, file_name: Optional[str]) -> str:
+        if file_name:
+            candidate = PurePosixPath(str(file_name).replace("\\", "/")).name
+            if candidate not in {"", ".", ".."}:
+                return candidate
+        return local_path.name
+
+    async def _create_file(
+        self,
+        *,
+        local_path: Path,
+        file_name: Optional[str] = None,
+    ) -> Dict[str, Any]:
         file_size = local_path.stat().st_size
         if file_size == 0:
             raise InvalidArgumentError("Understanding parser does not support empty files.")
@@ -440,13 +468,14 @@ class UnderstandingAPI(BaseParser):
                     f"upload_simple_max_bytes={self._upload_simple_max_bytes}; "
                     "enable parser_api.enable_resumable_upload to continue"
                 )
-            return await self._multipart_create_file(local_path)
+            return await self._multipart_create_file(local_path, file_name=file_name)
 
         data: Dict[str, Any] = {"purpose": "user_data"}
 
+        upload_file_name = self._resolve_upload_file_name(local_path, file_name)
         content_type = mimetypes.guess_type(str(local_path))[0] or "application/octet-stream"
         with open(local_path, "rb") as f:
-            files = {"file": (local_path.name, f, content_type)}
+            files = {"file": (upload_file_name, f, content_type)}
             async with httpx.AsyncClient(timeout=1200.0, follow_redirects=True) as client:
                 rsp = await client.post(
                     f"{self._api_base}/files",
@@ -607,9 +636,15 @@ class UnderstandingAPI(BaseParser):
                     return str(zip_obj["url"])
         return None
 
-    async def _uploads_init(self, *, file_path: Path) -> Dict[str, Any]:
+    async def _uploads_init(
+        self,
+        *,
+        file_path: Path,
+        file_name: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        upload_file_name = self._resolve_upload_file_name(file_path, file_name)
         payload = {
-            "file_name": file_path.name,
+            "file_name": upload_file_name,
             "file_size": file_path.stat().st_size,
             "content_type": mimetypes.guess_type(str(file_path))[0] or "application/octet-stream",
             "part_size": int(self._upload_part_size_bytes),
@@ -654,8 +689,13 @@ class UnderstandingAPI(BaseParser):
             )
         return self._read_api_response(rsp, context="uploads complete error")
 
-    async def _multipart_create_file(self, file_path: Path) -> Dict[str, Any]:
-        init_obj = await self._uploads_init(file_path=file_path)
+    async def _multipart_create_file(
+        self,
+        file_path: Path,
+        *,
+        file_name: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        init_obj = await self._uploads_init(file_path=file_path, file_name=file_name)
         upload_id = init_obj.get("upload_id") or init_obj.get("uploadId")
         object_key = init_obj.get("object_key") or init_obj.get("objectKey")
         part_size = int(

--- a/tests/parse/test_feishu_parser_api.py
+++ b/tests/parse/test_feishu_parser_api.py
@@ -358,7 +358,10 @@ async def test_legacy_accessor_output_does_not_enable_lark_protocol(tmp_path: Pa
         feishu_access_token="u-test",
     )
 
-    api._create_file.assert_awaited_once_with(local_path=markdown_path)
+    api._create_file.assert_awaited_once_with(
+        local_path=markdown_path,
+        file_name="document.md",
+    )
     api._create_response_for_file.assert_awaited_once_with(file_id="file-1")
     api._create_response_for_url.assert_not_awaited()
 

--- a/tests/parse/test_parser_router.py
+++ b/tests/parse/test_parser_router.py
@@ -247,6 +247,46 @@ def test_directories_never_route_to_understanding(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_submit_materialized_url_preserves_original_filename(tmp_path):
+    staged = tmp_path / "tmp8unv3f.txt"
+    staged.write_text("content")
+    resource = LocalResource(
+        path=staged,
+        source_type=SourceType.HTTP,
+        original_source="https://example.com/note.txt",
+        meta={"resolved_name": "note.txt", "original_filename": "note.txt"},
+    )
+    understanding = SimpleNamespace(submit_file=AsyncMock(return_value="response-1"))
+    router = ParserRouter(parser_registry=object())
+    router._understanding_api = understanding
+
+    response_id = await router.submit(resource)
+
+    assert response_id == "response-1"
+    understanding.submit_file.assert_awaited_once_with(staged, file_name="note.txt")
+
+
+@pytest.mark.asyncio
+async def test_upload_file_preserves_temp_upload_filename(tmp_path):
+    staged = tmp_path / "upload_0123456789abcdef.txt"
+    staged.write_text("content")
+    resource = LocalResource(
+        path=staged,
+        source_type=SourceType.LOCAL,
+        original_source=str(staged),
+        meta={"resolved_name": "note.txt", "original_filename": "note.txt"},
+    )
+    understanding = SimpleNamespace(upload_file=AsyncMock(return_value="file-1"))
+    router = ParserRouter(parser_registry=object())
+    router._understanding_api = understanding
+
+    file_id = await router.upload_file(resource)
+
+    assert file_id == "file-1"
+    understanding.upload_file.assert_awaited_once_with(staged, file_name="note.txt")
+
+
+@pytest.mark.asyncio
 async def test_normalized_feishu_markdown_stays_internal(monkeypatch, tmp_path):
     config = SimpleNamespace(
         parser_api=SimpleNamespace(

--- a/tests/parse/test_understanding_api.py
+++ b/tests/parse/test_understanding_api.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock
 
@@ -28,15 +29,16 @@ async def test_parse_uses_downloaded_file_and_resolved_extension(
     downloaded.write_bytes(content)
     zip_path = tmp_path / "result.zip"
     zip_path.write_bytes(b"zip")
-    uploaded: list[Path] = []
+    source_name = f"original.{source_format}"
+    uploaded: list[tuple[Path, str]] = []
 
     api = UnderstandingAPI.__new__(UnderstandingAPI)
     api._video_exts = {"mp4"}
     api._audio_exts = {"mp3"}
     api._image_exts = {"png"}
 
-    async def create_file(*, local_path):
-        uploaded.append(local_path)
+    async def create_file(*, local_path, file_name):
+        uploaded.append((local_path, file_name))
         return {"id": "file-1"}
 
     async def create_response_for_file(*, file_id):
@@ -62,10 +64,11 @@ async def test_parse_uses_downloaded_file_and_resolved_extension(
         downloaded,
         original_source=original_source,
         resource_name="report",
+        source_name=source_name,
         resolved_extension=resolved_extension,
     )
 
-    assert uploaded == [downloaded]
+    assert uploaded == [(downloaded, source_name)]
     assert result.source_path == original_source
     assert result.source_format == source_format
     assert result.root.title == "report"
@@ -89,10 +92,10 @@ async def test_upload_file_validates_input_and_returns_file_id(tmp_path):
     source.write_bytes(b"%PDF-1.7")
     api._create_file = AsyncMock(return_value={"id": "file-1"})
 
-    file_id = await api.upload_file(source)
+    file_id = await api.upload_file(source, file_name="report.pdf")
 
     assert file_id == "file-1"
-    api._create_file.assert_awaited_once_with(local_path=source)
+    api._create_file.assert_awaited_once_with(local_path=source, file_name="report.pdf")
 
 
 @pytest.mark.asyncio
@@ -154,10 +157,53 @@ async def test_file_above_simple_limit_uses_multipart_when_enabled(tmp_path):
     api._enable_resumable_upload = True
     api._multipart_create_file = AsyncMock(return_value={"id": "file-1"})
 
-    result = await api._create_file(local_path=source)
+    result = await api._create_file(local_path=source, file_name="report.pdf")
 
     assert result == {"id": "file-1"}
-    api._multipart_create_file.assert_awaited_once_with(source)
+    api._multipart_create_file.assert_awaited_once_with(source, file_name="report.pdf")
+
+
+@pytest.mark.asyncio
+async def test_simple_upload_uses_original_filename(monkeypatch, tmp_path):
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        return httpx.Response(200, json={"id": "file-1"})
+
+    api = _api_with_transport(monkeypatch, handler)
+    source = tmp_path / "upload_0123456789abcdef.txt"
+    source.write_text("content")
+
+    result = await api._create_file(local_path=source, file_name="note.txt")
+
+    assert result == {"id": "file-1"}
+    assert len(requests) == 1
+    assert b'filename="note.txt"' in requests[0].content
+    assert source.name.encode() not in requests[0].content
+
+
+@pytest.mark.asyncio
+async def test_resumable_upload_uses_original_filename(monkeypatch, tmp_path):
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        return httpx.Response(200, json={"upload_id": "upload-1"})
+
+    api = _api_with_transport(monkeypatch, handler)
+    source = tmp_path / "tmp8unv3f.txt"
+    source.write_text("content")
+
+    await api._uploads_init(file_path=source, file_name="note.txt")
+
+    assert len(requests) == 1
+    assert json.loads(requests[0].content) == {
+        "file_name": "note.txt",
+        "file_size": 7,
+        "content_type": "text/plain",
+        "part_size": 512,
+    }
 
 
 @pytest.mark.asyncio
@@ -190,7 +236,7 @@ async def test_parse_failure_preserves_observed_remote_ids(monkeypatch, tmp_path
         "doc_name": "original",
         "doc_type": "pdf",
         "source_name": "original.pdf",
-        "file_name": "report.pdf",
+        "file_name": "original.pdf",
         "file_id": "file-1",
         "response_id": "response-1",
     }


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Understanding uploads currently send the staged local basename to the Files API. For uploaded or materialized URL sources, this can make a file such as `note.txt` appear as `upload_<uuid>.txt` or `tmp*.txt` in the parser artifact even though the resource root uses the correct name.

This change sends the logical source filename while continuing to read the staged file and detect its MIME type from the staged path. Calls without filename metadata retain the existing basename fallback.

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

Fixes #4569

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Preserve `LocalResource` filename metadata when ParserRouter submits staged files to UnderstandingAPI.
- Use the logical basename for simple multipart uploads and resumable upload initialization.
- Add regression coverage for local uploads, materialized URL sources, synchronous parsing, and both upload protocols.

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

`python -m pytest -q -o addopts='' tests/parse/test_parser_router.py tests/parse/test_understanding_api.py tests/parse/test_feishu_parser_api.py::test_legacy_accessor_output_does_not_enable_lark_protocol --disable-warnings --maxfail=1` (`62 passed`)

`python -m pytest -q -o addopts='' tests/parse/test_url_filename_preservation.py tests/server/test_resource_ingest_parse_mode.py --disable-warnings --maxfail=1` (`47 passed`)

`ruff check` and `ruff format --check` pass for all changed Python files.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes require a documentation update
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

Not applicable.

## Additional Notes

<!-- Add any additional notes or context about the PR -->

A live Understanding API end-to-end run was not performed because it requires parser service credentials. The mocked HTTP tests verify the exact multipart filename and resumable upload payload sent at that boundary.
