### PR TITLE
feat(bot): bound concurrent subagents

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -315,6 +315,7 @@ Restart `vikingbot gateway` after changing the configuration.
 | `bot.agents.max_tool_iterations` | `50` | Maximum tool iterations in one turn |
 | `bot.agents.memory_window` | `50` | Local history window and session commit message threshold |
 | `bot.agents.subagent_enabled` | `true` | Whether to expose the `spawn` tool |
+| `bot.agents.subagent_max_concurrency` | `4` | Maximum number of background subagents running at once |
 | `bot.gateway.host` | `127.0.0.1` | Gateway listen address |
 | `bot.gateway.port` | `18790` | Gateway listen port |
 | `bot.sandbox.backend` | `direct` | Execution backend |

--- a/bot/README_CN.md
+++ b/bot/README_CN.md
@@ -312,6 +312,7 @@ export OPENVIKING_CONFIG_FILE=/path/to/ov.conf
 | `bot.agents.max_tool_iterations` | `50` | 单轮最大工具迭代数 |
 | `bot.agents.memory_window` | `50` | 本地历史窗口和会话提交消息阈值 |
 | `bot.agents.subagent_enabled` | `true` | 是否提供 `spawn` 工具 |
+| `bot.agents.subagent_max_concurrency` | `4` | 同时运行的后台子 Agent 数量上限 |
 | `bot.gateway.host` | `127.0.0.1` | Gateway 监听地址 |
 | `bot.gateway.port` | `18790` | Gateway 监听端口 |
 | `bot.sandbox.backend` | `direct` | 执行后端 |

--- a/bot/tests/test_subagent_skills_context.py
+++ b/bot/tests/test_subagent_skills_context.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Regression tests for subagent prompt skill loading."""
 
+import asyncio
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -122,3 +123,37 @@ Session-loaded instruction.
     assert "### Skill: session-skill" in prompt
     assert "Session-loaded instruction." in prompt
     assert "Global-loaded instruction." not in prompt
+
+
+@pytest.mark.asyncio
+async def test_subagent_spawn_rejects_tasks_above_concurrency_limit(tmp_path, monkeypatch):
+    blocker = asyncio.Event()
+    manager = SubagentManager(
+        provider=SimpleNamespace(get_default_model=lambda: "fake-model"),
+        workspace=tmp_path,
+        bus=MessageBus(),
+        config=SimpleNamespace(agents=SimpleNamespace(subagent_max_concurrency=1)),
+    )
+
+    async def blocked(*args, **kwargs):
+        await blocker.wait()
+
+    monkeypatch.setattr(manager, "_run_subagent", blocked)
+    session_key = SimpleNamespace()
+
+    first = await manager.spawn("first", session_key)
+    second = await manager.spawn("second", session_key)
+
+    assert "started" in first
+    assert second == "Error: Subagent concurrency limit reached (1)"
+    assert manager.get_running_count() == 1
+
+    tasks = list(manager._running_tasks.values())
+    blocker.set()
+    await asyncio.gather(*tasks, return_exceptions=True)
+    await asyncio.sleep(0)
+
+    third = await manager.spawn("third", session_key)
+
+    assert "started" in third
+    await asyncio.gather(*manager._running_tasks.values(), return_exceptions=True)

--- a/bot/vikingbot/agent/subagent.py
+++ b/bot/vikingbot/agent/subagent.py
@@ -49,6 +49,9 @@ class SubagentManager:
         self.temperature = temperature
         self.sandbox_manager = sandbox_manager
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
+        self._max_concurrency = getattr(
+            getattr(config, "agents", None), "subagent_max_concurrency", 4
+        )
 
     async def spawn(
         self,
@@ -70,6 +73,9 @@ class SubagentManager:
         Returns:
             Status message indicating the subagent was started.
         """
+        if len(self._running_tasks) >= self._max_concurrency:
+            return f"Error: Subagent concurrency limit reached ({self._max_concurrency})"
+
         task_id = str(uuid.uuid4())[:8]
         display_label = label or task[:30] + ("..." if len(task) > 30 else "")
 

--- a/bot/vikingbot/config/schema.py
+++ b/bot/vikingbot/config/schema.py
@@ -469,6 +469,11 @@ class AgentsConfig(BaseModel):
         default=True,
         description="Enable the spawn tool so the main agent can start background subagents.",
     )
+    subagent_max_concurrency: int = Field(
+        default=4,
+        ge=1,
+        description="Maximum number of background subagents running at once.",
+    )
     session_context_enabled: bool = True
     session_context_token_budget: int = 3000
     commit_token_threshold: int = 200000


### PR DESCRIPTION
## Description

Background subagents were started with `asyncio.create_task()` without a capacity check, so repeated or parallel `spawn` calls could create unbounded concurrent LLM, sandbox, and external-tool work.

This change adds a process-local limit at the shared `SubagentManager.spawn()` entry point. It rejects excess spawns explicitly and reuses the existing completion cleanup to release capacity.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Closes #4613

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add `bot.agents.subagent_max_concurrency`, defaulting to `4` and validated as `>= 1`.
- Reject `spawn` calls when the manager is at capacity.
- Verify rejection at capacity and slot reuse after task completion.
- Document the setting in the English and Chinese Bot READMEs.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

```bash
PYTHONPATH=bot:. uv run --no-project --with pytest --with pytest-asyncio --with pydantic-settings --with loguru --with pyyaml --with httpx --with fastapi --with json-repair --with litellm --with ruff -- python -m pytest --noconftest -o addopts='' -q bot/tests/test_subagent_skills_context.py bot/tests/test_channel_delivery_metadata.py
```

Result: `19 passed`. Ruff check, Ruff format check, and `git diff --check` also pass.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

I chose `4` as a conservative default and implemented it before waiting for a capacity decision so the trade-off is concrete. I am happy to adjust the default if maintainers prefer another value.

This intentionally rejects excess requests instead of adding a queue. A queue can be added later if callers need deferred execution semantics.
