### PR TITLE
fix(openclaw): align recall quota behavior

### DIFF
--- a/examples/openclaw-plugin/auto-recall.ts
+++ b/examples/openclaw-plugin/auto-recall.ts
@@ -1,5 +1,5 @@
 import type { FindResultItem, OpenVikingClient, SearchContextEntry } from "./client.js";
-import type { MemoryOpenVikingConfig } from "./config.js";
+import type { MemoryOpenVikingConfig, ParsedMemoryOpenVikingConfig } from "./config.js";
 import type { EffectiveQueryConfig } from "./query-config.js";
 import { toJsonLog } from "./memory-ranking.js";
 import { quickRecallPrecheck, withTimeout } from "./process-manager.js";
@@ -316,7 +316,8 @@ export function shouldRecallAgentExperience(input: {
 }
 
 export async function buildAutoRecallContext(params: {
-  cfg: Required<MemoryOpenVikingConfig>;
+  cfg: Required<MemoryOpenVikingConfig> &
+    Partial<Pick<ParsedMemoryOpenVikingConfig, "recallLimitConfigured">>;
   queryConfig?: EffectiveQueryConfig;
   client: OpenVikingClient;
   agentId: string;
@@ -349,6 +350,9 @@ export async function buildAutoRecallContext(params: {
     (async () => {
       const scoreThreshold = queryConfig?.scoreThreshold ?? cfg.recallScoreThreshold;
       const recallLimit = queryConfig?.recallLimit ?? cfg.recallLimit;
+      const recallLimitConfigured = queryConfig
+        ? queryConfig.sources.recallLimit !== "default"
+        : cfg.recallLimitConfigured !== false;
       const maxInjectedChars = queryConfig?.maxInjectedChars ?? cfg.recallMaxInjectedChars;
       const recallPreferAbstract = queryConfig?.recallPreferAbstract ?? cfg.recallPreferAbstract;
       const searchPlan = resolveRecallSearchPlan(params.resourceTypes ?? queryConfig?.resourceTypes ?? cfg.recallTargetTypes, {
@@ -367,7 +371,7 @@ export async function buildAutoRecallContext(params: {
       try {
         contextResult = await client.searchContext(queryText, {
           sessionId: params.ovSessionId,
-          limit: recallLimit,
+          ...(recallLimitConfigured ? { limit: recallLimit } : {}),
           scoreThreshold,
           contextType: contextTypes.length === 1 ? contextTypes[0] : contextTypes,
           queryExpansion: "auto",

--- a/examples/openclaw-plugin/config.ts
+++ b/examples/openclaw-plugin/config.ts
@@ -133,6 +133,8 @@ export type ParsedMemoryOpenVikingConfig = Required<
   apiKey: string;
   agentExperience: Required<NonNullable<MemoryOpenVikingConfig["agentExperience"]>>;
   recallTargetTypes: Array<"resource" | "user" | "agent">;
+  /** Internal provenance sentinel used to decide whether recall requests send a limit. */
+  readonly recallLimitConfigured: boolean;
 };
 
 const DEFAULT_BASE_URL = "http://127.0.0.1:1933";
@@ -143,7 +145,7 @@ const DEFAULT_CAPTURE_MAX_LENGTH = 24000;
 // Session-aware context search may spend up to 5 seconds on query expansion
 // before returning its server-side fallback, so leave headroom for retrieval.
 const DEFAULT_AUTO_RECALL_TIMEOUT_MS = 15000;
-const DEFAULT_RECALL_LIMIT = 6;
+const DEFAULT_RECALL_LIMIT = 10;
 const DEFAULT_RECALL_SCORE_THRESHOLD = 0.15;
 const DEFAULT_RECALL_MAX_CONTENT_CHARS = 5000;
 const DEFAULT_RECALL_PREFER_ABSTRACT = false;
@@ -521,6 +523,7 @@ export const memoryOpenVikingConfigSchema = {
         "autoRecallTimeoutMs",
         "recallResources",
         "recallLimit",
+        "recallLimitConfigured",
         "recallScoreThreshold",
         "recallMaxInjectedChars",
         "recallMaxContentChars",
@@ -614,7 +617,7 @@ export const memoryOpenVikingConfigSchema = {
     );
     const { enabledTools, disabledTools } = normalizeEnabledTools(cfg);
 
-    return {
+    const parsed: ParsedMemoryOpenVikingConfig = {
       mode,
       baseUrl: resolvedBaseUrl,
       peer_role: peerRole,
@@ -638,6 +641,10 @@ export const memoryOpenVikingConfigSchema = {
       ),
       recallResources,
       recallLimit: Math.max(1, Math.floor(toNumber(cfg.recallLimit, DEFAULT_RECALL_LIMIT))),
+      recallLimitConfigured:
+        typeof cfg.recallLimitConfigured === "boolean"
+          ? cfg.recallLimitConfigured
+          : Object.prototype.hasOwnProperty.call(cfg, "recallLimit"),
       recallScoreThreshold: Math.min(
         1,
         Math.max(0, toNumber(cfg.recallScoreThreshold, DEFAULT_RECALL_SCORE_THRESHOLD)),
@@ -768,6 +775,7 @@ export const memoryOpenVikingConfigSchema = {
         ),
       },
     };
+    return parsed;
   },
   uiHints: {
     baseUrl: {
@@ -814,7 +822,7 @@ export const memoryOpenVikingConfigSchema = {
     targetUri: {
       label: "Search Target URI",
       placeholder: DEFAULT_TARGET_URI,
-      help: "Default OpenViking target URI for memory search",
+      help: "Default exact search scope for ov_search and memory_forget. memory_recall uses an exact scope only when targetUri is passed as a tool argument.",
     },
     timeoutMs: {
       label: "Request Timeout (ms)",
@@ -862,6 +870,7 @@ export const memoryOpenVikingConfigSchema = {
       label: "Recall Limit",
       placeholder: String(DEFAULT_RECALL_LIMIT),
       advanced: true,
+      help: "Optional recall result target for auto-recall and memory_recall. When unset, the request omits quotas and uses the OpenViking server default; explicit values use the standard coding quota mapping.",
     },
     recallScoreThreshold: {
       label: "Recall Score Threshold",
@@ -872,7 +881,7 @@ export const memoryOpenVikingConfigSchema = {
       label: "Recall Max Injected Chars",
       placeholder: String(DEFAULT_RECALL_MAX_INJECTED_CHARS),
       advanced: true,
-      help: "Legacy auto-recall character budget. It is converted to the server context token budget at four characters per token.",
+      help: "Character budget for auto-recall and memory_recall. It is converted to the server context token budget at four characters per token.",
     },
     recallMaxContentChars: {
       label: "Deprecated Recall Max Content Chars",
@@ -883,7 +892,7 @@ export const memoryOpenVikingConfigSchema = {
     recallPreferAbstract: {
       label: "Recall Prefer Abstract",
       advanced: true,
-      help: "Pin server-assembled auto-recall entries to abstract detail. When disabled, the server chooses each category's default detail tier.",
+      help: "Pin server-assembled auto-recall and memory_recall entries to abstract detail. When disabled, the server chooses each category's default detail tier.",
     },
     recallTokenBudget: {
       label: "Deprecated Recall Token Budget",

--- a/examples/openclaw-plugin/docs/openviking-dynamic-query-config-test-report.md
+++ b/examples/openclaw-plugin/docs/openviking-dynamic-query-config-test-report.md
@@ -18,7 +18,7 @@
 | claw / session 粒度 | claw 以 `agentId` 为 key；session 优先 `ovSessionId`，其次 `sessionId`，再次 `sessionKey` | `query-config.ts:158`、`query-config.ts:367` |
 | 自动召回接入 | assemble 阶段获取有效查询配置，传入自动召回链路 | `context-engine.ts:891` |
 | 显式工具接入 | `memory_recall`、`ov_search` 使用运行期有效配置作为默认值，请求参数仍可覆盖 | `index.ts:1218` |
-| 排序权重参数化 | `rankingWeights`、`categoryWeights`、`resourceTypeWeights` 参与客户端侧排序 | `memory-ranking.ts` |
+| 旧排序权重兼容 | `rankingWeights`、`categoryWeights`、`resourceTypeWeights` 仍可解析和持久化，但 context-based recall 不再客户端重排 | `query-config.ts` |
 | CLI 管理入口 | 新增 `/ov-query-config` get/set/unset/reset | `index.ts:1225`、`index.ts:1748` |
 | Gateway URI 详情 | 新增只读详情接口，不重新触发搜索 | `index.ts:945`、`index.ts:1132` |
 | Gateway 最近 ov_search 清单 | 从 recall trace 中扁平化最近一次 `ov_search` 结果 | `index.ts:1019`、`index.ts:1133` |
@@ -46,8 +46,8 @@
 request 覆盖参数
   > session 运行期配置
   > claw 运行期配置
-  > plugins.entries.openviking.config 静态配置
-  > 代码默认值
+  > plugins.entries.openviking.config 显式静态配置
+  > OpenViking 服务端默认值
 ```
 
 说明：
@@ -64,7 +64,7 @@ request 覆盖参数
 | 标量字段 | 高优先级覆盖低优先级，如 `recallLimit`、`scoreThreshold` |
 | 数组字段 | 整体覆盖，不拼接，如 `resourceTypes` |
 | 对象字段 | 浅合并，如 `rankingWeights`、`categoryWeights`、`resourceTypeWeights` |
-| `candidateLimit` | 显式设置优先于 `recallLimit * candidateMultiplier` 派生值；且最终保证 `candidateLimit >= recallLimit` |
+| `candidateLimit` | 旧兼容字段，仅影响显式 `memory_recall.targetUri` 的精确检索路径 |
 | 非法数值 | 归一化时 clamp 到允许范围；非法 `targetUri` 会报错 |
 | 持久化文件损坏 | 保留 last known-good 内存配置，不阻断查询链路 |
 
@@ -72,14 +72,14 @@ request 覆盖参数
 
 | 字段 | 语义 | 范围/约束 | 默认来源 |
 |---|---|---|---|
-| `recallLimit` | 最终注入或展示结果数 | 1-50 | 静态 `recallLimit` |
-| `candidateLimit` | 每个 target URI 的候选检索数 | 1-200 | 派生值 |
-| `candidateMultiplier` | 候选数倍数，候选数 = `recallLimit * candidateMultiplier` | 1-20 | 4 |
-| `scoreThreshold` | 客户端后处理分数阈值 | 0-1 | 静态 `recallScoreThreshold` |
-| `maxInjectedChars` | 自动召回注入字符预算 | 100-50000 | 静态 `recallMaxInjectedChars` |
-| `recallPreferAbstract` | 是否优先使用 abstract 注入 | boolean | 静态 `recallPreferAbstract` |
+| `recallLimit` | auto-recall 与 `memory_recall` 的结果目标；显式值使用标准 coding quota 映射 | 1-50 | 未显式设置时省略 quotas，由服务端默认（当前 10） |
+| `candidateLimit` | 仅影响显式 `memory_recall.targetUri` 兼容路径 | 1-200 | 派生值 |
+| `candidateMultiplier` | 仅用于派生该兼容路径的候选数 | 1-20 | 4 |
+| `scoreThreshold` | 发送给服务端 context search 的分数阈值 | 0-1 | 静态 `recallScoreThreshold` |
+| `maxInjectedChars` | 两种 recall 均换算为服务端 `max_tokens` | 100-50000 | 静态 `recallMaxInjectedChars` |
+| `recallPreferAbstract` | true 时请求 abstract，false 时使用服务端默认 detail | boolean | 静态 `recallPreferAbstract` |
 | `resourceTypes` | 默认搜索范围 | `resource` / `user` / `agent` | 静态 `recallTargetTypes` |
-| `targetUri` | 强制搜索单一 URI | 必须以 `viking://` 开头 | 无 |
+| `targetUri` | `ov_search` / `memory_forget` 的单一 URI 范围；作为显式工具参数时也启用 `memory_recall` 兼容路径 | 必须以 `viking://` 开头 | 无 |
 | `ovSearchLimit` | `ov_search` 默认返回数 | 1-100 | 10 |
 | `rankingWeights.baseScore` | 语义分权重 | 0-2 | 1 |
 | `rankingWeights.leaf` | 叶子节点加权 | 0-2 | 0.12 |
@@ -331,9 +331,9 @@ curl --get 'http://127.0.0.1:<gateway-port>/api/openviking/recall-traces/latest-
 |---|---|
 | 单元测试 | 参数归一化、clamp、分层合并、字段来源、持久化、热加载、unset/reset、session alias 匹配 |
 | 命令测试 | `/ov-query-config` set/get/unset/reset、权重参数、空 patch 拒绝 |
-| 工具链路测试 | session 配置影响后续 `memory_recall`、`ov_search` 默认 limit/targetUri |
+| 工具链路测试 | session 配置影响后续 `memory_recall` coding quotas 与 `ov_search` 的 limit/targetUri |
 | 自动召回场景测试 | context engine assemble 阶段使用 session 有效配置 |
-| 排序测试 | rankingWeights、categoryWeights、resourceTypeWeights 对入选排序生效 |
+| 排序测试 | 旧 rankingWeights、categoryWeights、resourceTypeWeights 配置仍可归一化，并用于显式 `memory_recall.targetUri` 兼容路径 |
 | Gateway API 测试 | URI detail route、latest ov_search list route、skill 过滤、detailUrl 生成 |
 | 安装脚本契约测试 | standalone package contract、resource-only recall 配置、JSON 传参、env 单引号转义 |
 | 类型检查 | `tsc -p tsconfig.json` |
@@ -384,7 +384,7 @@ production-style runtime config stability check passed: in-flight load serializa
 ### 7.1 已关闭风险
 
 - 动态配置优先级已通过单测与场景测试验证。
-- `candidateLimit` 显式配置优先级已修复并回归。
+- `candidateLimit` 显式配置优先级仍保留兼容；context-based recall 已不再消费该字段。
 - 权重参数 CLI 设置已补齐。
 - 空 patch 不再覆盖已有配置。
 - 持久化写入采用临时文件 + rename，写队列失败后可恢复。

--- a/examples/openclaw-plugin/docs/openviking-openclaw-plugin-guide.md
+++ b/examples/openclaw-plugin/docs/openviking-openclaw-plugin-guide.md
@@ -48,7 +48,7 @@
 | `client.ts` | OpenViking HTTP Client；统一添加认证/租户/agent header；封装 session、search、resource、skill、tool-result API |
 | `config.ts` | 插件配置 schema、默认值、环境变量解析、peer identity routing 配置 |
 | `auto-recall.ts` | 自动召回查询清洗、召回超时控制、记忆块构建与注入 |
-| `memory-ranking.ts` | 显式 `memory_recall` 的结果去重、阈值过滤和本地重排；自动召回由服务端组装 |
+| `memory-ranking.ts` | `memory_forget` 候选处理及共用日志/分数工具；auto-recall 与 `memory_recall` 均由服务端组装 |
 | `text-utils.ts` | 会话文本清洗、metadata/心跳/命令过滤、增量 turn 消息提取、bypass session pattern |
 | `commands/setup.ts` | setup/status CLI，配置写入、health check、root/user key 探测、slot 激活 |
 | `session-transcript-repair.ts` | 修复 toolCall/toolResult 配对、去重、孤儿 tool result 等 transcript 结构问题 |
@@ -157,10 +157,10 @@ transformContext auto recall 流程：
 | 配置 | 默认值 | 说明 |
 | --- | --- | --- |
 | `autoRecall` | `true` | 是否启用自动召回 |
-| `recallLimit` | `6` | 最终注入记忆条数上限 |
-| `recallScoreThreshold` | `0.15` | 候选过滤阈值 |
-| `recallMaxInjectedChars` | `4000` | 注入总字符上限；单条记忆不截断，不完整则跳过 |
-| `recallPreferAbstract` | `false` | 是否优先使用 abstract，而非读取 leaf 记忆全文 |
+| `recallLimit` | 未配置（服务端当前默认 `10`） | auto-recall 与 `memory_recall` 的可选结果目标；显式值使用标准 coding quota 映射 |
+| `recallScoreThreshold` | `0.15` | 发送给服务端 context search 的候选过滤阈值 |
+| `recallMaxInjectedChars` | `4000` | 按 4 字符/token 换算为服务端 `max_tokens` |
+| `recallPreferAbstract` | `false` | true 时请求 abstract；false 时由服务端选择默认 detail |
 | `recallTargetTypes` | `["user","agent"]` | 自动召回和默认显式召回目标类型；可选 `resource`、`user`、`agent` |
 | `recallResources` | `false` | 旧兼容开关；仅在未显式配置 `recallTargetTypes` 时把 `resource` 追加到默认 `user` + `agent` |
 
@@ -260,8 +260,8 @@ transformContext auto recall 流程：
 
 | API | 官方用途 | 当前插件映射 | 关键参数 / 返回 |
 | --- | --- | --- | --- |
-| `POST /api/v1/search/find` | 快速语义检索，不依赖 session context | 自动召回、`memory_recall`、`ov_search`、`memory_forget` | body: `query`、`target_uri`、`limit`、`score_threshold`；返回 `memories[]`、`resources[]`、`skills[]`，每项含 `uri`、`level`、`abstract`、`score`、`category`：`client.ts:428` |
-| `POST /api/v1/search/search` | 带 session context 和 intent analysis 的检索 | 暂未使用 | body 可带 `session_id`；返回 `query_plan` / `query_results`。当前插件为了稳定和低延迟统一用 `find()`，session context 由插件自己组装 |
+| `POST /api/v1/search/find` | 快速语义检索，不依赖 session context | `ov_search`、`memory_forget` | body: `query`、`target_uri`、`limit`、`score_threshold`；返回 `memories[]`、`resources[]`、`skills[]`，每项含 `uri`、`level`、`abstract`、`score`、`category`：`client.ts:428` |
+| `POST /api/v1/search/search` | 带 session context、intent analysis 和 token budget 的检索 | 自动召回、`memory_recall` | 使用 `mode="context"`、`purpose="coding"`，可带 `session_id`、`quotas`、`max_tokens`；返回 `entries`、`digest`、`rendered`。未显式配置 recall limit 时不发送 `quotas`，使用服务端默认；显式值沿用标准 coding quota 映射 |
 | `POST /api/v1/search/grep` | 正则/关键词内容搜索 | `ov_archive_search` | body: `uri`、`pattern`、`case_insensitive`、`node_limit`；插件限定在 `viking://session/{id}/history` 内搜 archive：`client.ts:897` |
 | `POST /api/v1/search/glob` | glob 文件匹配 | 暂未封装 | body: `pattern`、`uri`、`node_limit`；适合按 `**/*.md`、`src/**/*.ts` 找资源路径 |
 
@@ -277,7 +277,7 @@ transformContext auto recall 流程：
 | `DELETE /api/v1/fs?uri=...&recursive=...` | 删除资源/目录 | `memory_forget`、`deleteUri` | 插件默认 `recursive=false`，用于删除具体 memory URI：`client.ts:934` |
 | `GET /api/v1/content/abstract?uri=...` | 读取 L0 abstract | 暂未封装 | 约 100 token 摘要，适合快速判断目录/文件主题 |
 | `GET /api/v1/content/overview?uri=...` | 读取 L1 overview | 暂未封装 | 目录级结构化概览，适合介于 abstract 和 full content 之间的排查 |
-| `GET /api/v1/content/read?uri=...&offset=...&limit=...` | 读取 L2 full content | 显式 `memory_recall`、`ov_read` | 自动召回的分层读取已由服务端 context search 完成；`ov_read` 暴露 `uri` 参数，未暴露 `offset/limit`。 |
+| `GET /api/v1/content/read?uri=...&offset=...&limit=...` | 读取 L2 full content | `ov_read` | 两种 recall 的分层读取均由服务端 context search 完成；`ov_read` 暴露 `uri` 参数，未暴露 `offset/limit`。 |
 
 #### 6.2.4 Resources / Skills Import
 
@@ -391,7 +391,7 @@ bash install.sh --source tos --channel prod --version 2026.6.2
 | --- | --- |
 | Node.js | >= 22 |
 | OpenClaw | >= 2026.5.27 |
-| OpenViking Server | >= 0.4.1 |
+| OpenViking Server | >= 0.4.13 |
 
 兼容性声明在 `install-manifest.json` 的 `compatibility` 字段。
 
@@ -716,7 +716,7 @@ openclaw config get plugins.slots.contextEngine
 | `accountId` | 空 | Root key/trusted 部署需要 |
 | `userId` | 空 | Root key/trusted 部署需要 |
 | `peer_prefix` | 空 | Peer 路由前缀；非空时形成 `<prefix>_<ctx.agentId>` |
-| `targetUri` | `viking://user/memories` | 默认 memory search 目标 |
+| `targetUri` | `viking://user/memories` | `ov_search` / `memory_forget` 默认精确搜索目标；`memory_recall` 默认不使用，显式工具参数可启用兼容路径 |
 | `timeoutMs` | `15000` | HTTP 请求超时 |
 | `autoCapture` | `true` | 是否每轮后写入 OpenViking session |
 | `captureMode` | `semantic` | `semantic` 全量候选；`keyword` 先过触发词 |
@@ -725,9 +725,9 @@ openclaw config get plugins.slots.contextEngine
 | `autoRecallTimeoutMs` | `15000` | 服务端组装自动召回的总超时；为 session query expansion 和检索留出预算 |
 | `recallTargetTypes` | `["user","agent"]` | 自动召回和默认显式召回目标类型；可选 `resource`、`user`、`agent` |
 | `recallResources` | `false` | 旧兼容开关；仅在未显式配置 `recallTargetTypes` 时追加 `resource` |
-| `recallLimit` | `6` | 召回条数 |
-| `recallScoreThreshold` | `0.15` | 召回阈值 |
-| `recallMaxInjectedChars` | `4000` | 注入字符预算 |
+| `recallLimit` | 未配置（服务端当前默认 `10`） | auto-recall 与 `memory_recall` 的可选结果目标；显式值使用标准 coding quota 映射 |
+| `recallScoreThreshold` | `0.15` | 两种 recall 均发送给服务端的召回阈值 |
+| `recallMaxInjectedChars` | `4000` | 两种 recall 均换算为服务端 `max_tokens` 的注入预算 |
 | `commitTokenThresholdRatio` | `0.5` | `pending_tokens` 达到「模型上下文窗口 × 该比例」触发 afterTurn commit（0-1，例 0.5=50%）；设 0 可每轮 commit |
 | `commitKeepRecentCount` | `10` | afterTurn commit 后保留最近消息数；compact 固定 0 |
 | `bypassSessionPatterns` | `[]` | 匹配 sessionKey/sessionId 时完全绕过 OpenViking |
@@ -764,16 +764,16 @@ openclaw config get plugins.slots.contextEngine
 | `userId` | 多租户搜索路由 | 空 | 是 | 是 | `OPENVIKING_USER_ID` | Root key / trusted 部署下显式指定 user，影响 user memory 检索范围：`config.ts:216` |
 | `peer_role` | session peer 归因和 actor-peer 路由 | `assistant` | 是 | 安装脚本/setup 参数支持 | `OPENVIKING_PEER_ROLE`（安装脚本写入 setup 参数） | `none` 关闭 peer 路由；`assistant` 使用 runtime agent；`person` 使用 sender 身份 |
 | `peer_prefix` | assistant peer 前缀 | 空 | 是 | 间接支持 | 可通过配置值写 `${ENV}` | 非空时拼成 `<prefix>_<ctx.agentId>`，用于 assistant `peer_id` 与 `X-OpenViking-Actor-Peer` |
-| `targetUri` | `memory_recall` / `memory_forget` 默认搜索范围 | `viking://user/memories` | 是 | 否 | — | 未显式传 `targetUri` 时的默认 memory 搜索位置：`config.ts:275`、`index.ts:1366` |
+| `targetUri` | `ov_search` / `memory_forget` 默认精确搜索范围 | `viking://user/memories` | 是 | 否 | — | `memory_recall` 默认走 context search；显式工具参数 `targetUri` 保留原来的精确 `/find` + read 路径。 |
 | `timeoutMs` | 所有搜索/读取请求超时 | `15000` | 是 | 否 | — | 控制 context search、`find/read/grep/session` 等 HTTP 请求超时：`config.ts:276` |
 | `autoRecall` | 自动召回总开关 | `true` | 是 | 否 | — | 关闭后插件不再在 `assemble()` 阶段自动发起 recall：`config.ts:283`、`context-engine.ts:1132` |
 | `autoRecallTimeoutMs` | 自动召回总超时 | `15000` | 是 | 否 | — | 覆盖单次服务端 context search；默认值为最长 5 秒的 session query expansion 及后续检索保留余量。显式配置的值仍会按 `1000..300000` ms 限制。 |
 | `recallTargetTypes` | 自动召回 + 默认 `memory_recall` 资源类型集合 | `["user","agent"]` | 是 | 安装脚本/setup 参数支持 | `OPENVIKING_RECALL_TARGET_TYPES`（安装脚本写入 setup 参数） | 当前默认只查 `user` + `agent` 记忆。设置为 `["resource"]` 才会切成 resource-only；可组合 `resource,user,agent`：`config.ts:174`、`config.ts:360` |
 | `recallResources` | 自动召回 + 默认 `memory_recall` resources 兼容开关 | `false` | 是 | 是 | `OPENVIKING_RECALL_RESOURCES` | 旧兼容字段；只有未显式配置 `recallTargetTypes` 时才把 `resource` 追加到默认 `user` + `agent`，不会覆盖显式 resource-only：`config.ts:360` |
-| `recallLimit` | 自动召回 / `memory_recall` 返回条数 | `6` | 是 | 否 | — | 自动召回按共享 context-search 契约映射为 coding quotas；显式 `memory_recall` 仍按该值做最终选择。 |
-| `recallScoreThreshold` | 自动召回 / `memory_recall` 过滤阈值 | `0.15` | 是 | 否 | — | 自动召回交给服务端过滤；显式 `memory_recall` 保留本地后处理。 |
-| `recallMaxInjectedChars` | 自动召回 / `memory_recall` 注入预算 | `4000` | 是 | 否 | — | 自动召回按 4 字符/token 换算为服务端 `max_tokens`；显式 `memory_recall` 仍使用字符预算。 |
-| `recallPreferAbstract` | 自动召回读取策略 | `false` | 是 | 否 | — | 为 `true` 时把服务端 detail 固定为 `abstract`；否则由服务端按类别选择默认层级。 |
+| `recallLimit` | 自动召回 / `memory_recall` 结果目标 | 未配置（服务端当前默认 `10`） | 是 | 否 | — | 未配置时省略 `quotas` 并使用服务端默认；显式值沿用其他 memory-plugin harness 的 coding quota 映射。 |
+| `recallScoreThreshold` | 自动召回 / `memory_recall` 过滤阈值 | `0.15` | 是 | 否 | — | 两种路径均交给服务端 context search 过滤。 |
+| `recallMaxInjectedChars` | 自动召回 / `memory_recall` 注入预算 | `4000` | 是 | 否 | — | 两种路径均按 4 字符/token 换算为服务端 `max_tokens`。 |
+| `recallPreferAbstract` | 自动召回 / `memory_recall` 读取策略 | `false` | 是 | 否 | — | 为 `true` 时固定 `detail="abstract"`；否则不指定 detail，由服务端选择默认层级。 |
 | `recallTokenBudget` | 自动召回预算旧别名 | 跟随 `recallMaxInjectedChars` | 是 | 否 | — | 已废弃，仅兼容旧配置；解析时会折叠为 `recallMaxInjectedChars`：`config.ts:257`、`config.ts:299` |
 | `recallMaxContentChars` | 旧版单条截断兼容项 | `5000` | 是 | 否 | — | 已废弃；当前自动召回不再裁剪单条 memory 内容：`config.ts:290` |
 | `captureMode` | 间接影响可搜索记忆的入库方式 | `semantic` | 是 | 否 | — | 虽然不是“搜索参数”，但它决定哪些用户内容会先被写入 session 并进入后续可检索空间：`config.ts:203`、`config.ts:278` |
@@ -887,10 +887,11 @@ export OPENVIKING_RECALL_RESOURCES=1
 
 搜索相关配置的实际生效顺序可以概括为：
 
-1. **显式工具参数优先**：例如 `memory_recall(limit=3, scoreThreshold=0.4, targetUri=...)`、`/ov-search --limit 20 --uri ...` 会优先覆盖默认配置：`index.ts:1046`、`index.ts:1050`、`index.ts:1054`、`index.ts:824`、`index.ts:408`
-2. **插件配置文件其次**：`plugins.entries.openviking.config.*`
-3. **环境变量补默认值**：只对少数支持 env 的项生效，如 `OPENVIKING_BASE_URL`、`OPENVIKING_API_KEY`、`OPENVIKING_RECALL_RESOURCES`：`config.ts:139`、`config.ts:202`、`config.ts:284`
-4. **代码默认值兜底**：例如 `recallLimit=6`、`recallScoreThreshold=0.15`、`recallMaxInjectedChars=4000`：`config.ts:63`、`config.ts:64`、`config.ts:67`
+1. **显式工具参数优先**：例如 `memory_recall(limit=3, scoreThreshold=0.4)`、`/ov-search --limit 20 --uri ...`。
+2. **session 运行期配置**：`/ov-query-config set --scope session ...`。
+3. **peer/claw 运行期配置**：`--scope peer`（`claw` 是兼容别名）。
+4. **显式插件静态配置**：`plugins.entries.openviking.config.*`。对 `recallLimit`，只有用户显式配置才会发送。
+5. **服务端默认值兜底**：若以上均未设置 recall limit，请求省略 `quotas`，由 OpenViking 服务端决定（当前默认 `10`）；显式值使用标准 coding quota 映射。
 
 ### 9.5 搜索相关配置的排查建议
 
@@ -900,8 +901,8 @@ export OPENVIKING_RECALL_RESOURCES=1
 | `memory_recall` 默认搜不到 resources | `recallResources` | 默认是 `false`，不会自动查 `viking://resources` |
 | 同样的 query 在不同 agent / user 命中不一致 | `accountId`、`userId`、`peer_role`、`peer_prefix` | actor peer 或租户身份不一致 |
 | `/ov-search` 查不到刚导入的内容 | `baseUrl`、`apiKey`、服务端队列状态 | 导入后语义/向量处理还没完成，或连到了错误服务 |
-| 明明命中结果很多，但注入数量少 | `recallLimit`、`recallMaxInjectedChars`、`recallPreferAbstract` | limit 太小或预算太紧，必要时改成 abstract 优先 |
-| 不知道插件自动召回使用了哪些范围 | `logFindRequests` | 开启后查看插件日志中的 context search routing；显式检索仍记录 `find POST` |
+| 明明命中结果很多，但注入数量少 | 服务端 quota、`recallMaxInjectedChars`、`recallPreferAbstract` | 条数或 token 预算太紧；必要时显式配置 `recallLimit` 或改成 abstract 优先。 |
+| 不知道插件召回使用了哪些范围 | `logFindRequests` | 开启后查看 context search routing；`ov_search` / `memory_forget` 仍记录 `find POST`。 |
 
 ---
 
@@ -1096,7 +1097,7 @@ OPENVIKING_DEBUG=1 openclaw gateway restart
 | 日志/字段 | 含义 | 关键路径 |
 | --- | --- | --- |
 | `openviking: context search POST .../api/v1/search/search {...}` | 自动召回向 OpenViking 发起服务端组装检索 | `purpose` / `quotas` / `session_id` / `context_type` / `query_expansion` / `max_tokens` / `peer_scope` / actor 与租户路由 |
-| `openviking: find POST .../api/v1/search/find {...}` | 显式 recall/search 工具发起底层语义检索 | `target_uri` / `target_uri_input` / `query` / `X_OpenViking_Agent` |
+| `openviking: find POST .../api/v1/search/find {...}` | `ov_search` / `memory_forget` 发起精确范围语义检索 | `target_uri` / `target_uri_input` / `query` / `X_OpenViking_Agent` |
 | `openviking: injecting N memories ...` | 插件决定向本轮 prompt 注入 N 条召回内容 | `N`、注入字符数、估算 token |
 | `openviking: inject-detail {...}` | 本轮实际注入模型的服务端组装条目摘要 | `entries[].uri`、`category`、`score`、`detail` |
 | `openviking: diag {"stage":"assemble_result"...}` | assemble 阶段是否发生自动召回 | `phase=transform_context`、`autoRecallMemoryCount` |
@@ -1202,9 +1203,9 @@ curl -sS "$OPENVIKING_BASE_URL/api/v1/content/read?uri=$(python3 -c 'import urll
 | --- | --- | --- | --- |
 | 健康检查 | `GET /health` | `openclaw openviking status` | 判断服务是否可达 |
 | 身份/用户探测 | `GET /api/v1/system/status` | `client.getRuntimeIdentity` | 解析服务端当前 user，辅助 canonical URI 展开 |
-| 服务端上下文组装 | `POST /api/v1/search/search` + `mode="context"` | auto recall | 结合 session 历史返回 `entries`、`rendered` 和预算/去重统计 |
-| 语义检索 | `POST /api/v1/search/find` | `memory_recall` / `ov_search` | 返回 `memories[]`、`resources[]`、`skills[]`，每项含 `uri`、`score`、`abstract`、`level` |
-| 内容读取 | `GET /api/v1/content/read?uri=...` | `memory_recall` / `ov_read` / 手工排查 | 根据命中的 `viking://...` URI 读取完整内容 |
+| 服务端上下文组装 | `POST /api/v1/search/search` + `mode="context"` | auto recall / `memory_recall` | 结合 session 历史返回 `entries`、`digest`、`rendered` 和预算/去重统计 |
+| 精确范围语义检索 | `POST /api/v1/search/find` | `ov_search` / `memory_forget` | 返回 `memories[]`、`resources[]`、`skills[]`，每项含 `uri`、`score`、`abstract`、`level` |
+| 内容读取 | `GET /api/v1/content/read?uri=...` | `ov_read` / 手工排查 | 根据命中的 `viking://...` URI 读取完整内容 |
 | 写入 session 消息 | `POST /api/v1/sessions/{sessionId}/messages` | `afterTurn` | 保存 OpenClaw 本轮 user/assistant/tool 片段 |
 | 获取 session 元信息 | `GET /api/v1/sessions/{sessionId}` | `afterTurn` | 查看 `pending_tokens`、message count、commit count |
 | 获取组装上下文 | `GET /api/v1/sessions/{sessionId}/context?token_budget=...` | 主 assemble / compact | 获取 archive summary + active messages |
@@ -1325,7 +1326,7 @@ python health_check_tools/ov-healthcheck.py
 6. **peer 配置要一致**：确认 `peer_role` / `peer_prefix` 与期望的 OpenClaw 会话身份一致，否则写入和召回会落在不同 actor peer 视角。
 7. **afterTurn commit 是异步抽取**：立即返回不代表长期记忆已可检索；看 task 或服务端日志。
 8. **compact 是同步边界**：需要明确压缩和抽取完成时用 compact，但它会阻塞等待服务端 Phase 2。
-9. **记忆注入有预算**：`recallMaxInjectedChars` 会跳过放不下的完整记忆，而不是截断。
+9. **记忆注入有预算**：`recallMaxInjectedChars` 按 4 字符/token 转成服务端 `max_tokens`，由服务端选择 detail 和最终注入内容。
 10. **bypassSessionPatterns 会完全绕过 OpenViking**：匹配后自动捕获、召回、工具都会跳过。
 11. **tool result 工具限制当前 session**：插件拒绝读取其他 session 的外置结果。
 12. **本地资源导入先上传**：本地文件/目录通过 temp upload，不把本地路径直接交给服务端；目录会 zip，注意权限与体积。

--- a/examples/openclaw-plugin/docs/openviking-plugin-reference.md
+++ b/examples/openclaw-plugin/docs/openviking-plugin-reference.md
@@ -95,13 +95,13 @@ $OPENCLAW_STATE_DIR/openclaw.json
 | --- | --- | --- | --- | --- |
 | `autoRecall` | boolean | `true` | — | 是否在 assemble 阶段自动召回并注入上下文。 |
 | `autoRecallTimeoutMs` | number | `15000` | — | 服务端组装 context search 的总超时，范围 `1000` 到 `300000` ms。 |
-| `targetUri` | string | `viking://user/memories` | — | `memory_recall` / `memory_forget` 默认搜索范围。 |
+| `targetUri` | string | `viking://user/memories` | — | `ov_search` / `memory_forget` 的默认精确搜索范围；`memory_recall` 默认使用 context search，只有显式工具参数 `targetUri` 才走兼容的精确检索。 |
 | `recallTargetTypes` | string[] | `["user", "agent"]` | — | 自动召回和默认 `memory_recall` 的搜索类型。允许 `resource`、`user`、`agent`。 |
 | `recallResources` | boolean | `false` | `OPENVIKING_RECALL_RESOURCES` | 旧兼容开关；仅在未显式配置 `recallTargetTypes` 时追加 `resource`。 |
-| `recallLimit` | number | `6` | — | 自动召回按共享 context-search 契约映射为 coding quotas；显式 `memory_recall` 保留本地候选扩展。 |
-| `recallScoreThreshold` | number | `0.15` | — | 自动召回交给服务端过滤；显式 `memory_recall` 保留本地后处理。范围 `0` 到 `1`。 |
-| `recallMaxInjectedChars` | number | `4000` | — | 自动召回按 4 字符/token 换算为服务端 `max_tokens`；显式召回仍使用字符预算。范围 `100` 到 `50000`。 |
-| `recallPreferAbstract` | boolean | `false` | — | 自动召回为 true 时请求服务端 abstract detail；否则由服务端按类别选择层级。 |
+| `recallLimit` | number | 未配置（服务端当前默认 `10`） | — | auto-recall 与 `memory_recall` 的可选结果目标。未配置时省略 `quotas` 并使用服务端默认；显式值沿用标准 coding quota 映射。 |
+| `recallScoreThreshold` | number | `0.15` | — | auto-recall 与 `memory_recall` 都交给服务端过滤。范围 `0` 到 `1`。 |
+| `recallMaxInjectedChars` | number | `4000` | — | auto-recall 与 `memory_recall` 均按 4 字符/token 换算为服务端 `max_tokens`。范围 `100` 到 `50000`。 |
+| `recallPreferAbstract` | boolean | `false` | — | 为 true 时请求服务端 abstract detail；否则不指定 detail，由服务端按类别选择默认层级。 |
 | `recallMaxContentChars` | number | `5000` | — | 已废弃兼容项。 |
 | `recallTokenBudget` | number | 跟随 `recallMaxInjectedChars` | — | 已废弃别名；未配置 `recallMaxInjectedChars` 时可作为 fallback。 |
 
@@ -435,7 +435,7 @@ Manifest 中声明了 runtime slash alias：
 | `ov_read` | `uri` | 读取精确 `viking://...` OpenViking URI 的完整内容。 |
 | `ov_multi_read` | `uris` | 一次读取多个精确 `viking://...` URI，适合 overview + 同级切片。 |
 | `ov_list` | `uri`、`recursive?`、`simple?`、`limit?` | 列出 OpenViking 目录，用于补齐同级切片和 `.overview.md`。 |
-| `memory_recall` | `query`、`limit?`、`scoreThreshold?`、`targetUri?`、`resourceTypes?` | 显式召回长期记忆或资源；session 历史请用 archive 工具。 |
+| `memory_recall` | `query`、`limit?`、`scoreThreshold?`、`targetUri?`、`resourceTypes?` | 默认通过 session-aware context/coding search 召回；显式 `targetUri` 保留原来的精确 `/find` + read 路径。session 历史请用 archive 工具。 |
 | `ov_recall_trace` | `turn?`、`traceId?`、`sessionId?`、`sessionKey?`、`ovSessionId?`、`source?`、`resourceTypes?`、`since?`、`until?`、`includeContent?`、`limit?` | 查询 recall trace。 |
 | `memory_store` | `text`、`role?`、`sessionId?` | 将文本写入 session 并触发记忆抽取。 |
 | `memory_forget` | `uri?`、`query?`、`targetUri?`、`limit?`、`scoreThreshold?` | 删除记忆 URI，或先搜索后删除唯一高置信候选。 |

--- a/examples/openclaw-plugin/docs/openviking-recall-trace-api.md
+++ b/examples/openclaw-plugin/docs/openviking-recall-trace-api.md
@@ -139,8 +139,8 @@ Trace 会记录实际召回范围，但召回范围本身由 `recallTargetTypes`
 | `resourceType` | `resource` \| `user` \| `agent` \| `archive` | 当前子搜索类型。 |
 | `targetUriInput` | string? | 输入或计划中的目标 URI。 |
 | `targetUriResolved` | string? | 解析后的目标 URI。 |
-| `limit` | number | 请求 limit。自动召回直接使用 `recallLimit`；显式 `memory_recall` 可先扩大候选数。 |
-| `scoreThreshold` | number? | 分数阈值。自动召回由服务端应用；显式 `memory_recall` 仍可在本地后处理。 |
+| `limit` | number | 插件侧诊断值。未显式设置 `recallLimit` 时，两条 recall 路径都省略 quotas 并使用服务端默认；显式值采用标准 coding quota 映射。 |
+| `scoreThreshold` | number? | 发送给服务端 context search 的分数阈值。 |
 | `durationMs` | number | 子搜索耗时，毫秒。 |
 | `total` | number | OpenViking 返回或插件统计的候选总数。 |
 | `results` | array | 候选结果摘要，最多 `traceRecallMaxResultsPerSearch` 条。 |
@@ -539,7 +539,7 @@ curl 'http://127.0.0.1:<gateway-port>/api/openviking/recall-traces/ov_search-178
 /ov-recall-trace --turn all --source memory_recall --limit 5
 ```
 
-重点查看 `resourceTypes` 和 `searches[].targetUriResolved`，确认是否默认查了 `viking://user/memories` 与 `agent recall target`，或是否按请求 `resourceTypes` 改变范围。
+重点查看 `resourceTypes` 和 context search trace，确认服务端是否按请求类型检索 `user`、`agent`、`resource`。显式传入 `targetUri` 时，`memory_recall` 会保留原来的精确 `/find` + read 路径，并在 trace 中记录该 URI。
 
 ### 9.3 排查 `/ov-search` 或 `ov_search` 为什么结果不符合预期
 

--- a/examples/openclaw-plugin/docs/openviking-runtime-query-config.md
+++ b/examples/openclaw-plugin/docs/openviking-runtime-query-config.md
@@ -12,11 +12,11 @@ Effective query config is resolved per request with this priority:
 explicit tool request arguments
   > session runtime config
   > peer runtime config
-  > static plugin config
-  > code defaults
+  > explicitly configured static plugin value
+  > plugin field default
 ```
 
-The higher layer wins field by field. Object fields such as ranking weights are shallow-merged. Array fields such as `resourceTypes` replace the lower layer.
+The higher layer wins field by field. Object fields such as ranking weights are shallow-merged. Array fields such as `resourceTypes` replace the lower layer. `recallLimit` is the exception at the bottom: when no layer sets it explicitly, the plugin omits quotas and uses the OpenViking server default.
 
 ## Scopes
 
@@ -33,20 +33,20 @@ For command compatibility, `--scope claw` is accepted as an alias for `peer`.
 
 | Field | Purpose |
 | --- | --- |
-| `recallLimit` | Number of final recall results to inject or display. |
-| `candidateLimit` | Number of candidates requested before local ranking/filtering by explicit `memory_recall`. |
-| `candidateMultiplier` | Multiplier used to derive the explicit `memory_recall` candidate count when `candidateLimit` is not explicit. |
-| `scoreThreshold` | Minimum score; auto-recall sends it to context search, while explicit `memory_recall` also applies local post-processing. |
-| `maxInjectedChars` | Injection budget; auto-recall converts it to server `max_tokens` at four characters per token. |
-| `recallPreferAbstract` | Pin server-assembled auto-recall to abstract detail; explicit `memory_recall` prefers abstracts locally. |
+| `recallLimit` | Optional result target for auto-recall and `memory_recall`; explicit values use the standard coding quota mapping. |
+| `candidateLimit` | Legacy candidate width used only by an explicit `memory_recall.targetUri` compatibility request. |
+| `candidateMultiplier` | Legacy multiplier used only to derive that targeted compatibility candidate width. |
+| `scoreThreshold` | Minimum score sent to server context search for auto-recall and `memory_recall`. |
+| `maxInjectedChars` | Injection budget converted to server `max_tokens` at four characters per token for both recall paths. |
+| `recallPreferAbstract` | When true, pin server-assembled recall to abstract detail; false leaves the server detail default unchanged. |
 | `resourceTypes` | Default semantic recall target types: `user`, `agent`, `resource`. |
-| `targetUri` | Force a single `viking://` target URI for search. |
+| `targetUri` | Exact `viking://` scope for `ov_search` and `memory_forget`. An explicit `memory_recall.targetUri` also selects the legacy targeted recall path. |
 | `ovSearchLimit` | Default result count for `ov_search`. |
-| `rankingWeights` | Local ranking weights for explicit `memory_recall`, such as base score and lexical overlap. |
-| `categoryWeights` | Optional category-specific adjustments for explicit `memory_recall`. |
-| `resourceTypeWeights` | Optional resource-type adjustments for explicit `memory_recall`. |
+| `rankingWeights` | Legacy ranking weights used only by an explicit `memory_recall.targetUri` request. |
+| `categoryWeights` | Legacy category weights used only by an explicit `memory_recall.targetUri` request. |
+| `resourceTypeWeights` | Legacy resource-type weights used only by an explicit `memory_recall.targetUri` request. |
 
-Automatic recall uses one session-aware context search and consumes `recallLimit`, `scoreThreshold`, `maxInjectedChars`, `recallPreferAbstract`, and `resourceTypes`. Candidate expansion and local ranking-weight fields remain available to explicit `memory_recall`, but no longer alter automatic recall assembly.
+Automatic recall and the default `memory_recall` path both use one session-aware context/coding search. When no tool, runtime, or static `recallLimit` is set, the request omits quotas and uses the server default. Explicit values follow the same coding quota mapping as the other memory-plugin harnesses. `memory_recall` returns the server's token-budgeted `digest` or `rendered` context directly. The explicit `targetUri` compatibility path keeps the previous targeted `/find`, local ranking, and read behavior.
 
 Session history is not a semantic recall target. Use `ov_archive_search` and `ov_archive_expand` for session archive recovery.
 

--- a/examples/openclaw-plugin/docs/openviking-websocket-rpc-api.md
+++ b/examples/openclaw-plugin/docs/openviking-websocket-rpc-api.md
@@ -160,10 +160,10 @@ Recall semantic memories and resources. Current semantic recall target types are
 | 字段 | 类型 | 必填 | 说明 |
 |------|------|------|------|
 | `query` | string | 是 | 召回查询文本 |
-| `limit` | number | 否 | 最终返回条数，默认使用插件配置 |
-| `scoreThreshold` | number | 否 | 最低分数，范围 0-1 |
-| `targetUri` | string | 否 | 指定单一搜索范围，例如 `viking://user/memories` |
-| `resourceTypes` | string[] | 否 | 未指定 `targetUri` 时使用，当前支持 `resource`、`user`、`agent`；session 历史走 `ov_archive_search` / `ov_archive_expand` |
+| `limit` | number | 否 | 召回结果目标；工具参数优先，其次是显式配置的 `recallLimit`。显式值使用标准 coding quota 映射，均未设置时使用服务端默认值 |
+| `scoreThreshold` | number | 否 | 发送给服务端 context search 的最低分数，范围 0-1 |
+| `targetUri` | string | 否 | 精确 `viking://` 范围；设置后使用兼容的 `/find` + read 路径 |
+| `resourceTypes` | string[] | 否 | 默认 context search 类型，支持 `resource`、`user`、`agent`；session 历史用 `ov_archive_search` / `ov_archive_expand` |
 
 ### `memory_store`
 

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -52,12 +52,12 @@ import {
   createMemoryOpenVikingContextEngine,
 } from "./context-engine.js";
 import {
+  buildMemoryLinesWithBudget,
+} from "./auto-recall.js";
+import {
   openClawSessionRefToOvStorageId,
   openClawSessionToOvStorageId,
 } from "./routing/identity-routing.js";
-import {
-  buildMemoryLinesWithBudget,
-} from "./auto-recall.js";
 import {
   normalizeRecallResourceTypes as normalizeResourceTypes,
   resolveRecallSearchPlan,

--- a/examples/openclaw-plugin/install-manifest.json
+++ b/examples/openclaw-plugin/install-manifest.json
@@ -57,7 +57,7 @@
   "compatibility": {
     "minOpenclawVersion": "2026.5.27",
     "recommendedOpenclawVersion": "2026.6.6",
-    "minOpenvikingVersion": "0.4.1",
-    "recommendedOpenvikingVersion": "0.4.1"
+    "minOpenvikingVersion": "0.4.13",
+    "recommendedOpenvikingVersion": "0.4.13"
   }
 }

--- a/examples/openclaw-plugin/openclaw.plugin.json
+++ b/examples/openclaw-plugin/openclaw.plugin.json
@@ -115,7 +115,7 @@
     "targetUri": {
       "label": "Search Target URI",
       "placeholder": "viking://~/memories",
-      "help": "Default OpenViking target URI for memory search"
+      "help": "Default exact search scope for ov_search and memory_forget. memory_recall uses an exact scope only when targetUri is passed as a tool argument."
     },
     "timeoutMs": {
       "label": "Request Timeout (ms)",
@@ -161,7 +161,8 @@
     },
     "recallLimit": {
       "label": "Recall Limit",
-      "placeholder": "6",
+      "placeholder": "10",
+      "help": "Optional recall result target for auto-recall and memory_recall. When unset, the request omits quotas and uses the OpenViking server default; explicit values use the standard coding quota mapping.",
       "advanced": true
     },
     "recallScoreThreshold": {
@@ -173,7 +174,7 @@
       "label": "Recall Max Injected Chars",
       "placeholder": "4000",
       "advanced": true,
-      "help": "Maximum total characters for auto-recall memory injection. Complete memories that do not fit are skipped, not truncated."
+      "help": "Character budget for auto-recall and memory_recall, converted to the server context token budget at four characters per token."
     },
     "recallMaxContentChars": {
       "label": "Deprecated Recall Max Content Chars",
@@ -184,7 +185,7 @@
     "recallPreferAbstract": {
       "label": "Recall Prefer Abstract",
       "advanced": true,
-      "help": "Use memory abstract instead of fetching full content when available"
+      "help": "Pin server-assembled auto-recall and memory_recall entries to abstract detail. When disabled, the server chooses each category's default detail tier."
     },
     "recallTokenBudget": {
       "label": "Deprecated Recall Token Budget",

--- a/examples/openclaw-plugin/plugin/openviking-memory-recall-tools.ts
+++ b/examples/openclaw-plugin/plugin/openviking-memory-recall-tools.ts
@@ -1,6 +1,6 @@
 import { Type } from "@sinclair/typebox";
 
-import type { FindResult, FindResultItem } from "../client.js";
+import type { FindResult, FindResultItem, SearchContextEntry, SearchContextResult } from "../client.js";
 import type { BuildMemoryLinesWithBudgetOptions } from "../auto-recall.js";
 import type { RankingOptions } from "../memory-ranking.js";
 import type { EffectiveQueryConfig, QueryConfigContext, RuntimeQueryParams } from "../query-config.js";
@@ -37,6 +37,20 @@ export type OpenVikingMemoryRecallClient = {
       actorPeerId?: string;
     },
   ) => Promise<FindResult>;
+  searchContext: (
+    query: string,
+    options: {
+      sessionId?: string;
+      limit?: number;
+      scoreThreshold?: number;
+      contextType?: string | string[];
+      queryExpansion?: "off" | "auto";
+      maxTokens?: number;
+      detail?: "abstract" | "overview" | "full";
+      peerScope?: "actor" | "all";
+      actorPeerId?: string;
+    },
+  ) => Promise<SearchContextResult>;
   read: (uri: string, agentId?: string) => Promise<string>;
   getDefaultAgentId: () => string;
 };
@@ -61,7 +75,7 @@ export type OpenVikingMemoryRecallToolsDeps = {
     ctx: { ovSessionId?: string; agentId?: string },
   ) => {
     resourceTypes: RecallResourceType[];
-    searches: Array<{ resourceType: RecallResourceType; targetUri?: string; contextType: "memory" | "resource" }>;
+    searches: Array<{ resourceType: RecallResourceType; contextType: "memory" | "resource" }>;
     skipped: Array<{ resourceType: RecallResourceType; reason: "missing_session" }>;
   };
   postProcessMemories: (
@@ -98,6 +112,21 @@ export type OpenVikingMemoryRecallToolsDeps = {
 };
 
 function toTraceResult(
+  item: SearchContextEntry,
+  deps: OpenVikingMemoryRecallToolsDeps,
+): RecallTraceResult {
+  const resourceType = deps.inferRecallResourceType(item.uri);
+  return {
+    uri: item.uri,
+    resourceType,
+    category: item.category,
+    score: item.score,
+    abstractPreview: deps.previewText(item.text, deps.cfg.traceRecallPreviewChars),
+    resultType: resourceType === "resource" ? "resource" : "memory",
+  };
+}
+
+function toLegacyTraceResult(
   item: FindResultItem,
   resultType: RecallTraceResult["resultType"],
   deps: OpenVikingMemoryRecallToolsDeps,
@@ -113,6 +142,8 @@ function toTraceResult(
   };
 }
 
+const CHARS_PER_TOKEN = 4;
+
 export function registerOpenVikingMemoryRecallTools(
   deps: OpenVikingMemoryRecallToolsDeps,
 ): void {
@@ -125,16 +156,16 @@ export function registerOpenVikingMemoryRecallTools(
       parameters: Type.Object({
         query: Type.String({ description: "Search query" }),
         limit: Type.Optional(
-          Type.Number({ description: "Max results (default: plugin config)" }),
+          Type.Number({ description: "Recall result target (tool/config value, otherwise server default)" }),
         ),
         scoreThreshold: Type.Optional(
           Type.Number({ description: "Minimum score (0-1, default: plugin config)" }),
         ),
         targetUri: Type.Optional(
-          Type.String({ description: "Search scope URI (default: plugin config)" }),
+          Type.String({ description: "Exact search scope URI; preserves the legacy targeted recall path" }),
         ),
         resourceTypes: Type.Optional(
-          Type.Array(Type.String({ description: "resource, user, or agent; used when targetUri is omitted" })),
+          Type.Array(Type.String({ description: "resource, user, or agent" })),
         ),
       }),
       async execute(_toolCallId: string, params: Record<string, unknown>) {
@@ -143,24 +174,31 @@ export function registerOpenVikingMemoryRecallTools(
         }
         const session = deps.resolvePluginSessionRouting(ctx);
         const { query } = params as { query: string };
+        const hasTargetUri = typeof (params as { targetUri?: unknown }).targetUri === "string";
         const queryConfig = await deps.queryConfigStore.getEffective(deps.toQueryConfigContext(session), {
           recallLimit: typeof (params as { limit?: number }).limit === "number" ? (params as { limit: number }).limit : undefined,
           scoreThreshold: typeof (params as { scoreThreshold?: number }).scoreThreshold === "number" ? (params as { scoreThreshold: number }).scoreThreshold : undefined,
-          targetUri: typeof (params as { targetUri?: string }).targetUri === "string" ? (params as { targetUri: string }).targetUri : undefined,
+          targetUri: hasTargetUri ? (params as { targetUri: string }).targetUri : undefined,
           resourceTypes: Object.prototype.hasOwnProperty.call(params, "resourceTypes")
             ? (params as { resourceTypes?: unknown }).resourceTypes as RuntimeQueryParams["resourceTypes"]
             : undefined,
         });
         const limit = queryConfig.recallLimit;
+        const limitSource = queryConfig.sources?.recallLimit ?? "static";
+        const limitConfigured = limitSource !== "default";
         const scoreThreshold = queryConfig.scoreThreshold;
-        const targetUri =
-          typeof (params as { targetUri?: string }).targetUri === "string"
-            ? (params as { targetUri: string }).targetUri
-            : queryConfig.targetUri;
         const requestedResourceTypes = Object.prototype.hasOwnProperty.call(params, "resourceTypes")
           ? (params as { resourceTypes?: unknown }).resourceTypes
           : queryConfig.resourceTypes;
-        const requestLimit = queryConfig.candidateLimit;
+        const searchPlan = deps.resolveRecallSearchPlan(requestedResourceTypes ?? deps.cfg.recallTargetTypes, {
+          ovSessionId: session.ovSessionId,
+          agentId: session.agentId,
+        });
+        const contextTypes = [...new Set(searchPlan.searches.map((search) => search.contextType))];
+        const maxTokens = Math.min(
+          32_000,
+          Math.max(64, Math.round(queryConfig.maxInjectedChars / CHARS_PER_TOKEN)),
+        );
 
         const recallClient = await deps.getClient();
         if (deps.cfg.logFindRequests) {
@@ -170,109 +208,171 @@ export function registerOpenVikingMemoryRecallTools(
           );
         }
 
-        let result: FindResult;
-        let memoryRecallSearches: RecallTraceEntry["searches"] = [];
-        if (targetUri) {
-          result = await recallClient.find(
-            query,
-          {
+        if (hasTargetUri) {
+          const targetUri = queryConfig.targetUri;
+          if (!targetUri) {
+            throw new Error("targetUri must be a non-empty viking:// URI");
+          }
+          const requestLimit = queryConfig.candidateLimit;
+          const startedAt = Date.now();
+          const result = await recallClient.find(query, {
             targetUri,
             limit: requestLimit,
             scoreThreshold: 0,
             actorPeerId: session.actorPeerId,
-          },
-        );
-          const traceResults = [
-            ...(result.memories ?? []).map((item) => toTraceResult(item, "memory", deps)),
-            ...(result.resources ?? []).map((item) => toTraceResult(item, "resource", deps)),
-          ].slice(0, deps.cfg.traceRecallMaxResultsPerSearch);
-          memoryRecallSearches = [{
-            resourceType: deps.inferRecallResourceType(targetUri) ?? "resource",
-            targetUriInput: targetUri,
-            targetUriResolved: targetUri,
+          });
+          const durationMs = Date.now() - startedAt;
+          const leafOnly = (result.memories ?? []).filter((item) => !item.level || item.level === 2);
+          const processed = deps.postProcessMemories(leafOnly, {
             limit: requestLimit,
             scoreThreshold,
-            durationMs: 0,
-            total: result.total ?? traceResults.length,
-            results: traceResults,
-          }];
-        } else {
-          const searchPlan = deps.resolveRecallSearchPlan(requestedResourceTypes ?? deps.cfg.recallTargetTypes, {
-            ovSessionId: session.ovSessionId,
-            agentId: session.agentId,
           });
-          const settled = await Promise.allSettled(searchPlan.searches.map((search) =>
-            recallClient.find(
-              query,
-              {
-                targetUri: search.targetUri,
+          const memories = deps.pickMemoriesForInjection(processed, limit, query, scoreThreshold, {
+            weights: queryConfig.rankingWeights,
+            categoryWeights: queryConfig.categoryWeights,
+            resourceTypeWeights: queryConfig.resourceTypeWeights,
+          });
+          const traceResults = [
+            ...(result.memories ?? []).map((item) => toLegacyTraceResult(item, "memory", deps)),
+            ...(result.resources ?? []).map((item) => toLegacyTraceResult(item, "resource", deps)),
+          ].slice(0, deps.cfg.traceRecallMaxResultsPerSearch);
+          const recordTargetedTrace = async (injectedUris: Set<string>) => {
+            await deps.traceRecorder?.recordAndFlush?.({
+              schemaVersion: "1.0",
+              traceId: deps.createTraceId("memory_recall"),
+              ts: Date.now(),
+              sessionId: session.sessionId,
+              sessionKey: session.sessionKey,
+              ovSessionId: session.ovSessionId,
+              agentId: session.agentId,
+              source: "memory_recall",
+              operationType: "semantic_find",
+              resourceTypes: [deps.inferRecallResourceType(targetUri) ?? "resource"],
+              trigger: deps.boundTraceQuery(query, deps.cfg.traceRecallQueryMaxChars),
+              searches: [{
+                resourceType: deps.inferRecallResourceType(targetUri) ?? "resource",
+                targetUriInput: targetUri,
+                targetUriResolved: targetUri,
                 limit: requestLimit,
-                scoreThreshold: 0,
-                contextType: search.contextType,
-                actorPeerId: session.actorPeerId,
+                scoreThreshold,
+                durationMs,
+                total: result.total ?? traceResults.length,
+                results: traceResults,
+              }],
+              selected: memories.map((item) => ({
+                uri: item.uri,
+                resourceType: deps.inferRecallResourceType(item.uri),
+                category: item.category,
+                score: item.score,
+                abstractPreview: deps.previewText(item.abstract || item.overview, deps.cfg.traceRecallPreviewChars),
+                injected: injectedUris.has(item.uri),
+                displayed: injectedUris.has(item.uri),
+              })),
+              stats: {
+                candidateCount: leafOnly.length,
+                selectedCount: memories.length,
+                injectedCount: injectedUris.size,
               },
-            ),
-          ));
-          const allMemories: FindResultItem[] = [];
-          for (let index = 0; index < settled.length; index += 1) {
-            const s = settled[index]!;
-            const search = searchPlan.searches[index]!;
-            if (s.status === "fulfilled") {
-              allMemories.push(...(s.value.memories ?? []), ...(s.value.resources ?? []));
-              memoryRecallSearches.push({
-                resourceType: search.resourceType,
-                targetUriInput: search.targetUri,
-                targetUriResolved: search.targetUri,
-                limit: requestLimit,
-                scoreThreshold,
-                durationMs: 0,
-                total: s.value.total ?? ((s.value.memories ?? []).length + (s.value.resources ?? []).length),
-                results: [
-                  ...(s.value.memories ?? []).map((item) => toTraceResult(item, "memory", deps)),
-                  ...(s.value.resources ?? []).map((item) => toTraceResult(item, "resource", deps)),
-                ].slice(0, deps.cfg.traceRecallMaxResultsPerSearch),
-              });
-            } else {
-              memoryRecallSearches.push({
-                resourceType: search.resourceType,
-                targetUriInput: search.targetUri,
-                targetUriResolved: search.targetUri,
-                limit: requestLimit,
-                scoreThreshold,
-                durationMs: 0,
-                total: 0,
-                results: [],
-                error: s.reason instanceof Error ? s.reason.message : String(s.reason),
-              });
-            }
+            });
+          };
+          if (memories.length === 0) {
+            await recordTargetedTrace(new Set());
+            return {
+              content: [{ type: "text", text: "No relevant OpenViking memories found." }],
+              details: { count: 0, total: result.total ?? 0, scoreThreshold, targetUri },
+            };
           }
-          const uniqueMemories = allMemories.filter((memory, index, self) =>
-            index === self.findIndex((m) => m.uri === memory.uri)
+          const { lines: memoryLines } = await deps.buildMemoryLinesWithBudget(
+            memories,
+            (uri) => recallClient.read(uri, session.actorPeerId),
+            {
+              recallPreferAbstract: false,
+              recallMaxInjectedChars: queryConfig.maxInjectedChars,
+            },
           );
-          const leafOnly = uniqueMemories.filter((m) => !m.level || m.level === 2);
-          result = {
-            memories: leafOnly,
-            total: leafOnly.length,
+          if (memoryLines.length === 0) {
+            await recordTargetedTrace(new Set());
+            return {
+              content: [{
+                type: "text",
+                text: `No complete OpenViking memories fit recallMaxInjectedChars=${queryConfig.maxInjectedChars}.`,
+              }],
+              details: {
+                count: 0,
+                memories,
+                total: result.total ?? memories.length,
+                scoreThreshold,
+                requestLimit,
+                targetUri,
+                recallMaxInjectedChars: queryConfig.maxInjectedChars,
+              },
+            };
+          }
+          await recordTargetedTrace(new Set(memories.slice(0, memoryLines.length).map((item) => item.uri)));
+          return {
+            content: [{
+              type: "text",
+              text: `Found ${memoryLines.length} memories:\n\n${memoryLines.join("\n")}`,
+            }],
+            details: {
+              count: memoryLines.length,
+              memories,
+              total: result.total ?? memories.length,
+              scoreThreshold,
+              requestLimit,
+              targetUri,
+              recallMaxInjectedChars: queryConfig.maxInjectedChars,
+            },
           };
         }
 
-        const leafOnly = (result.memories ?? []).filter((m) => !m.level || m.level === 2);
-        const processed = deps.postProcessMemories(leafOnly, {
-          limit: requestLimit,
+        const startedAt = Date.now();
+        const result = await recallClient.searchContext(query, {
+          sessionId: session.ovSessionId,
+          ...(limitConfigured ? { limit } : {}),
           scoreThreshold,
+          contextType: contextTypes.length === 1 ? contextTypes[0] : contextTypes,
+          queryExpansion: "auto",
+          maxTokens,
+          detail: queryConfig.recallPreferAbstract ? "abstract" : undefined,
+          peerScope: "actor",
+          actorPeerId: session.actorPeerId,
         });
-        const memories = deps.pickMemoriesForInjection(processed, limit, query, scoreThreshold, {
-          weights: queryConfig.rankingWeights,
-          categoryWeights: queryConfig.categoryWeights,
-          resourceTypeWeights: queryConfig.resourceTypeWeights,
+        const durationMs = Date.now() - startedAt;
+        const entries = (result.entries ?? []).filter((entry) => Boolean(entry.uri));
+        const candidateCount = typeof result.stats?.candidates === "number"
+          ? result.stats.candidates
+          : entries.length;
+        const rawRetrievalErrors = result.stats?.retrieval_errors;
+        const retrievalErrors = Array.isArray(rawRetrievalErrors)
+          ? rawRetrievalErrors.map((error) => String(error))
+          : [];
+        const memoryRecallSearches: RecallTraceEntry["searches"] = searchPlan.searches.map((search) => {
+          const matching = entries.filter((entry) => {
+            const isResource = deps.inferRecallResourceType(entry.uri) === "resource";
+            return search.contextType === "resource" ? isResource : !isResource;
+          });
+          return {
+            resourceType: search.resourceType,
+            contextType: search.contextType,
+            limit,
+            scoreThreshold,
+            durationMs,
+            total: matching.length,
+            results: matching
+              .map((entry) => toTraceResult(entry, deps))
+              .slice(0, deps.cfg.traceRecallMaxResultsPerSearch),
+            error: retrievalErrors.length > 0 ? retrievalErrors.join("; ") : undefined,
+          };
         });
-        const candidateTraceResults = leafOnly
-          .map((item) => toTraceResult(item, deps.inferRecallResourceType(item.uri) === "resource" ? "resource" : "memory", deps))
-          .slice(0, deps.cfg.traceRecallMaxResultsPerSearch);
-        const traceResourceTypes = [...new Set(
-          (targetUri ? [deps.inferRecallResourceType(targetUri)] : memoryRecallSearches.map((search) => search.resourceType))
-            .filter((resourceType): resourceType is RecallResourceType => Boolean(resourceType)),
-        )];
+        const rendered = result.digest?.trim() || result.rendered?.trim() || "";
+        const displayedUris = new Set(rendered ? entries.map((entry) => entry.uri) : []);
+        const memories = entries.map((entry) => ({
+          uri: entry.uri,
+          category: entry.category,
+          score: entry.score,
+          abstract: entry.text,
+        }));
         const recordMemoryRecallTrace = async (injectedUris: Set<string>) => {
           await deps.traceRecorder?.recordAndFlush?.({
             schemaVersion: "1.0",
@@ -284,82 +384,45 @@ export function registerOpenVikingMemoryRecallTools(
             agentId: session.agentId,
             source: "memory_recall",
             operationType: "semantic_find",
-            resourceTypes: traceResourceTypes.length > 0 ? traceResourceTypes : ["resource"],
+            resourceTypes: searchPlan.resourceTypes,
             trigger: deps.boundTraceQuery(query, deps.cfg.traceRecallQueryMaxChars),
-            searches: memoryRecallSearches.length > 0 ? memoryRecallSearches : [{
-              resourceType: "resource",
-              targetUriInput: targetUri,
-              targetUriResolved: targetUri ?? "viking://resources",
-              limit: requestLimit,
-              scoreThreshold,
-              durationMs: 0,
-              total: result.total ?? leafOnly.length,
-              results: candidateTraceResults,
-            }],
-            selected: memories.map((item) => ({
-              uri: item.uri,
-              resourceType: deps.inferRecallResourceType(item.uri),
-              category: item.category,
-              score: item.score,
-              abstractPreview: deps.previewText(item.abstract || item.overview, deps.cfg.traceRecallPreviewChars),
-              injected: injectedUris.has(item.uri),
-              displayed: injectedUris.has(item.uri),
+            searches: memoryRecallSearches,
+            selected: entries.map((entry) => ({
+              uri: entry.uri,
+              resourceType: deps.inferRecallResourceType(entry.uri),
+              category: entry.category,
+              score: entry.score,
+              abstractPreview: deps.previewText(entry.text, deps.cfg.traceRecallPreviewChars),
+              injected: injectedUris.has(entry.uri),
+              displayed: injectedUris.has(entry.uri),
             })),
             stats: {
-              candidateCount: leafOnly.length,
-              selectedCount: memories.length,
+              candidateCount,
+              selectedCount: entries.length,
               injectedCount: injectedUris.size,
+              estimatedTokens: typeof result.stats?.used_tokens === "number"
+                ? result.stats.used_tokens
+                : undefined,
             },
           });
         };
-        if (memories.length === 0) {
+        if (entries.length === 0 || !rendered) {
           await recordMemoryRecallTrace(new Set());
           return {
             content: [{ type: "text", text: "No relevant OpenViking memories found." }],
-            details: { count: 0, total: result.total ?? 0, scoreThreshold },
+            details: { count: 0, total: candidateCount, scoreThreshold, limitSource },
           };
         }
-        const { lines: memoryLines } = await deps.buildMemoryLinesWithBudget(
-          memories,
-          (uri) => recallClient.read(uri, session.actorPeerId),
-          {
-            recallPreferAbstract: false,
-            recallMaxInjectedChars: queryConfig.maxInjectedChars,
-          },
-        );
-        if (memoryLines.length === 0) {
-          await recordMemoryRecallTrace(new Set());
-          return {
-            content: [
-              {
-                type: "text",
-                text: `No complete OpenViking memories fit recallMaxInjectedChars=${queryConfig.maxInjectedChars}.`,
-              },
-            ],
-            details: {
-              count: 0,
-              memories,
-              total: result.total ?? memories.length,
-              scoreThreshold,
-              requestLimit,
-              recallMaxInjectedChars: queryConfig.maxInjectedChars,
-            },
-          };
-        }
-        await recordMemoryRecallTrace(new Set(memories.slice(0, memoryLines.length).map((item) => item.uri)));
+        await recordMemoryRecallTrace(displayedUris);
         return {
-          content: [
-            {
-              type: "text",
-              text: `Found ${memoryLines.length} memories:\n\n${memoryLines.join("\n")}`,
-            },
-          ],
+          content: [{ type: "text", text: rendered }],
           details: {
-            count: memoryLines.length,
+            count: entries.length,
             memories,
-            total: result.total ?? memories.length,
+            total: candidateCount,
             scoreThreshold,
-            requestLimit,
+            requestLimit: limitConfigured ? limit : undefined,
+            limitSource,
             recallMaxInjectedChars: queryConfig.maxInjectedChars,
           },
         };

--- a/examples/openclaw-plugin/query-config.ts
+++ b/examples/openclaw-plugin/query-config.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
-import type { MemoryOpenVikingConfig } from "./config.js";
+import type { MemoryOpenVikingConfig, ParsedMemoryOpenVikingConfig } from "./config.js";
 import { normalizeRecallResourceTypes, type RecallResourceType } from "./registries/recall-resource-types.js";
 
 export type RuntimeQueryParams = {
@@ -180,7 +180,10 @@ export class RuntimeQueryConfigStore {
     return new RuntimeQueryConfigStore({ staticConfig });
   }
 
-  constructor(private readonly options: { staticConfig: Required<MemoryOpenVikingConfig>; path?: string }) {}
+  constructor(private readonly options: {
+    staticConfig: Required<MemoryOpenVikingConfig> & Partial<Pick<ParsedMemoryOpenVikingConfig, "recallLimitConfigured">>;
+    path?: string;
+  }) {}
 
   async load(): Promise<void> {
     if (!this.options.path) return;
@@ -283,7 +286,7 @@ export class RuntimeQueryConfigStore {
       resourceTypeWeights: {},
       categoryWeights: {},
       sources: {
-        recallLimit: "static",
+        recallLimit: cfg.recallLimitConfigured === false ? "default" : "static",
         candidateMultiplier: "default",
         candidateLimit: "default",
         scoreThreshold: "static",

--- a/examples/openclaw-plugin/services/context-lifecycle-service.ts
+++ b/examples/openclaw-plugin/services/context-lifecycle-service.ts
@@ -88,7 +88,7 @@ export type AssembleOpenVikingSessionParams = {
   isBypassedSession: (params: { sessionId?: string; sessionKey?: string }) => boolean;
   queryConfigStore?: {
     getEffective(params: {
-      agentId?: string;
+      peerId: string;
       sessionId?: string;
       sessionKey?: string;
       ovSessionId?: string;
@@ -502,7 +502,7 @@ export async function assembleOpenVikingSession({
         assistantPeerId: agentId,
       });
       const queryConfig = await queryConfigStore?.getEffective({
-        agentId,
+        peerId: agentId,
         sessionId,
         sessionKey,
         ovSessionId,

--- a/examples/openclaw-plugin/skills/install-openviking-memory/SKILL.md
+++ b/examples/openclaw-plugin/skills/install-openviking-memory/SKILL.md
@@ -462,10 +462,10 @@ These are the plugin tools the agent can call once installed.
 | Parameter | Required | Description |
 |---|---|---|
 | `query` | Yes | Search query text |
-| `limit` | No | Maximum number of results (defaults to plugin config) |
-| `scoreThreshold` | No | Minimum relevance score 0–1 (defaults to plugin config) |
-| `targetUri` | No | Exact search scope URI. If provided, only that URI is searched. |
-| `resourceTypes` | No | Array of target types used when `targetUri` is omitted: `resource`, `user`, `agent`. Defaults to plugin `recallTargetTypes`. |
+| `limit` | No | Recall result target. Tool value wins; otherwise an explicitly configured `recallLimit` is used. If neither exists, the server default applies. Explicit values use the standard coding quota mapping. |
+| `scoreThreshold` | No | Minimum relevance score 0–1 sent to context search (defaults to plugin config). |
+| `targetUri` | No | Exact `viking://` scope. When set, preserves the legacy targeted `/find` and read path. |
+| `resourceTypes` | No | Default context-search target types: `resource`, `user`, `agent`. Defaults to plugin `recallTargetTypes`. |
 
 Example: user asks "What programming language did I say I like?"
 
@@ -587,18 +587,18 @@ These are the keys under `plugins.entries.openviking.config` in `openclaw.json`.
 | `peer_prefix` | `""` | Optional prefix for assistant `peer_id` / actor peer values when `peer_role=assistant`. Letters / digits / `_` / `-`. |
 | `accountId` | — | Required when `apiKey` is a root key. |
 | `userId` | — | Required when `apiKey` is a root key. |
-| `targetUri` | `viking://~/memories` | Default search scope URI. |
+| `targetUri` | `viking://~/memories` | Default exact search scope for `ov_search` and `memory_forget`; `memory_recall` uses an exact scope only when `targetUri` is passed as a tool argument. |
 | `timeoutMs` | (plugin default) | HTTP timeout for OpenViking calls. |
 | `autoCapture` | `true` | Auto-append turn messages to the OpenViking session at `afterTurn`; extraction runs only after a threshold commit, `/compact`, or explicit `memory_store`. |
 | `captureMode` | `"semantic"` | Filter mode used by the server-side extraction pipeline: `semantic` or `keyword`. |
 | `captureMaxLength` | `24000` | Max text length per archived turn. |
 | `autoRecall` | `true` | Auto-recall and inject memories before reply. |
-| `recallTargetTypes` | `user,agent` | Default target types when `targetUri` is omitted. Allowed: `resource`, `user`, `agent`. |
+| `recallTargetTypes` | `user,agent` | Default context-search target types for auto-recall and `memory_recall`. Allowed: `resource`, `user`, `agent`. |
 | `recallResources` | `false` | Compatibility shortcut that appends `resource` to default recall targets when `recallTargetTypes` is unset. |
-| `recallLimit` | `6` | Max memories injected per recall. |
+| `recallLimit` | unset (server currently defaults to `10`) | Optional result target for auto-recall and `memory_recall`. If unset, both requests omit quotas; explicit values use the standard coding quota mapping. |
 | `recallScoreThreshold` | `0.15` | Min relevance score to inject. |
-| `recallMaxInjectedChars` | `4000` | Hard cap on injected character count. Complete memories that do not fit are skipped, not truncated. |
-| `recallPreferAbstract` | (plugin default) | Prefer abstract memories over raw. |
+| `recallMaxInjectedChars` | `4000` | Converted to the server context-search `max_tokens` budget for auto-recall and `memory_recall`. |
+| `recallPreferAbstract` | (plugin default) | When true, request abstract detail for both recall paths; false leaves the server default unchanged. |
 | `recallTokenBudget` | deprecated | Compatibility alias for `recallMaxInjectedChars`. |
 | `commitTokenThresholdRatio` | `0.5` | Async-commit threshold as a fraction (0-1) of the model context window (e.g. 0.5 = 50%); `0` commits every turn. |
 | `commitKeepRecentCount` | `10` | Recent messages kept live after afterTurn commit. Compact always uses `0`. |

--- a/examples/openclaw-plugin/skills/openviking-context-database/SKILL.md
+++ b/examples/openclaw-plugin/skills/openviking-context-database/SKILL.md
@@ -67,16 +67,16 @@ Core config lives under `plugins.entries.openviking.config`:
 | `peer_role` | `assistant` | Peer identity mode: `none`, `assistant`, or `person`. Session messages use body `peer_id`; data-plane recall/search uses `X-OpenViking-Actor-Peer`. |
 | `peer_prefix` | empty | Optional prefix for assistant `peer_id` / actor peer values when `peer_role=assistant`. |
 | `accountId` / `userId` | empty | Advanced tenant identity headers for root-key or trusted deployments. |
-| `targetUri` | `viking://~/memories` | Default search scope for legacy targeted memory search. |
+| `targetUri` | `viking://~/memories` | Default exact scope for `ov_search` and `memory_forget`; `memory_recall` uses an exact scope only when `targetUri` is passed as a tool argument. |
 | `autoCapture` | `true` | Append sanitized turn text to OpenViking sessions. |
 | `captureMode` | `semantic` | `semantic` or `keyword`; affects server-side extraction filtering. |
 | `captureMaxLength` | `24000` | Max sanitized text length per captured turn. |
 | `autoRecall` | `true` | Run recall before replies and inject relevant context. |
-| `recallTargetTypes` | `user,agent` | Default target types when `targetUri` is omitted. Allowed: `resource`, `user`, `agent`. |
+| `recallTargetTypes` | `user,agent` | Default context-search target types for auto-recall and `memory_recall`. Allowed: `resource`, `user`, `agent`. |
 | `recallResources` | `false` | Compatibility shortcut that appends `resource` to default recall targets when `recallTargetTypes` is unset. |
-| `recallLimit` | `6` | Max selected recall items. |
-| `recallScoreThreshold` | `0.15` | Min score after post-processing. |
-| `recallMaxInjectedChars` | `4000` | Total injected character cap; complete memories that do not fit are skipped. |
+| `recallLimit` | unset (server currently defaults to `10`) | Optional result target for auto-recall and `memory_recall`; omitted requests use the server default, while explicit values use the standard coding quota mapping. |
+| `recallScoreThreshold` | `0.15` | Minimum score sent to server context search. |
+| `recallMaxInjectedChars` | `4000` | Converted to server context-search `max_tokens` for both recall paths. |
 | `commitTokenThresholdRatio` | `0.5` | Async-commit threshold as a fraction (0-1) of the model context window (e.g. 0.5 = 50%); `0` commits every turn. |
 | `commitKeepRecentCount` | `10` | Recent messages kept live after afterTurn commit. Compact always uses `0`. |
 | `bypassSessionPatterns` | empty | Glob-like session keys that completely bypass OpenViking (`*` segment, `**` multi-segment). |
@@ -126,12 +126,12 @@ Semantic search over memories/resources. Use archive tools for session history.
 | Parameter | Required | Description |
 |---|---|---|
 | `query` | Yes | Search query. |
-| `limit` | No | Max selected results. Defaults to `recallLimit`. |
+| `limit` | No | Recall result target. The tool argument wins; otherwise an explicitly configured `recallLimit` is used, then the server default. Explicit values use the standard coding quota mapping. |
 | `scoreThreshold` | No | Score threshold `0..1`. Defaults to `recallScoreThreshold`. |
-| `targetUri` | No | Exact search URI. If set, only this URI is searched. |
-| `resourceTypes` | No | Array of `resource`, `user`, `agent`; used only when `targetUri` is omitted. |
+| `targetUri` | No | Exact `viking://` scope. When set, preserves the legacy targeted `/find` and read path. |
+| `resourceTypes` | No | Default context-search targets: `resource`, `user`, `agent`. |
 
-Notes: when `targetUri` is omitted, the plugin resolves a search plan from `resourceTypes` or configured `recallTargetTypes`, fetches more candidates than requested, deduplicates, filters leaf memories, reranks, and respects `recallMaxInjectedChars`.
+Notes: the default path calls the session-aware context/coding search endpoint and returns its token-budgeted `digest` or `rendered` context directly. When no tool or configured limit exists, it omits quotas and uses the server default. Explicit values use the same coding quota mapping as the other memory-plugin harnesses. Passing `targetUri` selects the compatibility path instead.
 
 ### `memory_store`
 

--- a/examples/openclaw-plugin/tests/ut/architecture-boundaries.test.ts
+++ b/examples/openclaw-plugin/tests/ut/architecture-boundaries.test.ts
@@ -538,22 +538,22 @@ describe("architecture boundaries", () => {
     expect(addSessionMessageBlock).toMatch(/new OpenVikingClient\([\s\S]*\{\s*transport\s*\}/);
   });
 
-  it("keeps memory_recall L2 content tests on the plugin-injected transport seam", () => {
+  it("keeps memory_recall context search tests on the plugin-injected transport seam", () => {
     const toolsTestSource = readFileSync(join(rootDir, "tests/ut/tools.test.ts"), "utf8");
-    const start = toolsTestSource.indexOf('it("fills L2 content and filters explicit recall results like auto-recall"');
-    const end = toolsTestSource.indexOf('  it("applies recallMaxInjectedChars to explicit memory_recall output"', start);
+    const start = toolsTestSource.indexOf('it("sends an explicit tool limit to context search and returns the server digest"');
+    const end = toolsTestSource.indexOf('  it("converts recallMaxInjectedChars to max_tokens without client-side filtering"', start);
 
     expect(start).toBeGreaterThanOrEqual(0);
     expect(end).toBeGreaterThan(start);
 
-    const recallL2Block = toolsTestSource.slice(start, end);
-    expect(recallL2Block).not.toMatch(/vi\.stubGlobal\("fetch"/);
-    expect(recallL2Block).toContain("openVikingTransport");
+    const recallContextBlock = toolsTestSource.slice(start, end);
+    expect(recallContextBlock).not.toMatch(/vi\.stubGlobal\("fetch"/);
+    expect(recallContextBlock).toContain("openVikingTransport");
   });
 
-  it("keeps memory_recall injected char budget tests on the plugin-injected transport seam", () => {
+  it("keeps memory_recall token budget tests on the plugin-injected transport seam", () => {
     const toolsTestSource = readFileSync(join(rootDir, "tests/ut/tools.test.ts"), "utf8");
-    const start = toolsTestSource.indexOf('it("applies recallMaxInjectedChars to explicit memory_recall output"');
+    const start = toolsTestSource.indexOf('it("converts recallMaxInjectedChars to max_tokens without client-side filtering"');
     const end = toolsTestSource.indexOf('  it("applies /ov-query-config session settings to subsequent memory_recall"', start);
 
     expect(start).toBeGreaterThanOrEqual(0);

--- a/examples/openclaw-plugin/tests/ut/build-memory-lines.test.ts
+++ b/examples/openclaw-plugin/tests/ut/build-memory-lines.test.ts
@@ -372,7 +372,6 @@ describe("buildAutoRecallContext trace", () => {
     expect(client.searchContext).toHaveBeenCalledTimes(1);
     expect(client.searchContext.mock.calls[0]?.[1]).toMatchObject({
       sessionId: "ov-1",
-      limit: 6,
       scoreThreshold: 0.15,
       contextType: "memory",
       queryExpansion: "auto",
@@ -382,11 +381,33 @@ describe("buildAutoRecallContext trace", () => {
       peerScope: "actor",
       requestTimeoutMs: 15000,
     });
+    expect(client.searchContext.mock.calls[0]?.[1]).not.toHaveProperty("limit");
     expect(client.find).not.toHaveBeenCalled();
     expect(client.read).not.toHaveBeenCalled();
     const recorded = traces.query({ turn: "latest", sessionId: "session-resource-only", limit: 10 }).entries[0]!;
     expect(recorded.resourceTypes).toEqual(["user", "agent"]);
     expect(recorded.searches.map((search) => search.resourceType)).toEqual(["user"]);
+  });
+
+  it("sends recallLimit only when static config explicitly sets it", async () => {
+    const cfg = makeCfg({ recallLimit: 3, recallTargetTypes: ["user"] });
+    const client = {
+      healthCheck: vi.fn().mockResolvedValue(undefined),
+      searchContext: vi.fn().mockResolvedValue({ entries: [], rendered: "", stats: {} }),
+      find: vi.fn(),
+      read: vi.fn(),
+    };
+
+    await buildAutoRecallContext({
+      cfg,
+      client: client as any,
+      agentId: "agent-1",
+      queryText: "which explicit recall limit should apply?",
+      logger: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    expect(client.searchContext.mock.calls[0]?.[1]).toMatchObject({ limit: 3 });
+    expect(client.searchContext.mock.calls[0]?.[1]).not.toHaveProperty("quotas");
   });
 
   it("uses configured autoRecallTimeoutMs for both the request and outer budget", async () => {

--- a/examples/openclaw-plugin/tests/ut/client.test.ts
+++ b/examples/openclaw-plugin/tests/ut/client.test.ts
@@ -603,6 +603,14 @@ describe("OpenVikingClient canonical namespace policy", () => {
     expect(contextType).toEqual(["memory", "resource"]);
     expect(detail).toBe("abstract");
     expect(requestBody).not.toHaveProperty("limit");
+    expect(requestBody.quotas).toEqual({
+      events: 1,
+      entities: 1,
+      preferences: 1,
+      experiences: 1,
+      resources: 1,
+      skills: 1,
+    });
     expect(new Headers(init.headers).get("X-OpenViking-Actor-Peer")).toBe("agent-main");
     expect(new Headers(init.headers).get("X-OpenViking-Account")).toBe("acct-123");
     expect(new Headers(init.headers).get("X-OpenViking-User")).toBe("user-456");
@@ -636,6 +644,10 @@ describe("OpenVikingClient canonical namespace policy", () => {
       score: 0.82,
       origin: "self",
     });
+    const [, init] = transport.mock.calls[0] as [string, RequestInit];
+    const requestBody = JSON.parse(String(init.body));
+    expect(requestBody).not.toHaveProperty("limit");
+    expect(requestBody).not.toHaveProperty("quotas");
   });
 
   it("uses the shared session-aware timeout floor", async () => {

--- a/examples/openclaw-plugin/tests/ut/config.test.ts
+++ b/examples/openclaw-plugin/tests/ut/config.test.ts
@@ -12,7 +12,7 @@ describe("memoryOpenVikingConfigSchema.parse()", () => {
   it("empty object uses all defaults", () => {
     const cfg = memoryOpenVikingConfigSchema.parse({});
     expect(cfg.mode).toBe("remote");
-    expect(cfg.recallLimit).toBe(6);
+    expect(cfg.recallLimit).toBe(10);
     expect(cfg.recallScoreThreshold).toBe(0.15);
     expect(cfg.autoCapture).toBe(true);
     expect(cfg.autoRecall).toBe(true);
@@ -47,6 +47,18 @@ describe("memoryOpenVikingConfigSchema.parse()", () => {
     expect(cfg.enabledTools).not.toContain("add_resource");
     expect(cfg.disabledTools).toContain("add_resource");
     expect(cfg.agentExperience.enabled).toBe(false);
+    expect(cfg.recallLimitConfigured).toBe(false);
+  });
+
+  it("records whether recallLimit was explicitly configured", () => {
+    const defaultCfg = memoryOpenVikingConfigSchema.parse({});
+    const explicitCfg = memoryOpenVikingConfigSchema.parse({ recallLimit: 7 });
+    const reparsedDefaultCfg = memoryOpenVikingConfigSchema.parse({ ...defaultCfg });
+
+    expect(defaultCfg.recallLimitConfigured).toBe(false);
+    expect(reparsedDefaultCfg.recallLimitConfigured).toBe(false);
+    expect(explicitCfg.recallLimitConfigured).toBe(true);
+    expect(explicitCfg.recallLimit).toBe(7);
   });
 
   it("tolerates the deprecated commitTokenThreshold key and ignores it", () => {

--- a/examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts
@@ -234,6 +234,7 @@ describe("context-engine assemble()", () => {
         queryExpansion: "auto",
         dedupTurns: 5,
       });
+      expect(client.searchContext.mock.calls[0]?.[1]).not.toHaveProperty("limit");
       const recorded = traces.query({ turn: "latest", sessionId: "session-transform-resource-default", limit: 10 }).entries[0]!;
       expect(recorded.resourceTypes).toEqual(["user", "agent"]);
   });
@@ -247,10 +248,8 @@ describe("context-engine assemble()", () => {
       const queryConfigStore = RuntimeQueryConfigStore.createInMemory(localCfg);
       await queryConfigStore.set(
         "session",
-        { agentId: "agent:session-dynamic-query", sessionId: "session-dynamic-query" },
+        { peerId: "agent:session-dynamic-query", sessionId: "session-dynamic-query" },
         {
-          recallLimit: 1,
-          candidateLimit: 3,
           scoreThreshold: 0.5,
           resourceTypes: ["user"],
           maxInjectedChars: 1000,
@@ -291,12 +290,55 @@ describe("context-engine assemble()", () => {
       expect(client.searchContext).toHaveBeenCalledTimes(1);
       expect(client.searchContext.mock.calls[0]?.[1]).toMatchObject({
         contextType: "memory",
-        limit: 1,
         scoreThreshold: 0.5,
         maxTokens: 250,
       });
+      expect(client.searchContext.mock.calls[0]?.[1]).not.toHaveProperty("limit");
       expect(String(result.messages[0]?.content)).toContain("High-confidence dynamic query memory.");
       expect(String(result.messages[0]?.content)).not.toContain("Low-confidence memory should be filtered.");
+  });
+
+  it("applies claw-level query config to transformContext auto-recall", async () => {
+      const localCfg = memoryOpenVikingConfigSchema.parse({
+        ...cfg,
+        autoRecall: true,
+        recallPreferAbstract: true,
+      });
+      const queryConfigStore = RuntimeQueryConfigStore.createInMemory(localCfg);
+      await queryConfigStore.set(
+        "claw",
+        { peerId: "agent:session-claw-query" },
+        { scoreThreshold: 0.42 },
+      );
+      const { engine, client } = makeEngine(
+        {
+          latest_archive_overview: "unused",
+          pre_archive_abstracts: [],
+          messages: [],
+          estimatedTokens: 0,
+          stats: makeStats(),
+        },
+        {
+          cfgOverrides: {
+            autoRecall: true,
+            recallPreferAbstract: true,
+          },
+          queryConfigStore,
+        },
+      );
+      client.searchContext.mockResolvedValueOnce({
+        entries: [],
+        rendered: "",
+        stats: { candidates: 0, used_tokens: 0 },
+      });
+
+      await engine.assemble({
+        sessionId: "session-claw-query",
+        messages: [{ role: "user", content: "which claw-level recall setting applies?" }],
+      });
+
+      expect(client.searchContext.mock.calls[0]?.[1]).toMatchObject({ scoreThreshold: 0.42 });
+      expect(client.searchContext.mock.calls[0]?.[1]).not.toHaveProperty("limit");
   });
 
   it("passes through transformContext messages when the latest message is not user", async () => {

--- a/examples/openclaw-plugin/tests/ut/manifest-contracts.test.ts
+++ b/examples/openclaw-plugin/tests/ut/manifest-contracts.test.ts
@@ -163,8 +163,8 @@ describe("OpenClaw 5.5 package runtime contract", () => {
     expect(installManifest.compatibility).toMatchObject({
       minOpenclawVersion: "2026.5.27",
       recommendedOpenclawVersion: "2026.6.6",
-      minOpenvikingVersion: "0.4.1",
-      recommendedOpenvikingVersion: "0.4.1",
+      minOpenvikingVersion: "0.4.13",
+      recommendedOpenvikingVersion: "0.4.13",
     });
     // OpenClaw installers read these package fields as host-version floor metadata.
     expect(packageJson.engines?.openclaw).toBe(">=2026.5.27");

--- a/examples/openclaw-plugin/tests/ut/plugin-modules.test.ts
+++ b/examples/openclaw-plugin/tests/ut/plugin-modules.test.ts
@@ -27,6 +27,7 @@ import { registerOpenVikingMemoryRecallTools } from "../../plugin/openviking-mem
 import { registerOpenVikingQueryTools } from "../../plugin/openviking-query-tools.js";
 import { registerOpenVikingRecallTraceTools } from "../../plugin/openviking-recall-trace-tools.js";
 import { registerOpenVikingToolResultTools } from "../../plugin/openviking-tool-result-tools.js";
+import { resolveRecallSearchPlan } from "../../registries/recall-resource-types.js";
 
 describe("plugin module seams", () => {
   it("registers only enabled OpenViking tools through the tool-registration seam", () => {
@@ -911,29 +912,34 @@ describe("plugin module seams", () => {
     const memory = {
       uri: "viking://user/default/memories/m1",
       category: "preferences",
-      abstract: "User prefers TDD.",
+      text: "User prefers TDD.",
       score: 0.93,
-      level: 2,
     };
-    const find = vi.fn().mockResolvedValue({ memories: [memory], total: 1 });
-    const read = vi.fn().mockResolvedValue("User prefers TDD.");
+    const searchContext = vi.fn().mockResolvedValue({
+      entries: [memory],
+      rendered: "User prefers TDD.",
+      stats: { candidates: 1, used_tokens: 8 },
+    });
+    const find = vi.fn();
+    const read = vi.fn();
     const getDefaultAgentId = vi.fn().mockReturnValue("default-agent");
     const recordAndFlush = vi.fn().mockResolvedValue(undefined);
     const getEffective = vi.fn().mockResolvedValue({
-      recallLimit: 1,
+      recallLimit: 2,
       scoreThreshold: 0.5,
-      targetUri: "viking://user/default",
       resourceTypes: ["user"],
       candidateLimit: 4,
       maxInjectedChars: 500,
+      recallPreferAbstract: true,
       rankingWeights: {},
       categoryWeights: {},
       resourceTypeWeights: {},
+      sources: { recallLimit: "request" },
     });
 
     registerOpenVikingMemoryRecallTools({
       registerTool,
-      getClient: async () => ({ find, read, getDefaultAgentId }),
+      getClient: async () => ({ find, searchContext, read, getDefaultAgentId }),
       queryConfigStore: { getEffective },
       toQueryConfigContext: (session) => ({ agentId: session.agentId, sessionId: session.sessionId, sessionKey: session.sessionKey, ovSessionId: session.ovSessionId }),
       resolvePluginSessionRouting: () => ({
@@ -945,13 +951,10 @@ describe("plugin module seams", () => {
       }),
       isBypassedSession: () => false,
       makeBypassedToolResult: (toolName: string) => ({ content: [{ type: "text" as const, text: `bypassed ${toolName}` }], details: { toolName } }),
-      resolveRecallSearchPlan: vi.fn(),
+      resolveRecallSearchPlan,
       postProcessMemories: (items) => items,
-      pickMemoriesForInjection: (items) => items.slice(0, 1),
-      buildMemoryLinesWithBudget: vi.fn(async (items, readFn) => {
-        await readFn(items[0].uri);
-        return { lines: ["1. [preferences] User prefers TDD. (93%)"], estimatedTokens: 8 };
-      }),
+      pickMemoriesForInjection: (items) => items,
+      buildMemoryLinesWithBudget: vi.fn(),
       inferRecallResourceType: (uri) => uri.startsWith("viking://user/") ? "user" : "resource",
       createTraceId: () => "memory_recall-trace-1",
       boundTraceQuery: (query) => ({ query }),
@@ -983,13 +986,17 @@ describe("plugin module seams", () => {
       targetUri: undefined,
       resourceTypes: undefined,
     });
-    expect(find).toHaveBeenCalledWith("TDD preference", {
-      targetUri: "viking://user/default",
-      limit: 4,
-      scoreThreshold: 0,
+    expect(searchContext).toHaveBeenCalledWith("TDD preference", {
+      sessionId: "ov-session-1",
+      limit: 2,
+      scoreThreshold: 0.5,
+      contextType: "memory",
+      queryExpansion: "auto",
+      maxTokens: 125,
+      detail: "abstract",
+      peerScope: "actor",
       actorPeerId: "agent-main",
     });
-    expect(read).toHaveBeenCalledWith("viking://user/default/memories/m1", "agent-main");
     expect(recordAndFlush).toHaveBeenCalledWith(expect.objectContaining({
       traceId: "memory_recall-trace-1",
       sessionId: "session-1",
@@ -998,14 +1005,15 @@ describe("plugin module seams", () => {
       agentId: "agent-main",
       source: "memory_recall",
       resourceTypes: ["user"],
-      stats: { candidateCount: 1, selectedCount: 1, injectedCount: 1 },
+      stats: { candidateCount: 1, selectedCount: 1, injectedCount: 1, estimatedTokens: 8 },
     }));
-    expect(result.content[0].text).toContain("Found 1 memories");
+    expect(result.content[0].text).toBe("User prefers TDD.");
     expect(result.details).toMatchObject({
       count: 1,
       total: 1,
       scoreThreshold: 0.5,
-      requestLimit: 4,
+      requestLimit: 2,
+      limitSource: "request",
       recallMaxInjectedChars: 500,
     });
   });

--- a/examples/openclaw-plugin/tests/ut/plugin-normal-flow-real-server.test.ts
+++ b/examples/openclaw-plugin/tests/ut/plugin-normal-flow-real-server.test.ts
@@ -276,14 +276,6 @@ describe("plugin normal flow with healthy backend", () => {
     expect(contextSearchBody).toMatchObject({
       mode: "context",
       purpose: "coding",
-      quotas: {
-        events: 1,
-        entities: 1,
-        preferences: 1,
-        experiences: 1,
-        resources: 1,
-        skills: 1,
-      },
       session_id: "session-normal",
       context_type: "memory",
       query_expansion: "auto",
@@ -292,6 +284,7 @@ describe("plugin normal flow with healthy backend", () => {
       peer_scope: "actor",
     });
     expect(contextSearchBody).not.toHaveProperty("limit");
+    expect(contextSearchBody).not.toHaveProperty("quotas");
     expect(
       requests.some((entry) => entry.method === "GET" && entry.path.startsWith("/api/v1/sessions/session-normal/context")),
     ).toBe(true);

--- a/examples/openclaw-plugin/tests/ut/query-config.test.ts
+++ b/examples/openclaw-plugin/tests/ut/query-config.test.ts
@@ -49,6 +49,18 @@ describe("resolveSessionQueryConfigKey", () => {
 });
 
 describe("RuntimeQueryConfigStore", () => {
+  it("distinguishes the server default from an explicit static recallLimit", async () => {
+    const defaultStore = RuntimeQueryConfigStore.createInMemory(
+      memoryOpenVikingConfigSchema.parse({}),
+    );
+    const explicitStore = RuntimeQueryConfigStore.createInMemory(
+      memoryOpenVikingConfigSchema.parse({ recallLimit: 10 }),
+    );
+
+    expect((await defaultStore.getEffective({ peerId: "assistant-a" })).sources.recallLimit).toBe("default");
+    expect((await explicitStore.getEffective({ peerId: "assistant-a" })).sources.recallLimit).toBe("static");
+  });
+
   it("merges default, static, claw, session, and request layers with field sources", async () => {
     const cfg = memoryOpenVikingConfigSchema.parse({
       recallLimit: 6,
@@ -63,14 +75,14 @@ describe("RuntimeQueryConfigStore", () => {
 
     const effective = await store.getEffective(
       { peerId: "assistant-a", ovSessionId: "ov-session" },
-      { scoreThreshold: 0.05 },
+      { recallLimit: 2, scoreThreshold: 0.05 },
     );
 
-    expect(effective.recallLimit).toBe(3);
+    expect(effective.recallLimit).toBe(2);
     expect(effective.scoreThreshold).toBe(0.05);
     expect(effective.resourceTypes).toEqual(["resource"]);
     expect(effective.candidateLimit).toBe(20);
-    expect(effective.sources.recallLimit).toBe("session");
+    expect(effective.sources.recallLimit).toBe("request");
     expect(effective.sources.scoreThreshold).toBe("request");
     expect(effective.sources.resourceTypes).toBe("claw");
   });

--- a/examples/openclaw-plugin/tests/ut/tools.test.ts
+++ b/examples/openclaw-plugin/tests/ut/tools.test.ts
@@ -146,7 +146,7 @@ describe("Tool: memory_recall (registration)", () => {
     expect(recall!.description).toContain("Search long-term memories");
   });
 
-  it("registers with query, limit, scoreThreshold, targetUri parameters", () => {
+  it("registers with context-search parameters and the targetUri compatibility option", () => {
     const { tools, api } = setupPlugin();
     contextEnginePlugin.register(api as any);
     const recall = tools.get("memory_recall");
@@ -156,40 +156,29 @@ describe("Tool: memory_recall (registration)", () => {
     expect(props).toHaveProperty("query");
     expect(props).toHaveProperty("limit");
     expect(props).toHaveProperty("scoreThreshold");
+    expect(props).toHaveProperty("resourceTypes");
     expect(props).toHaveProperty("targetUri");
   });
 
-  it("fills L2 content and filters explicit recall results like auto-recall", async () => {
+  it("sends an explicit tool limit to context search and returns the server digest", async () => {
     const openVikingTransport = vi.fn(async (url: string, init?: RequestInit) => {
       const requestUrl = new URL(url);
       if (requestUrl.pathname === "/api/v1/system/status") {
         return okResponse({ user: "default" });
       }
 
-      if (requestUrl.pathname === "/api/v1/search/find") {
-        const body = JSON.parse(String(init?.body ?? "{}"));
-        const contextType = String(body.context_type ?? "");
-        const memories =
-          contextType === "memory"
-            ? [
-                makeMemory({
-                  uri: "viking://user/default/memories/high",
-                  abstract: "Abstract only text",
-                  score: 0.92,
-                }),
-                makeMemory({
-                  uri: "viking://user/default/memories/low",
-                  abstract: "Low score text",
-                  score: 0.05,
-                }),
-              ]
-            : [];
-        return okResponse({ memories, total: memories.length });
-      }
-
-      if (requestUrl.pathname === "/api/v1/content/read") {
-        expect(requestUrl.searchParams.get("uri")).toBe("viking://user/default/memories/high");
-        return okResponse("Full L2 content from read");
+      if (requestUrl.pathname === "/api/v1/search/search") {
+        return okResponse({
+          entries: [{
+            uri: "viking://user/default/memories/high",
+            category: "preferences",
+            score: 0.92,
+            text: "Server-selected abstract",
+          }],
+          rendered: "Server-rendered context",
+          digest: "Server digest",
+          stats: { candidates: 2, used_tokens: 7 },
+        });
       }
 
       return okResponse({});
@@ -213,54 +202,93 @@ describe("Tool: memory_recall (registration)", () => {
       scoreThreshold: 0.2,
     }) as ToolResult;
 
-    expect(result.content[0]!.text).toContain("Full L2 content from read");
-    expect(result.content[0]!.text).not.toContain("Abstract only text");
-    expect(result.content[0]!.text).not.toContain("Low score text");
+    expect(result.content[0]!.text).toBe("Server digest");
 
-    const findCalls = openVikingTransport.mock.calls.filter(([calledUrl]) =>
-      String(calledUrl).includes("/api/v1/search/find")
+    const searchCalls = openVikingTransport.mock.calls.filter(([calledUrl]) =>
+      String(calledUrl).includes("/api/v1/search/search")
     );
-    expect(findCalls).toHaveLength(1);
-    for (const [, init] of findCalls) {
-      const body = JSON.parse(String((init as RequestInit).body));
-      expect(body.limit).toBe(20);
-      expect(body.score_threshold).toBe(0);
-      expect(body.context_type).toBe("memory");
-      expect(body.target_uri).toBeUndefined();
-    }
+    expect(searchCalls).toHaveLength(1);
+    const body = JSON.parse(String((searchCalls[0]![1] as RequestInit).body));
+    expect(body).toMatchObject({
+      mode: "context",
+      purpose: "coding",
+      score_threshold: 0.2,
+      context_type: "memory",
+      detail: "abstract",
+    });
+    expect(body.limit).toBeUndefined();
+    expect(body.quotas).toEqual({
+      events: 1,
+      entities: 1,
+      preferences: 1,
+      experiences: 1,
+      resources: 1,
+      skills: 1,
+    });
+    expect(openVikingTransport.mock.calls.some(([url]) => String(url).includes("/api/v1/content/read"))).toBe(false);
   });
 
-  it("applies recallMaxInjectedChars to explicit memory_recall output", async () => {
+  it("preserves exact targetUri recall through the legacy find and read path", async () => {
+    const openVikingTransport = vi.fn(async (url: string, init?: RequestInit) => {
+      const requestUrl = new URL(url);
+      if (requestUrl.pathname === "/api/v1/search/find") {
+        const body = JSON.parse(String(init?.body ?? "{}"));
+        expect(body.target_uri).toBe("viking://user/default/memories");
+        expect(body.limit).toBe(20);
+        return okResponse({
+          memories: [makeMemory({
+            uri: "viking://user/default/memories/high",
+            abstract: "Abstract only text",
+            score: 0.92,
+          })],
+          total: 1,
+        });
+      }
+      if (requestUrl.pathname === "/api/v1/content/read") {
+        expect(requestUrl.searchParams.get("uri")).toBe("viking://user/default/memories/high");
+        return okResponse("Full L2 content from read");
+      }
+      return okResponse({});
+    });
+
+    const { factoryTools, api } = setupPlugin(undefined, {
+      recallLimit: 1,
+      recallScoreThreshold: 0.2,
+    });
+    (api as any).openVikingTransport = openVikingTransport;
+    contextEnginePlugin.register(api as any);
+    const tool = factoryTools.get("memory_recall")!({ sessionId: "test-session", agentId: "main" });
+    const result = await tool.execute("tc-memory-recall-target", {
+      query: "backend preference",
+      limit: 1,
+      scoreThreshold: 0.2,
+      targetUri: "viking://user/default/memories",
+    }) as ToolResult;
+
+    expect(result.content[0]!.text).toContain("Full L2 content from read");
+    expect(result.details).toMatchObject({
+      count: 1,
+      targetUri: "viking://user/default/memories",
+    });
+    expect(openVikingTransport.mock.calls.some(([url]) => String(url).includes("/api/v1/search/search"))).toBe(false);
+  });
+
+  it("converts recallMaxInjectedChars to max_tokens without client-side filtering", async () => {
     const openVikingTransport = vi.fn(async (url: string, init?: RequestInit) => {
       const requestUrl = new URL(url);
       if (requestUrl.pathname === "/api/v1/system/status") {
         return okResponse({ user: "default" });
       }
 
-      if (requestUrl.pathname === "/api/v1/search/find") {
-        const body = JSON.parse(String(init?.body ?? "{}"));
-        const contextType = String(body.context_type ?? "");
-        const memories =
-          contextType === "memory"
-            ? [
-                makeMemory({
-                  uri: "viking://user/default/memories/large",
-                  abstract: "Large abstract",
-                  score: 0.95,
-                }),
-                makeMemory({
-                  uri: "viking://user/default/memories/small",
-                  abstract: "Small abstract",
-                  score: 0.9,
-                }),
-              ]
-            : [];
-        return okResponse({ memories, total: memories.length });
-      }
-
-      if (requestUrl.pathname === "/api/v1/content/read") {
-        const uri = requestUrl.searchParams.get("uri");
-        return okResponse(uri?.endsWith("/large") ? "x".repeat(200) : "short");
+      if (requestUrl.pathname === "/api/v1/search/search") {
+        return okResponse({
+          entries: [
+            { uri: "viking://user/default/memories/large", category: "preferences", score: 0.95, text: "Large abstract" },
+            { uri: "viking://user/default/memories/small", category: "preferences", score: 0.9, text: "Small abstract" },
+          ],
+          rendered: "Server-bounded context",
+          stats: { candidates: 2, used_tokens: 5 },
+        });
       }
 
       return okResponse({});
@@ -268,7 +296,7 @@ describe("Tool: memory_recall (registration)", () => {
 
     const { factoryTools, api } = setupPlugin(undefined, {
       recallLimit: 2,
-      recallMaxInjectedChars: 20,
+      recallMaxInjectedChars: 400,
       recallScoreThreshold: 0.2,
       recallTargetTypes: ["user", "agent"],
     });
@@ -284,10 +312,14 @@ describe("Tool: memory_recall (registration)", () => {
       scoreThreshold: 0.2,
     }) as ToolResult;
 
-    expect(result.content[0]!.text).toContain("Found 1 memories");
-    expect(result.content[0]!.text).toContain("- [preferences] short");
-    expect(result.content[0]!.text).not.toContain("x".repeat(200));
-    expect(result.details.count).toBe(1);
+    expect(result.content[0]!.text).toBe("Server-bounded context");
+    expect(result.details.count).toBe(2);
+    const searchCall = openVikingTransport.mock.calls.find(([url]) =>
+      String(url).includes("/api/v1/search/search")
+    );
+    const body = JSON.parse(String((searchCall![1] as RequestInit).body));
+    expect(body.max_tokens).toBe(100);
+    expect(openVikingTransport.mock.calls.some(([url]) => String(url).includes("/api/v1/content/read"))).toBe(false);
   });
 
   it("applies /ov-query-config session settings to subsequent memory_recall", async () => {
@@ -297,28 +329,17 @@ describe("Tool: memory_recall (registration)", () => {
         return okResponse({ user: "default" });
       }
 
-      if (requestUrl.pathname === "/api/v1/search/find") {
-        const body = JSON.parse(String(init?.body ?? "{}"));
-        const contextType = String(body.context_type ?? "");
-        const memories = contextType === "memory"
-          ? [
-              makeMemory({
-                uri: "viking://user/default/memories/high",
-                abstract: "High score runtime memory",
-                score: 0.92,
-              }),
-              makeMemory({
-                uri: "viking://user/default/memories/low",
-                abstract: "Low score runtime memory",
-                score: 0.1,
-              }),
-            ]
-          : [];
-        return okResponse({ memories, total: memories.length });
-      }
-
-      if (requestUrl.pathname === "/api/v1/content/read") {
-        return okResponse("High score runtime memory content");
+      if (requestUrl.pathname === "/api/v1/search/search") {
+        return okResponse({
+          entries: [{
+            uri: "viking://user/default/memories/high",
+            category: "preferences",
+            score: 0.92,
+            text: "High score runtime memory",
+          }],
+          rendered: "High score runtime memory content",
+          stats: { candidates: 1, used_tokens: 8 },
+        });
       }
 
       return okResponse({});
@@ -347,14 +368,23 @@ describe("Tool: memory_recall (registration)", () => {
 
     expect(result.content[0]!.text).toContain("High score runtime memory content");
     expect(result.content[0]!.text).not.toContain("Low score runtime memory");
-    const findCalls = openVikingTransport.mock.calls.filter(([calledUrl]) =>
-      String(calledUrl).includes("/api/v1/search/find")
+    const searchCalls = openVikingTransport.mock.calls.filter(([calledUrl]) =>
+      String(calledUrl).includes("/api/v1/search/search")
     );
-    expect(findCalls).toHaveLength(1);
-    const body = JSON.parse(String((findCalls[0]![1] as RequestInit).body));
+    expect(searchCalls).toHaveLength(1);
+    const body = JSON.parse(String((searchCalls[0]![1] as RequestInit).body));
     expect(body.context_type).toBe("memory");
     expect(body.target_uri).toBeUndefined();
-    expect(body.limit).toBe(3);
+    expect(body.limit).toBeUndefined();
+    expect(body.score_threshold).toBe(0.5);
+    expect(body.quotas).toEqual({
+      events: 1,
+      entities: 1,
+      preferences: 1,
+      experiences: 1,
+      resources: 1,
+      skills: 1,
+    });
   });
 
   it("supports /ov-query-config get, unset, and reset for session scope", async () => {
@@ -1864,15 +1894,17 @@ describe("Tool: ov_recall_trace", () => {
       if (requestUrl.pathname === "/api/v1/system/status") {
         return okResponse({ user: "default" });
       }
-      if (requestUrl.pathname === "/api/v1/search/find") {
-        const body = JSON.parse(String(init?.body ?? "{}"));
-        const memories = String(body.context_type ?? "") === "memory"
-          ? [makeMemory({ uri: "viking://user/default/memories/high", abstract: "Backend preference", score: 0.91 })]
-          : [];
-        return okResponse({ memories, resources: [], skills: [], total: memories.length });
-      }
-      if (requestUrl.pathname === "/api/v1/content/read") {
-        return okResponse("Full backend memory content");
+      if (requestUrl.pathname === "/api/v1/search/search") {
+        return okResponse({
+          entries: [{
+            uri: "viking://user/default/memories/high",
+            category: "preferences",
+            score: 0.91,
+            text: "Backend preference",
+          }],
+          rendered: "Backend preference",
+          stats: { candidates: 1, used_tokens: 4 },
+        });
       }
       return okResponse({});
     });
@@ -1902,15 +1934,17 @@ describe("Tool: ov_recall_trace", () => {
   it("defaults explicit memory_recall to backward-compatible user and agent memory recall", async () => {
     const openVikingTransport = vi.fn(async (url: string, init?: RequestInit) => {
       const requestUrl = new URL(url);
-      if (requestUrl.pathname === "/api/v1/search/find") {
-        const body = JSON.parse(String(init?.body ?? "{}"));
-        const memories = String(body.context_type ?? "") === "memory"
-          ? [makeMemory({ uri: "viking://user/default/memories/project-docs", abstract: "User memory docs", score: 0.9 })]
-          : [];
-        return okResponse({ memories, resources: [], skills: [], total: memories.length });
-      }
-      if (requestUrl.pathname === "/api/v1/content/read") {
-        return okResponse("Full resource content");
+      if (requestUrl.pathname === "/api/v1/search/search") {
+        return okResponse({
+          entries: [{
+            uri: "viking://user/default/memories/project-docs",
+            category: "memories",
+            score: 0.9,
+            text: "User memory docs",
+          }],
+          rendered: "User memory docs",
+          stats: { candidates: 1, used_tokens: 4 },
+        });
       }
       return okResponse({});
     });
@@ -1919,19 +1953,21 @@ describe("Tool: ov_recall_trace", () => {
     (api as any).openVikingTransport = openVikingTransport;
     contextEnginePlugin.register(api as any);
     const recall = factoryTools.get("memory_recall")!({ sessionId: "test-session", agentId: "main" });
-    await recall.execute("tc-recall-resource", { query: "project docs", limit: 1, scoreThreshold: 0.2 });
+    await recall.execute("tc-recall-resource", { query: "project docs", scoreThreshold: 0.2 });
 
-    const findBodies = openVikingTransport.mock.calls
-      .filter(([calledUrl]) => String(calledUrl).includes("/api/v1/search/find"))
+    const searchBodies = openVikingTransport.mock.calls
+      .filter(([calledUrl]) => String(calledUrl).includes("/api/v1/search/search"))
       .map(([, init]) => JSON.parse(String((init as RequestInit).body)));
-    expect(findBodies).toHaveLength(1);
-    expect(findBodies[0]).toMatchObject({ context_type: "memory" });
-    expect(findBodies[0]!.target_uri).toBeUndefined();
+    expect(searchBodies).toHaveLength(1);
+    expect(searchBodies[0]).toMatchObject({ mode: "context", purpose: "coding", context_type: "memory" });
+    expect(searchBodies[0]!.limit).toBeUndefined();
+    expect(searchBodies[0]!.quotas).toBeUndefined();
+    expect(searchBodies[0]!.target_uri).toBeUndefined();
 
     const trace = factoryTools.get("ov_recall_trace")!({ sessionId: "test-session" });
     const result = await trace.execute("tc-trace", { source: "memory_recall", limit: 10 }) as ToolResult;
     const entry = (result.details.entries as any[])[0];
-    expect(entry.resourceTypes).toEqual(["user"]);
+    expect(entry.resourceTypes).toEqual(["user", "agent"]);
     expect(entry.searches.map((search: any) => search.resourceType)).toEqual(["user"]);
     expect(entry.searches[0].targetUriResolved).toBeUndefined();
   });
@@ -1939,15 +1975,17 @@ describe("Tool: ov_recall_trace", () => {
   it("allows explicit memory_recall resourceTypes to opt into user recall", async () => {
     const openVikingTransport = vi.fn(async (url: string, init?: RequestInit) => {
       const requestUrl = new URL(url);
-      if (requestUrl.pathname === "/api/v1/search/find") {
-        const body = JSON.parse(String(init?.body ?? "{}"));
-        const memories = String(body.context_type ?? "") === "memory"
-          ? [makeMemory({ uri: "viking://user/default/memories/preference", abstract: "User preference", score: 0.9 })]
-          : [];
-        return okResponse({ memories, resources: [], skills: [], total: memories.length });
-      }
-      if (requestUrl.pathname === "/api/v1/content/read") {
-        return okResponse("Full user preference content");
+      if (requestUrl.pathname === "/api/v1/search/search") {
+        return okResponse({
+          entries: [{
+            uri: "viking://user/default/memories/preference",
+            category: "preferences",
+            score: 0.9,
+            text: "User preference",
+          }],
+          rendered: "User preference",
+          stats: { candidates: 1, used_tokens: 4 },
+        });
       }
       return okResponse({});
     });
@@ -1963,12 +2001,23 @@ describe("Tool: ov_recall_trace", () => {
       resourceTypes: ["user"],
     });
 
-    const findBodies = openVikingTransport.mock.calls
-      .filter(([calledUrl]) => String(calledUrl).includes("/api/v1/search/find"))
+    const searchBodies = openVikingTransport.mock.calls
+      .filter(([calledUrl]) => String(calledUrl).includes("/api/v1/search/search"))
       .map(([, init]) => JSON.parse(String((init as RequestInit).body)));
-    expect(findBodies).toHaveLength(1);
-    expect(findBodies[0]).toMatchObject({ context_type: "memory" });
-    expect(findBodies[0]!.target_uri).toBeUndefined();
+    expect(searchBodies).toHaveLength(1);
+    expect(searchBodies[0]).toMatchObject({
+      context_type: "memory",
+      quotas: {
+        events: 1,
+        entities: 1,
+        preferences: 1,
+        experiences: 1,
+        resources: 1,
+        skills: 1,
+      },
+    });
+    expect(searchBodies[0]!.limit).toBeUndefined();
+    expect(searchBodies[0]!.target_uri).toBeUndefined();
 
     const trace = factoryTools.get("ov_recall_trace")!({ sessionId: "test-session" });
     const result = await trace.execute("tc-trace", { source: "memory_recall", limit: 10 }) as ToolResult;


### PR DESCRIPTION
## Why

- Align OpenClaw auto-recall and default memory_recall with the existing harness contract: omit quotas unless recallLimit is explicitly configured.
- Let the server apply its default coding quota when recallLimit is unset, without changing the server, shared recall core, or other harnesses.
- Preserve explicit targetUri calls through the legacy exact find/read compatibility path.
- Require OpenViking 0.4.13 for the context-search path.

## Tested

- Bundled Node: TypeScript typecheck passed.
- Focused OpenClaw unit suite: 268 passed.
- Focused memory_recall architecture checks: 3 passed.
- OpenClaw runtime/E2E not run, per machine-safety policy.