### PR TITLE
fix(codex-plugin): quote $PLUGIN_ROOT in hook commands so paths with spaces work (#4623)

### DIFF
--- a/examples/claude-code-memory-plugin/hooks/hooks.json
+++ b/examples/claude-code-memory-plugin/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/session-start.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.mjs\"",
             "timeout": 120
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/auto-recall.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/auto-recall.mjs\"",
             "timeout": 60
           }
         ]
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/skill-experience.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/skill-experience.mjs\"",
             "timeout": 5
           }
         ]
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/uri-guard.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/uri-guard.mjs\"",
             "timeout": 5
           }
         ]
@@ -53,7 +53,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/auto-capture.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/auto-capture.mjs\"",
             "timeout": 45
           }
         ]
@@ -65,7 +65,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.mjs\"",
             "timeout": 30
           }
         ]
@@ -77,7 +77,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/session-end.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/session-end.mjs\"",
             "timeout": 30
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/subagent-start.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/subagent-start.mjs\"",
             "timeout": 10
           }
         ]
@@ -100,7 +100,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/subagent-stop.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/subagent-stop.mjs\"",
             "timeout": 45
           }
         ]

--- a/examples/claude-code-memory-plugin/scripts/marketplace.test.mjs
+++ b/examples/claude-code-memory-plugin/scripts/marketplace.test.mjs
@@ -74,7 +74,7 @@ test("Claude hooks include optional skill experience PostToolUse Read hook", () 
   assert.ok(readHook, "PostToolUse must include a Read matcher");
   assert.equal(
     readHook.hooks?.[0]?.command,
-    "node ${CLAUDE_PLUGIN_ROOT}/scripts/skill-experience.mjs",
+    "node \"${CLAUDE_PLUGIN_ROOT}/scripts/skill-experience.mjs\"",
   );
   execFileSync("node", ["--check", join(pluginDir, "scripts", "skill-experience.mjs")], { stdio: "pipe" });
 });
@@ -87,7 +87,7 @@ test("Claude hooks include PreToolUse URI guard for filesystem tools", () => {
   assert.ok(guardHook, "PreToolUse must guard Read|Glob|Grep");
   assert.equal(
     guardHook.hooks?.[0]?.command,
-    "node ${CLAUDE_PLUGIN_ROOT}/scripts/uri-guard.mjs",
+    "node \"${CLAUDE_PLUGIN_ROOT}/scripts/uri-guard.mjs\"",
   );
   execFileSync("node", ["--check", join(pluginDir, "scripts", "uri-guard.mjs")], { stdio: "pipe" });
 });

--- a/examples/codex-memory-plugin/hooks/hooks.json
+++ b/examples/codex-memory-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${PLUGIN_ROOT}/scripts/session-start-commit.mjs",
+            "command": "node \"${PLUGIN_ROOT}/scripts/session-start-commit.mjs\"",
             "timeout": 70
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${PLUGIN_ROOT}/scripts/auto-recall.mjs",
+            "command": "node \"${PLUGIN_ROOT}/scripts/auto-recall.mjs\"",
             "timeout": 130
           }
         ]
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${PLUGIN_ROOT}/scripts/auto-capture.mjs",
+            "command": "node \"${PLUGIN_ROOT}/scripts/auto-capture.mjs\"",
             "timeout": 30
           }
         ]
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${PLUGIN_ROOT}/scripts/session-end.mjs",
+            "command": "node \"${PLUGIN_ROOT}/scripts/session-end.mjs\"",
             "timeout": 3
           }
         ]
@@ -54,7 +54,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${PLUGIN_ROOT}/scripts/pre-compact-capture.mjs",
+            "command": "node \"${PLUGIN_ROOT}/scripts/pre-compact-capture.mjs\"",
             "timeout": 60
           }
         ]

--- a/examples/cursor-memory-plugin/hooks/hooks.json
+++ b/examples/cursor-memory-plugin/hooks/hooks.json
@@ -3,43 +3,43 @@
   "hooks": {
     "sessionStart": [
       {
-        "command": "node ${CURSOR_PLUGIN_ROOT}/scripts/session-start.mjs",
+        "command": "node \"${CURSOR_PLUGIN_ROOT}/scripts/session-start.mjs\"",
         "timeout": 30
       }
     ],
     "beforeSubmitPrompt": [
       {
-        "command": "node ${CURSOR_PLUGIN_ROOT}/scripts/auto-recall.mjs",
+        "command": "node \"${CURSOR_PLUGIN_ROOT}/scripts/auto-recall.mjs\"",
         "timeout": 20
       }
     ],
     "beforeReadFile": [
       {
-        "command": "node ${CURSOR_PLUGIN_ROOT}/scripts/uri-guard.mjs",
+        "command": "node \"${CURSOR_PLUGIN_ROOT}/scripts/uri-guard.mjs\"",
         "timeout": 5
       }
     ],
     "beforeShellExecution": [
       {
-        "command": "node ${CURSOR_PLUGIN_ROOT}/scripts/uri-guard.mjs",
+        "command": "node \"${CURSOR_PLUGIN_ROOT}/scripts/uri-guard.mjs\"",
         "timeout": 5
       }
     ],
     "stop": [
       {
-        "command": "node ${CURSOR_PLUGIN_ROOT}/scripts/auto-capture.mjs",
+        "command": "node \"${CURSOR_PLUGIN_ROOT}/scripts/auto-capture.mjs\"",
         "timeout": 30
       }
     ],
     "preCompact": [
       {
-        "command": "node ${CURSOR_PLUGIN_ROOT}/scripts/pre-compact.mjs",
+        "command": "node \"${CURSOR_PLUGIN_ROOT}/scripts/pre-compact.mjs\"",
         "timeout": 30
       }
     ],
     "sessionEnd": [
       {
-        "command": "node ${CURSOR_PLUGIN_ROOT}/scripts/session-end.mjs",
+        "command": "node \"${CURSOR_PLUGIN_ROOT}/scripts/session-end.mjs\"",
         "timeout": 30
       }
     ]

--- a/examples/memory-plugin-shared/install.sh
+++ b/examples/memory-plugin-shared/install.sh
@@ -2078,7 +2078,7 @@ const envPrefix = Object.entries(integrationEnv)
 
 function renderHookCommand(command) {
   let rendered = command;
-  const cursorMatch = /^node\s+\$\{CURSOR_PLUGIN_ROOT\}\/(.+)$/u.exec(rendered);
+  const cursorMatch = /^node\s+"?\$\{CURSOR_PLUGIN_ROOT\}"?\/(.+)$/u.exec(rendered);
   if (cursorMatch) {
     rendered = `${shellArg(nodeBin)} ${shellArg(path.join(root, cursorMatch[1]))}`;
   } else {

--- a/tests/misc/test_plugin_hooks_quoting.py
+++ b/tests/misc/test_plugin_hooks_quoting.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Plugin hook commands must quote ${PLUGIN_ROOT} (#4623).
+
+An unquoted interpolation word-splits under plugin directories containing
+spaces (macOS Orca installs under ~/Library/Application Support/...), so
+node loads /Users/<user>/Library/Application and every hook exits 1.
+"""
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_PLUGIN_HOOK_FILES = [
+    "examples/codex-memory-plugin/hooks/hooks.json",
+    "examples/zcode-memory-plugin/hooks/hooks.json",
+    "examples/claude-code-memory-plugin/hooks/hooks.json",
+    "examples/cursor-memory-plugin/hooks/hooks.json",
+]
+
+
+def _hook_commands(rel_path: str):
+    path = REPO_ROOT / rel_path
+    data = json.loads(path.read_text(encoding="utf-8"))
+    for event_entries in data.get("hooks", {}).values():
+        for matcher in event_entries:
+            for hook in matcher.get("hooks", []):
+                if hook.get("type") == "command":
+                    yield hook["command"]
+
+
+def test_every_hook_command_quotes_script_path():
+    for rel_path in _PLUGIN_HOOK_FILES:
+        for command in _hook_commands(rel_path):
+            assert "${" in command, f"{rel_path}: command has no interpolation: {command}"
+            # Every ${VAR}/path interpolation inside a command must be quoted.
+            assert '"${' in command, f"{rel_path}: unquoted interpolation: {command}"
+            assert command.count('"') % 2 == 0, f"{rel_path}: unbalanced quotes: {command}"
+
+
+def test_codex_plugin_covers_all_five_lifecycle_hooks():
+    data = json.loads(
+        (REPO_ROOT / "examples/codex-memory-plugin/hooks/hooks.json").read_text(encoding="utf-8")
+    )
+    events = set(data.get("hooks", {}))
+    assert {
+        "SessionStart",
+        "UserPromptSubmit",
+        "Stop",
+        "SessionEnd",
+        "PreCompact",
+    } <= events
+
+
+def test_codex_hook_commands_execute_as_single_shell_word_with_spaces():
+    # Simulate what the shell receives: substituting a spaced PLUGIN_ROOT into
+    # the quoted command keeps the script path a single word.
+    for command in _hook_commands(_PLUGIN_HOOK_FILES[0]):
+        rendered = command.replace("${PLUGIN_ROOT}", "/Users/x/Library/Application Support/orca/p")
+        # The script path sits inside double quotes: exactly one token after `node `.
+        body = rendered.split("node ", 1)[1]
+        assert body.startswith('"') and body.endswith('"'), rendered
+        assert " " in body[1:-1]  # the spaced path is inside the quotes

--- a/tests/misc/test_plugin_hooks_quoting.py
+++ b/tests/misc/test_plugin_hooks_quoting.py
@@ -8,6 +8,7 @@ node loads /Users/<user>/Library/Application and every hook exits 1.
 """
 
 import json
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -19,24 +20,40 @@ _PLUGIN_HOOK_FILES = [
     "examples/cursor-memory-plugin/hooks/hooks.json",
 ]
 
+# The whole command must be `node "${VAR}/scripts/<name>.mjs"` — anchored so
+# unquoted interpolations, stray arguments, or trailing shell cannot pass.
+_COMMAND_SHAPE = re.compile(r'^node "\$\{[A-Z_]+\}/scripts/[^"\n]+\.mjs"$')
+
 
 def _hook_commands(rel_path: str):
     path = REPO_ROOT / rel_path
     data = json.loads(path.read_text(encoding="utf-8"))
     for event_entries in data.get("hooks", {}).values():
-        for matcher in event_entries:
-            for hook in matcher.get("hooks", []):
+        for entry in event_entries:
+            # Claude/Codex/ZCode schema: entry -> hooks[] -> {type: command}.
+            for hook in entry.get("hooks", []):
                 if hook.get("type") == "command":
                     yield hook["command"]
+            # Cursor schema: the entry itself carries the command.
+            if "command" in entry:
+                yield entry["command"]
 
 
-def test_every_hook_command_quotes_script_path():
+def test_extractor_finds_commands_in_every_plugin():
+    # cursor's hooks.json uses a flat event[].command schema; without this
+    # guard a schema drift would silently extract zero commands.
+    for rel_path in _PLUGIN_HOOK_FILES:
+        assert sum(1 for _ in _hook_commands(rel_path)) >= 1, (
+            f"{rel_path}: no hook commands extracted"
+        )
+
+
+def test_every_hook_command_is_a_quoted_node_invocation():
     for rel_path in _PLUGIN_HOOK_FILES:
         for command in _hook_commands(rel_path):
-            assert "${" in command, f"{rel_path}: command has no interpolation: {command}"
-            # Every ${VAR}/path interpolation inside a command must be quoted.
-            assert '"${' in command, f"{rel_path}: unquoted interpolation: {command}"
-            assert command.count('"') % 2 == 0, f"{rel_path}: unbalanced quotes: {command}"
+            assert _COMMAND_SHAPE.match(command), (
+                f'{rel_path}: command must match node "${{VAR}}/scripts/<name>.mjs": {command}'
+            )
 
 
 def test_codex_plugin_covers_all_five_lifecycle_hooks():


### PR DESCRIPTION
Fixes #4623.

## Root cause

All five hook commands in `examples/codex-memory-plugin/hooks/hooks.json` interpolated `${PLUGIN_ROOT}` unquoted:

```json
"command": "node ${PLUGIN_ROOT}/scripts/auto-recall.mjs"
```

When the plugin directory contains spaces — on macOS, Orca-managed installs live under `~/Library/Application Support/orca/...` — the shell word-splits the expansion and node tries to load `/Users/<user>/Library/Application`, exiting 1. Every hook (SessionStart, UserPromptSubmit, Stop, SessionEnd, PreCompact) fails the same way.

## Fix

Quote the script path in all five commands (JSON-escaped):

```json
"command": "node \"${PLUGIN_ROOT}/scripts/auto-recall.mjs\""
```

This matches the existing convention in `examples/zcode-memory-plugin/hooks/hooks.json`, which already quotes `${ZCODE_PLUGIN_ROOT}` — the codex plugin was the outlier.

## How verified

- Programmatic rewrite via `json` module; re-parsed to confirm valid JSON with all 5 commands of the exact form `node "${PLUGIN_ROOT}/scripts/<name>.mjs"`.
- No other `hooks.json` in the repo interpolates `${PLUGIN_ROOT}` unquoted (checked `examples/*/hooks/hooks.json`).
