### PR TITLE
fix(cli): keep unmodeled ovcli.conf keys through config rewrites

### DIFF
--- a/crates/ov_cli/src/config.rs
+++ b/crates/ov_cli/src/config.rs
@@ -100,6 +100,38 @@ pub struct Config {
     pub oidc_token: Option<String>,
 }
 
+/// Every top-level key `Config` models, deserialization aliases included.
+///
+/// `Config` has no catch-all, so serializing it over ovcli.conf silently drops
+/// any key it does not declare — including the `plugin` section the memory
+/// plugins read. The config writers carry the keys missing from this list over
+/// from the file they replace. `extra_header` is listed because it deserializes
+/// into `extra_headers` and is written back under the new spelling; preserving
+/// the old one would duplicate it.
+pub(crate) const KNOWN_CONFIG_KEYS: &[&str] = &[
+    "url",
+    "api_key",
+    "root_api_key",
+    "account",
+    "user",
+    "actor_peer_id",
+    "agent_id",
+    "timeout",
+    "output",
+    "echo_command",
+    "show_progress",
+    "verbose",
+    "profile",
+    "upload",
+    "extra_headers",
+    "extra_header",
+    "gateway_token",
+    "auth_mode",
+    "ldap_username",
+    "ldap_password",
+    "oidc_token",
+];
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct EffectiveAuth {
     pub api_key: Option<String>,
@@ -416,7 +448,62 @@ pub fn get_or_create_machine_id() -> Result<String> {
 mod tests {
     use crate::error::Error;
 
-    use super::{Config, merge_csv_options};
+    use super::{Config, KNOWN_CONFIG_KEYS, UploadConfig, merge_csv_options};
+
+    // A field added to `Config` but missing from KNOWN_CONFIG_KEYS would be
+    // treated as somebody else's key and restored from the file being replaced,
+    // making it impossible to clear.
+    #[test]
+    fn known_config_keys_covers_every_serialized_field() {
+        let config = Config {
+            url: "http://not-the-default".to_string(),
+            api_key: Some("k".into()),
+            root_api_key: Some("k".into()),
+            account: Some("a".into()),
+            user: Some("u".into()),
+            actor_peer_id: Some("p".into()),
+            agent_id: Some("g".into()),
+            timeout: 1.0,
+            output: "json".to_string(),
+            echo_command: false,
+            show_progress: true,
+            verbose: true,
+            profile: true,
+            upload: UploadConfig {
+                ignore_dirs: Some("d".into()),
+                include: Some("i".into()),
+                exclude: Some("e".into()),
+            },
+            extra_headers: Some(std::collections::HashMap::new()),
+            gateway_token: Some("t".into()),
+            auth_mode: Some("m".into()),
+            ldap_username: Some("n".into()),
+            ldap_password: Some("w".into()),
+            oidc_token: Some("o".into()),
+        };
+
+        let value = serde_json::to_value(&config).expect("config should serialize");
+        let serialized: Vec<&str> = value
+            .as_object()
+            .expect("config serializes to an object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+
+        for key in &serialized {
+            assert!(
+                KNOWN_CONFIG_KEYS.contains(key),
+                "Config serializes `{key}` but KNOWN_CONFIG_KEYS omits it",
+            );
+        }
+        for key in KNOWN_CONFIG_KEYS {
+            // `extra_header` is a deserialization alias, never serialized.
+            assert!(
+                serialized.contains(key) || *key == "extra_header",
+                "KNOWN_CONFIG_KEYS lists `{key}` but Config never serializes it",
+            );
+        }
+    }
 
     #[test]
     fn load_required_from_path_reports_missing_cli_config() {

--- a/crates/ov_cli/src/config_wizard/store.rs
+++ b/crates/ov_cli/src/config_wizard/store.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 use crate::{
     base_client::BaseClient,
-    config::{Config, DEFAULT_CUSTOM_PORT, default_config_path},
+    config::{Config, DEFAULT_CUSTOM_PORT, KNOWN_CONFIG_KEYS, default_config_path},
     error::{Error, Result},
 };
 
@@ -232,7 +232,18 @@ impl ConfigStore {
         }
         let content = fs::read(&path)
             .map_err(|e| Error::Config(format!("Failed to read config '{name}': {e}")))?;
-        write_file_atomically(&self.active_path, &content)
+        // The connection fields switch wholesale, but the keys `Config` does not
+        // model are machine-level settings rather than part of the profile, so
+        // they stay with the active file — unless the incoming profile names
+        // them itself.
+        match serde_json::from_slice::<Value>(&content) {
+            Ok(mut value) if value.is_object() => {
+                carry_over_unmodeled_keys(&self.active_path, &mut value);
+                let merged = serde_json::to_string_pretty(&value)?;
+                write_file_atomically(&self.active_path, merged.as_bytes())
+            }
+            _ => write_file_atomically(&self.active_path, &content),
+        }
     }
 
     pub fn save_and_activate(&self, name: &str, config: &Config) -> Result<()> {
@@ -258,7 +269,7 @@ impl ConfigStore {
             return Err(Error::Config(format!("Config '{new_name}' already exists")));
         }
 
-        self.save_named_config(new_name, config)?;
+        write_config_file_inheriting(&new_path, config, &old_path)?;
         if was_active {
             // Keep the active config consistent before removing the old saved file. If cleanup
             // fails, the user may see both names, but the active config still points at the edit.
@@ -729,8 +740,38 @@ pub(crate) fn validation_error_copy_zh(kind: ConfigKind, error: &Error) -> Strin
 }
 
 fn write_config_file(path: &Path, config: &Config) -> Result<()> {
-    let content = serde_json::to_string_pretty(config)?;
+    write_config_file_inheriting(path, config, path)
+}
+
+/// `inherit_from` is the file whose unmodeled keys survive the write: the file
+/// being replaced, except on a rename, where they live under the old name.
+fn write_config_file_inheriting(path: &Path, config: &Config, inherit_from: &Path) -> Result<()> {
+    let mut value = serde_json::to_value(config)?;
+    carry_over_unmodeled_keys(inherit_from, &mut value);
+    let content = serde_json::to_string_pretty(&value)?;
     write_file_atomically(path, content.as_bytes())
+}
+
+/// Re-attach the top-level keys `Config` does not model — above all the
+/// `plugin` section the memory plugins keep in ovcli.conf — to a freshly
+/// serialized config that is about to replace the whole file. Modeled keys are
+/// deliberately not carried over: one that is `None` was cleared on purpose,
+/// and restoring it would make clearing impossible.
+fn carry_over_unmodeled_keys(path: &Path, value: &mut Value) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+    let Ok(previous) = fs::read_to_string(path) else {
+        return;
+    };
+    let Ok(Value::Object(previous)) = serde_json::from_str::<Value>(&previous) else {
+        return;
+    };
+    for (key, previous_value) in previous {
+        if !KNOWN_CONFIG_KEYS.contains(&key.as_str()) {
+            object.entry(key).or_insert(previous_value);
+        }
+    }
 }
 
 fn write_file_atomically(path: &Path, content: &[u8]) -> Result<()> {
@@ -801,6 +842,116 @@ mod tests {
         config.url = url.to_string();
         config.api_key = api_key.map(ToString::to_string);
         config
+    }
+
+    fn plugin_section() -> serde_json::Value {
+        serde_json::json!({
+            "recallCompress": "auto",
+            "claude_code": { "recallCompress": "client" },
+        })
+    }
+
+    fn read_json(path: &Path) -> serde_json::Value {
+        serde_json::from_str(&fs::read_to_string(path).expect("config should exist"))
+            .expect("config should be valid JSON")
+    }
+
+    #[test]
+    fn rewriting_a_config_keeps_the_plugin_section() {
+        let dir = unique_dir("plugin-passthrough");
+        fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("ovcli.conf");
+        fs::write(
+            &path,
+            serde_json::json!({
+                "url": "http://old", "api_key": "old-key", "plugin": plugin_section(),
+            })
+            .to_string(),
+        )
+        .expect("seed config");
+
+        super::write_config_file(&path, &sample_config("http://new", Some("new-key"))).unwrap();
+
+        let written = read_json(&path);
+        assert_eq!(written["url"], "http://new");
+        assert_eq!(written["api_key"], "new-key");
+        assert_eq!(written["plugin"], plugin_section());
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn rewriting_a_config_still_clears_a_modeled_key() {
+        let dir = unique_dir("plugin-clear");
+        fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("ovcli.conf");
+        fs::write(
+            &path,
+            serde_json::json!({
+                "url": "http://local", "api_key": "old-key", "gateway_token": "old-token",
+            })
+            .to_string(),
+        )
+        .expect("seed config");
+
+        super::write_config_file(&path, &sample_config("http://local", Some("new-key"))).unwrap();
+
+        let written = read_json(&path);
+        assert_eq!(written["api_key"], "new-key");
+        assert!(
+            written.get("gateway_token").is_none(),
+            "a modeled key cleared to None must not come back from the old file",
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn renaming_a_config_carries_the_plugin_section_to_the_new_name() {
+        let dir = unique_dir("plugin-rename");
+        fs::create_dir_all(&dir).expect("temp dir");
+        let store = ConfigStore::for_config_dir(dir.clone());
+        let old_path = dir.join("ovcli.conf.before");
+        fs::write(
+            &old_path,
+            serde_json::json!({ "url": "http://local", "plugin": plugin_section() }).to_string(),
+        )
+        .expect("seed config");
+
+        store
+            .save_edited_config("before", "after", &sample_config("http://local", None))
+            .expect("rename should succeed");
+
+        assert_eq!(
+            read_json(&dir.join("ovcli.conf.after"))["plugin"],
+            plugin_section()
+        );
+        assert!(!old_path.exists(), "the old name should be removed");
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn activating_a_config_keeps_the_active_files_plugin_section() {
+        let dir = unique_dir("plugin-activate");
+        fs::create_dir_all(&dir).expect("temp dir");
+        let store = ConfigStore::for_config_dir(dir.clone());
+        fs::write(
+            dir.join("ovcli.conf"),
+            serde_json::json!({ "url": "http://old", "plugin": plugin_section() }).to_string(),
+        )
+        .expect("seed active config");
+        fs::write(
+            dir.join("ovcli.conf.other"),
+            serde_json::json!({ "url": "http://other" }).to_string(),
+        )
+        .expect("seed saved config");
+
+        store
+            .activate_config("other")
+            .expect("activate should succeed");
+
+        let active = read_json(&dir.join("ovcli.conf"));
+        assert_eq!(active["url"], "http://other");
+        assert_eq!(active["plugin"], plugin_section());
+        fs::remove_dir_all(&dir).ok();
     }
 
     #[test]


### PR DESCRIPTION
## Description

`ov config edit`, `ov config add --activate`, a rename via `ov config edit --new-name`, `ov config switch` and the interactive config wizard all silently delete every top-level key in `~/.openviking/ovcli.conf` that the Rust `Config` struct does not model. In practice that means the `plugin` section: a user changes a server URL with `ov config edit` and their entire memory-plugin configuration is gone, with no warning and no backup.

### Root cause

`ovcli.conf` is never patched — it is always replaced wholesale, by one of two writers in `crates/ov_cli/src/config_wizard/store.rs`:

- `write_config_file(path, config)` does `serde_json::to_string_pretty(config)` and writes the result over the file. `Config` (in `crates/ov_cli/src/config.rs`) declares the connection fields only — `url`, `api_key`, `root_api_key`, `account`, `user`, `actor_peer_id`, `agent_id`, `timeout`, `output`, `echo_command`, `show_progress`, `verbose`, `profile`, `upload`, `extra_headers`, `gateway_token`, `auth_mode`, `ldap_username`, `ldap_password`, `oidc_token` — and has no `#[serde(flatten)]` catch-all. Unknown keys are dropped at deserialize time and were never in the struct at serialize time, so they are simply absent from the bytes that replace the file. This is reached by `save_named_config`, `save_and_activate`, `save_active_config` and `save_edited_config`.
- `activate_config(name)` byte-copies `ovcli.conf.<name>` over `ovcli.conf`. The saved profile was itself written by `write_config_file` and therefore holds connection fields only, so the copy overwrites the active file's `plugin` section with a file that has none. This is the last write performed by `ov config switch` and by `ov config edit --activate`, so it matters even where `write_config_file` is also involved.

The casualty that matters is the `plugin` section. `examples/memory-plugin-shared/lib/plugin-config.mjs` (and its per-plugin copies) resolves per-harness memory-plugin settings as env → `ovcli.conf` `plugin.<harness>` → `ovcli.conf` `plugin` → legacy `ov.conf` harness section → defaults, so `plugin` is where the Claude Code and Codex plugins keep `recallCompress`, `recallQueryExpansion` and friends.

The whole-file rewrite has been the behavior since the CLI revamp in #2198 (2026-05-29, `7ae22460d`), which introduced both `write_config_file` and `activate_config`. It only became destructive when the `plugin` section moved into `ovcli.conf` in #3534 (2026-08-05, `2cc96e393`), which gave the file a top-level key that `Config` does not model.

### The fix

`KNOWN_CONFIG_KEYS` in `config.rs` enumerates the top-level keys `Config` owns (including the `extra_header` deserialization alias, which is written back under the `extra_headers` spelling and would otherwise be duplicated). Before a write lands, `carry_over_unmodeled_keys` reads the file being replaced and re-attaches every top-level key absent from that list.

Modeled keys are deliberately *not* carried over: a modeled field that is `None` was cleared on purpose, and restoring it from the old file would make clearing impossible. `ov config edit --clear-api-key` still clears the key.

`inherit_from` is the file being replaced, with two exceptions: a rename inherits from the old name rather than the (nonexistent) destination, and `activate_config` inherits from the active file, since the unmodeled keys are machine-level settings rather than part of the connection profile. In both cases `Map::entry(..).or_insert(..)` means a profile that names such a key itself still wins.

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- `crates/ov_cli/src/config.rs`: add `KNOWN_CONFIG_KEYS`, the list of top-level keys `Config` models, plus a test that fails if a `Config` field is added without listing it.
- `crates/ov_cli/src/config_wizard/store.rs`: `write_config_file` now goes through `write_config_file_inheriting`, which calls `carry_over_unmodeled_keys` to re-attach the keys `Config` does not model from the file being replaced.
- `crates/ov_cli/src/config_wizard/store.rs`: `save_edited_config` inherits those keys from the old name when renaming, so they follow the profile to its new file.
- `crates/ov_cli/src/config_wizard/store.rs`: `activate_config` merges the incoming profile over the active file's unmodeled keys instead of byte-copying over them, falling back to the byte copy when the profile is not a JSON object.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

`cargo build -p ov_cli` and `cargo test -p ov_cli` are green (489 passed, 0 failed). `rustfmt --edition 2024 --check` is clean on both touched files. Five tests were added: `known_config_keys_covers_every_serialized_field`, `rewriting_a_config_keeps_the_plugin_section`, `rewriting_a_config_still_clears_a_modeled_key`, `renaming_a_config_carries_the_plugin_section_to_the_new_name`, `activating_a_config_keeps_the_active_files_plugin_section`.

### Manual reproduction

Run against a throwaway `HOME` with a local stub answering `GET /health` on ports 18801/18802, seeding `$HOME/.openviking/ovcli.conf` before each case with:

```json
{
  "url": "http://127.0.0.1:18801",
  "api_key": "sk-old",
  "gateway_token": "gw-old",
  "plugin": {
    "recallCompress": "auto",
    "claude_code": { "enabled": true, "recallCompress": "client" },
    "codex": { "enabled": true }
  }
}
```

```
ov config add custom --name local --url http://127.0.0.1:18801 --activate
ov config edit local --url http://127.0.0.1:18802 --activate
ov config edit local --new-name renamed            # profile file seeded with the same content
ov config switch other                             # ovcli.conf.other holds only a url
ov config edit local --clear-api-key --activate    # control: clearing a modeled key
```

Before (`origin/main` @ `da2aaa0ed`):

```
==================== 1. ov config add --activate ====================
--- ovcli.conf now:
{
  "url": "http://127.0.0.1:18801",
  "account": "default",
  "user": "default"
}
--- plugin section: GONE

==================== 2. ov config edit --activate ====================
--- plugin section: GONE

==================== 3. ov config edit --new-name (rename) ====================
--- plugin section in the renamed profile: GONE

==================== 4. ov config switch ====================
--- ovcli.conf now:
{ "url": "http://127.0.0.1:18802" }

--- plugin section: GONE

==================== 5. clearing a modeled key still works ====================
--- plugin section: GONE
--- api_key after --clear-api-key: cleared
```

After:

```
==================== 1. ov config add --activate ====================
--- ovcli.conf now:
{
  "url": "http://127.0.0.1:18801",
  "account": "default",
  "user": "default",
  "plugin": {
    "recallCompress": "auto",
    "claude_code": {
      "enabled": true,
      "recallCompress": "client"
    },
    "codex": {
      "enabled": true
    }
  }
}
--- plugin section: PRESENT

==================== 2. ov config edit --activate ====================
--- plugin section: PRESENT

==================== 3. ov config edit --new-name (rename) ====================
--- plugin section in the renamed profile: PRESENT

==================== 4. ov config switch ====================
--- ovcli.conf now:
{
  "url": "http://127.0.0.1:18802",
  "plugin": {
    "recallCompress": "auto",
    "claude_code": {
      "enabled": true,
      "recallCompress": "client"
    },
    "codex": {
      "enabled": true
    }
  }
}
--- plugin section: PRESENT

==================== 5. clearing a modeled key still works ====================
--- plugin section: PRESENT
--- api_key after --clear-api-key: cleared
```

Building with only the `write_config_file` half of the fix (leaving `activate_config` as a byte copy) still loses the section in cases 2 and 4, which is why the `activate_config` change is part of this fix rather than a separate improvement.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published

`cargo clippy -p ov_cli --all-targets` reports no new warnings in either touched file. No documentation change: this restores the behavior the docs already imply, and adds no user-visible surface.

## Screenshots (if applicable)

N/A

## Additional Notes

Scope was kept to the deletion itself. No `#[serde(flatten)]` catch-all was added to `Config` — that would change the struct's public shape and how unknown keys flow through every consumer, which is a larger decision than this bug warrants. No new CLI flags, config options, migration path, or refactoring of the surrounding config code.

Existing files that were already rewritten before this lands are not recoverable — the fix prevents future loss, it cannot restore a `plugin` section that a previous `ov config edit` already removed.

`Config::save_default()` in `config.rs` has the same whole-file-serialize shape but currently has no callers, so it is left untouched; it would need the same treatment if it is ever wired up.
