### PR TITLE
fix(session): bound the session-extraction trajectory prompt (#3226)

### DIFF
--- a/openviking/session/memory/session_extract_context_provider.py
+++ b/openviking/session/memory/session_extract_context_provider.py
@@ -122,9 +122,52 @@ class SessionExtractContextProvider(ExtractContextProvider):
                 get_vlm=self._get_vision_vlm,
                 logger=logger,
             )
+            self.messages = self._apply_session_extract_budget(self.messages)
             self._extract_context = None
             self._output_language = self._detect_language()
         self._vision_messages_prepared = True
+
+    def _apply_session_extract_budget(self, messages: Any) -> Any:
+        """Clamp the trajectory to ``semantic.max_session_extract_prompt_chars``.
+
+        The session compression / memory-extraction path historically sent the
+        accumulated trajectory however large it was; a single oversized request
+        could saturate the serving backend and, on single-step-prefill engines,
+        OOM it (#3226). Oldest messages are dropped first — the memory-relevant
+        tail is kept — and a lone over-budget message is preserved so extraction
+        never runs on an empty trajectory.
+        """
+        if not isinstance(messages, list) or len(messages) <= 1:
+            return messages
+        budget = get_openviking_config().semantic.max_session_extract_prompt_chars
+        if budget <= 0:
+            return messages
+
+        def _size(message: Any) -> int:
+            total = 0
+            for part in getattr(message, "parts", []) or []:
+                text = getattr(part, "text", None)
+                if isinstance(text, str):
+                    total += len(text)
+            return total
+
+        sizes = [_size(m) for m in messages]
+        total = sum(sizes)
+        drop = 0
+        while total > budget and len(messages) - drop > 1:
+            total -= sizes[drop]
+            drop += 1
+        if drop:
+            logger.warning(
+                "session extraction trajectory %d chars exceeds budget %d; "
+                "dropping %d oldest of %d messages",
+                sum(sizes),
+                budget,
+                drop,
+                len(messages),
+            )
+            return messages[drop:]
+        return messages
 
     def _get_vision_vlm(self):
         if self._vision_vlm is not None:

--- a/openviking_cli/utils/config/parser_config.py
+++ b/openviking_cli/utils/config/parser_config.py
@@ -700,6 +700,11 @@ class SemanticConfig:
     """Maximum characters allowed in the overview generation prompt.
     If exceeded, file summaries are batched and merged."""
 
+    max_session_extract_prompt_chars: int = 60000
+    """Maximum characters of session trajectory fed to the compression /
+    memory-extraction prompt. Oldest messages are dropped first when exceeded,
+    so one huge session cannot send an unbounded prompt to the VLM (#3226)."""
+
     overview_batch_size: int = 50
     """Maximum number of file summaries per batch when splitting oversized prompts."""
 

--- a/tests/session/memory/test_session_extract_budget.py
+++ b/tests/session/memory/test_session_extract_budget.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Budget clamp for the session-extraction trajectory (#3226)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.message import Message
+from openviking.message.part import TextPart
+from openviking.session.memory.session_extract_context_provider import (
+    SessionExtractContextProvider,
+)
+
+
+def _message(idx: int, text: str) -> Message:
+    return Message(
+        id=f"msg-{idx}",
+        role="user",
+        parts=[TextPart(text=text)],
+        created_at="2026-09-03T00:00:00Z",
+    )
+
+
+@pytest.fixture
+def budget_config(monkeypatch):
+    def _install(budget: int):
+        config = SimpleNamespace(
+            semantic=SimpleNamespace(max_session_extract_prompt_chars=budget),
+            memory=SimpleNamespace(eager_prefetch=False, prefetch_search_topn=5, link_enabled=True),
+            language_fallback="en",
+        )
+        for target in (
+            "openviking.session.memory.session_extract_context_provider.get_openviking_config",
+            "openviking.session.memory.utils.language.get_openviking_config",
+        ):
+            monkeypatch.setattr(target, lambda: config)
+
+    return _install
+
+
+def test_over_budget_drops_oldest_first(budget_config):
+    budget_config(3500)
+    msgs = [_message(i, "x" * 1000) for i in range(10)]  # 10k chars total
+    provider = SessionExtractContextProvider(messages=list(msgs))
+    kept = provider._apply_session_extract_budget(provider.messages)
+    assert len(kept) == 3  # 3 x 1000 <= 3500 < 4 x 1000
+    assert [m.id for m in kept] == ["msg-7", "msg-8", "msg-9"]
+
+
+def test_within_budget_keeps_everything(budget_config):
+    budget_config(60000)
+    msgs = [_message(i, "x" * 1000) for i in range(10)]
+    provider = SessionExtractContextProvider(messages=list(msgs))
+    kept = provider._apply_session_extract_budget(provider.messages)
+    assert kept is provider.messages
+
+
+def test_single_over_budget_message_is_kept(budget_config):
+    budget_config(100)
+    msgs = [_message(0, "x" * 5000)]
+    provider = SessionExtractContextProvider(messages=list(msgs))
+    kept = provider._apply_session_extract_budget(provider.messages)
+    assert [m.id for m in kept] == ["msg-0"]
+
+
+def test_zero_budget_disables_clamp(budget_config):
+    budget_config(0)
+    msgs = [_message(i, "x" * 1000) for i in range(10)]
+    provider = SessionExtractContextProvider(messages=list(msgs))
+    kept = provider._apply_session_extract_budget(provider.messages)
+    assert len(kept) == 10

--- a/tests/session/memory/test_session_extract_budget.py
+++ b/tests/session/memory/test_session_extract_budget.py
@@ -70,3 +70,27 @@ def test_zero_budget_disables_clamp(budget_config):
     provider = SessionExtractContextProvider(messages=list(msgs))
     kept = provider._apply_session_extract_budget(provider.messages)
     assert len(kept) == 10
+
+
+@pytest.mark.asyncio
+async def test_prepare_extraction_messages_applies_budget(budget_config, monkeypatch):
+    """The clamp runs inside prepare(), after vision normalization."""
+    budget_config(2500)
+
+    async def fake_replace(messages, get_vlm=None, logger=None):
+        return list(messages)
+
+    monkeypatch.setattr(
+        "openviking.session.memory.session_extract_context_provider"
+        ".replace_image_parts_with_descriptions",
+        fake_replace,
+    )
+    msgs = [_message(i, "y" * 1000) for i in range(10)]
+    provider = SessionExtractContextProvider(messages=msgs)
+    provider._vision_vlm = None
+
+    await provider.prepare_extraction_messages()
+
+    assert len(provider.messages) == 2  # 2 x 1000 <= 2500 < 3 x 1000
+    assert [m.id for m in provider.messages] == ["msg-8", "msg-9"]
+    assert provider._vision_messages_prepared is True


### PR DESCRIPTION

## Root cause

Directory overview generation respects `semantic.max_overview_prompt_chars`, but the session compression / trajectory memory-extraction path has no equivalent: `SessionExtractContextProvider` hands the accumulated session to the VLM however large it is. The report shows a single compression request with `prompt_token_ids_len=52,794` (≈200k chars) in production, with bursts that saturated the serving backend (32 running / 56 queued, unrelated requests pushed to 150–190s), and on a single-step-prefill engine (`max-num-batched-tokens` = `max-model-len`) the 52k-token request CUDA-OOM-killed the engine.

## Fix

`SessionExtractContextProvider.prepare_extraction_messages` now clamps the trajectory right after the vision-normalization step:

- New `semantic.max_session_extract_prompt_chars` (default **60000 chars**, matching the existing overview budget) bounds the prompt input.
- **Oldest messages are dropped first** — memory extraction is most sensitive to the recent tail, and the archive/overview path already carries the early-session context forward.
- A lone over-budget message is kept (extraction never runs on an empty trajectory), `budget <= 0` disables the clamp, and every clamp logs the total size and dropped share so oversized sessions stay visible.

## How verified

- 4 new conftest-free tests in `tests/session/memory/test_session_extract_budget.py`: over-budget drops oldest-first and keeps the recent tail; within-budget returns the list untouched; a single over-budget message survives; `0` disables the clamp.
- Adjacent provider tests (`test_memory_timestamp_parsing.py`) show no delta: `test_conversation_message_accepts_z_suffix_timestamps` fails identically on clean `upstream/main` in this environment (pre-existing, config-file dependent), all others pass with the change.
- `py_compile` on both touched modules.
