### PR TITLE
fix(session): don't fail session_commit on telemetry URI validation (#4492)

### DIFF
--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -170,16 +170,26 @@ def _report_extraction_telemetry(result: Any, operations: ResolvedOperations) ->
         type_actions = actions_by_type.setdefault(normalized_type, {})
         type_actions[action] = type_actions.get(action, 0) + 1
 
+    def type_for(uri: Any) -> Optional[str]:
+        # Look up lazily: dict.get evaluates its default eagerly, so the old
+        # code parsed every URI even when the type was already known, and it
+        # raised on non-viking:// placeholders (issue #4492). Unresolvable
+        # URIs are counted under "unknown" by ``add``.
+        memory_type = types_by_uri.get(str(uri))
+        if memory_type is None:
+            memory_type = MemoryUpdater.memory_type_from_uri(str(uri))
+        return memory_type
+
     for uri in result.written_uris:
-        add(types_by_uri.get(str(uri), MemoryUpdater.memory_type_from_uri(uri)), "created")
+        add(type_for(uri), "created")
     for uri in result.edited_uris:
-        add(types_by_uri.get(str(uri), MemoryUpdater.memory_type_from_uri(uri)), "merged")
+        add(type_for(uri), "merged")
     for uri in result.deleted_uris:
-        add(types_by_uri.get(str(uri), MemoryUpdater.memory_type_from_uri(uri)), "deleted")
+        add(type_for(uri), "deleted")
     for operation in result.skipped_operations:
         add(getattr(operation, "memory_type", None), "skipped")
     for uri, _error in result.errors:
-        add(types_by_uri.get(str(uri), MemoryUpdater.memory_type_from_uri(uri)), "failed")
+        add(type_for(uri), "failed")
 
     for memory_type, actions in actions_by_type.items():
         for action, value in actions.items():

--- a/openviking/session/memory/memory_updater.py
+++ b/openviking/session/memory/memory_updater.py
@@ -841,7 +841,15 @@ class MemoryUpdater:
 
     @staticmethod
     def memory_type_from_uri(uri: str) -> Optional[str]:
-        parts = [part for part in VikingURI(uri).full_path.split("/") if part]
+        try:
+            parts = [part for part in VikingURI(uri).full_path.split("/") if part]
+        except ValueError:
+            # Non-viking:// placeholder (e.g. "unknown" or "events(page_id=3)"
+            # recorded into MemoryUpdateResult.errors by apply_operations) is
+            # not a parseable URI; report "no memory type" instead of raising.
+            # See issue #4492: telemetry crashed on these placeholders after
+            # memories were already written, failing the whole session_commit.
+            return None
         try:
             memories_idx = parts.index("memories")
         except ValueError:

--- a/tests/session/memory/test_memory_updater.py
+++ b/tests/session/memory/test_memory_updater.py
@@ -1733,3 +1733,21 @@ class TestConsecutivePatchesSameURI:
         assert "ALPHA" in parsed["content"]
         assert "BETA" in parsed["content"]
         assert "gamma" in parsed["content"]
+
+
+def test_memory_type_from_uri_tolerates_non_viking_placeholders():
+    """Regression test for issue #4492.
+
+    ``apply_operations`` records placeholder targets such as ``"unknown"``
+    (batch-level errors) and ``"{memory_type}(page_id=...)"`` (unresolved
+    operations) into ``MemoryUpdateResult.errors``. Parsing those must yield
+    ``None`` instead of raising ``ValueError`` so telemetry and diff helpers
+    can degrade them to "unknown".
+    """
+    assert MemoryUpdater.memory_type_from_uri("unknown") is None
+    assert MemoryUpdater.memory_type_from_uri("events(page_id=xyz)") is None
+    assert MemoryUpdater.memory_type_from_uri("") is None
+    assert (
+        MemoryUpdater.memory_type_from_uri("viking://user/u/memories/events/e1.md")
+        == "events"
+    )

--- a/tests/session/memory/test_memory_updater.py
+++ b/tests/session/memory/test_memory_updater.py
@@ -1751,3 +1751,17 @@ def test_memory_type_from_uri_tolerates_non_viking_placeholders():
         MemoryUpdater.memory_type_from_uri("viking://user/u/memories/events/e1.md")
         == "events"
     )
+
+
+def test_memory_type_from_uri_placeholder_edge_matrix():
+    """Harder placeholder shapes observed in failure paths (#4492 follow-up).
+
+    Whitespace-only targets, wrong-scheme or malformed prefixes, and
+    case-variants must all degrade to None rather than raise, so a single
+    bad URI can never flip session_commit to failed via telemetry/diff.
+    """
+    assert MemoryUpdater.memory_type_from_uri("   ") is None
+    assert MemoryUpdater.memory_type_from_uri("VIKING://user/u/memories/events/e.md") is None
+    assert MemoryUpdater.memory_type_from_uri("viking:/user/u/memories/events/e.md") is None
+    assert MemoryUpdater.memory_type_from_uri("skills(page_id=7)") is None
+    assert MemoryUpdater.memory_type_from_uri("viking://user/u/memories/events/e1.md") == "events"

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -15,6 +15,7 @@ from openviking.session import create_session_compressor
 from openviking.session.compressor_v3 import (
     SessionCompressorV3,
     _commit_experience_snapshot,
+    _report_extraction_telemetry,
     _experience_root_uri,
     _experience_snapshot_provenance,
     _experience_trajectory_map,
@@ -1819,3 +1820,42 @@ async def test_v3_training_links_case_to_trajectory_and_experience_via_trajector
             "ctx": _ctx(),
         }
     ]
+
+
+def test_report_extraction_telemetry_tolerates_placeholder_error_uris(monkeypatch):
+    """Regression test for issue #4492.
+
+    ``MemoryUpdater.apply_operations`` records non-viking:// placeholder
+    targets (``"unknown"`` for batch-level errors and
+    ``"{memory_type}(page_id=...)"`` for unresolved operations) into
+    ``result.errors``. Telemetry must count them under "unknown" instead of
+    raising ``ValueError: URI must start with 'viking://'`` — the old eager
+    ``dict.get`` default crashed after memories were already written and
+    marked the whole session_commit as failed.
+    """
+    recorded: dict = {}
+
+    class _StubTelemetry:
+        def set(self, key: str, value) -> None:
+            recorded[key] = value
+
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.get_current_telemetry",
+        lambda: _StubTelemetry(),
+    )
+
+    result = MemoryUpdateResult()
+    result.add_written("viking://user/u/memories/events/e1.md")
+    result.add_error("unknown", ValueError("batch-level error"))
+    result.add_error("events(page_id=xyz)", ValueError("resolution failed"))
+    operations = ResolvedOperations(
+        upsert_operations=[], delete_file_contents=[], errors=[]
+    )
+
+    # Must not raise despite the non-viking:// placeholders above.
+    _report_extraction_telemetry(result, operations)
+
+    assert recorded["memory.extract.created"] == 1
+    assert recorded["memory.extract.failed"] == 2
+    assert recorded["memory.extract.by_type.events.created"] == 1
+    assert recorded["memory.extract.by_type.unknown.failed"] == 2

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -1859,3 +1859,37 @@ def test_report_extraction_telemetry_tolerates_placeholder_error_uris(monkeypatc
     assert recorded["memory.extract.failed"] == 2
     assert recorded["memory.extract.by_type.events.created"] == 1
     assert recorded["memory.extract.by_type.unknown.failed"] == 2
+
+
+def test_report_extraction_telemetry_tolerates_placeholder_deleted_uris(monkeypatch):
+    """Deleted/skipped rows can carry the same placeholders as errors (#4492).
+
+    A delete recorded against a placeholder target (batch rollback paths)
+    must degrade to "unknown" in telemetry, not raise — the same invariant
+    the error-path regression pins, on the remaining actions.
+    """
+    recorded: dict = {}
+
+    class _StubTelemetry:
+        def set(self, key: str, value) -> None:
+            recorded[key] = value
+
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.get_current_telemetry",
+        lambda: _StubTelemetry(),
+    )
+
+    result = MemoryUpdateResult()
+    result.deleted_uris.append("events(page_id=rollback)")
+    result.skipped_operations.append({"memory_type": "skills(page_id=3)"})
+    operations = ResolvedOperations(
+        upsert_operations=[], delete_file_contents=[], errors=[]
+    )
+
+    # Must not raise despite the non-viking:// placeholders on deleted/skipped.
+    _report_extraction_telemetry(result, operations)
+
+    assert recorded["memory.extract.deleted"] == 1
+    assert recorded["memory.extract.skipped"] == 1
+    assert recorded["memory.extract.by_type.unknown.deleted"] == 1
+    assert recorded["memory.extract.by_type.unknown.skipped"] == 1


### PR DESCRIPTION

Fixes #4492

## Root cause

Two compounding defects made the `long_term` step of `session_commit` fail **after** the long-term memories were already written and indexed:

1. **Eager `dict.get` default.** All four counting loops in `_report_extraction_telemetry` (`openviking/session/compressor_v3.py`) used `types_by_uri.get(str(uri), MemoryUpdater.memory_type_from_uri(uri))`. Python evaluates the `default` argument unconditionally, so `memory_type_from_uri` ran for every URI even when the type was already known.

2. **Legitimate non-`viking://` placeholders in `result.errors`.** `MemoryUpdater.apply_operations` records `result.add_error("unknown", ...)` for batch-level errors and `error_target = f"{memory_type}(page_id={page_id})"` for unresolved operations. `memory_type_from_uri` called `VikingURI(uri).full_path` on those placeholders, which raises `ValueError("URI must start with 'viking://'")`.

Net effect: any memory operation that fails URI resolution (or any operation-level batch error) crashed the telemetry step after the memories were persisted, so the whole commit task was marked `failed` (`{"stage": "memory_extraction", "error": "URI must start with 'viking://'"}`), the session meta `memories_extracted` counter stayed 0, and the per-type telemetry counts were lost — despite no actual data loss.

## Fix

Two small, complementary changes (either alone stops the crash; both make the observability path robust):

- **`openviking/session/memory/memory_updater.py`** — `memory_type_from_uri` now returns `None` (its documented `Optional[str]` contract; all existing callers already treat a falsy result as "unknown") for unparseable URIs instead of raising `ValueError`. This also hardens the other call sites (`fs_service`, `content_write`, `_build_memory_diff`) against the same placeholder inputs.
- **`openviking/session/compressor_v3.py`** — `_report_extraction_telemetry` resolves the memory type lazily via a local `type_for()` helper, removing the eager `dict.get` default in all four loops; unresolvable URIs are counted under `unknown` by the existing `add()` normalization.

Also audited per the issue: `_build_memory_diff` uses the same `or "unknown"` fallback pattern; with `memory_type_from_uri` no longer raising, that path is safe without further changes.

## Verification

Reproduced the exact crash from the issue on `upstream/main` (minimal, no session needed):

```python
result = MemoryUpdateResult()
result.add_error("unknown", ValueError("boom"))
_report_extraction_telemetry(result, ResolvedOperations(...))  # ValueError: URI must start with 'viking://'
```

After the fix the same snippet completes and counts placeholders under `unknown`.

Regression tests added:

- `tests/session/test_compressor_v3.py::test_report_extraction_telemetry_tolerates_placeholder_error_uris` — telemetry with `result.errors = [("unknown", ...), ("events(page_id=xyz)", ...)]` must not raise and must emit `memory.extract.by_type.unknown.failed == 2` plus correct per-type counts.
- `tests/session/memory/test_memory_updater.py::test_memory_type_from_uri_tolerates_non_viking_placeholders` — `memory_type_from_uri` returns `None` for `"unknown"`, `"events(page_id=xyz)"`, `""`, and still returns `"events"` for a real `viking://user/u/memories/events/...` URI.

```
$ python3 -m pytest --noconftest -o addopts="" \
    tests/session/test_compressor_v3.py::test_report_extraction_telemetry_tolerates_placeholder_error_uris \
    tests/session/memory/test_memory_updater.py::test_memory_type_from_uri_tolerates_non_viking_placeholders -q
2 passed

$ python3 -m pytest --noconftest -o addopts="" \
    tests/session/test_compressor_v3.py tests/session/memory/test_memory_updater.py -q
23 failed, 44 passed    # with this change
# pristine upstream/main in a separate worktree: 23 failed, 42 passed
# → identical pre-existing failures (local env lacks full test deps);
#   the only delta is the 2 new regression tests passing. Zero regressions.

$ python3 -m py_compile openviking/session/compressor_v3.py openviking/session/memory/memory_updater.py  # OK
```
