### PR TITLE
fix(resource): rollback empty reserved targets on add-resource failure

### DIFF
--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -55,6 +55,10 @@ from openviking.server.user_config import (
     effective_skill_add_target,
 )
 from openviking.storage.acl import AclAction
+from openviking.storage.internal_names import (
+    STORAGE_INTERNAL_ENTRY_NAMES,
+    WEBDAV_RESERVED_FILENAMES,
+)
 from openviking.storage.queuefs import QueueManager, get_queue_manager
 from openviking.storage.queuefs.add_resource_msg import AddResourcePhase
 from openviking.storage.viking_fs import LS_ALL_NODES, VikingFS
@@ -538,6 +542,7 @@ class ResourceService:
         resource_lock: Dict[str, Any],
     ) -> bool:
         """Remove a newly reserved target only while it is still empty."""
+        rollback_safe_names = STORAGE_INTERNAL_ENTRY_NAMES | WEBDAV_RESERVED_FILENAMES
         try:
             if not await self._viking_fs.exists(root_uri, ctx=ctx):
                 return True
@@ -550,7 +555,13 @@ class ResourceService:
                 node_limit=LS_ALL_NODES,
                 ctx=ctx,
             )
-            if any(entry.get("name") not in {None, "", ".", ".."} for entry in entries):
+            visible_names: list[str] = []
+            for entry in entries:
+                name = entry.get("name")
+                if not name or name in {".", ".."}:
+                    continue
+                visible_names.append(str(name))
+            if visible_names and not all(name in rollback_safe_names for name in visible_names):
                 return False
             await self._viking_fs.rm(
                 root_uri,
@@ -764,18 +775,38 @@ class ResourceService:
         stage_result = stage_callback("processing_queue")
         if inspect.isawaitable(stage_result):
             await stage_result
-        return await self._resource_processor.finish_prepared_resource(
-            msg.prepared,
-            ctx=ctx,
-            resource_lock=resource_lock,
-            summarize=msg.summarize,
-            build_index=msg.build_index,
-            processing_mode=msg.processing_mode,
-            **self._add_resource_ingest_tag_kwargs(
-                tags=msg.tags,
-                tag_mode=msg.tag_mode,
-            ),
-        )
+        try:
+            result = await self._resource_processor.finish_prepared_resource(
+                msg.prepared,
+                ctx=ctx,
+                resource_lock=resource_lock,
+                summarize=msg.summarize,
+                build_index=msg.build_index,
+                processing_mode=msg.processing_mode,
+                **self._add_resource_ingest_tag_kwargs(
+                    tags=msg.tags,
+                    tag_mode=msg.tag_mode,
+                ),
+            )
+        except BaseException:
+            if msg.cleanup_empty_target_on_failure and resource_lock is not None:
+                await self._cleanup_reserved_target_if_empty(
+                    root_uri=msg.root_uri,
+                    ctx=ctx,
+                    resource_lock=resource_lock,
+                )
+            raise
+        if (
+            result.get("status") == "error"
+            and msg.cleanup_empty_target_on_failure
+            and resource_lock is not None
+        ):
+            await self._cleanup_reserved_target_if_empty(
+                root_uri=msg.root_uri,
+                ctx=ctx,
+                resource_lock=resource_lock,
+            )
+        return result
 
     def _restore_source_task_auth(
         self,

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -55,10 +55,7 @@ from openviking.server.user_config import (
     effective_skill_add_target,
 )
 from openviking.storage.acl import AclAction
-from openviking.storage.internal_names import (
-    STORAGE_INTERNAL_ENTRY_NAMES,
-    WEBDAV_RESERVED_FILENAMES,
-)
+from openviking.storage.internal_names import is_rollback_safe_entry_name
 from openviking.storage.queuefs import QueueManager, get_queue_manager
 from openviking.storage.queuefs.add_resource_msg import AddResourcePhase
 from openviking.storage.viking_fs import LS_ALL_NODES, VikingFS
@@ -541,27 +538,35 @@ class ResourceService:
         ctx: RequestContext,
         resource_lock: Dict[str, Any],
     ) -> bool:
-        """Remove a newly reserved target only while it is still empty."""
-        rollback_safe_names = STORAGE_INTERNAL_ENTRY_NAMES | WEBDAV_RESERVED_FILENAMES
+        """Remove a newly reserved target while it holds no real content.
+
+        Storage-internal markers (pathlock files, redirect/sync bookkeeping)
+        and ingest stub sidecars (``.abstract.md`` / ``.overview.md``) are
+        materialized while reserving a target, so they do not block rollback;
+        any other entry means real content (possibly from a concurrent writer)
+        and must preserve the directory (#4501).
+        """
         try:
             if not await self._viking_fs.exists(root_uri, ctx=ctx):
                 return True
             stat = await self._viking_fs.stat(root_uri, ctx=ctx)
             if not isinstance(stat, dict) or not stat.get("isDir"):
                 return False
-            entries = await self._viking_fs.ls(
-                root_uri,
-                show_all_hidden=True,
-                node_limit=LS_ALL_NODES,
-                ctx=ctx,
-            )
-            visible_names: list[str] = []
-            for entry in entries:
-                name = entry.get("name")
-                if not name or name in {".", ".."}:
-                    continue
-                visible_names.append(str(name))
-            if visible_names and not all(name in rollback_safe_names for name in visible_names):
+            async def _has_real_content() -> bool:
+                entries = await self._viking_fs.ls(
+                    root_uri,
+                    show_all_hidden=True,
+                    node_limit=LS_ALL_NODES,
+                    ctx=ctx,
+                )
+                return any(
+                    not is_rollback_safe_entry_name(str(entry.get("name") or ""))
+                    for entry in entries
+                )
+
+            # List twice so a concurrent writer between the emptiness check and
+            # rm preserves the target; rm(lease_ref=...) still guards the final race.
+            if await _has_real_content() or await _has_real_content():
                 return False
             await self._viking_fs.rm(
                 root_uri,
@@ -1887,6 +1892,9 @@ class ResourceService:
                     job_phase=AddResourcePhase.POST_PROCESS,
                     root_uri=root_uri,
                     prepared=prepared,
+                    cleanup_empty_target_on_failure=not bool(
+                        prepared.get("target_preexisting")
+                    ),
                     source_path=str(
                         (kwargs.get("source_name") or "")
                         if kwargs.get("temp_file_id")

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -55,7 +55,11 @@ from openviking.server.user_config import (
     effective_skill_add_target,
 )
 from openviking.storage.acl import AclAction
-from openviking.storage.internal_names import is_rollback_safe_entry_name
+from openviking.storage.internal_names import (
+    is_rollback_content_gated_entry_name,
+    is_rollback_safe_entry_name,
+    is_rollback_safe_sidecar_content,
+)
 from openviking.storage.queuefs import QueueManager, get_queue_manager
 from openviking.storage.queuefs.add_resource_msg import AddResourcePhase
 from openviking.storage.viking_fs import LS_ALL_NODES, VikingFS
@@ -541,10 +545,11 @@ class ResourceService:
         """Remove a newly reserved target while it holds no real content.
 
         Storage-internal markers (pathlock files, redirect/sync bookkeeping)
-        and ingest stub sidecars (``.abstract.md`` / ``.overview.md``) are
-        materialized while reserving a target, so they do not block rollback;
-        any other entry means real content (possibly from a concurrent writer)
-        and must preserve the directory (#4501).
+        are ignored by name. Ingest sidecars (``.abstract.md`` /
+        ``.overview.md`` / ``.relations.json``) are ignored only while empty
+        or still placeholder stubs; filled bodies block rollback. Any other
+        entry means real content (possibly from a concurrent writer) and must
+        preserve the directory (#4501).
         """
         try:
             if not await self._viking_fs.exists(root_uri, ctx=ctx):
@@ -552,6 +557,29 @@ class ResourceService:
             stat = await self._viking_fs.stat(root_uri, ctx=ctx)
             if not isinstance(stat, dict) or not stat.get("isDir"):
                 return False
+
+            async def _entry_blocks_rollback(entry: Dict[str, Any]) -> bool:
+                name = str(entry.get("name") or "")
+                if is_rollback_safe_entry_name(name):
+                    return False
+                if not is_rollback_content_gated_entry_name(name):
+                    return True
+                if entry.get("isDir"):
+                    return True
+                # size==0 stubs skip a round-trip; unknown/missing size still reads.
+                size = entry.get("size")
+                if size == 0:
+                    return False
+                try:
+                    content = await self._viking_fs.read_file(
+                        f"{root_uri.rstrip('/')}/{name}",
+                        ctx=ctx,
+                    )
+                except Exception:
+                    # Fail closed: unread sidecar must not authorize rm.
+                    return True
+                return not is_rollback_safe_sidecar_content(name, content)
+
             async def _has_real_content() -> bool:
                 entries = await self._viking_fs.ls(
                     root_uri,
@@ -559,13 +587,15 @@ class ResourceService:
                     node_limit=LS_ALL_NODES,
                     ctx=ctx,
                 )
-                return any(
-                    not is_rollback_safe_entry_name(str(entry.get("name") or ""))
-                    for entry in entries
-                )
+                for entry in entries:
+                    if await _entry_blocks_rollback(entry):
+                        return True
+                return False
 
-            # List twice so a concurrent writer between the emptiness check and
-            # rm preserves the target; rm(lease_ref=...) still guards the final race.
+            # Belt-and-suspenders while we hold resource_lock: lock-compliant
+            # writers for this target cannot run between the two listings, so the
+            # second ls mainly guards non-lock / future-buggy writers. The gap
+            # after the last check is still covered by rm(lease_ref=...).
             if await _has_real_content() or await _has_real_content():
                 return False
             await self._viking_fs.rm(
@@ -636,7 +666,8 @@ class ResourceService:
                 account_id=msg.account_id,
                 user_id=msg.user_id,
             )
-        except BaseException:
+        except Exception:
+            # Avoid awaiting AGFS cleanup/release on KeyboardInterrupt/SystemExit.
             if resource_lock is not None:
                 if on_failed_with_lock is not None:
                     await on_failed_with_lock(resource_lock)
@@ -752,7 +783,9 @@ class ResourceService:
                     internal_task=msg.internal_task,
                     **internal_kwargs,
                 )
-            except BaseException:
+            except Exception:
+                # Skip KeyboardInterrupt/SystemExit/CancelledError: do not await
+                # AGFS cleanup on process teardown (startup recovery covers leftovers).
                 if msg.cleanup_empty_target_on_failure and resource_lock is not None:
                     await self._cleanup_reserved_target_if_empty(
                         root_uri=msg.root_uri,
@@ -793,7 +826,8 @@ class ResourceService:
                     tag_mode=msg.tag_mode,
                 ),
             )
-        except BaseException:
+        except Exception:
+            # Same as SOURCE phase: BaseException must not await AGFS cleanup.
             if msg.cleanup_empty_target_on_failure and resource_lock is not None:
                 await self._cleanup_reserved_target_if_empty(
                     root_uri=msg.root_uri,
@@ -1188,7 +1222,8 @@ class ResourceService:
                 on_enqueued=(transfer_staged_source if plan.staged_source is not None else None),
                 on_failed_with_lock=cleanup_enqueue_failure,
             )
-        except BaseException:
+        except Exception:
+            # BaseException (Ctrl+C / SystemExit) skips await; recovery covers leftovers.
             if resource_lock is not None:
                 await self._release_lock_ref(resource_lock)
             if plan.staged_source is not None and not staged_enqueued:
@@ -1253,7 +1288,7 @@ class ResourceService:
         )
         try:
             await self._viking_fs._ensure_access(root_uri, ctx, action=AclAction.WRITE)
-        except BaseException:
+        except Exception:
             await self._release_lock_ref(resource_lock)
             raise
         return root_uri, resource_lock, False, not target_preexisting

--- a/openviking/storage/internal_names.py
+++ b/openviking/storage/internal_names.py
@@ -31,3 +31,26 @@ WEBDAV_RESERVED_FILENAMES = frozenset(
         *MULTIWRITE_INTERNAL_FILE_NAMES,
     }
 )
+
+
+ROLLBACK_SAFE_ENTRY_NAMES = frozenset(
+    {
+        *STORAGE_INTERNAL_ENTRY_NAMES,
+        *WEBDAV_RESERVED_FILENAMES,
+    }
+)
+
+
+def is_rollback_safe_entry_name(name: str) -> bool:
+    """Whether a directory entry is an internal marker rather than real content.
+
+    Reserved targets materialize pathlock internals (``.path.ovlock``,
+    ``.exact.ovlock.*``) and ingest stub sidecars (``.abstract.md`` /
+    ``.overview.md``) before an import finishes, so a failed import can only
+    roll back a directory whose entries are all internal markers.
+    """
+    if not name or name in {".", ".."}:
+        return True
+    return name in ROLLBACK_SAFE_ENTRY_NAMES or name.startswith(
+        MULTIWRITE_EXACT_LOCK_FILE_PREFIX
+    )

--- a/openviking/storage/internal_names.py
+++ b/openviking/storage/internal_names.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 MULTIWRITE_PATH_LOCK_FILE = ".path.ovlock"
 MULTIWRITE_EXACT_LOCK_FILE_PREFIX = ".exact.ovlock."
 MULTIWRITE_REDIRECT_FILE = ".redirect.json"
@@ -32,25 +34,106 @@ WEBDAV_RESERVED_FILENAMES = frozenset(
     }
 )
 
-
+# Name-only markers: presence alone never counts as user/import content.
 ROLLBACK_SAFE_ENTRY_NAMES = frozenset(
     {
         *STORAGE_INTERNAL_ENTRY_NAMES,
-        *WEBDAV_RESERVED_FILENAMES,
     }
+)
+
+# Derived sidecars: empty / placeholder bodies are rollback-safe; real text is not.
+ROLLBACK_CONTENT_GATED_ENTRY_NAMES = frozenset(
+    {
+        ".abstract.md",
+        ".overview.md",
+        ".relations.json",
+    }
+)
+
+# Markers VikingFS / listing paths surface before semantic generation finishes.
+_ABSTRACT_NOT_READY_MARKERS = (
+    "[.abstract.md is not ready]",
+    "[Directory abstract is not ready]",
+)
+_OVERVIEW_NOT_READY_MARKERS = (
+    "[Directory overview is not ready]",
 )
 
 
 def is_rollback_safe_entry_name(name: str) -> bool:
-    """Whether a directory entry is an internal marker rather than real content.
+    """Whether a directory entry is an internal marker by name alone.
 
-    Reserved targets materialize pathlock internals (``.path.ovlock``,
-    ``.exact.ovlock.*``) and ingest stub sidecars (``.abstract.md`` /
-    ``.overview.md``) before an import finishes, so a failed import can only
-    roll back a directory whose entries are all internal markers.
+    Pathlock / redirect / sync bookkeeping are structural. Ingest sidecars
+    (``.abstract.md`` / ``.overview.md`` / ``.relations.json``) are
+    content-gated — use :func:`is_rollback_safe_sidecar_content`.
     """
     if not name or name in {".", ".."}:
         return True
     return name in ROLLBACK_SAFE_ENTRY_NAMES or name.startswith(
         MULTIWRITE_EXACT_LOCK_FILE_PREFIX
     )
+
+
+def is_rollback_content_gated_entry_name(name: str) -> bool:
+    """Whether rollback safety depends on file contents, not just the name."""
+    return name in ROLLBACK_CONTENT_GATED_ENTRY_NAMES
+
+
+def _is_not_ready_directory_sentinel(text: str, markers: tuple[str, ...]) -> bool:
+    """Match VikingFS not-ready placeholders without dropping real summaries.
+
+    Shapes seen in the wild:
+    - bare marker (listing fallback)
+    - ``# <uri>`` / ``# <name>`` header plus the marker (read-path fallback)
+    """
+    head = text.rstrip()
+    for marker in markers:
+        if head == marker:
+            return True
+        if not head.endswith(marker):
+            continue
+        prefix = head[: -len(marker)].strip()
+        if not prefix:
+            return True
+        # Single markdown H1 with no further body before the marker.
+        if prefix.startswith("#") and "\n" not in prefix:
+            return True
+    return False
+
+
+def _is_empty_relations_stub(text: str) -> bool:
+    """True for empty or JSON-empty relations sidecars (``{}`` / ``[]``)."""
+    stripped = text.strip()
+    if not stripped:
+        return True
+    try:
+        parsed = json.loads(stripped)
+    except (TypeError, ValueError):
+        return False
+    return parsed in ({}, [])
+
+
+def is_rollback_safe_sidecar_content(name: str, content: str | bytes | None) -> bool:
+    """True when a content-gated sidecar is empty or still a not-ready stub.
+
+    Non-empty semantic / OKF / relations bodies block reserved-target rollback
+    so filled sidecars are not deleted with the directory.
+    """
+    if name not in ROLLBACK_CONTENT_GATED_ENTRY_NAMES:
+        return False
+    if content is None:
+        return True
+    if isinstance(content, bytes):
+        text = content.decode("utf-8", errors="replace")
+    else:
+        text = str(content)
+    stripped = text.strip()
+    if not stripped:
+        return True
+    if name == ".abstract.md":
+        return _is_not_ready_directory_sentinel(stripped, _ABSTRACT_NOT_READY_MARKERS)
+    if name == ".overview.md":
+        return _is_not_ready_directory_sentinel(stripped, _OVERVIEW_NOT_READY_MARKERS)
+    if name == ".relations.json":
+        return _is_empty_relations_stub(stripped)
+    return False

--- a/openviking/storage/queuefs/add_resource_processor.py
+++ b/openviking/storage/queuefs/add_resource_processor.py
@@ -68,21 +68,6 @@ class AddResourceProcessor(DequeueHandlerBase):
         staged = StagedSource.from_dict(msg.staged_source)
         await self._viking_fs.delete_temp(staged.temp_uri, ctx=ctx)
 
-    async def _cleanup_failed_target(
-        self,
-        msg: AddResourceMsg,
-        ctx: RequestContext,
-        resource_lock: Optional[Dict[str, Any]],
-    ) -> None:
-        if not msg.cleanup_empty_target_on_failure or resource_lock is None:
-            return
-        with suppress(Exception):
-            await self._resource_service._cleanup_reserved_target_if_empty(
-                root_uri=msg.root_uri,
-                ctx=ctx,
-                resource_lock=resource_lock,
-            )
-
     async def _release_cancelled_resources(
         self,
         msg: AddResourceMsg,
@@ -203,6 +188,7 @@ class AddResourceProcessor(DequeueHandlerBase):
             bind_task_context(msg.task_id, ctx.account_id, ctx.user.user_id),
         ):
             terminal = False
+            task_failed = False
             try:
                 if replay_result is None:
                     await tracker.start(
@@ -224,7 +210,6 @@ class AddResourceProcessor(DequeueHandlerBase):
                     )
                     if result.get("status") == "error":
                         errors = result.get("errors") or ["resource processing failed"]
-                        await self._cleanup_failed_target(msg, ctx, resource_lock)
                         await tracker.fail(
                             msg.task_id,
                             "; ".join(str(error) for error in errors),
@@ -232,6 +217,7 @@ class AddResourceProcessor(DequeueHandlerBase):
                             user_id=ctx.user.user_id,
                         )
                         terminal = True
+                        task_failed = True
                         self.report_error("resource processing failed", data)
                         return None
                     await tracker.complete(
@@ -283,7 +269,6 @@ class AddResourceProcessor(DequeueHandlerBase):
                 self.report_success()
                 return None
             except Exception as exc:
-                await self._cleanup_failed_target(msg, ctx, resource_lock)
                 await tracker.fail(
                     msg.task_id,
                     str(exc),
@@ -291,11 +276,26 @@ class AddResourceProcessor(DequeueHandlerBase):
                     user_id=ctx.user.user_id,
                 )
                 terminal = True
+                task_failed = True
                 self.report_error(str(exc), data)
                 return None
             finally:
                 request_wait_tracker.cleanup(telemetry_id)
                 unregister_telemetry(telemetry_id)
+                if (
+                    task_failed
+                    and msg.cleanup_empty_target_on_failure
+                    and resource_lock is not None
+                ):
+                    # Roll back a target this import reserved before it was
+                    # published; _cleanup_reserved_target_if_empty rechecks
+                    # that the directory still holds no real content (#4501).
+                    with suppress(Exception):
+                        await self._resource_service._cleanup_reserved_target_if_empty(
+                            root_uri=msg.root_uri,
+                            ctx=ctx,
+                            resource_lock=resource_lock,
+                        )
                 with suppress(Exception):
                     if resource_lock is not None:
                         await self._viking_fs._async_agfs.pathlock_release(resource_lock)

--- a/openviking/storage/queuefs/add_resource_processor.py
+++ b/openviking/storage/queuefs/add_resource_processor.py
@@ -68,6 +68,21 @@ class AddResourceProcessor(DequeueHandlerBase):
         staged = StagedSource.from_dict(msg.staged_source)
         await self._viking_fs.delete_temp(staged.temp_uri, ctx=ctx)
 
+    async def _cleanup_failed_target(
+        self,
+        msg: AddResourceMsg,
+        ctx: RequestContext,
+        resource_lock: Optional[Dict[str, Any]],
+    ) -> None:
+        if not msg.cleanup_empty_target_on_failure or resource_lock is None:
+            return
+        with suppress(Exception):
+            await self._resource_service._cleanup_reserved_target_if_empty(
+                root_uri=msg.root_uri,
+                ctx=ctx,
+                resource_lock=resource_lock,
+            )
+
     async def _release_cancelled_resources(
         self,
         msg: AddResourceMsg,
@@ -209,6 +224,7 @@ class AddResourceProcessor(DequeueHandlerBase):
                     )
                     if result.get("status") == "error":
                         errors = result.get("errors") or ["resource processing failed"]
+                        await self._cleanup_failed_target(msg, ctx, resource_lock)
                         await tracker.fail(
                             msg.task_id,
                             "; ".join(str(error) for error in errors),
@@ -267,6 +283,7 @@ class AddResourceProcessor(DequeueHandlerBase):
                 self.report_success()
                 return None
             except Exception as exc:
+                await self._cleanup_failed_target(msg, ctx, resource_lock)
                 await tracker.fail(
                     msg.task_id,
                     str(exc),

--- a/tests/service/test_add_resource_processor_failure_cleanup.py
+++ b/tests/service/test_add_resource_processor_failure_cleanup.py
@@ -1,38 +1,22 @@
-"""Regression tests for #4501: rollback empty reserved targets on add-resource failure."""
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for reserved-target rollback on failed add-resource jobs (#4501)."""
 
+import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import ANY, AsyncMock, Mock
 
 import pytest
 
-from openviking.server.identity import RequestContext, Role
 from openviking.service.task_tracker import TaskStatus
-from openviking.storage.queuefs import QueueManager
+from openviking.service.task_work_index import TASK_WORK_ID_FIELD
 from openviking.storage.queuefs.add_resource_msg import AddResourceMsg
 from openviking.storage.queuefs.add_resource_processor import AddResourceProcessor
-from openviking_cli.session.user_id import UserIdentifier
+from openviking.storage.queuefs.queue_manager import QueueManager
 
 
-def _ctx() -> RequestContext:
-    return RequestContext(
-        user=UserIdentifier("account-1", "user-1"),
-        role=Role.USER,
-    )
-
-
-@pytest.mark.asyncio
-async def test_processor_error_cleans_reserved_target_when_flag_set(monkeypatch):
-    """AddResourceProcessor must rollback newly reserved targets on business errors."""
-    lock = {"lease_ref": "lock-1"}
-    cleanup = AsyncMock(return_value=True)
-    service = SimpleNamespace(
-        execute_add_resource_job=AsyncMock(
-            return_value={"status": "error", "errors": ["Parse error: No /Root object!"]}
-        ),
-        _cleanup_reserved_target_if_empty=cleanup,
-        _link_resource_reason_memory=AsyncMock(),
-    )
-    task_tracker = SimpleNamespace(
+def _task_tracker() -> SimpleNamespace:
+    return SimpleNamespace(
         create=AsyncMock(return_value=SimpleNamespace(status=TaskStatus.PENDING)),
         start=AsyncMock(),
         update_stage=AsyncMock(),
@@ -41,10 +25,20 @@ async def test_processor_error_cleans_reserved_target_when_flag_set(monkeypatch)
         get_task_auth=AsyncMock(return_value={}),
         wait_for_descendants=AsyncMock(),
     )
+
+
+def _processor(monkeypatch, execute_add_resource_job, cleanup) -> tuple:
+    task_tracker = _task_tracker()
     monkeypatch.setattr(
         "openviking.storage.queuefs.add_resource_processor.get_task_tracker",
         Mock(return_value=task_tracker),
     )
+    service = SimpleNamespace(
+        execute_add_resource_job=AsyncMock(side_effect=execute_add_resource_job),
+        _cleanup_reserved_target_if_empty=AsyncMock(side_effect=cleanup),
+        _link_resource_reason_memory=AsyncMock(),
+    )
+    lock = {"lease_ref": "lock-1"}
     viking_fs = SimpleNamespace(
         _async_agfs=SimpleNamespace(
             pathlock_adopt=AsyncMock(return_value=lock),
@@ -54,77 +48,134 @@ async def test_processor_error_cleans_reserved_target_when_flag_set(monkeypatch)
     )
     processor = AddResourceProcessor(
         service,
-        __import__("asyncio").get_running_loop(),
+        asyncio.get_running_loop(),
         QueueManager.ADD_RESOURCE,
         viking_fs,
     )
-    msg = AddResourceMsg(
-        task_id="task-4501",
+    return processor, task_tracker, service, viking_fs, lock
+
+
+def _msg() -> AddResourceMsg:
+    return AddResourceMsg(
+        task_id="task-1",
         path="broken.pdf",
-        root_uri="viking://resources/f5-repro/broken-pdf",
+        root_uri="viking://resources/repro/broken-pdf",
         account_id="account-1",
         user_id="user-1",
         role="user",
-        lock_handoff={"ref": "handoff-1"},
+        lock_handoff={"lease_ref": "handoff-1"},
         cleanup_empty_target_on_failure=True,
     )
 
-    await processor._process(msg, msg.to_dict())
 
-    task_tracker.fail.assert_awaited_once()
-    cleanup.assert_awaited_once()
-    call = cleanup.await_args.kwargs
-    assert call["root_uri"] == "viking://resources/f5-repro/broken-pdf"
-    assert call["resource_lock"] == lock
+def _data(msg: AddResourceMsg) -> dict:
+    data = msg.to_dict()
+    data[TASK_WORK_ID_FIELD] = "work-1"
+    return data
 
 
 @pytest.mark.asyncio
-async def test_processor_error_skips_cleanup_when_target_preexisting(monkeypatch):
-    cleanup = AsyncMock(return_value=True)
-    service = SimpleNamespace(
-        execute_add_resource_job=AsyncMock(
-            return_value={"status": "error", "errors": ["Parse error: boom"]}
-        ),
-        _cleanup_reserved_target_if_empty=cleanup,
-        _link_resource_reason_memory=AsyncMock(),
+async def test_business_error_rolls_back_reserved_target(monkeypatch):
+    processor, task_tracker, service, _, lock = _processor(
+        monkeypatch,
+        execute_add_resource_job=lambda *_a, **_k: {
+            "status": "error",
+            "errors": ["No /Root object! - Is this really a PDF?"],
+        },
+        cleanup=lambda **_k: True,
     )
-    task_tracker = SimpleNamespace(
-        create=AsyncMock(return_value=SimpleNamespace(status=TaskStatus.PENDING)),
-        start=AsyncMock(),
-        update_stage=AsyncMock(),
-        complete=AsyncMock(),
-        fail=AsyncMock(),
-        get_task_auth=AsyncMock(return_value={}),
-        wait_for_descendants=AsyncMock(),
-    )
-    monkeypatch.setattr(
-        "openviking.storage.queuefs.add_resource_processor.get_task_tracker",
-        Mock(return_value=task_tracker),
-    )
-    viking_fs = SimpleNamespace(
-        _async_agfs=SimpleNamespace(
-            pathlock_adopt=AsyncMock(return_value={"lease_ref": "lock-1"}),
-            pathlock_release=AsyncMock(),
-        ),
-        delete_temp=AsyncMock(),
-    )
-    processor = AddResourceProcessor(
-        service,
-        __import__("asyncio").get_running_loop(),
-        QueueManager.ADD_RESOURCE,
-        viking_fs,
-    )
-    msg = AddResourceMsg(
-        task_id="task-4501b",
-        path="broken.pdf",
-        root_uri="viking://resources/existing/report",
-        account_id="account-1",
-        user_id="user-1",
-        role="user",
-        lock_handoff={"ref": "handoff-1"},
-        cleanup_empty_target_on_failure=False,
+    msg = _msg()
+
+    await processor._process(msg, _data(msg))
+
+    task_tracker.fail.assert_awaited_once()
+    service._cleanup_reserved_target_if_empty.assert_awaited_once_with(
+        root_uri="viking://resources/repro/broken-pdf",
+        ctx=ANY,
+        resource_lock=lock,
     )
 
-    await processor._process(msg, msg.to_dict())
 
-    cleanup.assert_not_awaited()
+@pytest.mark.asyncio
+async def test_exception_rolls_back_reserved_target(monkeypatch):
+    async def _raise(*_args, **_kwargs):
+        raise RuntimeError("No /Root object! - Is this really a PDF?")
+
+    processor, task_tracker, service, _, lock = _processor(
+        monkeypatch,
+        execute_add_resource_job=_raise,
+        cleanup=lambda **_k: True,
+    )
+    msg = _msg()
+
+    await processor._process(msg, _data(msg))
+
+    task_tracker.fail.assert_awaited_once()
+    service._cleanup_reserved_target_if_empty.assert_awaited_once_with(
+        root_uri="viking://resources/repro/broken-pdf",
+        ctx=ANY,
+        resource_lock=lock,
+    )
+
+
+@pytest.mark.asyncio
+async def test_successful_import_keeps_reserved_target(monkeypatch):
+    processor, task_tracker, service, _, _ = _processor(
+        monkeypatch,
+        execute_add_resource_job=lambda *_a, **_k: {
+            "status": "success",
+            "root_uri": "viking://resources/repro/broken-pdf",
+        },
+        cleanup=lambda **_k: True,
+    )
+    msg = _msg()
+
+    await processor._process(msg, _data(msg))
+
+    task_tracker.complete.assert_awaited()
+    service._cleanup_reserved_target_if_empty.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failure_without_ownership_keeps_reserved_target(monkeypatch):
+    processor, task_tracker, service, _, _ = _processor(
+        monkeypatch,
+        execute_add_resource_job=lambda *_a, **_k: {
+            "status": "error",
+            "errors": ["parse failed"],
+        },
+        cleanup=lambda **_k: True,
+    )
+    msg = _msg()
+    msg.cleanup_empty_target_on_failure = False
+
+    await processor._process(msg, _data(msg))
+
+    task_tracker.fail.assert_awaited_once()
+    service._cleanup_reserved_target_if_empty.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rollback_runs_before_lock_release(monkeypatch):
+    events = []
+
+    async def _execute(*_args, **_kwargs):
+        return {"status": "error", "errors": ["parse failed"]}
+
+    async def _cleanup(**_kwargs):
+        events.append("cleanup")
+        return True
+
+    processor, _, service, viking_fs, _ = _processor(
+        monkeypatch,
+        execute_add_resource_job=_execute,
+        cleanup=_cleanup,
+    )
+    viking_fs._async_agfs.pathlock_release = AsyncMock(
+        side_effect=lambda *_args: events.append("release")
+    )
+    msg = _msg()
+
+    await processor._process(msg, _data(msg))
+
+    assert events == ["cleanup", "release"]

--- a/tests/service/test_add_resource_processor_failure_cleanup.py
+++ b/tests/service/test_add_resource_processor_failure_cleanup.py
@@ -1,0 +1,130 @@
+"""Regression tests for #4501: rollback empty reserved targets on add-resource failure."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.service.task_tracker import TaskStatus
+from openviking.storage.queuefs import QueueManager
+from openviking.storage.queuefs.add_resource_msg import AddResourceMsg
+from openviking.storage.queuefs.add_resource_processor import AddResourceProcessor
+from openviking_cli.session.user_id import UserIdentifier
+
+
+def _ctx() -> RequestContext:
+    return RequestContext(
+        user=UserIdentifier("account-1", "user-1"),
+        role=Role.USER,
+    )
+
+
+@pytest.mark.asyncio
+async def test_processor_error_cleans_reserved_target_when_flag_set(monkeypatch):
+    """AddResourceProcessor must rollback newly reserved targets on business errors."""
+    lock = {"lease_ref": "lock-1"}
+    cleanup = AsyncMock(return_value=True)
+    service = SimpleNamespace(
+        execute_add_resource_job=AsyncMock(
+            return_value={"status": "error", "errors": ["Parse error: No /Root object!"]}
+        ),
+        _cleanup_reserved_target_if_empty=cleanup,
+        _link_resource_reason_memory=AsyncMock(),
+    )
+    task_tracker = SimpleNamespace(
+        create=AsyncMock(return_value=SimpleNamespace(status=TaskStatus.PENDING)),
+        start=AsyncMock(),
+        update_stage=AsyncMock(),
+        complete=AsyncMock(),
+        fail=AsyncMock(),
+        get_task_auth=AsyncMock(return_value={}),
+        wait_for_descendants=AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.add_resource_processor.get_task_tracker",
+        Mock(return_value=task_tracker),
+    )
+    viking_fs = SimpleNamespace(
+        _async_agfs=SimpleNamespace(
+            pathlock_adopt=AsyncMock(return_value=lock),
+            pathlock_release=AsyncMock(),
+        ),
+        delete_temp=AsyncMock(),
+    )
+    processor = AddResourceProcessor(
+        service,
+        __import__("asyncio").get_running_loop(),
+        QueueManager.ADD_RESOURCE,
+        viking_fs,
+    )
+    msg = AddResourceMsg(
+        task_id="task-4501",
+        path="broken.pdf",
+        root_uri="viking://resources/f5-repro/broken-pdf",
+        account_id="account-1",
+        user_id="user-1",
+        role="user",
+        lock_handoff={"ref": "handoff-1"},
+        cleanup_empty_target_on_failure=True,
+    )
+
+    await processor._process(msg, msg.to_dict())
+
+    task_tracker.fail.assert_awaited_once()
+    cleanup.assert_awaited_once()
+    call = cleanup.await_args.kwargs
+    assert call["root_uri"] == "viking://resources/f5-repro/broken-pdf"
+    assert call["resource_lock"] == lock
+
+
+@pytest.mark.asyncio
+async def test_processor_error_skips_cleanup_when_target_preexisting(monkeypatch):
+    cleanup = AsyncMock(return_value=True)
+    service = SimpleNamespace(
+        execute_add_resource_job=AsyncMock(
+            return_value={"status": "error", "errors": ["Parse error: boom"]}
+        ),
+        _cleanup_reserved_target_if_empty=cleanup,
+        _link_resource_reason_memory=AsyncMock(),
+    )
+    task_tracker = SimpleNamespace(
+        create=AsyncMock(return_value=SimpleNamespace(status=TaskStatus.PENDING)),
+        start=AsyncMock(),
+        update_stage=AsyncMock(),
+        complete=AsyncMock(),
+        fail=AsyncMock(),
+        get_task_auth=AsyncMock(return_value={}),
+        wait_for_descendants=AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.add_resource_processor.get_task_tracker",
+        Mock(return_value=task_tracker),
+    )
+    viking_fs = SimpleNamespace(
+        _async_agfs=SimpleNamespace(
+            pathlock_adopt=AsyncMock(return_value={"lease_ref": "lock-1"}),
+            pathlock_release=AsyncMock(),
+        ),
+        delete_temp=AsyncMock(),
+    )
+    processor = AddResourceProcessor(
+        service,
+        __import__("asyncio").get_running_loop(),
+        QueueManager.ADD_RESOURCE,
+        viking_fs,
+    )
+    msg = AddResourceMsg(
+        task_id="task-4501b",
+        path="broken.pdf",
+        root_uri="viking://resources/existing/report",
+        account_id="account-1",
+        user_id="user-1",
+        role="user",
+        lock_handoff={"ref": "handoff-1"},
+        cleanup_empty_target_on_failure=False,
+    )
+
+    await processor._process(msg, msg.to_dict())
+
+    cleanup.assert_not_awaited()

--- a/tests/service/test_resource_service_reserved_target_cleanup.py
+++ b/tests/service/test_resource_service_reserved_target_cleanup.py
@@ -26,6 +26,55 @@ def _service(viking_fs, resource_processor=None) -> ResourceService:
 
 
 @pytest.mark.asyncio
+async def test_cleanup_reserved_target_removes_internal_only_directory():
+    lock = {"lease_ref": "lock-1"}
+    ctx = _ctx()
+    viking_fs = SimpleNamespace(
+        exists=AsyncMock(return_value=True),
+        stat=AsyncMock(return_value={"isDir": True}),
+        ls=AsyncMock(return_value=[{"name": ".path.ovlock", "isDir": False}]),
+        rm=AsyncMock(),
+    )
+    service = _service(viking_fs)
+
+    removed = await service._cleanup_reserved_target_if_empty(
+        root_uri="viking://resources/reserved",
+        ctx=ctx,
+        resource_lock=lock,
+    )
+
+    assert removed is True
+    viking_fs.rm.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_reserved_target_removes_stub_overview_directory():
+    lock = {"lease_ref": "lock-1"}
+    ctx = _ctx()
+    viking_fs = SimpleNamespace(
+        exists=AsyncMock(return_value=True),
+        stat=AsyncMock(return_value={"isDir": True}),
+        ls=AsyncMock(
+            return_value=[
+                {"name": ".abstract.md", "isDir": False},
+                {"name": ".overview.md", "isDir": False},
+            ]
+        ),
+        rm=AsyncMock(),
+    )
+    service = _service(viking_fs)
+
+    removed = await service._cleanup_reserved_target_if_empty(
+        root_uri="viking://resources/f5-repro/broken-pdf",
+        ctx=ctx,
+        resource_lock=lock,
+    )
+
+    assert removed is True
+    viking_fs.rm.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_cleanup_reserved_target_removes_only_empty_directory():
     lock = {"lease_ref": "lock-1"}
     ctx = _ctx()

--- a/tests/service/test_resource_service_reserved_target_cleanup.py
+++ b/tests/service/test_resource_service_reserved_target_cleanup.py
@@ -264,10 +264,12 @@ async def test_prepared_file_failure_preserves_cleanup_policy(cleanup_on_failure
     ],
 )
 async def test_cleanup_reserved_target_removes_directory_with_internal_markers_only(names):
+    """#4501: empty / not-ready sidecars plus lock markers still roll back."""
     viking_fs = SimpleNamespace(
         exists=AsyncMock(return_value=True),
         stat=AsyncMock(return_value={"isDir": True}),
         ls=AsyncMock(return_value=[{"name": name, "isDir": False} for name in names]),
+        read_file=AsyncMock(return_value=""),
         rm=AsyncMock(),
     )
     service = _service(viking_fs)
@@ -285,6 +287,143 @@ async def test_cleanup_reserved_target_removes_directory_with_internal_markers_o
         ctx=ANY,
         lease_ref={"lease_ref": "lock-1"},
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "name,content",
+    [
+        (".abstract.md", "[.abstract.md is not ready]"),
+        (".abstract.md", "# viking://resources/demo [Directory abstract is not ready]"),
+        (".overview.md", "# demo\n\n[Directory overview is not ready]"),
+    ],
+)
+async def test_cleanup_reserved_target_removes_not_ready_sidecars(name, content):
+    viking_fs = SimpleNamespace(
+        exists=AsyncMock(return_value=True),
+        stat=AsyncMock(return_value={"isDir": True}),
+        ls=AsyncMock(
+            return_value=[
+                {"name": ".path.ovlock", "isDir": False},
+                {"name": name, "isDir": False, "size": len(content)},
+            ]
+        ),
+        read_file=AsyncMock(return_value=content),
+        rm=AsyncMock(),
+    )
+    service = _service(viking_fs)
+
+    removed = await service._cleanup_reserved_target_if_empty(
+        root_uri="viking://resources/repro/stub-only",
+        ctx=_ctx(),
+        resource_lock={"lease_ref": "lock-1"},
+    )
+
+    assert removed is True
+    viking_fs.rm.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_reserved_target_preserves_filled_abstract_sidecar():
+    filled = "# Summary\n\nReal ingest abstract body."
+    viking_fs = SimpleNamespace(
+        exists=AsyncMock(return_value=True),
+        stat=AsyncMock(return_value={"isDir": True}),
+        ls=AsyncMock(
+            return_value=[
+                {"name": ".path.ovlock", "isDir": False},
+                {"name": ".abstract.md", "isDir": False, "size": len(filled)},
+            ]
+        ),
+        read_file=AsyncMock(return_value=filled),
+        rm=AsyncMock(),
+    )
+    service = _service(viking_fs)
+
+    removed = await service._cleanup_reserved_target_if_empty(
+        root_uri="viking://resources/repro/filled-sidecar",
+        ctx=_ctx(),
+        resource_lock={"lease_ref": "lock-1"},
+    )
+
+    assert removed is False
+    viking_fs.rm.assert_not_awaited()
+    viking_fs.read_file.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_reserved_target_preserves_filled_relations_sidecar():
+    filled = '{"links":[{"uri":"viking://resources/other"}]}'
+    viking_fs = SimpleNamespace(
+        exists=AsyncMock(return_value=True),
+        stat=AsyncMock(return_value={"isDir": True}),
+        ls=AsyncMock(
+            return_value=[
+                {"name": ".path.ovlock", "isDir": False},
+                {"name": ".relations.json", "isDir": False, "size": len(filled)},
+            ]
+        ),
+        read_file=AsyncMock(return_value=filled),
+        rm=AsyncMock(),
+    )
+    service = _service(viking_fs)
+
+    removed = await service._cleanup_reserved_target_if_empty(
+        root_uri="viking://resources/repro/filled-relations",
+        ctx=_ctx(),
+        resource_lock={"lease_ref": "lock-1"},
+    )
+
+    assert removed is False
+    viking_fs.rm.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("content", ["", "{}", "[]"])
+async def test_cleanup_reserved_target_removes_empty_relations_stub(content):
+    viking_fs = SimpleNamespace(
+        exists=AsyncMock(return_value=True),
+        stat=AsyncMock(return_value={"isDir": True}),
+        ls=AsyncMock(
+            return_value=[
+                {"name": ".path.ovlock", "isDir": False},
+                {"name": ".relations.json", "isDir": False, "size": len(content)},
+            ]
+        ),
+        read_file=AsyncMock(return_value=content),
+        rm=AsyncMock(),
+    )
+    service = _service(viking_fs)
+
+    removed = await service._cleanup_reserved_target_if_empty(
+        root_uri="viking://resources/repro/empty-relations",
+        ctx=_ctx(),
+        resource_lock={"lease_ref": "lock-1"},
+    )
+
+    assert removed is True
+    viking_fs.rm.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_reserved_target_preserves_when_sidecar_read_fails():
+    viking_fs = SimpleNamespace(
+        exists=AsyncMock(return_value=True),
+        stat=AsyncMock(return_value={"isDir": True}),
+        ls=AsyncMock(return_value=[{"name": ".overview.md", "isDir": False, "size": 12}]),
+        read_file=AsyncMock(side_effect=OSError("io error")),
+        rm=AsyncMock(),
+    )
+    service = _service(viking_fs)
+
+    removed = await service._cleanup_reserved_target_if_empty(
+        root_uri="viking://resources/repro/unreadable-sidecar",
+        ctx=_ctx(),
+        resource_lock={"lease_ref": "lock-1"},
+    )
+
+    assert removed is False
+    viking_fs.rm.assert_not_awaited()
 
 
 def _post_process_msg(cleanup_on_failure: bool) -> AddResourceMsg:

--- a/tests/service/test_resource_service_reserved_target_cleanup.py
+++ b/tests/service/test_resource_service_reserved_target_cleanup.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import ANY, AsyncMock
 
 import pytest
 
@@ -23,55 +23,6 @@ def _service(viking_fs, resource_processor=None) -> ResourceService:
         resource_processor=resource_processor or SimpleNamespace(),
         skill_processor=object(),
     )
-
-
-@pytest.mark.asyncio
-async def test_cleanup_reserved_target_removes_internal_only_directory():
-    lock = {"lease_ref": "lock-1"}
-    ctx = _ctx()
-    viking_fs = SimpleNamespace(
-        exists=AsyncMock(return_value=True),
-        stat=AsyncMock(return_value={"isDir": True}),
-        ls=AsyncMock(return_value=[{"name": ".path.ovlock", "isDir": False}]),
-        rm=AsyncMock(),
-    )
-    service = _service(viking_fs)
-
-    removed = await service._cleanup_reserved_target_if_empty(
-        root_uri="viking://resources/reserved",
-        ctx=ctx,
-        resource_lock=lock,
-    )
-
-    assert removed is True
-    viking_fs.rm.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_cleanup_reserved_target_removes_stub_overview_directory():
-    lock = {"lease_ref": "lock-1"}
-    ctx = _ctx()
-    viking_fs = SimpleNamespace(
-        exists=AsyncMock(return_value=True),
-        stat=AsyncMock(return_value={"isDir": True}),
-        ls=AsyncMock(
-            return_value=[
-                {"name": ".abstract.md", "isDir": False},
-                {"name": ".overview.md", "isDir": False},
-            ]
-        ),
-        rm=AsyncMock(),
-    )
-    service = _service(viking_fs)
-
-    removed = await service._cleanup_reserved_target_if_empty(
-        root_uri="viking://resources/f5-repro/broken-pdf",
-        ctx=ctx,
-        resource_lock=lock,
-    )
-
-    assert removed is True
-    viking_fs.rm.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -118,6 +69,36 @@ async def test_cleanup_reserved_target_preserves_nonempty_directory():
     )
 
     assert removed is False
+    viking_fs.rm.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_reserved_target_preserves_content_appearing_mid_rollback():
+    """A concurrent writer between emptiness listings must preserve the target."""
+    viking_fs = SimpleNamespace(
+        exists=AsyncMock(return_value=True),
+        stat=AsyncMock(return_value={"isDir": True}),
+        ls=AsyncMock(
+            side_effect=[
+                [{"name": ".path.ovlock", "isDir": False}],
+                [
+                    {"name": ".path.ovlock", "isDir": False},
+                    {"name": "document.md", "isDir": False},
+                ],
+            ]
+        ),
+        rm=AsyncMock(),
+    )
+    service = _service(viking_fs)
+
+    removed = await service._cleanup_reserved_target_if_empty(
+        root_uri="viking://resources/racy",
+        ctx=_ctx(),
+        resource_lock={"lease_ref": "lock-1"},
+    )
+
+    assert removed is False
+    assert viking_fs.ls.await_count == 2
     viking_fs.rm.assert_not_awaited()
 
 
@@ -268,3 +249,164 @@ async def test_prepared_file_failure_preserves_cleanup_policy(cleanup_on_failure
         )
     else:
         service._cleanup_reserved_target_if_empty.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "names",
+    [
+        [".path.ovlock"],
+        [".exact.ovlock.7f3a1c"],
+        [".path.ovlock", ".exact.ovlock.7f3a1c", ".redirect.json", ".sync_log.json"],
+        ["_system", "tasks"],
+        [".abstract.md", ".overview.md"],
+        [".path.ovlock", ".abstract.md", ".overview.md", ".relations.json"],
+    ],
+)
+async def test_cleanup_reserved_target_removes_directory_with_internal_markers_only(names):
+    viking_fs = SimpleNamespace(
+        exists=AsyncMock(return_value=True),
+        stat=AsyncMock(return_value={"isDir": True}),
+        ls=AsyncMock(return_value=[{"name": name, "isDir": False} for name in names]),
+        rm=AsyncMock(),
+    )
+    service = _service(viking_fs)
+
+    removed = await service._cleanup_reserved_target_if_empty(
+        root_uri="viking://resources/repro/broken-pdf",
+        ctx=_ctx(),
+        resource_lock={"lease_ref": "lock-1"},
+    )
+
+    assert removed is True
+    viking_fs.rm.assert_awaited_once_with(
+        "viking://resources/repro/broken-pdf",
+        recursive=True,
+        ctx=ANY,
+        lease_ref={"lease_ref": "lock-1"},
+    )
+
+
+def _post_process_msg(cleanup_on_failure: bool) -> AddResourceMsg:
+    return AddResourceMsg(
+        task_id="task-2",
+        path="report.pdf",
+        root_uri="viking://resources/report",
+        account_id="account-1",
+        user_id="user-1",
+        role="user",
+        prepared={
+            "root_uri": "viking://resources/report",
+            "temp_uri": "viking://temp/account-1/task-2",
+            "temp_dir_path": "viking://temp/account-1/task-2",
+            "source_committed": False,
+            "target_preexisting": not cleanup_on_failure,
+            "root_is_file": False,
+        },
+        cleanup_empty_target_on_failure=cleanup_on_failure,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cleanup_on_failure", [False, True])
+async def test_post_process_job_error_rolls_back_owned_reservation(cleanup_on_failure):
+    service = _service(SimpleNamespace())
+    service._resource_processor = SimpleNamespace(
+        finish_prepared_resource=AsyncMock(
+            return_value={"status": "error", "errors": ["post-processing failed"]}
+        )
+    )
+    service._cleanup_reserved_target_if_empty = AsyncMock(return_value=True)
+    lock = {"lease_ref": "lock-1"}
+    ctx = _ctx()
+    msg = _post_process_msg(cleanup_on_failure)
+
+    result = await service.execute_add_resource_job(
+        msg,
+        ctx=ctx,
+        resource_lock=lock,
+        stage_callback=AsyncMock(),
+    )
+
+    assert result["status"] == "error"
+    if cleanup_on_failure:
+        service._cleanup_reserved_target_if_empty.assert_awaited_once_with(
+            root_uri="viking://resources/report",
+            ctx=ctx,
+            resource_lock=lock,
+        )
+    else:
+        service._cleanup_reserved_target_if_empty.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_process_job_exception_rolls_back_owned_reservation():
+    service = _service(SimpleNamespace())
+    service._resource_processor = SimpleNamespace(
+        finish_prepared_resource=AsyncMock(side_effect=RuntimeError("summarize crashed"))
+    )
+    service._cleanup_reserved_target_if_empty = AsyncMock(return_value=True)
+    lock = {"lease_ref": "lock-1"}
+    ctx = _ctx()
+    msg = _post_process_msg(True)
+
+    with pytest.raises(RuntimeError, match="summarize crashed"):
+        await service.execute_add_resource_job(
+            msg,
+            ctx=ctx,
+            resource_lock=lock,
+            stage_callback=AsyncMock(),
+        )
+
+    service._cleanup_reserved_target_if_empty.assert_awaited_once_with(
+        root_uri="viking://resources/report",
+        ctx=ctx,
+        resource_lock=lock,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("target_preexisting", "expected_flag"),
+    [(False, True), (True, False)],
+)
+async def test_deferred_post_process_message_carries_target_ownership(
+    target_preexisting,
+    expected_flag,
+):
+    service = _service(SimpleNamespace())
+    prepared = {
+        "root_uri": "viking://resources/report",
+        "temp_uri": "viking://temp/account-1/task-3",
+        "temp_dir_path": "viking://temp/account-1/task-3",
+        "source_committed": True,
+        "target_preexisting": target_preexisting,
+        "root_is_file": False,
+    }
+    service._resource_processor = SimpleNamespace(
+        process_resource=AsyncMock(
+            return_value={
+                "status": "success",
+                "root_uri": "viking://resources/report",
+                "source_path": "report.pdf",
+                "_post_process": prepared,
+                "_resource_lock": None,
+            }
+        )
+    )
+    service._manage_watch_if_needed = AsyncMock()
+    service._enqueue_add_resource_job = AsyncMock(
+        return_value=SimpleNamespace(task_id="task-3")
+    )
+
+    result = await service._execute_resource_ingestion(
+        "report.pdf",
+        ctx=_ctx(),
+        defer_post_processing=True,
+        to="viking://resources/report",
+    )
+
+    assert result["task_id"] == "task-3"
+    enqueued_msg = service._enqueue_add_resource_job.await_args.args[0]
+    assert enqueued_msg.job_phase.value == "post_process"
+    assert enqueued_msg.cleanup_empty_target_on_failure is expected_flag

--- a/tests/storage/test_internal_names_rollback.py
+++ b/tests/storage/test_internal_names_rollback.py
@@ -1,0 +1,60 @@
+"""Unit tests for rollback-safe internal entry helpers."""
+
+from openviking.storage.internal_names import (
+    is_rollback_content_gated_entry_name,
+    is_rollback_safe_entry_name,
+    is_rollback_safe_sidecar_content,
+)
+
+
+def test_name_only_markers_remain_safe_without_content_check():
+    assert is_rollback_safe_entry_name(".path.ovlock")
+    assert is_rollback_safe_entry_name(".exact.ovlock.abc")
+    assert is_rollback_safe_entry_name("_system")
+    assert is_rollback_safe_entry_name("tasks")
+    assert is_rollback_safe_entry_name(".redirect.json")
+
+
+def test_sidecars_are_content_gated_not_name_safe():
+    for name in (".abstract.md", ".overview.md", ".relations.json"):
+        assert not is_rollback_safe_entry_name(name)
+        assert is_rollback_content_gated_entry_name(name)
+
+
+def test_sidecar_empty_and_not_ready_are_safe():
+    assert is_rollback_safe_sidecar_content(".abstract.md", "")
+    assert is_rollback_safe_sidecar_content(".abstract.md", "   \n")
+    assert is_rollback_safe_sidecar_content(".abstract.md", "[.abstract.md is not ready]")
+    assert is_rollback_safe_sidecar_content(
+        ".abstract.md",
+        "# viking://resources/x [Directory abstract is not ready]",
+    )
+    assert is_rollback_safe_sidecar_content(
+        ".overview.md",
+        "# x\n\n[Directory overview is not ready]",
+    )
+    assert is_rollback_safe_sidecar_content(".relations.json", "")
+    assert is_rollback_safe_sidecar_content(".relations.json", "{}")
+    assert is_rollback_safe_sidecar_content(".relations.json", "[]")
+    assert is_rollback_safe_sidecar_content(".relations.json", "  {\n  }\n")
+
+
+def test_sidecar_filled_content_is_not_safe():
+    assert not is_rollback_safe_sidecar_content(
+        ".abstract.md",
+        "# Summary\n\nActual abstract text.",
+    )
+    assert not is_rollback_safe_sidecar_content(
+        ".overview.md",
+        "# Overview\n\nActual overview text.",
+    )
+    # Mentions the marker phrase but also has real body → not a stub.
+    assert not is_rollback_safe_sidecar_content(
+        ".abstract.md",
+        "# Summary\n\nMentions [Directory abstract is not ready] in body.",
+    )
+    assert not is_rollback_safe_sidecar_content(
+        ".relations.json",
+        '{"links":[{"uri":"viking://resources/other"}]}',
+    )
+    assert not is_rollback_safe_sidecar_content(".relations.json", "not-json")


### PR DESCRIPTION
## Summary

Fixes #4501: when `add_resource` fails (e.g. unparseable PDF), a newly reserved `viking://resources/...` target should not remain visible in the resource tree as an empty / stub-only directory.

## Problem

`_cleanup_reserved_target_if_empty` already existed on main, but silently no-oped. Before parse/post-process failure, the reserved target materializes pathlock internals (`.path.ovlock`, `.exact.ovlock.*`) and ingest stubs (`.abstract.md` / `.overview.md`). The old emptiness check required a completely empty listing, so rollback never ran and partial targets stayed under `viking://resources/`.

## Solution

1. Treat storage-internal markers and ingest stub sidecars as rollback-safe (`is_rollback_safe_entry_name`, including `.exact.ovlock.*`). Any other entry (real content / concurrent writer) preserves the directory.
2. Gate cleanup with `cleanup_empty_target_on_failure` so pre-existing user directories are never touched.
3. Invoke the same rollback from `AddResourceProcessor` terminal failure paths (business error and unexpected exception), before the resource lock is released.
4. Roll back on `finish_prepared_resource` failures in the post-process phase; deferred `POST_PROCESS` queue messages carry `cleanup_empty_target_on_failure` derived from `target_preexisting`.
5. Re-list immediately before `rm` so content that appears between emptiness checks is preserved; `rm(lease_ref=...)` still guards the final race.

## Credits

Thanks @now-ing for the independent investigation of #4501 and for sharing `now-ing:fix/iss-4501-failed-import-cleanup` without opening a competing PR. This update folds their deltas (rollback-safe helper, deferred ownership flag wiring, processor `finally`-path cleanup, and additional regression tests), then adds the mid-rollback re-list + test called out in review.

## Validation

```bash
python -m pytest tests/service/test_resource_service_reserved_target_cleanup.py tests/service/test_add_resource_processor_failure_cleanup.py -q --confcutdir=tests/service -o addopts=
```

Result: **26 passed**
