### PR TITLE
fix(metrics): pre-initialize error counter series so increase() counts the first increment

### DIFF
--- a/openviking/metrics/collectors/base.py
+++ b/openviking/metrics/collectors/base.py
@@ -122,6 +122,27 @@ class CollectorMetricWriter:
             label_names=final_label_names,
         )
 
+    def init_counter_series(
+        self,
+        name: str,
+        *,
+        labels: dict[str, str] | None = None,
+        label_names: tuple[str, ...] = (),
+        account_id: str | None = None,
+    ) -> None:
+        """Pre-initialize one zero-valued counter series after resolving account labels."""
+        final_labels, final_label_names = self._with_account_labels(
+            metric_name=name,
+            labels=labels,
+            label_names=label_names,
+            explicit_account_id=account_id,
+        )
+        self._registry.init_counter_series(
+            name,
+            labels=final_labels,
+            label_names=final_label_names,
+        )
+
     def set_gauge(
         self,
         name: str,

--- a/openviking/metrics/collectors/queue.py
+++ b/openviking/metrics/collectors/queue.py
@@ -52,6 +52,11 @@ class QueueCollector(StateMetricCollector):
         The datasource provides cumulative `processed` and `error_count` values. This collector
         converts them into Prometheus counters by incrementing by positive deltas and ignoring
         decreases.
+
+        Counter series are also pre-initialized to zero for every queue seen in the status
+        snapshot. Without this, a series only appears together with its first increment, so
+        Prometheus never scrapes the pre-increment sample and `increase()` misses that first
+        increment (issue #4500).
         """
         statuses = metric_input
         for queue_name, status in statuses.items():
@@ -65,6 +70,17 @@ class QueueCollector(StateMetricCollector):
             registry.set_gauge(
                 self.IN_PROGRESS,
                 float(status.in_progress),
+                labels=labels,
+                label_names=("queue",),
+            )
+
+            registry.init_counter_series(
+                self.PROCESSED_TOTAL,
+                labels=labels,
+                label_names=("queue",),
+            )
+            registry.init_counter_series(
+                self.ERRORS_TOTAL,
                 labels=labels,
                 label_names=("queue",),
             )

--- a/openviking/metrics/collectors/resource.py
+++ b/openviking/metrics/collectors/resource.py
@@ -20,7 +20,7 @@ from typing import ClassVar
 
 from openviking.metrics.core.base import MetricCollector
 
-from .base import EventMetricCollector
+from .base import CollectorMetricWriter, EventMetricCollector
 
 
 @dataclass
@@ -49,9 +49,34 @@ class ResourceIngestionCollector(EventMetricCollector):
 
     SUPPORTED_EVENTS: ClassVar[frozenset[str]] = frozenset({"resource.stage", "resource.wait"})
 
+    # Closed sets of pipeline stage names and outcomes, mirroring the instrumentation sites
+    # in `openviking/utils/resource_processor.py`. They are enumerated eagerly so every
+    # stage/status series is scraped at zero before its first increment (issue #4500).
+    KNOWN_STAGES: ClassVar[tuple[str, ...]] = ("finalize", "parse", "persist", "summarize")
+    KNOWN_STATUSES: ClassVar[tuple[str, ...]] = ("error", "ok")
+
     def collect(self, registry=None) -> None:
         """Implement the collector interface as a no-op because resource metrics are push-driven."""
         return None
+
+    def preinitialize_series(self, registry) -> None:
+        """
+        Create zero-valued `stage_total` series for every known stage/status label pair.
+
+        Following the Prometheus client guidance of initializing label values, this makes
+        each series visible to scrapes before any error occurs, so PromQL `increase()` can
+        account for the first increment of a label set instead of silently dropping it.
+        The `account_id` dimension resolves with no request context, which is the label
+        value (`__unknown__`) used by the background resource pipeline in practice.
+        """
+        writer = CollectorMetricWriter(registry)
+        for stage in self.KNOWN_STAGES:
+            for status in self.KNOWN_STATUSES:
+                writer.init_counter_series(
+                    self.STAGE_TOTAL,
+                    labels={"stage": stage, "status": status},
+                    label_names=("stage", "status"),
+                )
 
     def receive_hook(self, event_name: str, payload: dict, registry) -> None:
         """
@@ -87,6 +112,17 @@ class ResourceIngestionCollector(EventMetricCollector):
         account_id: str | None = None,
     ) -> None:
         """Record one named resource stage outcome together with its execution latency."""
+        # Pre-initialize every known outcome for this stage and account before incrementing,
+        # so a series that has not been scraped yet is exposed at zero rather than appearing
+        # with its first increment (issue #4500).
+        normalized_stage = str(stage)
+        for known_status in self.KNOWN_STATUSES:
+            registry.init_counter_series(
+                self.STAGE_TOTAL,
+                labels={"stage": normalized_stage, "status": known_status},
+                label_names=("stage", "status"),
+                account_id=account_id,
+            )
         labels = {"stage": str(stage), "status": str(status)}
         registry.inc_counter(
             self.STAGE_TOTAL,

--- a/openviking/metrics/core/registry.py
+++ b/openviking/metrics/core/registry.py
@@ -106,6 +106,30 @@ class MetricRegistry:
         """
         self.counter(name, label_names=label_names).inc(labels=labels, amount=float(amount))
 
+    def init_counter_series(
+        self,
+        name: str,
+        *,
+        labels: Mapping[str, str] | None = None,
+        label_names: Sequence[str] = (),
+    ) -> None:
+        """
+        Pre-initialize one Counter series to zero without incrementing it.
+
+        Args:
+            name: Prometheus metric name.
+            labels: Optional label dict. Keys must exactly match `label_names`.
+            label_names: Ordered label key tuple for this metric name.
+
+        Notes:
+            This is the in-process equivalent of the Prometheus client library's
+            "initialize label values" guidance: creating a zero-valued series up front
+            lets Prometheus scrape the pre-increment sample, so `increase()`/`rate()`
+            can account for the first real increment of that label set. Existing series
+            are left untouched, making repeated calls idempotent.
+        """
+        self.counter(name, label_names=label_names).init(labels=labels)
+
     def set_gauge(
         self,
         name: str,
@@ -376,6 +400,22 @@ class _CounterFamily:
                 return
             self._values[key] = self._values.get(key, 0.0) + float(amount)
 
+    def init(self, *, labels: Mapping[str, str] | None) -> None:
+        """
+        Ensure one counter series exists with value zero, without incrementing it.
+
+        New series creation is subject to the same family-level cardinality cap as
+        regular increments. If the series already exists, its current value is
+        preserved, so this operation is idempotent.
+        """
+        key = self._normalize_and_validate(labels)
+        with self._lock:
+            if key not in self._values:
+                if len(self._values) >= self._max_series:
+                    self._on_drop(self.name)
+                    return
+                self._values[key] = 0.0
+
     def copy_values(self) -> dict[tuple[tuple[str, str], ...], float]:
         """Return a detached copy of all series values in this family."""
         with self._lock:
@@ -619,6 +659,10 @@ class _Counter:
     def inc(self, amount: float = 1.0, *, labels: Mapping[str, str] | None = None) -> None:
         """Increment one series in the bound counter family using the public wrapper API."""
         self._family.inc(labels=labels, amount=amount)
+
+    def init(self, *, labels: Mapping[str, str] | None = None) -> None:
+        """Pre-initialize one series in the bound counter family to zero, idempotently."""
+        self._family.init(labels=labels)
 
 
 class _Gauge:

--- a/openviking/metrics/global_api.py
+++ b/openviking/metrics/global_api.py
@@ -301,6 +301,9 @@ def _build_event_router(registry: MetricRegistry) -> EventCollectorRouter:
     vlm_collector = VLMCollector()
     session_collector = SessionCollector()
     resource_collector = ResourceIngestionCollector()
+    # Pre-initialize known resource stage/status counter series at zero so Prometheus can
+    # scrape the pre-increment sample and `increase()` counts the first error (#4500).
+    resource_collector.preinitialize_series(registry)
     retrieval_collector = RetrievalCollector()
     encryption_collector = EncryptionCollector()
     telemetry_bridge_collector = TelemetryBridgeCollector()

--- a/tests/metrics/collectors/test_state_collectors.py
+++ b/tests/metrics/collectors/test_state_collectors.py
@@ -74,6 +74,45 @@ def test_queue_collector_preinitializes_counter_series_at_zero(monkeypatch):
     assert 'openviking_queue_processed_total{queue="AddResource"} 0' in text
 
 
+def test_queue_counter_first_error_visible_across_scrapes(monkeypatch):
+    """End-to-end scrape sequence for queue counters (#4500).
+
+    Prometheus evaluates increase() between two scrapes; the series must
+    exist at zero in scrape A for the first error recorded before scrape
+    B to be counted. Drives two collection cycles with cumulative
+    error_count going 0 -> 1.
+    """
+
+    class DummyQueueStatus:
+        def __init__(self, pending, in_progress, processed, error_count):
+            self.pending = pending
+            self.in_progress = in_progress
+            self.processed = processed
+            self.error_count = error_count
+
+    state = {"errors": 0}
+
+    class DummyQueueManager:
+        async def check_status(self):
+            return {"AddResource": DummyQueueStatus(1, 0, 0, state["errors"])}
+
+    monkeypatch.setattr(
+        "openviking.metrics.datasources.queue.get_queue_manager",
+        lambda: DummyQueueManager(),
+    )
+    registry = MetricRegistry()
+    collector = QueueCollector(data_source=QueuePipelineStateDataSource())
+
+    collector.collect(registry)
+    scrape_a = PrometheusExporter(registry=registry).render()
+    assert 'openviking_queue_errors_total{queue="AddResource"} 0' in scrape_a
+
+    state["errors"] = 1  # first error arrives between scrapes
+    collector.collect(registry)
+    scrape_b = PrometheusExporter(registry=registry).render()
+    assert 'openviking_queue_errors_total{queue="AddResource"} 1' in scrape_b
+
+
 def test_task_tracker_collector_maps_counts(monkeypatch):
     class DummyTracker:
         def snapshot_counts_by_type(self):

--- a/tests/metrics/collectors/test_state_collectors.py
+++ b/tests/metrics/collectors/test_state_collectors.py
@@ -47,6 +47,33 @@ def test_queue_collector_maps_status(monkeypatch):
     assert 'openviking_queue_errors_total{queue="semantic"} 2' in text
 
 
+def test_queue_collector_preinitializes_counter_series_at_zero(monkeypatch):
+    class DummyQueueStatus:
+        def __init__(
+            self, pending: int, in_progress: int, processed: int, error_count: int
+        ) -> None:
+            self.pending = pending
+            self.in_progress = in_progress
+            self.processed = processed
+            self.error_count = error_count
+
+    class DummyQueueManager:
+        async def check_status(self):
+            return {"AddResource": DummyQueueStatus(1, 0, 0, 0)}
+
+    monkeypatch.setattr(
+        "openviking.metrics.datasources.queue.get_queue_manager",
+        lambda: DummyQueueManager(),
+    )
+    registry = MetricRegistry()
+    QueueCollector(data_source=QueuePipelineStateDataSource()).collect(registry)
+    text = PrometheusExporter(registry=registry).render()
+    # Regression for #4500: series must be scraped at zero before the first increment so
+    # Prometheus `increase()` does not miss the first error of each queue label set.
+    assert 'openviking_queue_errors_total{queue="AddResource"} 0' in text
+    assert 'openviking_queue_processed_total{queue="AddResource"} 0' in text
+
+
 def test_task_tracker_collector_maps_counts(monkeypatch):
     class DummyTracker:
         def snapshot_counts_by_type(self):

--- a/tests/metrics/core/test_registry.py
+++ b/tests/metrics/core/test_registry.py
@@ -7,6 +7,7 @@ import pytest
 
 from openviking.metrics.core.base import MetricCollector
 from openviking.metrics.core.registry import MetricRegistry
+from openviking.metrics.exporters.prometheus import PrometheusExporter
 
 
 def test_metric_collector_metric_name_includes_namespace_and_optional_unit():
@@ -52,6 +53,39 @@ def test_registry_canonicalizes_label_name_order_for_same_family(render_promethe
 
     text = render_prometheus(registry)
     assert 'openviking_ordered_total{provider="local",status="ok"} 2' in text
+
+
+def test_init_counter_series_preinitializes_zero_and_is_idempotent():
+    registry = MetricRegistry()
+    registry.init_counter_series(
+        "openviking_preinit_total", labels={"queue": "q"}, label_names=("queue",)
+    )
+    assert (
+        'openviking_preinit_total{queue="q"} 0' in PrometheusExporter(registry=registry).render()
+    )
+
+    registry.inc_counter(
+        "openviking_preinit_total", labels={"queue": "q"}, label_names=("queue",)
+    )
+    registry.init_counter_series(
+        "openviking_preinit_total", labels={"queue": "q"}, label_names=("queue",)
+    )
+    assert (
+        'openviking_preinit_total{queue="q"} 1' in PrometheusExporter(registry=registry).render()
+    )
+
+
+def test_init_counter_series_enforces_label_contract():
+    registry = MetricRegistry()
+    registry.init_counter_series(
+        "openviking_preinit_contract_total", labels={"a": "1"}, label_names=("a",)
+    )
+    with pytest.raises(ValueError):
+        registry.init_counter_series(
+            "openviking_preinit_contract_total",
+            labels={"a": "1", "b": "2"},
+            label_names=("a", "b"),
+        )
 
 
 def test_counter_only_increases():

--- a/tests/metrics/integration/test_bootstrap.py
+++ b/tests/metrics/integration/test_bootstrap.py
@@ -17,6 +17,7 @@ from openviking.metrics.core.registry import MetricRegistry
 from openviking.metrics.datasources.base import EventMetricDataSource
 from openviking.metrics.datasources.resource import ResourceIngestionEventDataSource
 from openviking.metrics.exporters.prometheus import PrometheusExporter
+from openviking.metrics.global_api import _build_event_router
 
 
 def test_create_default_collector_manager_registers_expected_collectors_in_order():
@@ -172,3 +173,72 @@ def test_resource_ingestion_event_datasource_can_drive_resource_ingestion_collec
     )
 
     reset_metric_account_dimension()
+
+
+def test_resource_stage_counter_series_preinitialized_by_event_router():
+    registry = MetricRegistry()
+    _build_event_router(registry)
+    text = PrometheusExporter(registry=registry).render()
+    # Regression for #4500: every known stage/status series must exist at zero right after
+    # metrics bootstrap, before any resource event happens, so `increase()` can observe the
+    # first increment of each label set.
+    for stage in ResourceIngestionCollector.KNOWN_STAGES:
+        for status in ResourceIngestionCollector.KNOWN_STATUSES:
+            assert (
+                f'openviking_resource_stage_total{{account_id="__unknown__",stage="{stage}",'
+                f'status="{status}"}} 0' in text
+            )
+
+
+def test_resource_stage_first_error_is_visible_to_increase(monkeypatch):
+    registry = MetricRegistry()
+    _build_event_router(registry)
+    collector = ResourceIngestionCollector()
+
+    def _emit(event_name: str, payload: dict) -> None:
+        collector.receive(event_name, payload, registry)
+
+    monkeypatch.setattr(EventMetricDataSource, "_emit", staticmethod(_emit), raising=False)
+
+    # Prometheus scrapes the pre-initialized zero-valued series first...
+    first_scrape = PrometheusExporter(registry=registry).render()
+    assert (
+        'openviking_resource_stage_total{account_id="__unknown__",stage="parse",status="error"} 0'
+        in first_scrape
+    )
+    # ...then the very first parse error lands and increments the series from zero.
+    ResourceIngestionEventDataSource.record_stage(stage="parse", status="error", duration_seconds=0.02)
+    second_scrape = PrometheusExporter(registry=registry).render()
+    assert (
+        'openviking_resource_stage_total{account_id="__unknown__",stage="parse",status="error"} 1'
+        in second_scrape
+    )
+
+
+def test_resource_stage_first_event_initializes_sibling_status_series():
+    configure_metric_account_dimension(
+        enabled=True,
+        metric_allowlist={ResourceIngestionCollector.STAGE_TOTAL},
+        max_active_accounts=10,
+    )
+    try:
+        registry = MetricRegistry()
+        collector = ResourceIngestionCollector()
+        # A brand-new (stage, account) pair whose first event is "ok" must also expose the
+        # matching "error" series at zero, so a later first error is not invisible to `increase()`.
+        collector.receive(
+            "resource.stage",
+            {"stage": "persist", "status": "ok", "duration_seconds": 0.1, "account_id": "acct-new"},
+            registry,
+        )
+        text = PrometheusExporter(registry=registry).render()
+        assert (
+            'openviking_resource_stage_total{account_id="acct-new",stage="persist",status="ok"} 1'
+            in text
+        )
+        assert (
+            'openviking_resource_stage_total{account_id="acct-new",stage="persist",status="error"} 0'
+            in text
+        )
+    finally:
+        reset_metric_account_dimension()


### PR DESCRIPTION

Fixes #4500

## Root cause

OpenViking's in-process `MetricRegistry` creates a counter time series lazily, on the first
`inc() > 0`, and rejects non-positive increments. As a result:

- `QueueCollector` only touched `openviking_queue_errors_total{queue=...}` (and
  `openviking_queue_processed_total`) when the cumulative error/processed delta was non-zero,
  so a queue's series did not exist until its first error.
- `ResourceIngestionCollector` only touched
  `openviking_resource_stage_total{stage=...,status=...}` when a `resource.stage` event
  arrived, so `status="error"` series did not exist until the first error.
- There was no API equivalent to the Prometheus client library's
  ["initialize label values"](https://prometheus.github.io/client_python/instrumenting/labels/)
  operation to create a zero-valued series up front.

When Prometheus scrapes such a series for the first time it already carries the value `1`
(never `0`), so PromQL `increase()`/`rate()` cannot observe the initial increment and return
`0`. Grafana panels and alert rules built on those queries miss the first error of every
label set — for low-frequency one-off failures, permanently.

## Fix

Pre-initialize error counter series to zero, following the Prometheus "initialize label
values" guidance, so scrapes observe the pre-increment sample:

1. **`MetricRegistry.init_counter_series()`** (`openviking/metrics/core/registry.py`):
   new public API that idempotently creates a zero-valued counter series (existing series
   untouched; the family-level series cap still applies).
2. **`CollectorMetricWriter.init_counter_series()`**
   (`openviking/metrics/collectors/base.py`): same helper with account-dimension label
   resolution, matching `inc_counter()`.
3. **`QueueCollector`** (`openviking/metrics/collectors/queue.py`): pre-initializes
   `openviking_queue_errors_total` and `openviking_queue_processed_total` for every queue in
   the status snapshot, so the counters appear at `0` together with the pending/in_progress
   gauges on the first scrape.
4. **`ResourceIngestionCollector`** (`openviking/metrics/collectors/resource.py`):
   - New closed-set enums `KNOWN_STAGES` = parse/finalize/persist/summarize and
     `KNOWN_STATUSES` = ok/error (mirroring the instrumentation sites in
     `openviking/utils/resource_processor.py`).
   - New `preinitialize_series()`: creates `openviking_resource_stage_total` series for every
     stage x status pair; wired into `_build_event_router()` in
     `openviking/metrics/global_api.py` so the series exist right after metrics bootstrap,
     before any resource is processed. The account dimension resolves to its no-context value
     (`__unknown__`), which is what the background resource pipeline reports in practice.
   - `record_stage()` also pre-initializes sibling status series for a new
     (stage, account_id) pair before incrementing, so a first "ok" event exposes the "error"
     series at zero for that account too (bounded: high-cardinality account values are never
     enumerated, only touched as they actually occur).

No histogram or gauge semantics changed; counters keep rejecting non-positive increments.

## Verification

- `python3 -m py_compile` on all changed modules.
- `ruff check` clean on all changed files.
- New regression tests (run with `pytest --noconftest -o addopts=""`):
  - `tests/metrics/core/test_registry.py::test_init_counter_series_preinitializes_zero_and_is_idempotent`
    and `::test_init_counter_series_enforces_label_contract`
  - `tests/metrics/collectors/test_state_collectors.py::test_queue_collector_preinitializes_counter_series_at_zero`
    (queue counters exported at `0` with zero cumulative errors/processed)
  - `tests/metrics/integration/test_bootstrap.py::test_resource_stage_counter_series_preinitialized_by_event_router`
    (all 8 stage x status series at `0` right after `_build_event_router`)
  - `tests/metrics/integration/test_bootstrap.py::test_resource_stage_first_error_is_visible_to_increase`
    (simulates two scrapes: first sees `0`, first parse error flips the series to `1`)
  - `tests/metrics/integration/test_bootstrap.py::test_resource_stage_first_event_initializes_sibling_status_series`
    (first "ok" event for a new account exposes the "error" series at `0`)
- All pre-existing queue/resource/registry/bootstrap tests in the touched suites still pass
  (23 passed; the only 2 errors are `--noconftest` fixture-resolution artifacts unrelated to
  this change).

Manual equivalent of the issue repro: after bootstrap, `curl /metrics` shows
`openviking_queue_errors_total{queue="AddResource"} 0` and
`openviking_resource_stage_total{account_id="__unknown__",stage="parse",status="error"} 0`
before any error; after the first parse failure the series reads `1`, so
`increase(...[15m])` returns `1` instead of `0`.
