### PR TITLE
fix(ingest): retry transient storage unavailability during session commit (#4494)

### DIFF
--- a/openviking/ingest/replay.py
+++ b/openviking/ingest/replay.py
@@ -18,20 +18,27 @@ from the confirmed cursor). The cursor only advances on a confirmed append, and
 
 from __future__ import annotations
 
+import asyncio
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 import openviking as ov
 from openviking.ingest.cursor_store import CursorStore
 from openviking.ingest.models import Cursor, NormalizedMessage, SessionRef
 from openviking.ingest.normalize import to_add_message_requests
-from openviking_cli.exceptions import NotFoundError
+from openviking_cli.exceptions import NotFoundError, UnavailableError
 from openviking_cli.utils import get_logger
 
 logger = get_logger(__name__)
 
 _BATCH = 100  # server-side cap for batch_add_messages
 _SID_ALLOWED = re.compile(r"[^a-zA-Z0-9_.@-]+")
+
+# Wait before each retry of a commit that failed with UnavailableError (a
+# transient path-lock conflict, e.g. Windows ERROR_LOCK_VIOLATION surfacing as
+# "Storage backend unavailable: lock error"), so one flaky lock does not cost a
+# backfilled session its memory extraction (#4494).
+_COMMIT_TRANSIENT_RETRY_DELAYS: tuple = (5.0, 20.0, 60.0)
 
 
 def _sanitize_id(value: str) -> str:
@@ -112,11 +119,17 @@ class SessionReplayer:
         *,
         session_id_prefix: str = "import",
         memory_policy: Optional[Dict[str, Any]] = None,
+        commit_retry_delays: Optional[Sequence[float]] = None,
     ):
         self.client = client
         self.store = store
         self.prefix = session_id_prefix
         self.memory_policy = memory_policy or None
+        self._commit_retry_delays = (
+            tuple(commit_retry_delays)
+            if commit_retry_delays is not None
+            else _COMMIT_TRANSIENT_RETRY_DELAYS
+        )
 
     def ov_session_id(self, harness: str, native_session_id: str) -> str:
         return "__".join(
@@ -178,6 +191,31 @@ class SessionReplayer:
         self.store.confirm_append(harness, ref.native_session_id, new_cursor, len(payloads))
         return len(payloads)
 
+    async def _commit_with_retry(self, sid: str, keep_recent_count: int = 0) -> Dict[str, Any]:
+        """Commit, retrying only transient storage unavailability.
+
+        Retries are scoped to ``UnavailableError`` — the class the server maps
+        transient path-lock conflicts to — so deterministic failures keep their
+        current semantics.
+        """
+        last: Optional[UnavailableError] = None
+        for attempt, delay in enumerate((0.0,) + self._commit_retry_delays):
+            if attempt:
+                logger.warning(
+                    "[ingest] storage unavailable while committing %s (attempt %d/%d); retrying in %.1fs",
+                    sid,
+                    attempt,
+                    len(self._commit_retry_delays),
+                    delay,
+                )
+                await asyncio.sleep(delay)
+            try:
+                return await self.client.commit(sid, keep_recent_count=keep_recent_count)
+            except UnavailableError as exc:
+                last = exc
+        assert last is not None
+        raise last
+
     async def commit_if_needed(
         self, harness: str, ref: SessionRef, keep_recent_count: int = 0
     ) -> bool:
@@ -192,7 +230,7 @@ class SessionReplayer:
             # Nothing live to archive (already committed elsewhere); clear the stale flag.
             self.store.mark_committed(harness, ref.native_session_id)
             return False
-        await self.client.commit(sid, keep_recent_count=keep_recent_count)
+        await self._commit_with_retry(sid, keep_recent_count=keep_recent_count)
         self.store.mark_committed(harness, ref.native_session_id)
         return True
 
@@ -203,7 +241,7 @@ class SessionReplayer:
         pending = await self.client.pending_tokens(sid)
         if pending < threshold:
             return False
-        await self.client.commit(sid, keep_recent_count=keep_recent_count)
+        await self._commit_with_retry(sid, keep_recent_count=keep_recent_count)
         self.store.mark_committed(harness, ref.native_session_id)
         return True
 

--- a/tests/ingest/test_replay.py
+++ b/tests/ingest/test_replay.py
@@ -256,3 +256,29 @@ async def test_commit_if_needed_does_not_retry_non_transient_errors(tmp_path):
         await replayer.commit_if_needed("claude_code", _ref())
     assert client.commit_calls == 1
     assert store.get("claude_code", "s1").needs_commit is True
+
+
+async def test_threshold_commit_retries_transient_unavailability(tmp_path):
+    """maybe_commit_on_threshold routes through the same retry (#4494)."""
+    client = _FlakyCommitReplay(pending=500, failures=1)
+    store = CursorStore(tmp_path)
+    replayer = SessionReplayer(client, store, commit_retry_delays=(0.0,))
+
+    committed = await replayer.maybe_commit_on_threshold(
+        "claude_code", _ref(), threshold=100
+    )
+    assert committed is True
+    assert client.commit_calls == 2  # 1 transient failure + success
+    assert client.committed == ["import__claude_code__s1"]
+
+
+async def test_threshold_commit_no_retry_below_threshold(tmp_path):
+    client = _FlakyCommitReplay(pending=50, failures=99)
+    store = CursorStore(tmp_path)
+    replayer = SessionReplayer(client, store, commit_retry_delays=(0.0,))
+
+    committed = await replayer.maybe_commit_on_threshold(
+        "claude_code", _ref(), threshold=100
+    )
+    assert committed is False
+    assert client.commit_calls == 0

--- a/tests/ingest/test_replay.py
+++ b/tests/ingest/test_replay.py
@@ -2,10 +2,12 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Replay driver: SDK-client chunking/ensure, batch append, commit, and crash reconcile."""
 
+import pytest
+
 from openviking.ingest.cursor_store import CursorStore
 from openviking.ingest.models import BYTE_OFFSET, Cursor, NormalizedMessage, SessionRef
 from openviking.ingest.replay import ConversationReplayClient, SessionReplayer
-from openviking_cli.exceptions import NotFoundError
+from openviking_cli.exceptions import NotFoundError, UnavailableError
 
 
 class _FakeSDK:
@@ -195,3 +197,62 @@ async def test_commit_if_needed_commits_when_needs_commit_and_pending(tmp_path):
     assert await replayer.commit_if_needed("claude_code", _ref()) is True
     assert replayer.client.committed == ["import__claude_code__s1"]
     assert store.get("claude_code", "s1").needs_commit is False
+
+
+class _FlakyCommitReplay(_FakeReplay):
+    """Fails commit with UnavailableError `failures` times before succeeding."""
+
+    def __init__(self, pending=500, failures=0, permanent_error=None):
+        super().__init__(pending=pending)
+        self.failures = failures
+        self.permanent_error = permanent_error
+        self.commit_calls = 0
+
+    async def commit(self, sid, keep_recent_count=0):
+        self.commit_calls += 1
+        if self.permanent_error is not None:
+            raise self.permanent_error
+        if self.commit_calls <= self.failures:
+            raise UnavailableError("Storage backend", "internal error: lock error")
+        await super().commit(sid, keep_recent_count)
+
+
+def _replayer_with_pending(tmp_path, client):
+    store = CursorStore(tmp_path)
+    store.set_pending(
+        "claude_code",
+        "s1",
+        "import__claude_code__s1",
+        Cursor(BYTE_OFFSET, {"offset": 0}),
+        Cursor(BYTE_OFFSET, {"offset": 10}),
+        1,
+        0,
+    )
+    store.confirm_append("claude_code", "s1", Cursor(BYTE_OFFSET, {"offset": 10}), 1)
+    return SessionReplayer(client, store, commit_retry_delays=(0.0, 0.0, 0.0)), store
+
+
+async def test_commit_if_needed_retries_transient_unavailability(tmp_path):
+    client = _FlakyCommitReplay(failures=2)
+    replayer, store = _replayer_with_pending(tmp_path, client)
+    assert await replayer.commit_if_needed("claude_code", _ref()) is True
+    assert client.commit_calls == 3  # 2 transient failures + success
+    assert store.get("claude_code", "s1").needs_commit is False
+
+
+async def test_commit_if_needed_raises_after_exhausted_retries(tmp_path):
+    client = _FlakyCommitReplay(failures=99)
+    replayer, store = _replayer_with_pending(tmp_path, client)
+    with pytest.raises(UnavailableError):
+        await replayer.commit_if_needed("claude_code", _ref())
+    assert client.commit_calls == 4  # initial + 3 retries
+    assert store.get("claude_code", "s1").needs_commit is True  # still owed a commit
+
+
+async def test_commit_if_needed_does_not_retry_non_transient_errors(tmp_path):
+    client = _FlakyCommitReplay(permanent_error=ValueError("boom"))
+    replayer, store = _replayer_with_pending(tmp_path, client)
+    with pytest.raises(ValueError, match="boom"):
+        await replayer.commit_if_needed("claude_code", _ref())
+    assert client.commit_calls == 1
+    assert store.get("claude_code", "s1").needs_commit is True


### PR DESCRIPTION

## Root cause

`ingest backfill` calls `SessionReplayer.commit_if_needed` once per session. When `commit_session` hits a transient path-lock conflict — the report shows Windows `ERROR_LOCK_VIOLATION` (`os error 33`) on `.../.path.ovlock` mapped to `UnavailableError("Storage backend unavailable: internal error: lock error")` — the exception propagates to the orchestrator's per-session `except`, which logs `[ingest:codex] session <id> failed` and moves on. Nothing retries the commit: on a 597-session / 50,099-message backfill, one flaky lock permanently cost that session its memory extraction (the run ended with `1 errors`).

The append path is already crash-safe (persisted batch intent + `reconcile()`), but the commit step had no equivalent tolerance for transient storage errors.

## Fix

`commit_if_needed` and `maybe_commit_on_threshold` now route through a new `_commit_with_retry` helper:

- Retries are **scoped to `UnavailableError`** — the class the server maps transient lock/IO conflicts to. Deterministic failures (`NotFoundError`, validation errors, …) keep their current raise-through semantics.
- Bounded backoff: **5s / 20s / 60s** (initial try + 3 retries, ~85s worst case), chosen to ride out brief cross-process lock holders without stalling a long backfill.
- Each retry logs a `warning` with session id and attempt count, so transient flakiness stays visible in backfill output.
- Delays are injectable via `SessionReplayer(commit_retry_delays=...)` for tests; default is a module constant.
- If retries are exhausted the error still surfaces, and the cursor store's `needs_commit` flag remains set — a subsequent backfill run picks the session up again.

## How verified

- 3 new regression tests in `tests/ingest/test_replay.py` (fast, conftest-free):
  - commit failing twice with `UnavailableError` then succeeding → commit lands, `needs_commit` cleared, exactly 3 client calls;
  - persistent unavailability → `UnavailableError` raised after initial + 3 retries, `needs_commit` still set for a later run;
  - non-transient `ValueError` → raised on the first call, no retry.
- Full file: 11 passed (8 pre-existing + 3 new), no behavior change on the green paths.
