### PR TITLE
feat(web-studio): add manual cancel action for background tasks (#4553)

### DIFF
--- a/web-studio/src/i18n/locales/en/workspace.ts
+++ b/web-studio/src/i18n/locales/en/workspace.ts
@@ -284,6 +284,16 @@ const workspace = {
       noResultCancelledDescription:
         'This task was cancelled before it returned a result.',
     },
+    actions: {
+      cancelTask: 'Cancel task',
+    },
+    cancelDialog: {
+      title: 'Cancel this task?',
+      description:
+        "Request cancellation of task {{taskId}}. The task stops cooperatively at the next safe checkpoint, its queue slot is released, and the status becomes 'Cancelled'.",
+      confirm: 'Cancel task',
+      dismiss: 'Keep running',
+    },
     filters: {
       label: 'Filter',
       type: 'Task type',

--- a/web-studio/src/i18n/locales/zh-CN/workspace.ts
+++ b/web-studio/src/i18n/locales/zh-CN/workspace.ts
@@ -274,6 +274,16 @@ const workspace = {
       noResultFailedDescription: '该任务未返回结果，请查看上方失败原因。',
       noResultCancelledDescription: '该任务已取消，未返回执行结果。',
     },
+    actions: {
+      cancelTask: '取消任务',
+    },
+    cancelDialog: {
+      title: '确认取消该任务？',
+      description:
+        '将请求取消任务 {{taskId}}。任务会在下一个安全检查点协作式停止，队列槽位随即释放，状态将更新为“已取消”。',
+      confirm: '取消任务',
+      dismiss: '继续运行',
+    },
     filters: {
       label: '筛选',
       type: '任务类型',

--- a/web-studio/src/routes/tasks/-lib/task-list.test.ts
+++ b/web-studio/src/routes/tasks/-lib/task-list.test.ts
@@ -1,14 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { fetchTasks, MAX_TASKS } from './task-list'
+import {
+  canCancelTask,
+  cancelTask,
+  fetchTasks,
+  isCancellableTaskType,
+  isTaskCancelling,
+  MAX_TASKS,
+} from './task-list'
 
 const clientMocks = vi.hoisted(() => ({
   getTasks: vi.fn(),
+  post: vi.fn(),
 }))
 
 vi.mock('#/lib/ov-client', () => ({
   getOvResult: async (value: unknown) => value,
   getTasks: clientMocks.getTasks,
+  ovClient: { instance: { post: clientMocks.post } },
 }))
 
 beforeEach(() => {
@@ -72,5 +81,79 @@ describe('task list requests', () => {
     clientMocks.getTasks.mockRejectedValue(new Error('request failed'))
 
     await expect(fetchTasks('all', 'all')).rejects.toThrow('request failed')
+  })
+})
+
+describe('cancellable task helpers', () => {
+  it('mirrors the backend cancellable type whitelist', () => {
+    expect(isCancellableTaskType('session_commit')).toBe(true)
+    expect(isCancellableTaskType('add_resource')).toBe(true)
+    expect(isCancellableTaskType('admin_reindex')).toBe(true)
+    expect(isCancellableTaskType('snapshot_restore_reindex')).toBe(true)
+    expect(isCancellableTaskType('add_skill')).toBe(false)
+    expect(isCancellableTaskType('connector_import')).toBe(false)
+    expect(isCancellableTaskType()).toBe(false)
+  })
+
+  it('only allows cancelling pending or running tasks', () => {
+    const task = { task_id: 'task-1', task_type: 'session_commit' }
+    expect(canCancelTask({ ...task, status: 'pending' })).toBe(true)
+    expect(canCancelTask({ ...task, status: 'running' })).toBe(true)
+    expect(canCancelTask({ ...task, status: 'cancelling' })).toBe(false)
+    expect(canCancelTask({ ...task, status: 'completed' })).toBe(false)
+    expect(canCancelTask({ ...task, status: 'failed' })).toBe(false)
+    expect(canCancelTask({ ...task, status: 'cancelled' })).toBe(false)
+    expect(
+      canCancelTask({
+        task_id: 'task-2',
+        task_type: 'add_skill',
+        status: 'running',
+      }),
+    ).toBe(false)
+    expect(
+      canCancelTask({ task_type: 'session_commit', status: 'running' }),
+    ).toBe(false)
+  })
+
+  it('reports the cancelling intermediate state for cancellable types', () => {
+    expect(
+      isTaskCancelling({
+        task_id: 'task-1',
+        task_type: 'session_commit',
+        status: 'cancelling',
+      }),
+    ).toBe(true)
+    expect(
+      isTaskCancelling({
+        task_id: 'task-1',
+        task_type: 'session_commit',
+        status: 'running',
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('cancelTask', () => {
+  it('posts to the task cancel endpoint with an escaped id', async () => {
+    // The module-level mock keeps getOvResult as an identity function, so
+    // the raw axios response is returned as-is here.
+    const response = {
+      data: {
+        status: 'ok',
+        result: { task_id: 'task/1', status: 'cancelling' },
+      },
+    }
+    clientMocks.post.mockResolvedValue(response)
+
+    await expect(cancelTask('task/1')).resolves.toBe(response)
+    expect(clientMocks.post).toHaveBeenCalledWith(
+      '/api/v1/tasks/task%2F1/cancel',
+    )
+  })
+
+  it('propagates backend errors to the mutation error state', async () => {
+    clientMocks.post.mockRejectedValue(new Error('cancel failed'))
+
+    await expect(cancelTask('task-1')).rejects.toThrow('cancel failed')
   })
 })

--- a/web-studio/src/routes/tasks/-lib/task-list.ts
+++ b/web-studio/src/routes/tasks/-lib/task-list.ts
@@ -1,4 +1,4 @@
-import { getOvResult, getTasks } from '#/lib/ov-client'
+import { getOvResult, getTasks, ovClient } from '#/lib/ov-client'
 import {
   normalizeTasks,
   normalizeTaskStatus,
@@ -39,6 +39,43 @@ export function getEffectiveTaskStatus(
     (task) => task.task_id === taskItem.task_id,
   )
   return index >= MAX_EFFECTIVE_RUNNING_TASKS ? 'pending' : 'running'
+}
+
+// Mirrors the backend `_CANCELLABLE_TASK_TYPES` whitelist in
+// openviking/service/task_tracker.py: only these task types support
+// cooperative cancellation via POST /api/v1/tasks/{task_id}/cancel.
+const CANCELLABLE_TASK_TYPES: ReadonlySet<string> = new Set([
+  'add_resource',
+  'session_commit',
+  'admin_reindex',
+  'snapshot_restore_reindex',
+])
+
+export function isCancellableTaskType(taskType?: string): boolean {
+  return taskType ? CANCELLABLE_TASK_TYPES.has(taskType) : false
+}
+
+export function canCancelTask(task: TaskRecord): boolean {
+  if (!task.task_id || !isCancellableTaskType(task.task_type)) {
+    return false
+  }
+  const status = normalizeTaskStatus(task.status)
+  return status === 'pending' || status === 'running'
+}
+
+export function isTaskCancelling(task: TaskRecord): boolean {
+  return (
+    isCancellableTaskType(task.task_type) &&
+    normalizeTaskStatus(task.status) === 'cancelling'
+  )
+}
+
+export async function cancelTask(taskId: string): Promise<TaskRecord> {
+  return getOvResult<TaskRecord>(
+    ovClient.instance.post(
+      `/api/v1/tasks/${encodeURIComponent(taskId)}/cancel`,
+    ),
+  )
 }
 
 export async function fetchTasks(

--- a/web-studio/src/routes/tasks/route.test.tsx
+++ b/web-studio/src/routes/tasks/route.test.tsx
@@ -1,0 +1,235 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { TasksRoute } from './route'
+
+const apiMocks = vi.hoisted(() => ({
+  cancelTask: vi.fn(),
+  fetchTasks: vi.fn(),
+}))
+
+const toastMocks = vi.hoisted(() => ({
+  dismiss: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  loading: vi.fn(() => 'toast-1'),
+  success: vi.fn(),
+  warning: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    i18n: { language: 'en', resolvedLanguage: 'en' },
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('sonner', () => ({ toast: toastMocks }))
+
+vi.mock('#/hooks/use-app-connection', () => ({
+  useAppConnection: () => ({ identityScopeKey: 'default/default' }),
+}))
+
+vi.mock('#/routes/monitoring/-components/queue-status-card', () => ({
+  QueueStatusCard: () => <div data-testid="mock-queue-status-card" />,
+}))
+
+vi.mock('./-components/task-detail-sheet', () => ({
+  TaskDetailSheet: () => null,
+}))
+
+vi.mock('#/lib/sessions/api', () => ({
+  commitSession: vi.fn(),
+}))
+
+vi.mock('#/gen/ov-client', () => ({
+  postResources: vi.fn(),
+}))
+
+vi.mock('#/lib/ov-client', () => ({
+  ovClient: { instance: { post: vi.fn() } },
+}))
+
+vi.mock('./-lib/task-list', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    cancelTask: apiMocks.cancelTask,
+    fetchTasks: apiMocks.fetchTasks,
+  }
+})
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  })
+  const result = render(
+    <QueryClientProvider client={queryClient}>
+      <TasksRoute />
+    </QueryClientProvider>,
+  )
+  return { ...result, queryClient }
+}
+
+const runningTask = {
+  created_at: 2,
+  status: 'running',
+  task_id: 'task-running',
+  task_type: 'session_commit',
+}
+
+const pendingTask = {
+  created_at: 1,
+  status: 'pending',
+  task_id: 'task-pending',
+  task_type: 'add_resource',
+}
+
+const completedTask = {
+  created_at: 0,
+  status: 'completed',
+  task_id: 'task-completed',
+  task_type: 'session_commit',
+}
+
+beforeEach(() => {
+  apiMocks.fetchTasks.mockResolvedValue([
+    runningTask,
+    pendingTask,
+    completedTask,
+  ])
+  apiMocks.cancelTask.mockResolvedValue({
+    task_id: 'task-running',
+    status: 'cancelling',
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('TasksRoute cancel action', () => {
+  it('shows the cancel action for pending and running cancellable tasks', async () => {
+    renderPage()
+
+    const cancelButtons = await screen.findAllByRole('button', {
+      name: 'actions.cancelTask',
+    })
+    expect(cancelButtons).toHaveLength(2)
+  })
+
+  it('hides the cancel action for terminal statuses and non-cancellable types', async () => {
+    apiMocks.fetchTasks.mockResolvedValue([
+      completedTask,
+      {
+        created_at: 3,
+        status: 'running',
+        task_id: 'task-skill',
+        task_type: 'add_skill',
+      },
+    ])
+
+    renderPage()
+
+    await screen.findByText('task-skill')
+    expect(
+      screen.queryByRole('button', { name: 'actions.cancelTask' }),
+    ).toBeNull()
+  })
+
+  it('shows the cancelling intermediate state without an active button', async () => {
+    apiMocks.fetchTasks.mockResolvedValue([
+      {
+        created_at: 2,
+        status: 'cancelling',
+        task_id: 'task-cancelling',
+        task_type: 'session_commit',
+      },
+    ])
+
+    renderPage()
+
+    expect(await screen.findByTitle('status.cancelling')).toBeDefined()
+    expect(
+      screen.queryByRole('button', { name: 'actions.cancelTask' }),
+    ).toBeNull()
+  })
+
+  it('asks for confirmation and calls the cancel endpoint', async () => {
+    renderPage()
+
+    const cancelButton = await screen.findAllByRole('button', {
+      name: 'actions.cancelTask',
+    })
+    fireEvent.click(cancelButton[0])
+
+    expect(await screen.findByText('cancelDialog.title')).toBeDefined()
+    expect(screen.getByText('cancelDialog.description')).toBeDefined()
+    expect(apiMocks.cancelTask).not.toHaveBeenCalled()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'cancelDialog.confirm' }),
+    )
+
+    await waitFor(() => {
+      expect(apiMocks.cancelTask).toHaveBeenCalledWith('task-running')
+    })
+    await waitFor(() => {
+      expect(toastMocks.success).toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(screen.queryByText('cancelDialog.title')).toBeNull()
+    })
+  })
+
+  it('keeps the dialog open and reports failures', async () => {
+    apiMocks.cancelTask.mockRejectedValue(new Error('cancel rejected'))
+
+    renderPage()
+
+    const cancelButton = await screen.findAllByRole('button', {
+      name: 'actions.cancelTask',
+    })
+    fireEvent.click(cancelButton[0])
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'cancelDialog.confirm' }),
+    )
+
+    await waitFor(() => {
+      expect(toastMocks.error).toHaveBeenCalledWith('cancel rejected')
+    })
+    expect(await screen.findByText('cancelDialog.title')).toBeDefined()
+  })
+
+  it('dismisses the dialog without cancelling', async () => {
+    renderPage()
+
+    const cancelButton = await screen.findAllByRole('button', {
+      name: 'actions.cancelTask',
+    })
+    fireEvent.click(cancelButton[0])
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'cancelDialog.dismiss' }),
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByText('cancelDialog.title')).toBeNull()
+    })
+    expect(apiMocks.cancelTask).not.toHaveBeenCalled()
+  })
+})

--- a/web-studio/src/routes/tasks/route.tsx
+++ b/web-studio/src/routes/tasks/route.tsx
@@ -17,6 +17,15 @@ import {
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '#/components/ui/alert-dialog'
 import { Badge } from '#/components/ui/badge'
 import { Button } from '#/components/ui/button'
 import { Card } from '#/components/ui/card'
@@ -52,7 +61,14 @@ import { TaskDetailSheet } from '#/routes/tasks/-components/task-detail-sheet'
 import { normalizeTaskStatus } from '#/routes/tasks/-lib/task-record'
 import type { TaskRecord } from '#/routes/tasks/-lib/task-record'
 import { formatTaskDuration, getTaskDate } from '#/routes/tasks/-lib/task-time'
-import { fetchTasks, getEffectiveTaskStatus, MAX_TASKS } from './-lib/task-list'
+import {
+  canCancelTask,
+  cancelTask,
+  fetchTasks,
+  getEffectiveTaskStatus,
+  isTaskCancelling,
+  MAX_TASKS,
+} from './-lib/task-list'
 import type { TaskStatusFilter, TaskTypeFilter } from './-lib/task-list'
 import { getTaskPipelineGroups } from './-lib/task-pipeline'
 
@@ -81,7 +97,7 @@ const TASK_STATUS_OPTIONS: Exclude<TaskStatusFilter, 'all'>[] = [
   'cancelled',
 ]
 
-function TasksRoute() {
+export function TasksRoute() {
   const { i18n, t } = useTranslation('tasksPage')
   const { identityScopeKey } = useAppConnection()
   const queryClient = useQueryClient()
@@ -94,6 +110,8 @@ function TasksRoute() {
   const [selectedTaskId, setSelectedTaskId] = React.useState<string | null>(
     null,
   )
+  const [cancelTargetTask, setCancelTargetTask] =
+    React.useState<TaskRecord | null>(null)
   const tasksQuery = useQuery({
     queryFn: () => fetchTasks(taskType, statusFilter),
     queryKey: ['tasks', identityScopeKey, taskType, statusFilter],
@@ -205,6 +223,31 @@ function TasksRoute() {
     },
   })
 
+  const cancelMutation = useMutation({
+    mutationFn: (task: TaskRecord) => {
+      if (!task.task_id) {
+        throw new Error(
+          i18n.language.startsWith('zh')
+            ? '任务缺少任务 ID，无法取消'
+            : 'Missing task ID, unable to cancel',
+        )
+      }
+      return cancelTask(task.task_id)
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : String(error))
+    },
+    onSuccess: async () => {
+      toast.success(
+        i18n.language.startsWith('zh')
+          ? '已请求取消该任务，取消完成后状态将自动更新'
+          : 'Cancellation requested, the status will update shortly',
+      )
+      setCancelTargetTask(null)
+      await queryClient.invalidateQueries({ queryKey: ['tasks'] })
+    },
+  })
+
   React.useEffect(() => {
     if (page > totalPages) {
       setPage(totalPages)
@@ -270,6 +313,8 @@ function TasksRoute() {
     const status = normalizeTaskStatus(effStatus)
     const pct = getTaskProgressPct(task)
     const isRetrying = retryMutation.isPending && retryMutation.variables.task_id === taskId
+    const isRequestingCancel =
+      cancelMutation.isPending && cancelMutation.variables.task_id === taskId
     const Icon =
       status === 'completed'
         ? CheckCircle2Icon
@@ -324,6 +369,33 @@ function TasksRoute() {
               <RotateCcwIcon className="size-3 shrink-0" />
             )}
           </button>
+        )}
+        {canCancelTask(task) && (
+          <button
+            type="button"
+            disabled={isRequestingCancel}
+            className="ml-1 inline-flex items-center justify-center rounded p-0.5 text-destructive hover:bg-destructive/15 active:scale-95 transition-all cursor-pointer disabled:opacity-50"
+            title={t('actions.cancelTask')}
+            aria-label={t('actions.cancelTask')}
+            onClick={(e) => {
+              e.stopPropagation()
+              setCancelTargetTask(task)
+            }}
+          >
+            {isRequestingCancel ? (
+              <LoaderCircleIcon className="size-3 shrink-0 animate-spin" />
+            ) : (
+              <XIcon className="size-3 shrink-0" />
+            )}
+          </button>
+        )}
+        {isTaskCancelling(task) && (
+          <span
+            className="ml-1 inline-flex items-center justify-center rounded p-0.5 text-destructive/70"
+            title={t('status.cancelling')}
+          >
+            <LoaderCircleIcon className="size-3 shrink-0 animate-spin" />
+          </span>
         )}
       </Badge>
     )
@@ -989,6 +1061,46 @@ function TasksRoute() {
           </div>
         </Card>
       )}
+
+      <AlertDialog
+        open={Boolean(cancelTargetTask)}
+        onOpenChange={(open) => {
+          if (!open && !cancelMutation.isPending) {
+            setCancelTargetTask(null)
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('cancelDialog.title')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('cancelDialog.description', {
+                taskId: cancelTargetTask?.task_id ?? '',
+              })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('cancelDialog.dismiss')}</AlertDialogCancel>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={cancelMutation.isPending}
+              onClick={() => {
+                if (cancelTargetTask) {
+                  cancelMutation.mutate(cancelTargetTask)
+                }
+              }}
+            >
+              {cancelMutation.isPending ? (
+                <LoaderCircleIcon className="animate-spin" />
+              ) : (
+                <XIcon />
+              )}
+              {t('cancelDialog.confirm')}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <TaskDetailSheet
         identityScopeKey={identityScopeKey}


### PR DESCRIPTION

## Summary

The Web Studio Task Center was read-only: when a background task got stuck in
`running` (for example, its worker went offline mid-task), there was no way to
intervene from the UI. In the reported case, a `session_commit` task hung in
`running` for 55 minutes, held the serial worker slot, and starved every
pending task behind it. Cancelling it manually resolved the situation within
seconds and released the slot with no side effects.

This PR wires the already-shipped backend endpoint
(`POST /api/v1/tasks/{task_id}/cancel`, idempotent cooperative cancellation
`cancelling -> cancelled`) into the Task Center:

- Pending and running tasks whose type supports cooperative cancellation now
  show an inline cancel action (X icon, destructive color) inside the status
  badge, next to the existing re-trigger action on failed tasks.
- Clicking it opens a confirmation dialog (existing `AlertDialog` component,
  same pattern as the delete-account dialog) explaining that the task stops
  cooperatively, its queue slot is released, and the status becomes
  "Cancelled".
- Confirming calls the cancel endpoint, shows a success toast, and invalidates
  the task list so the existing 10s polling picks up the new state.
- While a cancellation request is in flight, or while a task is in the
  `cancelling` state, the badge renders a disabled spinner intermediate state
  instead of the action, so users can see cancellation is underway.

## Implementation

- `web-studio/src/routes/tasks/-lib/task-list.ts`
  - `cancelTask(taskId)` — posts to `/api/v1/tasks/{id}/cancel` through the
    shared `ovClient` axios instance and unwraps the standard response
    envelope via `getOvResult`, consistent with `fetchTasks`.
  - `CANCELLABLE_TASK_TYPES` / `isCancellableTaskType()` — mirrors the backend
    `_CANCELLABLE_TASK_TYPES` whitelist in `openviking/service/task_tracker.py`
    (`add_resource`, `session_commit`, `admin_reindex`,
    `snapshot_restore_reindex`), so the button never appears for task types
    the backend would reject.
  - `canCancelTask(task)` — true only for `pending`/`running` tasks with an id
    and a cancellable type; `isTaskCancelling(task)` — drives the
    intermediate state.
- `web-studio/src/routes/tasks/route.tsx`
  - `cancelMutation` (react-query `useMutation`, same shape as the existing
    `retryMutation`): error toast on failure, success toast + dialog close +
    `invalidateQueries(['tasks'])` on success.
  - Inline cancel button in `renderStatus` (destructive color, restrained
    hover, disabled-with-spinner while the request is pending) and a
    non-interactive spinner chip for the `cancelling` state.
  - `AlertDialog` confirmation with `Button variant="destructive"` confirm
    action, matching the `delete-account-button` dialog conventions.
- `web-studio/src/i18n/locales/{en,zh-CN}/workspace.ts` — new
  `tasksPage.actions.cancelTask` and `tasksPage.cancelDialog.*` strings,
  following the existing bilingual namespace layout.

## Testing

- New `web-studio/src/routes/tasks/route.test.tsx` (jsdom + Testing Library,
  same harness as `watches/route.test.tsx`), covering:
  - the cancel action appears only for pending/running cancellable tasks;
  - it stays hidden for terminal statuses and non-cancellable types
    (e.g. `add_skill`);
  - the `cancelling` state renders the intermediate spinner and no action;
  - confirmation flow: dialog opens first (no premature API call), confirm
    calls `cancelTask('task-running')`, fires the success toast, closes the
    dialog;
  - failure keeps the dialog open and surfaces the error toast;
  - dismiss cancels nothing.
- Extended `web-studio/src/routes/tasks/-lib/task-list.test.ts` with unit
  tests for the type whitelist, the state gating, URL escaping in the cancel
  request, and error propagation.
- Full web-studio suite: `npx vitest run` — 60 files / 281 tests passed
  (21 in the tasks scope, 6 of them new interaction tests).
- `npx tsc --noEmit` and `npx eslint` introduce no new findings in the
  touched files (the remaining tsc/eslint output on this route predates this
  change and is untouched).
