### PR TITLE
fix(opencode-plugin): isolate flushAll session failures

### DIFF
--- a/examples/opencode-plugin/lib/memory-session.mjs
+++ b/examples/opencode-plugin/lib/memory-session.mjs
@@ -264,8 +264,18 @@ export function createMemorySessionManager({ config, pluginRoot }) {
       clearTimeout(saveTimer)
       saveTimer = null
     }
+    // Do not abort the whole dispose flush when one session fails (e.g. server
+    // already GC'd a stale session). Continue so later sessions still commit.
+    // See https://github.com/volcengine/OpenViking/issues/4490
     for (const sessionId of sessions.keys()) {
-      await flushSession(sessionId, { commit, reason: "flushAll" })
+      try {
+        await flushSession(sessionId, { commit, reason: "flushAll" })
+      } catch (err) {
+        console.warn(
+          `[opencode-plugin] flushAll skipped session ${sessionId}:`,
+          err?.message || err,
+        )
+      }
     }
     await enqueueSave()
   }


### PR DESCRIPTION
## Summary
- Wrap each `flushSession` call inside `flushAll` in try/catch so one failed session (e.g. already GC'd) does not abort dispose flush for later sessions.

Fixes #4490

## Test plan
- [ ] With two tracked sessions, force the first `flushSession` to throw and confirm the second still commits
- [ ] Normal dispose with healthy sessions still flushes all