### PR TITLE
fix(opencode-plugin): make messageID optional in prependSyntheticRecallPart

### DIFF
--- a/examples/opencode-plugin/lib/memory-recall.mjs
+++ b/examples/opencode-plugin/lib/memory-recall.mjs
@@ -57,8 +57,10 @@ export function extractCurrentUserText(parts) {
 
 function prependSyntheticRecallPart(input, output, injection) {
   const sessionID = input.sessionID ?? output.message?.sessionID
-  const messageID = input.messageID ?? output.message?.id
-  if (!sessionID || !messageID) return false
+  // messageID is optional in opencode's chat.message API (messageID?: string).
+  // When absent, generate a fallback so recall context is always injected.
+  const messageID = input.messageID ?? output.message?.id ?? `ov-recall-${Date.now()}`
+  if (!sessionID) return false
 
   output.parts.unshift({
     id: `prt-ov-recall-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,


### PR DESCRIPTION
## Problem

The `chat.message` hook in opencode's plugin API declares `messageID` as **optional** (`messageID?: string` in `@opencode-ai/plugin/dist/index.d.ts`). However, `prependSyntheticRecallPart` requires both `sessionID` AND `messageID`:

```javascript
const messageID = input.messageID ?? output.message?.id
if (!sessionID || !messageID) return false  // silently discards the recall block
```

When opencode invokes the hook without a `messageID`, the null check fails, `return false` executes, and the retrieved OV context is discarded — **no error is logged, no warning is raised**. This means the autoRecall feature silently fails for all opencode versions/sessions that don't pass `messageID`.

## Fix

Generate a timestamp-based fallback for `messageID` when absent. `sessionID` remains the only hard requirement:

```diff
- const messageID = input.messageID ?? output.message?.id
- if (!sessionID || !messageID) return false
+ const messageID = input.messageID ?? output.message?.id ?? `ov-recall-${Date.now()}`
+ if (!sessionID) return false
```

## Verification

Tested against opencode 1.18.26 (24+ hours in production):
- Before: 0 `<openviking-context>` parts in any session (36+ hours of silent failure)
- After: synthetic recall parts injected on every user message (confirmed via opencode session database)