### PR TITLE
fix(vlm): raise httpx keepalive_expiry to stop intermittent ReadTimeout on image calls (#4464)

### DIFF
--- a/examples/ov.conf.example
+++ b/examples/ov.conf.example
@@ -154,6 +154,7 @@
         "api_base": "https://ark.cn-beijing.volces.com/api/v3",
         "temperature": 0.0,
         "max_retries": 2,
+        "keepalive_expiry": 0,
         "provider": "volcengine",
         "thinking": false,
         "media": {

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -19,6 +19,8 @@ try:
 except ImportError:
     openai = None
 
+import httpx
+
 from openviking.utils.model_retry import retry_async, retry_sync
 
 from ..base import ToolCall, VLMBase, VLMResponse
@@ -45,6 +47,23 @@ def _is_reasoning_model(model: Optional[str]) -> bool:
         return False
     name = model.lower()
     return any(name.startswith(p) for p in _REASONING_MODEL_PREFIXES)
+
+
+def _build_httpx_limits(keepalive_expiry: float) -> httpx.Limits:
+    """Build httpx connection limits with an explicit ``keepalive_expiry``.
+
+    The OpenAI SDK leaves ``keepalive_expiry`` at the httpx default of 5.0s.
+    A pooled keep-alive connection can outlive the server-side idle timeout,
+    and the next request that reuses it blocks until ``httpcore.ReadTimeout``
+    instead of the configured request timeout (#4464). ``keepalive_expiry=0``
+    disables connection reuse (one fresh connection per request); the
+    remaining limits match the OpenAI SDK defaults.
+    """
+    return httpx.Limits(
+        max_connections=1000,
+        max_keepalive_connections=100,
+        keepalive_expiry=keepalive_expiry,
+    )
 
 
 def _build_openai_client_kwargs(
@@ -84,6 +103,7 @@ class OpenAIVLM(VLMBase):
         self._async_client_cache = LoopScopedAsyncClientCache()
         self.api_version = config.get("api_version")
         self.reasoning_effort = config.get("reasoning_effort", "low")
+        self.keepalive_expiry = config.get("keepalive_expiry", 0.0)
 
     def get_client(self):
         """Get sync client"""
@@ -97,6 +117,10 @@ class OpenAIVLM(VLMBase):
                 self.api_version,
                 self.extra_headers,
                 self.timeout,
+            )
+            kwargs["http_client"] = httpx.Client(
+                limits=_build_httpx_limits(self.keepalive_expiry),
+                timeout=self.timeout,
             )
             if self.provider == "azure":
                 self._sync_client = openai.AzureOpenAI(**kwargs)
@@ -115,6 +139,10 @@ class OpenAIVLM(VLMBase):
             self.api_version,
             self.extra_headers,
             self.timeout,
+        )
+        kwargs["http_client"] = httpx.AsyncClient(
+            limits=_build_httpx_limits(self.keepalive_expiry),
+            timeout=self.timeout,
         )
         if self.provider == "azure":
             return openai.AsyncAzureOpenAI(**kwargs)

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -49,19 +49,24 @@ def _is_reasoning_model(model: Optional[str]) -> bool:
     return any(name.startswith(p) for p in _REASONING_MODEL_PREFIXES)
 
 
-def _build_httpx_limits(keepalive_expiry: float) -> httpx.Limits:
-    """Build httpx connection limits with an explicit ``keepalive_expiry``.
+def _build_httpx_limits(max_concurrent: int, keepalive_expiry: float) -> httpx.Limits:
+    """Build connection-pool limits bound to the configured VLM concurrency.
 
-    The OpenAI SDK leaves ``keepalive_expiry`` at the httpx default of 5.0s.
-    A pooled keep-alive connection can outlive the server-side idle timeout,
-    and the next request that reuses it blocks until ``httpcore.ReadTimeout``
-    instead of the configured request timeout (#4464). ``keepalive_expiry=0``
-    disables connection reuse (one fresh connection per request); the
-    remaining limits match the OpenAI SDK defaults.
+    The pool follows the same bound-the-pool-to-the-concurrency-cap approach as
+    the embedder side (0f58d62a): connections beyond ``max_concurrent`` can
+    never be used simultaneously, so an unbounded pool only hides leaks.
+
+    ``keepalive_expiry`` is explicit because the OpenAI SDK leaves it at the
+    httpx default of 5.0s. A pooled keep-alive connection can outlive the
+    server-side idle timeout, and the next request that reuses it blocks until
+    ``httpcore.ReadTimeout`` instead of the configured request timeout (#4464).
+    ``keepalive_expiry=0`` disables connection reuse (one fresh connection per
+    request).
     """
+    pool_limit = max(1, int(max_concurrent))
     return httpx.Limits(
-        max_connections=1000,
-        max_keepalive_connections=100,
+        max_connections=pool_limit,
+        max_keepalive_connections=pool_limit,
         keepalive_expiry=keepalive_expiry,
     )
 
@@ -104,6 +109,7 @@ class OpenAIVLM(VLMBase):
         self.api_version = config.get("api_version")
         self.reasoning_effort = config.get("reasoning_effort", "low")
         self.keepalive_expiry = config.get("keepalive_expiry", 0.0)
+        self.max_concurrent = config.get("max_concurrent", 32)
 
     def get_client(self):
         """Get sync client"""
@@ -118,8 +124,8 @@ class OpenAIVLM(VLMBase):
                 self.extra_headers,
                 self.timeout,
             )
-            kwargs["http_client"] = httpx.Client(
-                limits=_build_httpx_limits(self.keepalive_expiry),
+            kwargs["http_client"] = openai.DefaultHttpxClient(
+                limits=_build_httpx_limits(self.max_concurrent, self.keepalive_expiry),
                 timeout=self.timeout,
             )
             if self.provider == "azure":
@@ -140,8 +146,8 @@ class OpenAIVLM(VLMBase):
             self.extra_headers,
             self.timeout,
         )
-        kwargs["http_client"] = httpx.AsyncClient(
-            limits=_build_httpx_limits(self.keepalive_expiry),
+        kwargs["http_client"] = openai.DefaultAsyncHttpxClient(
+            limits=_build_httpx_limits(self.max_concurrent, self.keepalive_expiry),
             timeout=self.timeout,
         )
         if self.provider == "azure":

--- a/openviking_cli/utils/config/vlm_config.py
+++ b/openviking_cli/utils/config/vlm_config.py
@@ -137,6 +137,18 @@ class VLMConfig(BaseModel):
             "high-latency endpoints (e.g., DashScope, local inference servers)."
         ),
     )
+    keepalive_expiry: float = Field(
+        default=0.0,
+        ge=0.0,
+        description=(
+            "httpx keep-alive expiry in seconds for pooled VLM HTTP connections. "
+            "The default 0 disables connection reuse so requests never land on a "
+            "keep-alive connection the server may have already closed (fixes "
+            "intermittent httpcore.ReadTimeout on reused connections). Set to a "
+            "positive value (e.g. 60) to re-enable pooling against endpoints "
+            "whose idle timeout is known to be longer."
+        ),
+    )
 
     provider: Optional[str] = Field(default=None, description="Provider type")
     backend: Optional[str] = Field(
@@ -638,6 +650,7 @@ class VLMConfig(BaseModel):
             "temperature": self.temperature,
             "max_retries": self.max_retries,
             "timeout": self.timeout,
+            "keepalive_expiry": self.keepalive_expiry,
             "provider": credential.provider,
             "thinking": self.thinking,
             "max_tokens": (
@@ -671,6 +684,7 @@ class VLMConfig(BaseModel):
             "temperature": self.temperature,
             "max_retries": self.max_retries,
             "timeout": self.timeout,
+            "keepalive_expiry": self.keepalive_expiry,
             "provider": name,
             "thinking": self.thinking,
             "max_tokens": self.max_tokens,

--- a/openviking_cli/utils/config/vlm_config.py
+++ b/openviking_cli/utils/config/vlm_config.py
@@ -651,6 +651,7 @@ class VLMConfig(BaseModel):
             "max_retries": self.max_retries,
             "timeout": self.timeout,
             "keepalive_expiry": self.keepalive_expiry,
+            "max_concurrent": self.max_concurrent,
             "provider": credential.provider,
             "thinking": self.thinking,
             "max_tokens": (
@@ -685,6 +686,7 @@ class VLMConfig(BaseModel):
             "max_retries": self.max_retries,
             "timeout": self.timeout,
             "keepalive_expiry": self.keepalive_expiry,
+            "max_concurrent": self.max_concurrent,
             "provider": name,
             "thinking": self.thinking,
             "max_tokens": self.max_tokens,

--- a/tests/models/vlm/test_keepalive_config.py
+++ b/tests/models/vlm/test_keepalive_config.py
@@ -15,6 +15,18 @@ import httpx
 import pytest
 from pydantic import ValidationError
 
+
+@pytest.fixture(autouse=True)
+def _no_proxy_env(monkeypatch):
+    """Keep client construction independent of the developer shell's proxy env.
+
+    ``openai.DefaultHttpxClient`` honors proxy environment variables; a local
+    SOCKS proxy without the optional ``socksio`` extra would otherwise fail
+    construction before the assertions run.
+    """
+    for var in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy", "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(var, raising=False)
+
 from openviking.models.vlm.backends.openai_vlm import (
     OpenAIVLM,
     _build_httpx_limits,
@@ -37,12 +49,20 @@ def test_vlm_config_rejects_negative_keepalive_expiry():
         VLMConfig(model="gpt-4o-mini", api_key="sk-x", keepalive_expiry=-1.0)
 
 
-def test_build_httpx_limits_overrides_keepalive_expiry():
-    limits = _build_httpx_limits(0.0)
+def test_build_httpx_limits_bounds_pool_to_concurrency():
+    limits = _build_httpx_limits(4, 0.0)
     assert limits.keepalive_expiry == 0.0
-    # Remaining limits stay aligned with the OpenAI SDK defaults.
-    assert limits.max_connections == 1000
-    assert limits.max_keepalive_connections == 100
+    # Pool is bound to the configured concurrency cap, mirroring the embedder
+    # side (0f58d62a); connections beyond the cap can never be used.
+    assert limits.max_connections == 4
+    assert limits.max_keepalive_connections == 4
+
+
+def test_build_httpx_limits_floors_pool_at_one():
+    limits = _build_httpx_limits(0, 30.0)
+    assert limits.max_connections == 1
+    assert limits.max_keepalive_connections == 1
+    assert limits.keepalive_expiry == 30.0
 
 
 def test_vlm_config_propagates_keepalive_expiry_to_backend_dict():
@@ -55,6 +75,7 @@ def test_vlm_config_propagates_keepalive_expiry_to_backend_dict():
     )
     config_dict = cfg._build_vlm_config_dict()
     assert config_dict["keepalive_expiry"] == 30.0
+    assert config_dict["max_concurrent"] == cfg.max_concurrent
 
 
 def _pool_keepalive_expiry(client) -> float:
@@ -76,6 +97,8 @@ def test_sync_client_injects_http_client_without_connection_reuse():
     http_client = fake.call_args.kwargs.get("http_client")
     assert isinstance(http_client, httpx.Client)
     assert _pool_keepalive_expiry(http_client) == 0.0
+    pool = http_client._transport._pool
+    assert pool._max_connections == 32  # VLMConfig.max_concurrent default
 
 
 def test_sync_client_respects_configured_keepalive_expiry():
@@ -93,6 +116,8 @@ def test_sync_client_respects_configured_keepalive_expiry():
 
     http_client = fake.call_args.kwargs.get("http_client")
     assert _pool_keepalive_expiry(http_client) == 60.0
+    pool = http_client._transport._pool
+    assert pool._max_keepalive_connections == 32
 
 
 def test_sync_client_keeps_configured_request_timeout():

--- a/tests/models/vlm/test_keepalive_config.py
+++ b/tests/models/vlm/test_keepalive_config.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for ``vlm.keepalive_expiry`` configuration propagation (#4464).
+
+The OpenAI SDK leaves httpx ``keepalive_expiry`` at its 5.0s default. A pooled
+keep-alive connection that outlives the server-side idle timeout surfaces as an
+intermittent ``httpcore.ReadTimeout`` when reused. The VLM backend therefore
+injects an httpx client with an explicit ``keepalive_expiry`` (default 0 =
+no connection reuse); the value is configurable via ``ov.conf``.
+"""
+
+from unittest import mock
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from openviking.models.vlm.backends.openai_vlm import (
+    OpenAIVLM,
+    _build_httpx_limits,
+)
+from openviking_cli.utils.config.vlm_config import VLMConfig
+
+
+def test_vlm_config_keepalive_expiry_defaults_to_zero():
+    cfg = VLMConfig(model="gpt-4o-mini", api_key="sk-x")
+    assert cfg.keepalive_expiry == 0.0
+
+
+def test_vlm_config_accepts_positive_keepalive_expiry():
+    cfg = VLMConfig(model="gpt-4o-mini", api_key="sk-x", keepalive_expiry=60.0)
+    assert cfg.keepalive_expiry == 60.0
+
+
+def test_vlm_config_rejects_negative_keepalive_expiry():
+    with pytest.raises(ValidationError):
+        VLMConfig(model="gpt-4o-mini", api_key="sk-x", keepalive_expiry=-1.0)
+
+
+def test_build_httpx_limits_overrides_keepalive_expiry():
+    limits = _build_httpx_limits(0.0)
+    assert limits.keepalive_expiry == 0.0
+    # Remaining limits stay aligned with the OpenAI SDK defaults.
+    assert limits.max_connections == 1000
+    assert limits.max_keepalive_connections == 100
+
+
+def test_vlm_config_propagates_keepalive_expiry_to_backend_dict():
+    cfg = VLMConfig(
+        provider="openai",
+        model="gpt-4o-mini",
+        api_key="sk-x",
+        api_base="https://example.invalid",
+        keepalive_expiry=30.0,
+    )
+    config_dict = cfg._build_vlm_config_dict()
+    assert config_dict["keepalive_expiry"] == 30.0
+
+
+def _pool_keepalive_expiry(client) -> float:
+    return client._transport._pool._keepalive_expiry
+
+
+def test_sync_client_injects_http_client_without_connection_reuse():
+    vlm = OpenAIVLM(
+        {
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "api_key": "sk-x",
+            "api_base": "https://example.invalid",
+        }
+    )
+    with mock.patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI") as fake:
+        vlm.get_client()
+
+    http_client = fake.call_args.kwargs.get("http_client")
+    assert isinstance(http_client, httpx.Client)
+    assert _pool_keepalive_expiry(http_client) == 0.0
+
+
+def test_sync_client_respects_configured_keepalive_expiry():
+    vlm = OpenAIVLM(
+        {
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "api_key": "sk-x",
+            "api_base": "https://example.invalid",
+            "keepalive_expiry": 60.0,
+        }
+    )
+    with mock.patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI") as fake:
+        vlm.get_client()
+
+    http_client = fake.call_args.kwargs.get("http_client")
+    assert _pool_keepalive_expiry(http_client) == 60.0
+
+
+def test_sync_client_keeps_configured_request_timeout():
+    vlm = OpenAIVLM(
+        {
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "api_key": "sk-x",
+            "api_base": "https://example.invalid",
+            "timeout": 120.0,
+        }
+    )
+    with mock.patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI") as fake:
+        vlm.get_client()
+
+    kwargs = fake.call_args.kwargs
+    assert kwargs.get("timeout") == 120.0
+    assert kwargs["http_client"].timeout == httpx.Timeout(120.0)
+
+
+def test_async_client_injects_http_client_without_connection_reuse():
+    vlm = OpenAIVLM(
+        {
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "api_key": "sk-x",
+            "api_base": "https://example.invalid",
+        }
+    )
+    with mock.patch("openviking.models.vlm.backends.openai_vlm.openai.AsyncOpenAI") as fake:
+        vlm._build_async_client()
+
+    http_client = fake.call_args.kwargs.get("http_client")
+    assert isinstance(http_client, httpx.AsyncClient)
+    assert _pool_keepalive_expiry(http_client) == 0.0
+
+
+def test_azure_sync_client_injects_http_client():
+    vlm = OpenAIVLM(
+        {
+            "provider": "azure",
+            "model": "gpt-4o-mini",
+            "api_key": "sk-x",
+            "api_base": "https://example.invalid",
+        }
+    )
+    with mock.patch("openviking.models.vlm.backends.openai_vlm.openai.AzureOpenAI") as fake:
+        vlm.get_client()
+
+    http_client = fake.call_args.kwargs.get("http_client")
+    assert isinstance(http_client, httpx.Client)
+    assert _pool_keepalive_expiry(http_client) == 0.0


### PR DESCRIPTION

Fixes #4464

## Root cause

`OpenAIVLM` (`openviking/models/vlm/backends/openai_vlm.py`) built its OpenAI/Azure clients purely from kwargs, so the openai SDK constructed the underlying httpx client with httpx's default `keepalive_expiry=5.0s`. HTTP/1.1 keep-alive pooling does no liveness check on reuse, so whenever the server (or an intermediate LB) closed an idle pooled connection, the next VLM request that reused it blocked until `httpcore.ReadTimeout` — not the configured request timeout. This is intermittent by construction (depends on the idle gap between calls) and hits image-understanding / memory-extraction pipelines hardest because they fire VLM calls in bursts. The 600s default request timeout added in 0.4.16 made the hang worse to diagnose without fixing the reuse race.

## Fix

- Inject an explicit httpx client into the sync (`httpx.Client`) and async (`httpx.AsyncClient`) OpenAI/Azure clients built by `OpenAIVLM`, with `httpx.Limits(max_connections=1000, max_keepalive_connections=100, keepalive_expiry=...)` — the two capacity limits match the openai SDK defaults, only `keepalive_expiry` changes.
- Default `keepalive_expiry=0` (no pooled connection reuse: one fresh connection per request), the value the issue reporter validated in production for weeks. A fresh connection per request costs one TLS handshake, negligible relative to multi-second VLM inference calls.
- New `vlm.keepalive_expiry` config key (pydantic-validated, `>= 0`) in `VLMConfig`, propagated to every VLM backend dict (single, per-credential, and providers modes), so deployments that know their endpoint's idle timeout can re-enable pooling (e.g. `keepalive_expiry = 60`).
- Example config updated: `"keepalive_expiry": 0` added to the `vlm` section of `examples/ov.conf.example`.
- All other timeout semantics unchanged: the request-level `timeout` kwarg is still passed to the SDK (which overrides the client default per request), `max_retries=0` and OpenViking-owned retry/backoff untouched.

Scope notes: `CodexVLM` builds a fresh client per request (immune to pool reuse); `VolcEngineVLM` uses the volcengine Ark SDK, a different HTTP stack, both out of scope for this fix.

## Verification

- `python -m py_compile` on the two modified modules.
- New unit tests `tests/models/vlm/test_keepalive_config.py` (10 tests): config default/validation/propagation, limits helper, sync/async/azure client injection (asserts the injected client's connection pool `_keepalive_expiry`), and that request timeout semantics are preserved.
- Existing regression suites pass: `tests/models/vlm/test_timeout_config.py`, `tests/unit/test_vlm_reasoning_models.py`, `tests/unit/test_codex_vlm.py`.
- Inline assertions (host env) additionally verified pool `_keepalive_expiry` values (0.0 default / 60.0 configured) on the real constructed httpx clients.
