### PR TITLE
fix: Fix memory telemetry placeholder URI handling

### DIFF
--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -165,21 +165,29 @@ def _report_extraction_telemetry(result: Any, operations: ResolvedOperations) ->
     types_by_uri = _memory_type_by_uri(operations)
     actions_by_type: dict[str, dict[str, int]] = {}
 
+    def memory_type_for_telemetry(uri: Any) -> str:
+        if memory_type := types_by_uri.get(str(uri)):
+            return str(memory_type)
+        try:
+            return str(MemoryUpdater.memory_type_from_uri(str(uri)) or "unknown")
+        except ValueError:
+            return "unknown"
+
     def add(memory_type: Any, action: str) -> None:
         normalized_type = str(memory_type or "unknown")
         type_actions = actions_by_type.setdefault(normalized_type, {})
         type_actions[action] = type_actions.get(action, 0) + 1
 
     for uri in result.written_uris:
-        add(types_by_uri.get(str(uri), MemoryUpdater.memory_type_from_uri(uri)), "created")
+        add(memory_type_for_telemetry(uri), "created")
     for uri in result.edited_uris:
-        add(types_by_uri.get(str(uri), MemoryUpdater.memory_type_from_uri(uri)), "merged")
+        add(memory_type_for_telemetry(uri), "merged")
     for uri in result.deleted_uris:
-        add(types_by_uri.get(str(uri), MemoryUpdater.memory_type_from_uri(uri)), "deleted")
+        add(memory_type_for_telemetry(uri), "deleted")
     for operation in result.skipped_operations:
         add(getattr(operation, "memory_type", None), "skipped")
     for uri, _error in result.errors:
-        add(types_by_uri.get(str(uri), MemoryUpdater.memory_type_from_uri(uri)), "failed")
+        add(memory_type_for_telemetry(uri), "failed")
 
     for memory_type, actions in actions_by_type.items():
         for action, value in actions.items():

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -18,6 +18,7 @@ from openviking.session.compressor_v3 import (
     _experience_root_uri,
     _experience_snapshot_provenance,
     _experience_trajectory_map,
+    _report_extraction_telemetry,
     _visible_experience_snapshot_uris,
 )
 from openviking.session.memory.dataclass import (
@@ -46,6 +47,7 @@ from openviking.session.train import (
     Trajectory,
 )
 from openviking.session.train.components.session_commit import _case_spec_message_to_request
+from openviking.telemetry import OperationTelemetry, bind_telemetry
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -109,6 +111,44 @@ def test_extract_long_term_memories_preserves_legacy_positional_parameter_order(
         "event_search_tags",
         "peer_memory_enabled",
     ]
+
+
+def test_report_extraction_telemetry_handles_placeholder_error_targets():
+    operations = ResolvedOperations(
+        upsert_operations=[
+            ResolvedOperation(
+                old_memory_file_content=None,
+                memory_fields={},
+                memory_type="events",
+                uris=["unknown"],
+            )
+        ],
+        delete_file_contents=[],
+        errors=[],
+    )
+    result = MemoryUpdateResult()
+    result.add_written("unknown")
+    result.add_edited("viking://user/u/memories/preferences/pref.md")
+    result.add_deleted("viking://user/u/memories/events/old.md")
+    result.add_error("events(page_id=xyz)", ValueError("Missing resolved URI"))
+
+    telemetry = OperationTelemetry(operation="session.commit", enabled=True)
+    with bind_telemetry(telemetry):
+        _report_extraction_telemetry(result, operations)
+
+    summary = telemetry.finish().summary
+    extract = summary["memory"]["extract"]
+    assert extract["actions"] == {
+        "created": 1,
+        "merged": 1,
+        "deleted": 1,
+        "failed": 1,
+    }
+    assert extract["actions_by_type"] == {
+        "events": {"created": 1, "deleted": 1},
+        "preferences": {"merged": 1},
+        "unknown": {"failed": 1},
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

修复 session commit 长期记忆写入后的 telemetry 统计问题：当 memory update result 中包含 `unknown` 或 `events(page_id=...)` 这类非 `viking://` 占位符时，统计逻辑不再把它们当作真实 URI 解析并抛出 `ValueError`。这样可以避免 memory 已经写入成功后，commit 任务在收尾统计阶段被错误标记为 failed。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4492

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 在 `_report_extraction_telemetry` 内新增 telemetry 专用的 memory type 解析 helper，先使用已知 URI 到 memory type 的映射，避免 `dict.get(..., default)` 提前求值。
- 对合法 `viking://.../memories/<type>/...` URI 保留原有 fallback 解析行为。
- 对 `unknown`、`events(page_id=...)` 等非 URI 占位符在 telemetry 中归类为 `unknown`，不放宽底层 `MemoryUpdater.memory_type_from_uri()` 的严格校验。
- 新增回归测试，覆盖 created、merged、deleted、failed 四类 telemetry action，以及 mapped placeholder 和 unmapped placeholder 两种场景。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

执行过的测试：

```bash
OPENVIKING_CONFIG_FILE="$PWD/.tmp/ov-test.conf" .venv/bin/python -m pytest tests/session/test_compressor_v3.py::test_report_extraction_telemetry_handles_placeholder_error_targets -q --no-cov
```

结果：`1 passed`。

说明：本地尝试 `uv sync --extra test` 时卡在本地包构建阶段，因此改为补齐缺失测试插件后运行目标回归测试；未运行完整测试套件。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

本次修复只限制在 telemetry 统计层。`MemoryUpdater.memory_type_from_uri("unknown")` 仍会抛出 `ValueError: URI must start with 'viking://'`，用于保持 storage/content write 等真实 URI 调用路径的严格校验语义。
