### PR TITLE
fix(memory): make strip_line_numbers() idempotent so line-number prefixes cannot accumulate in merged memories (#4413)

### DIFF
--- a/openviking/session/memory/merge_op/patch.py
+++ b/openviking/session/memory/merge_op/patch.py
@@ -13,7 +13,6 @@ from openviking.session.memory.merge_op.base import (
     StrPatch,
     get_python_type_for_field,
 )
-from openviking.session.memory.utils.line_numbers import strip_display_prefixes
 
 
 class PatchOp(MergeOpBase):
@@ -105,10 +104,12 @@ class PatchOp(MergeOpBase):
         # 空字符串和 None 都保持原值
         if patch_value is None or patch_value == "":
             return current_value
-        if isinstance(patch_value, str):
-            # Write-path cleanup (#4413): a full replacement copied from the
-            # numbered read view must not store display prefixes.
-            return strip_display_prefixes(patch_value)
+        # Stored verbatim (#4413): a full replacement carries no SEARCH to
+        # prove the model copied the numbered read view, and consecutive
+        # numeric columns (years, quarter indexes) are indistinguishable from
+        # display prefixes by shape alone. Stripping here destroys genuine
+        # data, so prefix cleanup only happens where SEARCH itself is numbered
+        # (see _clean_replace_prefixes in patch_handler).
         return patch_value
 
     def _extract_replace_when_no_original(self, patch_value: Any) -> Any:
@@ -130,13 +131,11 @@ class PatchOp(MergeOpBase):
         # patch. Taking only blocks[0] would silently drop every subsequent
         # fact/preference the model extracted.
         if isinstance(patch_value, StrPatch):
-            # Clean each block before joining: per-block numbered views are
-            # consecutive, but the joined numbers restart per block (#4413).
-            replaces = [
-                strip_display_prefixes(b.replace)
-                for b in patch_value.blocks
-                if b.replace is not None
-            ]
+            # Block replaces are stored verbatim (#4413): an empty SEARCH
+            # carries no evidence that prefixes were copied from the numbered
+            # read view, and stripping by shape alone would eat consecutive
+            # numeric columns (years, quarter indexes).
+            replaces = [b.replace for b in patch_value.blocks if b.replace is not None]
             return "\n".join(replaces) if replaces else ""
 
         # Case 2: dict form (from JSON parsing) — same, collect every block.
@@ -150,11 +149,11 @@ class PatchOp(MergeOpBase):
                 else:
                     replace = None
                 if replace is not None:
-                    replaces.append(strip_display_prefixes(replace))
+                    replaces.append(replace)
             return "\n".join(replaces) if replaces else ""
 
         # Case 3: Simple string - use as is
         if isinstance(patch_value, str):
-            return strip_display_prefixes(patch_value)
+            return patch_value
 
         return ""

--- a/openviking/session/memory/merge_op/patch.py
+++ b/openviking/session/memory/merge_op/patch.py
@@ -13,6 +13,7 @@ from openviking.session.memory.merge_op.base import (
     StrPatch,
     get_python_type_for_field,
 )
+from openviking.session.memory.utils.line_numbers import strip_display_prefixes
 
 
 class PatchOp(MergeOpBase):
@@ -104,6 +105,10 @@ class PatchOp(MergeOpBase):
         # 空字符串和 None 都保持原值
         if patch_value is None or patch_value == "":
             return current_value
+        if isinstance(patch_value, str):
+            # Write-path cleanup (#4413): a full replacement copied from the
+            # numbered read view must not store display prefixes.
+            return strip_display_prefixes(patch_value)
         return patch_value
 
     def _extract_replace_when_no_original(self, patch_value: Any) -> Any:
@@ -125,7 +130,13 @@ class PatchOp(MergeOpBase):
         # patch. Taking only blocks[0] would silently drop every subsequent
         # fact/preference the model extracted.
         if isinstance(patch_value, StrPatch):
-            replaces = [b.replace for b in patch_value.blocks if b.replace is not None]
+            # Clean each block before joining: per-block numbered views are
+            # consecutive, but the joined numbers restart per block (#4413).
+            replaces = [
+                strip_display_prefixes(b.replace)
+                for b in patch_value.blocks
+                if b.replace is not None
+            ]
             return "\n".join(replaces) if replaces else ""
 
         # Case 2: dict form (from JSON parsing) — same, collect every block.
@@ -139,11 +150,11 @@ class PatchOp(MergeOpBase):
                 else:
                     replace = None
                 if replace is not None:
-                    replaces.append(replace)
+                    replaces.append(strip_display_prefixes(replace))
             return "\n".join(replaces) if replaces else ""
 
         # Case 3: Simple string - use as is
         if isinstance(patch_value, str):
-            return patch_value
+            return strip_display_prefixes(patch_value)
 
         return ""

--- a/openviking/session/memory/merge_op/patch_handler.py
+++ b/openviking/session/memory/merge_op/patch_handler.py
@@ -28,7 +28,6 @@ from openviking.session.memory.utils.line_numbers import (
     add_line_numbers,
     every_line_has_line_numbers,
     extract_start_line_number,
-    strip_display_prefixes,
     strip_line_numbers,
 )
 from openviking_cli.utils import get_logger
@@ -878,18 +877,19 @@ def _delete_complete_lines(content: str, delete_content: str) -> str:
 def _clean_replace_prefixes(search_content: str, replace_content: str) -> str:
     """Return REPLACE with numbered-view display prefixes removed (#4413).
 
-    When SEARCH itself is fully numbered, the block was copied from the
-    numbered read view, so REPLACE prefixes (when present on every line) are
-    display prefixes too, even when the numbers are non-consecutive (partial
-    copies). When SEARCH is clean, REPLACE is only stripped when it
-    independently forms a consecutive numbered view (single lines included),
-    which genuine tabular data almost never does.
+    Evidence-based: REPLACE prefixes are stripped only when SEARCH itself is
+    fully numbered, which proves the block was copied from the numbered read
+    view (partial copies with non-consecutive numbers included). When SEARCH
+    is clean, REPLACE is stored verbatim: consecutive numeric columns (years,
+    quarter indexes) are indistinguishable from display prefixes by shape
+    alone, and stripping them destroys genuine data — a stored display prefix
+    is recoverable noise, a stripped data column is not.
     """
     if every_line_has_line_numbers(search_content):
         if every_line_has_line_numbers(replace_content) or replace_content.strip() == "":
             return strip_line_numbers(replace_content)
         return replace_content
-    return strip_display_prefixes(replace_content)
+    return replace_content
 
 
 def _clean_block_prefixes(search_content: str, replace_content: str) -> tuple[str, str]:

--- a/openviking/session/memory/merge_op/patch_handler.py
+++ b/openviking/session/memory/merge_op/patch_handler.py
@@ -28,6 +28,7 @@ from openviking.session.memory.utils.line_numbers import (
     add_line_numbers,
     every_line_has_line_numbers,
     extract_start_line_number,
+    strip_display_prefixes,
     strip_line_numbers,
 )
 from openviking_cli.utils import get_logger
@@ -874,6 +875,36 @@ def _delete_complete_lines(content: str, delete_content: str) -> str:
     return content[:start] + content[end:]
 
 
+def _clean_replace_prefixes(search_content: str, replace_content: str) -> str:
+    """Return REPLACE with numbered-view display prefixes removed (#4413).
+
+    When SEARCH itself is fully numbered, the block was copied from the
+    numbered read view, so REPLACE prefixes (when present on every line) are
+    display prefixes too, even when the numbers are non-consecutive (partial
+    copies). When SEARCH is clean, REPLACE is only stripped when it
+    independently forms a consecutive numbered view (single lines included),
+    which genuine tabular data almost never does.
+    """
+    if every_line_has_line_numbers(search_content):
+        if every_line_has_line_numbers(replace_content) or replace_content.strip() == "":
+            return strip_line_numbers(replace_content)
+        return replace_content
+    return strip_display_prefixes(replace_content)
+
+
+def _clean_block_prefixes(search_content: str, replace_content: str) -> tuple[str, str]:
+    """Clean display prefixes from both sides of a patch block (#4413).
+
+    SEARCH is stripped only when fully numbered; stripped SEARCH text that
+    matches several locations needs the caller's start-line disambiguation,
+    so the exact-match fast path must use _clean_replace_prefixes() instead.
+    """
+    cleaned_replace = _clean_replace_prefixes(search_content, replace_content)
+    if every_line_has_line_numbers(search_content):
+        return strip_line_numbers(search_content), cleaned_replace
+    return search_content, cleaned_replace
+
+
 def apply_str_patch(original_content: str, patch: StrPatch) -> str:
     """Apply a StrPatch to original content.
 
@@ -894,6 +925,13 @@ def apply_str_patch(original_content: str, patch: StrPatch) -> str:
     for block in patch.blocks:
         search_content = unescape_markers(block.search)
         replace_content = unescape_markers(block.replace)
+
+        # Write-path cleanup (#4413): REPLACE copied from the numbered read
+        # view keeps its display prefixes even when SEARCH matches exactly,
+        # and this fast path would write them verbatim into stored memories.
+        # SEARCH stays untouched here: stripped SEARCH text matching several
+        # locations needs the fallback's start-line disambiguation.
+        replace_content = _clean_replace_prefixes(search_content, replace_content)
 
         if search_content == replace_content:
             continue
@@ -966,20 +1004,17 @@ def apply_str_patch(original_content: str, patch: StrPatch) -> str:
         search_content = unescape_markers(search_content)
         replace_content = unescape_markers(replace_content)
 
-        # Strip line numbers if present
-        has_all_line_numbers = (
-            every_line_has_line_numbers(search_content)
-            and every_line_has_line_numbers(replace_content)
-        ) or (every_line_has_line_numbers(search_content) and replace_content.strip() == "")
-
-        if has_all_line_numbers and start_line == 0:
+        # Infer the start line from a numbered SEARCH before stripping it.
+        if every_line_has_line_numbers(search_content) and start_line == 0:
             inferred_start_line = extract_start_line_number(search_content)
             if inferred_start_line is not None:
                 start_line = inferred_start_line
 
-        if has_all_line_numbers:
-            search_content = strip_line_numbers(search_content)
-            replace_content = strip_line_numbers(replace_content)
+        # Write-path cleanup (#4413): covers mixed blocks too, where only one
+        # side carries display prefixes.
+        search_content, replace_content = _clean_block_prefixes(
+            search_content, replace_content
+        )
 
         # If search and replace are identical, treat as success (no changes needed)
         if search_content == replace_content:

--- a/openviking/session/memory/utils/line_numbers.py
+++ b/openviking/session/memory/utils/line_numbers.py
@@ -6,6 +6,13 @@ from typing import Optional
 
 _LINE_NUMBER_PREFIX_RE = re.compile(r"^(\d+)\t")
 _LINE_NUMBER_PREFIX_WITH_LEADING_SPACE_RE = re.compile(r"^\s*(\d+)\t")
+# Repeated variants used only by strip_line_numbers: line-number prefixes can
+# stack when add_line_numbers() runs on content that already carries a prefix
+# (e.g. a patch whose REPLACE block echoes the numbered view of the file). A
+# single anchored substitution removes only one prefix per line, so stripping
+# must match every leading prefix to stay idempotent (issue #4413).
+_LINE_NUMBER_PREFIXES_RE = re.compile(r"^(?:\d+\t)+")
+_LINE_NUMBER_PREFIXES_WITH_LEADING_SPACE_RE = re.compile(r"^(?:\s*\d+\t)+")
 _LINE_SPLIT_RE = re.compile(r"\r?\n")
 
 
@@ -18,6 +25,10 @@ def split_content_lines(content: str) -> list[str]:
 def add_line_numbers(content: str, start_line: int = 1) -> str:
     if not content:
         return ""
+    if every_line_has_line_numbers(content):
+        # Already line numbered (possibly by a previous call): numbering again
+        # would stack prefixes (issue #4413).
+        return content
     return "\n".join(
         f"{index + start_line}\t{line}" for index, line in enumerate(split_content_lines(content))
     )
@@ -44,7 +55,11 @@ def extract_start_line_number(content: str) -> Optional[int]:
 
 
 def strip_line_numbers(content: str, aggressive: bool = False) -> str:
-    pattern = _LINE_NUMBER_PREFIX_WITH_LEADING_SPACE_RE if aggressive else _LINE_NUMBER_PREFIX_RE
+    pattern = (
+        _LINE_NUMBER_PREFIXES_WITH_LEADING_SPACE_RE
+        if aggressive
+        else _LINE_NUMBER_PREFIXES_RE
+    )
     return "\n".join(pattern.sub("", line) for line in split_content_lines(content))
 
 

--- a/openviking/session/memory/utils/line_numbers.py
+++ b/openviking/session/memory/utils/line_numbers.py
@@ -68,3 +68,36 @@ def every_line_has_line_numbers(content: str) -> bool:
     if not lines:
         return False
     return all(_LINE_NUMBER_PREFIX_RE.match(line) for line in lines)
+
+
+def looks_like_line_numbered_view(content: str) -> bool:
+    """Whether the whole content reads as a numbered view add_line_numbers() produced.
+
+    Every line (a trailing newline allowed) must start with an ``N\\t`` prefix
+    and the numbers must form one consecutive increasing run. Genuine
+    tabular data whose first column happens to be numeric almost never forms
+    an exact consecutive run, so this keeps real content intact.
+    """
+    lines = split_content_lines(content)
+    if lines and lines[-1] == "":
+        lines = lines[:-1]
+    if not lines:
+        return False
+    numbers = []
+    for line in lines:
+        match = _LINE_NUMBER_PREFIX_RE.match(line)
+        if match is None:
+            return False
+        numbers.append(int(match.group(1)))
+    return all(right - left == 1 for left, right in zip(numbers, numbers[1:]))
+
+
+def strip_display_prefixes(content: str) -> str:
+    """Strip line-number prefixes when content looks like a numbered view.
+
+    No-op otherwise, so genuine numeric/tabular content is preserved
+    (issue #4413 write-path cleanup).
+    """
+    if not looks_like_line_numbered_view(content):
+        return content
+    return strip_line_numbers(content)

--- a/openviking/session/memory/utils/line_numbers.py
+++ b/openviking/session/memory/utils/line_numbers.py
@@ -68,36 +68,3 @@ def every_line_has_line_numbers(content: str) -> bool:
     if not lines:
         return False
     return all(_LINE_NUMBER_PREFIX_RE.match(line) for line in lines)
-
-
-def looks_like_line_numbered_view(content: str) -> bool:
-    """Whether the whole content reads as a numbered view add_line_numbers() produced.
-
-    Every line (a trailing newline allowed) must start with an ``N\\t`` prefix
-    and the numbers must form one consecutive increasing run. Genuine
-    tabular data whose first column happens to be numeric almost never forms
-    an exact consecutive run, so this keeps real content intact.
-    """
-    lines = split_content_lines(content)
-    if lines and lines[-1] == "":
-        lines = lines[:-1]
-    if not lines:
-        return False
-    numbers = []
-    for line in lines:
-        match = _LINE_NUMBER_PREFIX_RE.match(line)
-        if match is None:
-            return False
-        numbers.append(int(match.group(1)))
-    return all(right - left == 1 for left, right in zip(numbers, numbers[1:]))
-
-
-def strip_display_prefixes(content: str) -> str:
-    """Strip line-number prefixes when content looks like a numbered view.
-
-    No-op otherwise, so genuine numeric/tabular content is preserved
-    (issue #4413 write-path cleanup).
-    """
-    if not looks_like_line_numbered_view(content):
-        return content
-    return strip_line_numbers(content)

--- a/tests/session/memory/test_merge_ops.py
+++ b/tests/session/memory/test_merge_ops.py
@@ -471,6 +471,38 @@ class TestApplyStrPatch:
 
         assert result == "alpha\nBETA\ngamma"
 
+    def test_numbered_patch_strips_accumulated_line_number_prefixes(self):
+        """A REPLACE block echoing a stacked numbered view must not leak prefixes (#4413)."""
+        original = "## Roadmap\n- step one"
+        patch = StrPatch(
+            blocks=[
+                SearchReplaceBlock(
+                    search="1\t## Roadmap\n2\t- step one",
+                    replace="1\t1\t## Roadmap\n2\t2\t- step one\n3\t3\t- step two",
+                )
+            ]
+        )
+
+        result = apply_str_patch(original, patch)
+
+        assert result == "## Roadmap\n- step one\n- step two"
+
+    def test_numbered_patch_with_accumulated_prefixes_in_search_matches_clean_content(self):
+        """SEARCH copied from a stacked numbered view must fully strip prefixes (#4413)."""
+        original = "## Roadmap\n- step one"
+        patch = StrPatch(
+            blocks=[
+                SearchReplaceBlock(
+                    search="1\t1\t## Roadmap\n2\t2\t- step one",
+                    replace="1\t1\t## Roadmap\n2\t2\t- step one\n3\t3\t- step two",
+                )
+            ]
+        )
+
+        result = apply_str_patch(original, patch)
+
+        assert result == "## Roadmap\n- step one\n- step two"
+
 
 # ============================================================================
 # Test Schema Generation Integration - tested in test_schema_models.py

--- a/tests/session/memory/test_merge_ops.py
+++ b/tests/session/memory/test_merge_ops.py
@@ -90,6 +90,39 @@ class TestPatchOp:
         assert await op_int.apply(100, 200) == 200
 
     @pytest.mark.asyncio
+    async def test_full_string_replacement_strips_display_prefixes(self):
+        """A full replacement copied from the numbered read view must not store
+        display prefixes (#4413)."""
+        op = PatchOp(FieldType.STRING)
+        numbered = "1\t# Deployment\n2\t- Auth: required"
+
+        assert await op.apply("old", numbered) == "# Deployment\n- Auth: required"
+
+    @pytest.mark.asyncio
+    async def test_full_string_replacement_preserves_tabular_data(self):
+        """Non-consecutive numeric columns are genuine data (#4413)."""
+        op = PatchOp(FieldType.STRING)
+        tsv = "1\tfoo\tbar\n3\tbaz\tqux"
+
+        assert await op.apply("old", tsv) == tsv
+
+    @pytest.mark.asyncio
+    async def test_no_original_content_strips_display_prefixes_per_block(self):
+        """New-memory patches are cleaned per block before joining, so numbers
+        that restart per block cannot reappear (#4413)."""
+        op = PatchOp(FieldType.STRING)
+        patch = StrPatch(
+            blocks=[
+                SearchReplaceBlock(search="", replace="1\t## Deploy\n2\t- Auth: required"),
+                SearchReplaceBlock(search="", replace="1\t- Bind: loopback"),
+            ]
+        )
+
+        result = await op.apply(None, patch)
+
+        assert result == "## Deploy\n- Auth: required\n- Bind: loopback"
+
+    @pytest.mark.asyncio
     async def test_apply_dict_patch(self, monkeypatch):
         """Dict-form string patches should be applied without blocking the event loop."""
         from openviking.session.memory.merge_op import patch_handler
@@ -502,6 +535,60 @@ class TestApplyStrPatch:
         result = apply_str_patch(original, patch)
 
         assert result == "## Roadmap\n- step one\n- step two"
+
+    def test_exact_match_replace_with_prefix_cannot_write_display_prefixes(self):
+        """REPLACE copied from the numbered view must not leak prefixes via the
+        exact-match fast path, even when SEARCH itself is clean (#4413)."""
+        original = "# Deployment\n- Bind: loopback"
+        patch = StrPatch(
+            blocks=[
+                SearchReplaceBlock(
+                    search="- Bind: loopback",
+                    replace="2\t- Bind: Tailscale",
+                )
+            ]
+        )
+
+        result = apply_str_patch(original, patch)
+
+        assert result == "# Deployment\n- Bind: Tailscale"
+
+    def test_write_path_strips_consecutive_prefixes_from_replace_only_blocks(self):
+        """A REPLACE that independently forms a consecutive numbered view is cleaned
+        even when SEARCH carries no prefixes at all (#4413)."""
+        original = "## Deploy\n- Auth: required"
+        patch = StrPatch(
+            blocks=[
+                SearchReplaceBlock(
+                    search="- Auth: required",
+                    replace="2\t- Auth: optional\n3\t- Bind: loopback",
+                )
+            ]
+        )
+
+        result = apply_str_patch(original, patch)
+
+        assert result == "## Deploy\n- Auth: optional\n- Bind: loopback"
+
+    def test_write_path_preserves_genuine_tabular_replace(self):
+        """Non-consecutive numeric first columns are real data, not display
+        prefixes, and must survive the write path (#4413)."""
+        tsv = "1\tfoo\tbar\n3\tbaz\tqux"
+        patch = StrPatch(blocks=[SearchReplaceBlock(search="header", replace=tsv)])
+
+        result = apply_str_patch("header", patch)
+
+        assert result == tsv
+
+    def test_write_path_preserves_mixed_numbered_and_plain_replace(self):
+        """Mixed numbered/plain REPLACE lines carry no numbered-view proof and
+        must be stored verbatim (#4413)."""
+        mixed = "1\theader\nplain line\n3\tmore"
+        patch = StrPatch(blocks=[SearchReplaceBlock(search="seed", replace=mixed)])
+
+        result = apply_str_patch("seed", patch)
+
+        assert result == mixed
 
 
 # ============================================================================

--- a/tests/session/memory/test_merge_ops.py
+++ b/tests/session/memory/test_merge_ops.py
@@ -90,13 +90,31 @@ class TestPatchOp:
         assert await op_int.apply(100, 200) == 200
 
     @pytest.mark.asyncio
-    async def test_full_string_replacement_strips_display_prefixes(self):
-        """A full replacement copied from the numbered read view must not store
-        display prefixes (#4413)."""
+    async def test_full_string_replacement_preserves_numbered_content(self):
+        """A full replacement has no SEARCH to prove the model copied the
+        numbered read view, so it is stored verbatim (#4413)."""
         op = PatchOp(FieldType.STRING)
         numbered = "1\t# Deployment\n2\t- Auth: required"
 
-        assert await op.apply("old", numbered) == "# Deployment\n- Auth: required"
+        assert await op.apply("old", numbered) == numbered
+
+    @pytest.mark.asyncio
+    async def test_full_string_replacement_preserves_consecutive_numeric_columns(self):
+        """Consecutive numeric columns (years + measurements) are genuine data
+        and must not be stripped as display prefixes (#4413)."""
+        op = PatchOp(FieldType.STRING)
+        tsv = "2024\t17\n2025\t19"
+
+        assert await op.apply("old content", tsv) == tsv
+
+    @pytest.mark.asyncio
+    async def test_full_string_replacement_preserves_one_based_consecutive_columns(self):
+        """A 1-based consecutive run (quarter index) is still indistinguishable
+        from a display prefix by shape, so it must be preserved (#4413)."""
+        op = PatchOp(FieldType.STRING)
+        quarters = "1\t120000\n2\t138000\n3\t141000"
+
+        assert await op.apply("old content", quarters) == quarters
 
     @pytest.mark.asyncio
     async def test_full_string_replacement_preserves_tabular_data(self):
@@ -107,9 +125,10 @@ class TestPatchOp:
         assert await op.apply("old", tsv) == tsv
 
     @pytest.mark.asyncio
-    async def test_no_original_content_strips_display_prefixes_per_block(self):
-        """New-memory patches are cleaned per block before joining, so numbers
-        that restart per block cannot reappear (#4413)."""
+    async def test_no_original_content_preserves_block_replaces_verbatim(self):
+        """New-memory block replaces carry no SEARCH evidence, so they are
+        joined verbatim — stripping by shape would eat consecutive numeric
+        columns (#4413)."""
         op = PatchOp(FieldType.STRING)
         patch = StrPatch(
             blocks=[
@@ -120,7 +139,16 @@ class TestPatchOp:
 
         result = await op.apply(None, patch)
 
-        assert result == "## Deploy\n- Auth: required\n- Bind: loopback"
+        assert result == "1\t## Deploy\n2\t- Auth: required\n1\t- Bind: loopback"
+
+    @pytest.mark.asyncio
+    async def test_no_original_content_preserves_consecutive_numeric_columns(self):
+        """A new memory whose content is a consecutive numeric table survives
+        the write path intact (#4413)."""
+        op = PatchOp(FieldType.STRING)
+        tsv = "2024\t17\n2025\t19"
+
+        assert await op.apply(None, tsv) == tsv
 
     @pytest.mark.asyncio
     async def test_apply_dict_patch(self, monkeypatch):
@@ -536,9 +564,11 @@ class TestApplyStrPatch:
 
         assert result == "## Roadmap\n- step one\n- step two"
 
-    def test_exact_match_replace_with_prefix_cannot_write_display_prefixes(self):
-        """REPLACE copied from the numbered view must not leak prefixes via the
-        exact-match fast path, even when SEARCH itself is clean (#4413)."""
+    def test_exact_match_clean_search_stores_numbered_replace_verbatim(self):
+        """With a clean SEARCH there is no proof the REPLACE prefixes were
+        copied from the numbered view, so the replace is stored verbatim
+        (#4413) — a stored display prefix is noise, a stripped data column
+        is loss."""
         original = "# Deployment\n- Bind: loopback"
         patch = StrPatch(
             blocks=[
@@ -551,11 +581,12 @@ class TestApplyStrPatch:
 
         result = apply_str_patch(original, patch)
 
-        assert result == "# Deployment\n- Bind: Tailscale"
+        assert result == "# Deployment\n2\t- Bind: Tailscale"
 
-    def test_write_path_strips_consecutive_prefixes_from_replace_only_blocks(self):
-        """A REPLACE that independently forms a consecutive numbered view is cleaned
-        even when SEARCH carries no prefixes at all (#4413)."""
+    def test_write_path_clean_search_stores_consecutive_numbered_replace_verbatim(self):
+        """A REPLACE forming a consecutive numbered view is stored verbatim
+        when SEARCH carries no prefixes — consecutive numeric columns are
+        indistinguishable from display prefixes by shape (#4413)."""
         original = "## Deploy\n- Auth: required"
         patch = StrPatch(
             blocks=[
@@ -568,7 +599,24 @@ class TestApplyStrPatch:
 
         result = apply_str_patch(original, patch)
 
-        assert result == "## Deploy\n- Auth: optional\n- Bind: loopback"
+        assert result == "## Deploy\n2\t- Auth: optional\n3\t- Bind: loopback"
+
+    def test_write_path_clean_search_preserves_year_columns(self):
+        """Real year+measurement columns survive SEARCH/REPLACE edits with a
+        clean SEARCH (#4413)."""
+        original = "## Metrics\nheader"
+        patch = StrPatch(
+            blocks=[
+                SearchReplaceBlock(
+                    search="header",
+                    replace="2024\t17\n2025\t19",
+                )
+            ]
+        )
+
+        result = apply_str_patch(original, patch)
+
+        assert result == "## Metrics\n2024\t17\n2025\t19"
 
     def test_write_path_preserves_genuine_tabular_replace(self):
         """Non-consecutive numeric first columns are real data, not display

--- a/tests/unit/session/memory/test_line_numbers.py
+++ b/tests/unit/session/memory/test_line_numbers.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from openviking.session.memory.utils.line_numbers import (
+    add_line_numbers,
+    every_line_has_line_numbers,
+    extract_start_line_number,
+    strip_line_numbers,
+)
+
+
+class TestAddLineNumbers:
+    def test_numbers_plain_content(self):
+        assert add_line_numbers("alpha\nbeta") == "1\talpha\n2\tbeta"
+
+    def test_respects_start_line(self):
+        assert add_line_numbers("alpha\nbeta", start_line=3) == "3\talpha\n4\tbeta"
+
+    def test_empty_content_returns_empty(self):
+        assert add_line_numbers("") == ""
+
+    def test_does_not_renumber_already_numbered_content(self):
+        """Numbering already-numbered content must not stack prefixes (#4413)."""
+        numbered = add_line_numbers("alpha\nbeta")
+        assert add_line_numbers(numbered) == numbered
+
+
+class TestStripLineNumbers:
+    def test_strips_single_prefix(self):
+        assert strip_line_numbers("1\talpha\n2\tbeta") == "alpha\nbeta"
+
+    def test_strips_all_accumulated_prefixes(self):
+        """Merged memories can carry several stacked prefixes (#4413)."""
+        assert strip_line_numbers("1\t1\t## Title\n2\t2\t- fact one") == (
+            "## Title\n- fact one"
+        )
+
+    def test_strip_is_idempotent(self):
+        content = "1\t1\t1\t## Title\n2\t2\t2\t- fact one"
+        once = strip_line_numbers(content)
+        assert once == "## Title\n- fact one"
+        assert strip_line_numbers(once) == once
+
+    def test_round_trips_stacked_add_on_plain_content(self):
+        plain = "## Title\n- fact one"
+        stacked = "1\t1\t## Title\n2\t2\t- fact one"  # add_line_numbers applied twice
+        assert strip_line_numbers(stacked) == plain
+
+    def test_plain_content_unchanged(self):
+        assert strip_line_numbers("alpha\nbeta") == "alpha\nbeta"
+
+    def test_keeps_inner_tabs_after_prefix(self):
+        assert strip_line_numbers("1\talpha\tkeeps inner tabs") == "alpha\tkeeps inner tabs"
+
+    def test_non_aggressive_keeps_leading_whitespace(self):
+        assert strip_line_numbers(" 1\talpha") == " 1\talpha"
+
+    def test_aggressive_strips_all_accumulated_prefixes_with_whitespace(self):
+        assert strip_line_numbers(" 1\t 1\talpha", aggressive=True) == "alpha"
+
+
+class TestEveryLineHasLineNumbers:
+    def test_true_for_fully_numbered_content(self):
+        assert every_line_has_line_numbers("1\ta\n2\tb") is True
+
+    def test_true_for_content_with_accumulated_prefixes(self):
+        assert every_line_has_line_numbers("1\t1\ta\n2\t2\tb") is True
+
+    def test_false_for_plain_content(self):
+        assert every_line_has_line_numbers("a\nb") is False
+
+    def test_false_for_partially_numbered_content(self):
+        assert every_line_has_line_numbers("1\ta\nb") is False
+
+    def test_false_for_empty_content(self):
+        assert every_line_has_line_numbers("") is False
+
+
+class TestExtractStartLineNumber:
+    def test_reads_first_prefix(self):
+        assert extract_start_line_number("3\talpha\n4\tbeta") == 3
+
+    def test_reads_first_prefix_from_accumulated_prefixes(self):
+        assert extract_start_line_number("3\t3\talpha") == 3
+
+    def test_none_for_plain_content(self):
+        assert extract_start_line_number("alpha\nbeta") is None

--- a/tests/unit/session/memory/test_line_numbers.py
+++ b/tests/unit/session/memory/test_line_numbers.py
@@ -5,8 +5,6 @@ from openviking.session.memory.utils.line_numbers import (
     add_line_numbers,
     every_line_has_line_numbers,
     extract_start_line_number,
-    looks_like_line_numbered_view,
-    strip_display_prefixes,
     strip_line_numbers,
 )
 
@@ -87,57 +85,3 @@ class TestExtractStartLineNumber:
 
     def test_none_for_plain_content(self):
         assert extract_start_line_number("alpha\nbeta") is None
-
-
-class TestLooksLikeLineNumberedView:
-    def test_true_for_consecutive_run(self):
-        assert looks_like_line_numbered_view("1\ta\n2\tb\n3\tc") is True
-
-    def test_true_for_run_with_offset_start(self):
-        assert looks_like_line_numbered_view("37\ta\n38\tb") is True
-
-    def test_true_for_single_numbered_line(self):
-        assert looks_like_line_numbered_view("2\t- Bind: Tailscale") is True
-
-    def test_true_despite_trailing_newline(self):
-        assert looks_like_line_numbered_view("1\ta\n2\tb\n") is True
-
-    def test_false_for_non_consecutive_numbers(self):
-        """Genuine tabular data keeps real numeric columns (#4413)."""
-        assert looks_like_line_numbered_view("1\tfoo\tbar\n3\tbaz\tqux") is False
-
-    def test_false_for_plain_content(self):
-        assert looks_like_line_numbered_view("a\nb") is False
-
-    def test_false_for_mixed_numbered_and_plain_lines(self):
-        assert looks_like_line_numbered_view("1\theader\nplain\n3\tmore") is False
-
-    def test_false_for_empty_content(self):
-        assert looks_like_line_numbered_view("") is False
-
-    def test_false_for_descending_numbers(self):
-        assert looks_like_line_numbered_view("2\ta\n1\tb") is False
-
-
-class TestStripDisplayPrefixes:
-    def test_strips_consecutive_view(self):
-        assert strip_display_prefixes("1\t## Deploy\n2\t- Auth: required") == (
-            "## Deploy\n- Auth: required"
-        )
-
-    def test_strips_single_prefix(self):
-        assert strip_display_prefixes("2\t- Bind: Tailscale") == "- Bind: Tailscale"
-
-    def test_keeps_trailing_newline(self):
-        assert strip_display_prefixes("1\tA\n2\tB\n") == "A\nB\n"
-
-    def test_preserves_non_consecutive_tabular_data(self):
-        tsv = "1\tfoo\tbar\n3\tbaz\tqux"
-        assert strip_display_prefixes(tsv) == tsv
-
-    def test_preserves_mixed_numbered_and_plain_lines(self):
-        mixed = "1\theader\nplain line\n3\tmore"
-        assert strip_display_prefixes(mixed) == mixed
-
-    def test_noop_on_plain_content(self):
-        assert strip_display_prefixes("alpha\nbeta") == "alpha\nbeta"

--- a/tests/unit/session/memory/test_line_numbers.py
+++ b/tests/unit/session/memory/test_line_numbers.py
@@ -5,6 +5,8 @@ from openviking.session.memory.utils.line_numbers import (
     add_line_numbers,
     every_line_has_line_numbers,
     extract_start_line_number,
+    looks_like_line_numbered_view,
+    strip_display_prefixes,
     strip_line_numbers,
 )
 
@@ -85,3 +87,57 @@ class TestExtractStartLineNumber:
 
     def test_none_for_plain_content(self):
         assert extract_start_line_number("alpha\nbeta") is None
+
+
+class TestLooksLikeLineNumberedView:
+    def test_true_for_consecutive_run(self):
+        assert looks_like_line_numbered_view("1\ta\n2\tb\n3\tc") is True
+
+    def test_true_for_run_with_offset_start(self):
+        assert looks_like_line_numbered_view("37\ta\n38\tb") is True
+
+    def test_true_for_single_numbered_line(self):
+        assert looks_like_line_numbered_view("2\t- Bind: Tailscale") is True
+
+    def test_true_despite_trailing_newline(self):
+        assert looks_like_line_numbered_view("1\ta\n2\tb\n") is True
+
+    def test_false_for_non_consecutive_numbers(self):
+        """Genuine tabular data keeps real numeric columns (#4413)."""
+        assert looks_like_line_numbered_view("1\tfoo\tbar\n3\tbaz\tqux") is False
+
+    def test_false_for_plain_content(self):
+        assert looks_like_line_numbered_view("a\nb") is False
+
+    def test_false_for_mixed_numbered_and_plain_lines(self):
+        assert looks_like_line_numbered_view("1\theader\nplain\n3\tmore") is False
+
+    def test_false_for_empty_content(self):
+        assert looks_like_line_numbered_view("") is False
+
+    def test_false_for_descending_numbers(self):
+        assert looks_like_line_numbered_view("2\ta\n1\tb") is False
+
+
+class TestStripDisplayPrefixes:
+    def test_strips_consecutive_view(self):
+        assert strip_display_prefixes("1\t## Deploy\n2\t- Auth: required") == (
+            "## Deploy\n- Auth: required"
+        )
+
+    def test_strips_single_prefix(self):
+        assert strip_display_prefixes("2\t- Bind: Tailscale") == "- Bind: Tailscale"
+
+    def test_keeps_trailing_newline(self):
+        assert strip_display_prefixes("1\tA\n2\tB\n") == "A\nB\n"
+
+    def test_preserves_non_consecutive_tabular_data(self):
+        tsv = "1\tfoo\tbar\n3\tbaz\tqux"
+        assert strip_display_prefixes(tsv) == tsv
+
+    def test_preserves_mixed_numbered_and_plain_lines(self):
+        mixed = "1\theader\nplain line\n3\tmore"
+        assert strip_display_prefixes(mixed) == mixed
+
+    def test_noop_on_plain_content(self):
+        assert strip_display_prefixes("alpha\nbeta") == "alpha\nbeta"


### PR DESCRIPTION

## Root cause

`strip_line_numbers()` in `openviking/session/memory/utils/line_numbers.py` substituted a single `^`-anchored prefix pattern (`^(\d+)\t`), so each call removed at most one `N<TAB>` prefix per line. Nothing stopped `add_line_numbers()` from running on content that already carried a prefix (a patch whose SEARCH/REPLACE block echoes the numbered view of the file, the retry "Original Content" section, or a stored card whose previous merge left a prefix behind). Each merge stripped one layer but could still write content with prefixes back to storage, so prefixes stacked with every merge until cards looked like `1\t1\t1\t## Title` — the version-correlated corruption reported in #4413.

## Fix

Two complementary changes in `line_numbers.py`; no call-site changes:

1. `strip_line_numbers()` now strips every leading `N<TAB>` prefix per line via the repeated patterns `^(?:\d+\t)+` / `^(?:\s*\d+\t)+` (used only by stripping), making it idempotent: `strip(strip(x)) == strip(x)`, and legacy stacked content is fully cleaned in one pass. `extract_start_line_number()` keeps its single-prefix capture semantics unchanged.
2. `add_line_numbers()` now returns content unchanged when every line already carries a line-number prefix, so numbering can no longer stack at the source (`add(add(c)) == add(c)`).

Known trade-off (raised in the issue): stripping all prefixes can also remove a legitimate leading numeric TSV column. This was already partially true before (one prefix was stripped per pass); the repeated pattern only extends it to consecutive prefixes, and the `add_line_numbers()` guard keeps such content from being re-numbered, which is where the stacking started.

## How verified

- New unit tests `tests/unit/session/memory/test_line_numbers.py` (20 cases): no re-numbering of already-numbered content, idempotent stripping (incl. triple-stacked), aggressive mode, unchanged `extract_start_line_number`, plus the issue's repro (`1\t1\t## Title` -> `## Title`).
- New merge-path regressions in `tests/session/memory/test_merge_ops.py` (`TestApplyStrPatch`): SEARCH/REPLACE blocks echoing single- and double-numbered views now store clean content via `apply_str_patch`.
- `python3 -m pytest --noconftest -o addopts="" tests/unit/session/memory/test_line_numbers.py tests/session/memory/test_merge_ops.py -q` -> **76 passed**; adjacent suites (`test_memory_utils.py`, `test_memory_patch.py`) also pass.
- Re-ran the suite against the pre-fix `line_numbers.py` (via `git stash`): the 7 new prefix tests fail while the other 69 pass, confirming the tests pin the regression.

Fixes #4413
