### PR TITLE
fix(server): improve invalid config diagnostics

### DIFF
--- a/openviking/server/bootstrap.py
+++ b/openviking/server/bootstrap.py
@@ -216,7 +216,19 @@ def main():
         config = load_server_config(args.config)
         OpenVikingConfigSingleton.initialize(config_path=args.config)
     except (FileNotFoundError, ValueError) as e:
-        print(e, file=sys.stderr)
+        if isinstance(e, ValueError):
+            print(
+                f"Failed to load OpenViking server configuration from {resolved_config_path}:\n{e}",
+                file=sys.stderr,
+            )
+            print(
+                "\nValidate the configuration with:\n"
+                "  openviking-server doctor\n\n"
+                "See examples/ov.conf.example for supported fields.",
+                file=sys.stderr,
+            )
+        else:
+            print(e, file=sys.stderr)
         sys.exit(1)
 
     # Configure logging early so that all subsequent steps have proper logging

--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -459,7 +459,7 @@ def load_server_config(config_path: Optional[str] = None) -> ServerConfig:
     if server_data is None:
         server_data = {}
     if not isinstance(server_data, dict):
-        raise ValueError("Invalid server config: 'server' section must be an object")
+        raise ValueError(f"Invalid server config in {path}: 'server' section must be an object")
 
     # Convert auth_mode string — built-in enums are converted to their string
     # value; custom modes are kept as-is for plugin extensibility.

--- a/tests/server/test_bootstrap.py
+++ b/tests/server/test_bootstrap.py
@@ -4,7 +4,10 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 import openviking.server.app as app_module
 import openviking.server.bootstrap as bootstrap
@@ -217,6 +220,48 @@ def test_bot_alias_propagates_resolved_config_to_workers(monkeypatch):
         assert captured["app"] == "openviking.server.app:create_worker_app"
         assert os.environ[app_module.WORKER_WITH_BOT_ENV] == "1"
         assert os.environ[app_module.WORKER_BOT_API_URL_ENV] == "http://127.0.0.1:19000"
+
+
+def test_main_prints_config_diagnostics_on_validation_error(monkeypatch, capsys):
+    """An unknown top-level config field must exit 1 with actionable diagnostics."""
+    config = ServerConfig(host="127.0.0.1", port=1933)
+
+    monkeypatch.setattr(bootstrap, "resolve_config_path", lambda *a, **k: Path("/tmp/ov.conf"))
+    monkeypatch.setattr(bootstrap, "load_server_config", lambda *a, **k: config)
+
+    def failing_initialize(cls, config_path):
+        raise ValueError("Unknown config field 'claude_code' in OpenVikingConfig")
+
+    monkeypatch.setattr(
+        OpenVikingConfigSingleton,
+        "initialize",
+        classmethod(failing_initialize),
+    )
+    monkeypatch.setattr(
+        bootstrap.argparse.ArgumentParser,
+        "parse_args",
+        lambda self: SimpleNamespace(
+            host=None,
+            port=None,
+            config="/tmp/ov.conf",
+            workers=None,
+            bot=False,
+            with_bot=False,
+            bot_url="http://localhost:18790",
+            enable_bot_logging=None,
+            bot_log_dir="/tmp/bot-logs",
+        ),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        bootstrap.main()
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "/tmp/ov.conf" in err
+    assert "Unknown config field 'claude_code'" in err
+    assert "openviking-server doctor" in err
+    assert "examples/ov.conf.example" in err
 
 
 def test_worker_factory_replays_bot_overrides(monkeypatch):


### PR DESCRIPTION
## Description

Invalid `ov.conf` validation currently aborts server startup with only the raw parse/validation error. For errors such as an unknown top-level field, the output does not identify which config file was loaded or provide an actionable recovery path. Under an auto-restarting process manager, this can turn a configuration mistake into an opaque crash loop.

This PR keeps strict configuration validation and startup semantics unchanged, and improves only the failure diagnostics:

* report the resolved `ov.conf` path when startup catches a configuration `ValueError`;
* preserve the original validation error;
* point the operator to `openviking-server doctor` and `examples/ov.conf.example`;
* include the resolved path in the local invalid-`server`-section type error for consistency.

`FileNotFoundError` behavior and the existing exit code (`1`) are unchanged.

## Human Involvement

* [x] A human participated in the implementation or review loop
* [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4579

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Refactoring (no functional changes)
* [ ] Performance improvement
* [x] Test update

## Changes Made

* Enrich server startup `ValueError` diagnostics with the already-resolved config path plus `openviking-server doctor` and example-config remediation hints.
* Preserve the existing `FileNotFoundError` output, strict config validation behavior, and `sys.exit(1)` semantics.
* Add the resolved config path to the `server`-section-not-an-object error and add a regression test covering the real unknown-top-level-field startup path.

## Testing

* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing relevant unit tests pass locally with my changes
* [ ] I have tested this on the following platforms:

  * [x] Linux
  * [ ] macOS
  * [ ] Windows

Validation performed:

* `tests/server/test_bootstrap.py` — 9 passed.
* `tests/test_config_loader.py` + `tests/server/test_server_config.py` — 67 passed.
* Final regression test after adding the diagnostic-headline assertion — 1 passed.
* `git diff --check upstream/main...HEAD` — passed.
* Working tree clean after validation.
* Ruff 0.15.5: this change introduces no new lint issues. `bootstrap.py` has one pre-existing import-sorting violation that was intentionally left outside this PR's scope.
* mypy 1.19.1 on the three changed paths reports the repository's existing type-checking debt (`1468 errors in 206 files`); none of the reported errors are on lines changed by this PR.

A broader local test run also encountered four existing environment errors in `test_add_locations.py` because the `ragfs_python` native Rust binding was not built in the local environment. Those errors are unrelated to this change.

## Checklist

* [x] My code follows the project's coding style
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This PR is intentionally limited to startup diagnostics. It does not change the configuration schema, accepted fields, resolution precedence, validation strictness, or process exit code.

No documentation changes are included because the existing documentation already recommends `openviking-server doctor`; this change makes the startup failure point operators to that existing remediation path.
