### PR TITLE
fix(uri): preserve file extension when sanitize_segment truncates

### DIFF
--- a/openviking_cli/utils/uri.py
+++ b/openviking_cli/utils/uri.py
@@ -278,11 +278,26 @@ class VikingURI:
         )
         # Merge consecutive underscores
         safe = re.sub(r"_+", "_", safe)
-        # Strip leading/trailing underscores and dots, limit length
-        safe = safe.strip("_.")[:50]
+        # Strip leading/trailing underscores and dots
+        safe = safe.strip("_.")
+        # Split a trailing extension off before applying the cap. After the
+        # strip a dot can only sit mid-string, so the last dot-run is the
+        # extension candidate; require an ASCII-alphanumeric tail of <=5 chars
+        # (covers .md/.pdf/.docx/.html/.ipynb; longer runs like .markdown and
+        # tails containing non-alphanumerics keep the old plain-truncation
+        # behavior) so version dots followed by long stems ("v1.2<long stem>")
+        # are not misread as extensions.
+        suffix = ""
+        if len(safe) > 50 and "." in safe:
+            tail = safe.rsplit(".", 1)[1]
+            if tail.isascii() and tail.isalnum() and len(tail) <= 5:
+                suffix = f".{tail}"
+        if len(safe) > 50:
+            safe = safe[: 50 - len(suffix)].rstrip("_.") + suffix
         # Defuse Win32 reserved device names (CON/PRN/NUL/AUX/COM1../LPT9..)
         # so the segment is a valid path component on Windows, mirroring PR
-        # #4517's guard on the memory path.
+        # #4517's guard on the memory path. Checked on the rejoined name so
+        # the stem alone (``CON`` in ``CON.txt``) is what gets defused.
         if _windows_reserved_stem(safe) in _WINDOWS_RESERVED_STEMS:
             safe = f"_{safe}"
         return safe or "unnamed"

--- a/openviking_cli/utils/uri.py
+++ b/openviking_cli/utils/uri.py
@@ -285,13 +285,20 @@ class VikingURI:
         # extension candidate; require an ASCII-alphanumeric tail of <=5 chars
         # (covers .md/.pdf/.docx/.html/.ipynb; longer runs like .markdown and
         # tails containing non-alphanumerics keep the old plain-truncation
-        # behavior) so version dots followed by long stems ("v1.2<long stem>")
-        # are not misread as extensions.
+        # behavior — purely numeric tails such as .12345 do count, which is
+        # harmless since the tail is kept verbatim either way) so version dots
+        # followed by long stems ("v1.2<long stem>") are not misread as
+        # extensions.
         suffix = ""
         if len(safe) > 50 and "." in safe:
             tail = safe.rsplit(".", 1)[1]
             if tail.isascii() and tail.isalnum() and len(tail) <= 5:
                 suffix = f".{tail}"
+        # The cap counts code points (a 50-char segment is <=200 UTF-8 bytes,
+        # within common 255-byte filename limits). The stem budget can eat
+        # into the hash tail of a no-split temp name (`<41 chars>_<hash8>.md`
+        # keeps 5 of 8 hash chars); avoiding that needs the parser to budget
+        # the extension in _sanitize_for_path upstream.
         if len(safe) > 50:
             safe = safe[: 50 - len(suffix)].rstrip("_.") + suffix
         # Defuse Win32 reserved device names (CON/PRN/NUL/AUX/COM1../LPT9..)

--- a/tests/misc/test_tree_builder_dedup.py
+++ b/tests/misc/test_tree_builder_dedup.py
@@ -112,6 +112,42 @@ class TestFinalizeFromTemp:
         assert tree._root_is_file is True
 
     @pytest.mark.asyncio
+    async def test_no_split_flatten_preserves_extension_on_long_name(self):
+        """A 53-char no-split temp file keeps its ``.md`` suffix after the cap.
+
+        Mirrors the real no-split PDF shape: ``MarkdownParser._sanitize_for_path``
+        emits a 50-char stem (41 chars + ``_`` + 8-char hash) and ``.md`` is
+        appended afterwards, so the temp file name is 53 chars. The segment cap
+        must budget for the extension instead of amputating it, otherwise the
+        stored URI loses its ``.md`` suffix.
+        """
+        from openviking.parse.tree_builder import TreeBuilder
+        from openviking.server.identity import RequestContext, Role
+        from openviking_cli.session.user_id import UserIdentifier
+
+        stem = "a" * 41 + "_d1e2f3a4"  # 50 chars, _sanitize_for_path output shape
+        entries = {
+            "viking://temp/import": [{"name": stem, "isDir": True}],
+            f"viking://temp/import/{stem}": [{"name": f"{stem}.md", "isDir": False}],
+        }
+        fs = self._make_fs(entries, {"viking://resources"})
+        ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+
+        with patch("openviking.parse.tree_builder.get_viking_fs", return_value=fs):
+            tree = await TreeBuilder().finalize_from_temp(
+                temp_dir_path="viking://temp/import",
+                ctx=ctx,
+                scope="resources",
+                to_uri="viking://resources",
+                flatten_single_file=True,
+            )
+
+        assert tree.root.uri == f"viking://resources/{stem[:47]}.md"
+        assert tree.root.temp_uri == f"viking://temp/import/{stem}/{stem}.md"
+        assert tree._candidate_uri == tree.root.uri
+        assert tree._root_is_file is True
+
+    @pytest.mark.asyncio
     async def test_explicit_to_is_preserved_for_single_no_split_file(self):
         from openviking.parse.tree_builder import TreeBuilder
         from openviking.server.identity import RequestContext, Role

--- a/tests/unit/test_cli_uri_windows_safe.py
+++ b/tests/unit/test_cli_uri_windows_safe.py
@@ -73,9 +73,14 @@ def test_sanitize_segment_no_split_md_hash_shape():
     assert result.startswith("x" * 41)
 
 
-def test_sanitize_segment_multiple_dots():
-    """Only the last dot-run is treated as the extension candidate."""
-    assert VikingURI.sanitize_segment("a.b.c") == "a.b.c"
+def test_sanitize_segment_multiple_dots_last_run_is_candidate():
+    """Only the last dot-run is treated as the extension candidate.
+
+    ``"x" * 45 + ".md.pdf"`` (53 chars) keeps only ``.pdf``: the cut lands
+    exactly on the ``.md`` dot, and the stem rstrip must eat it or the
+    result would read ``x*45..pdf``.
+    """
+    assert VikingURI.sanitize_segment("x" * 45 + ".md.pdf") == "x" * 45 + ".pdf"
 
 
 def test_sanitize_segment_trailing_dot_stripped():

--- a/tests/unit/test_cli_uri_windows_safe.py
+++ b/tests/unit/test_cli_uri_windows_safe.py
@@ -46,3 +46,74 @@ def test_sanitize_segment_preserves_normal_names():
     # CJK characters are preserved by the existing sanitizer and must not be
     # touched by the reserved-name guard.
     assert VikingURI.sanitize_segment("报告") == "报告"
+
+
+def test_sanitize_segment_preserves_extension_on_long_names():
+    """The length cap bounds the whole segment, not the stem alone.
+
+    A 60-char stem carrying ``.pdf`` must keep its extension after the cap:
+    no-split ingest flattens temp files shaped like ``<stem>.md`` into the
+    stored URI, and the old inline ``[:50]`` used to amputate the extension.
+    """
+    result = VikingURI.sanitize_segment("a" * 60 + ".pdf")
+    assert result.endswith(".pdf")
+    assert len(result) <= 50
+
+
+def test_sanitize_segment_no_split_md_hash_shape():
+    """The exact shape produced by no-split ingest keeps its ``.md`` suffix.
+
+    ``MarkdownParser._sanitize_for_path`` emits ``<41 chars>_<8-char hash>``
+    (50 chars) and ``.md`` is appended afterwards, so the temp file name is
+    53 chars. The cap must budget for the extension instead of cutting it.
+    """
+    result = VikingURI.sanitize_segment("x" * 41 + "_abcd1234.md")
+    assert result.endswith(".md")
+    assert len(result) == 50
+    assert result.startswith("x" * 41)
+
+
+def test_sanitize_segment_multiple_dots():
+    """Only the last dot-run is treated as the extension candidate."""
+    assert VikingURI.sanitize_segment("a.b.c") == "a.b.c"
+
+
+def test_sanitize_segment_trailing_dot_stripped():
+    """Trailing dots are stripped before any extension detection runs."""
+    assert VikingURI.sanitize_segment("名字.") == "名字"
+
+
+def test_sanitize_segment_long_cjk_truncates():
+    """Names without a dot keep the plain truncation behavior."""
+    assert VikingURI.sanitize_segment("报" * 60) == "报" * 50
+
+
+def test_sanitize_segment_long_reserved_with_extension():
+    """A long reserved-stem name keeps its extension without the guard.
+
+    The rejoined stem is no longer a bare device name, so no ``_`` prefix
+    is added; the extension must still survive the cap.
+    """
+    result = VikingURI.sanitize_segment("CON" + "a" * 50 + ".md")
+    assert result.endswith(".md")
+    assert len(result) <= 50
+    assert not result.startswith("_")
+
+
+def test_sanitize_segment_long_version_tail_not_extension():
+    """A long tail after a version dot is not misread as an extension.
+
+    ``v1.2`` followed by 48 chars has a 49-char tail (``2`` + stem), which
+    exceeds the extension budget, so the name falls back to plain truncation.
+    """
+    name = "v1.2" + "b" * 48
+    assert VikingURI.sanitize_segment(name) == name[:50]
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["report.md", "v1.2", "a.b.c", "my.song_mp4", "draft_v2.pdf"],
+)
+def test_sanitize_segment_short_names_unchanged(name: str):
+    """Short names pass through exactly as before the cap change."""
+    assert VikingURI.sanitize_segment(name) == name


### PR DESCRIPTION
  Adding a long-named PDF with no-split parse produces a temp file shaped
  like `<41 chars>_<8-char hash>.md` (53 chars); the inline [:50] cut in
  VikingURI.sanitize_segment then amputated the extension, so the stored
  URI lost its .md suffix.

  Split the trailing extension (ASCII alphanumeric, <=5 chars) off before
  applying the cap, truncate the stem against a whole-segment budget of
  50, then rejoin. One fix covers all call sites in tree_builder
  (resolve_target_uri / finalize_from_temp).

## Description

<!-- Provide a brief description of the changes in this PR -->
当资源上传使用参数：no_split 添加长文件名 PDF 时，入库条目丢失 .md 后缀，变成viking://resources/aaaa..._d1e2f 这样的无后缀 URI。

  根因:VikingURI.sanitize_segment(openviking_cli/utils/uri.py)对含扩展名的完整文件名做 [:50] 盲切。触发链：

  1. no_split 下 MarkdownParser 生成 temp 单文件 <41字符>_<8位hash>.md,共 53 字符
  2. TreeBuilder.finalize_from_temp(flatten 分支)和 resolve_target_uri 先后对其调用 sanitize_segment
  3. [:50] 恰好把末尾 3 个字符 .md 切掉，最终 URI 无后缀

  默认(拆分)模式不受影响：temp 产物是目录，.md 在目录内文件上，目录名无扩展名。

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- 原来的 safe = safe.strip("_.")[:50] 盲切，改为：仅当整体超长时，分离尾部扩展名(判据：最后一个点后的尾段为 ASCII字母数字且 ≤5 字符，覆盖 .md/.pdf/.docx 等)，按总长 50 预算截 stem 后拼回
- 版本号尾巴(如 v1.2 后跟长正文)因尾段超 5 字符不会误判为扩展名；media 的 {stem}_{ext} 无点拼接名天然豁免；现有CON.txt → _CON.txt Windows 保留名行为不变

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

test3 为修复后
<img width="465" height="120" alt="image" src="https://github.com/user-attachments/assets/41dacd2f-24ea-43e9-9e9a-17cf19afb479" />

## Additional Notes

<!-- Add any additional notes or context about the PR -->
