### PR TITLE
feat(telemetry): surface extraction parse failures as structured counters (RFC #4243)

### DIFF
--- a/openviking/metrics/collectors/telemetry_bridge.py
+++ b/openviking/metrics/collectors/telemetry_bridge.py
@@ -111,6 +111,16 @@ class TelemetryBridgeCollector(EventMetricCollector):
     MEMORY_PARSE_EXHAUSTED_TOTAL: ClassVar[str] = MetricCollector.metric_name(
         DOMAIN_MEMORY, "parse_exhausted", unit="total"
     )
+    # rule: <METRICS_NAMESPACE>_<DOMAIN_MEMORY>_parse_format_retries
+    # e.g.: openviking_memory_parse_format_retries (histogram)
+    MEMORY_PARSE_FORMAT_RETRIES: ClassVar[str] = MetricCollector.metric_name(
+        DOMAIN_MEMORY, "parse_format_retries"
+    )
+    # rule: <METRICS_NAMESPACE>_<DOMAIN_MEMORY>_parse_iterations
+    # e.g.: openviking_memory_parse_iterations (histogram)
+    MEMORY_PARSE_ITERATIONS: ClassVar[str] = MetricCollector.metric_name(
+        DOMAIN_MEMORY, "parse_iterations"
+    )
     # rule: <METRICS_NAMESPACE>_<DOMAIN_RESOURCE>_stage_total
     # e.g.: openviking_resource_stage_total
     RESOURCE_STAGE_TOTAL: ClassVar[str] = MetricCollector.metric_name(
@@ -309,6 +319,24 @@ class TelemetryBridgeCollector(EventMetricCollector):
                     self.MEMORY_PARSE_EXHAUSTED_TOTAL,
                     labels={"operation": operation},
                     label_names=("operation",),
+                )
+            iterations = int(parse.get("iterations_used", 0) or 0)
+            if iterations > 0:
+                # Aggregate-safe observability for "N iterations / M format retries used":
+                # histograms expose distributions without per-operation label cardinality.
+                registry.observe_histogram(
+                    self.MEMORY_PARSE_ITERATIONS,
+                    iterations,
+                    labels={"operation": operation},
+                    label_names=("operation",),
+                    buckets=(1, 2, 3, 4, 6, 8, 12, 16),
+                )
+                registry.observe_histogram(
+                    self.MEMORY_PARSE_FORMAT_RETRIES,
+                    int(parse.get("format_retries_used", 0) or 0),
+                    labels={"operation": operation},
+                    label_names=("operation",),
+                    buckets=(0, 1, 2, 3, 4, 8),
                 )
 
         actions = extract.get("actions") or {}

--- a/openviking/metrics/collectors/telemetry_bridge.py
+++ b/openviking/metrics/collectors/telemetry_bridge.py
@@ -101,6 +101,16 @@ class TelemetryBridgeCollector(EventMetricCollector):
     MEMORY_OPERATIONS_TOTAL: ClassVar[str] = MetricCollector.metric_name(
         DOMAIN_MEMORY, "operations", unit="total"
     )
+    # rule: <METRICS_NAMESPACE>_<DOMAIN_MEMORY>_parse_failures_total
+    # e.g.: openviking_memory_parse_failures_total
+    MEMORY_PARSE_FAILURES_TOTAL: ClassVar[str] = MetricCollector.metric_name(
+        DOMAIN_MEMORY, "parse_failures", unit="total"
+    )
+    # rule: <METRICS_NAMESPACE>_<DOMAIN_MEMORY>_parse_exhausted_total
+    # e.g.: openviking_memory_parse_exhausted_total
+    MEMORY_PARSE_EXHAUSTED_TOTAL: ClassVar[str] = MetricCollector.metric_name(
+        DOMAIN_MEMORY, "parse_exhausted", unit="total"
+    )
     # rule: <METRICS_NAMESPACE>_<DOMAIN_RESOURCE>_stage_total
     # e.g.: openviking_resource_stage_total
     RESOURCE_STAGE_TOTAL: ClassVar[str] = MetricCollector.metric_name(
@@ -284,6 +294,22 @@ class TelemetryBridgeCollector(EventMetricCollector):
                 label_names=("operation", "memory_type"),
                 amount=extracted,
             )
+
+        parse = extract.get("parse") or {}
+        if isinstance(parse, Mapping) and parse:
+            failure_kind = str(parse.get("failure_kind") or "")
+            if failure_kind:
+                registry.inc_counter(
+                    self.MEMORY_PARSE_FAILURES_TOTAL,
+                    labels={"operation": operation, "failure_kind": failure_kind},
+                    label_names=("operation", "failure_kind"),
+                )
+            if int(parse.get("exhausted", 0) or 0) > 0:
+                registry.inc_counter(
+                    self.MEMORY_PARSE_EXHAUSTED_TOTAL,
+                    labels={"operation": operation},
+                    label_names=("operation",),
+                )
 
         actions = extract.get("actions") or {}
         if isinstance(actions_by_type, Mapping) and actions_by_type:

--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -150,8 +150,27 @@ def _memory_type_by_uri(operations: ResolvedOperations) -> dict[str, str]:
     return types_by_uri
 
 
-def _report_extraction_telemetry(result: Any, operations: ResolvedOperations) -> None:
+def _report_extraction_telemetry(
+    result: Any,
+    operations: ResolvedOperations,
+    parse_stats: Optional[dict[str, Any]] = None,
+) -> None:
     telemetry = get_current_telemetry()
+    # RFC #4243 first slice: surface the parse outcome itself so zero-extraction
+    # sessions are answerable from metrics (failure kind, retry usage,
+    # iteration exhaustion) even when no memory candidate ever existed.
+    if parse_stats:
+        failure_kind = parse_stats.get("failure_kind")
+        if failure_kind:
+            telemetry.set(f"memory.extract.parse.failure.{failure_kind}", 1)
+        telemetry.set(
+            "memory.extract.parse.format_retries_used",
+            parse_stats.get("format_retries_used", 0),
+        )
+        telemetry.set("memory.extract.parse.iterations_used", parse_stats.get("iterations_used", 0))
+        telemetry.set(
+            "memory.extract.parse.exhausted", 1 if parse_stats.get("exhausted") else 0
+        )
     telemetry.set(
         "memory.extract.candidates.total",
         len(result.written_uris) + len(result.edited_uris),
@@ -756,7 +775,9 @@ class SessionCompressorV3:
 
         result = update_result.apply_result
         patch_operations = update_result.operations
-        _report_extraction_telemetry(result, patch_operations)
+        _report_extraction_telemetry(
+            result, patch_operations, getattr(orchestrator, "parse_stats", None)
+        )
 
         memory_diff = None
         if archive_uri and viking_fs and result is not None:

--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -173,6 +173,14 @@ class ExtractLoop:
     def _record_parse_exhausted(self) -> None:
         self.parse_stats["exhausted"] = True
 
+    def _record_parse_recovery(self) -> None:
+        """Clear attempt-level failure once a parse finally succeeds.
+
+        parse_stats["failure_kind"] must mean "the FINAL response was
+        unparseable" (per the PR contract), not "some attempt failed".
+        """
+        self.parse_stats["failure_kind"] = None
+
         # Schema 生成器（在 run() 中初始化）
         self.schema_model_generator = None
 
@@ -396,6 +404,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
                         console=True,
                     )
                     continue
+                self._record_parse_recovery()
                 break
             # If no tool calls either, continue to next iteration (don't break!)
             failure_kind = self._last_llm_failure_kind or "unknown"
@@ -428,6 +437,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
                         "keeping the first-pass operations",
                         console=True,
                     )
+                    self._record_parse_recovery()
                     break
                 tracer.info(
                     "Memory extraction final response could not be parsed as JSON operations "

--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -148,6 +148,17 @@ class ExtractLoop:
         self._format_retry_count = 0
         self._last_llm_failure_kind: Optional[str] = None
         self._last_llm_failure_content: str = ""
+        # Structured parse-failure stats surfaced to extraction telemetry
+        # (RFC #4243 first slice): zero-extraction sessions fail before any
+        # memory candidate exists, so their diagnosable signal is the parse
+        # outcome itself — failure kind, retry usage, iteration exhaustion.
+        self.parse_stats: Dict[str, Any] = {
+            "failure_kind": None,
+            "format_retries_used": 0,
+            "iterations_used": 0,
+            "max_iterations": 0,
+            "exhausted": False,
+        }
 
         # Schema 生成器（在 run() 中初始化）
         self.schema_model_generator = None
@@ -272,7 +283,9 @@ The final output of the model must strictly follow the JSON Schema format shown 
         for uri in self.context_provider.read_file_contents:
             self._extract_context.page_id_map.get_page_id(uri)
 
+        self.parse_stats["max_iterations"] = max_iterations
         while iteration < max_iterations:
+            self.parse_stats["iterations_used"] = iteration + 1
             iteration += 1
             tracer.info(f"ReAct iteration {iteration}/{max_iterations}")
 
@@ -374,6 +387,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
                 break
             # If no tool calls either, continue to next iteration (don't break!)
             failure_kind = self._last_llm_failure_kind or "unknown"
+            self.parse_stats["failure_kind"] = failure_kind
             failure_preview = _preview_text(self._last_llm_failure_content)
             tracer.error(
                 "LLM returned neither tool calls nor operations "
@@ -383,6 +397,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
             # Add format error message if parse failed (max 1 retry)
             if self._format_retry_count == 0:
                 self._format_retry_count += 1
+                self.parse_stats["format_retries_used"] = self._format_retry_count
                 max_iterations += 1
                 retry_reason = (
                     "refusal_text" if failure_kind == "refusal_text" else "format_retry"
@@ -407,6 +422,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
                     f"after {max_iterations} iterations — treating as no operations "
                     f"failure_kind={failure_kind} response_preview={failure_preview!r}"
                 )
+                self.parse_stats["exhausted"] = True
                 final_operations = ResolvedOperations(
                     upsert_operations=[],
                     delete_file_contents=[],

--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -160,6 +160,19 @@ class ExtractLoop:
             "exhausted": False,
         }
 
+    def _record_parse_attempt(self, iteration: int, max_iterations: int) -> None:
+        self.parse_stats["iterations_used"] = iteration + 1
+        self.parse_stats["max_iterations"] = max_iterations
+
+    def _record_parse_failure(self, failure_kind: str) -> None:
+        self.parse_stats["failure_kind"] = failure_kind
+
+    def _record_format_retry(self) -> None:
+        self.parse_stats["format_retries_used"] = self._format_retry_count
+
+    def _record_parse_exhausted(self) -> None:
+        self.parse_stats["exhausted"] = True
+
         # Schema 生成器（在 run() 中初始化）
         self.schema_model_generator = None
 
@@ -283,9 +296,8 @@ The final output of the model must strictly follow the JSON Schema format shown 
         for uri in self.context_provider.read_file_contents:
             self._extract_context.page_id_map.get_page_id(uri)
 
-        self.parse_stats["max_iterations"] = max_iterations
         while iteration < max_iterations:
-            self.parse_stats["iterations_used"] = iteration + 1
+            self._record_parse_attempt(iteration, max_iterations)
             iteration += 1
             tracer.info(f"ReAct iteration {iteration}/{max_iterations}")
 
@@ -387,7 +399,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
                 break
             # If no tool calls either, continue to next iteration (don't break!)
             failure_kind = self._last_llm_failure_kind or "unknown"
-            self.parse_stats["failure_kind"] = failure_kind
+            self._record_parse_failure(failure_kind)
             failure_preview = _preview_text(self._last_llm_failure_content)
             tracer.error(
                 "LLM returned neither tool calls nor operations "
@@ -397,7 +409,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
             # Add format error message if parse failed (max 1 retry)
             if self._format_retry_count == 0:
                 self._format_retry_count += 1
-                self.parse_stats["format_retries_used"] = self._format_retry_count
+                self._record_format_retry()
                 max_iterations += 1
                 retry_reason = (
                     "refusal_text" if failure_kind == "refusal_text" else "format_retry"
@@ -422,7 +434,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
                     f"after {max_iterations} iterations — treating as no operations "
                     f"failure_kind={failure_kind} response_preview={failure_preview!r}"
                 )
-                self.parse_stats["exhausted"] = True
+                self._record_parse_exhausted()
                 final_operations = ResolvedOperations(
                     upsert_operations=[],
                     delete_file_contents=[],

--- a/openviking/telemetry/operation.py
+++ b/openviking/telemetry/operation.py
@@ -389,6 +389,22 @@ class TelemetrySummaryBuilder:
                         for public_key, metric_key in cls._MEMORY_EXTRACT_STAGE_KEYS.items()
                     },
                 }
+                if cls._has_metric_prefix("memory.extract.parse", counters, gauges):
+                    failure_kind = None
+                    failure_prefix = "memory.extract.parse.failure."
+                    for key, value in gauges.items():
+                        if key.startswith(failure_prefix) and cls._i(value, 0) > 0:
+                            failure_kind = key[len(failure_prefix):]
+                    memory_summary["extract"]["parse"] = {
+                        "failure_kind": failure_kind,
+                        "format_retries_used": cls._i(
+                            gauges.get("memory.extract.parse.format_retries_used"), 0
+                        ),
+                        "iterations_used": cls._i(
+                            gauges.get("memory.extract.parse.iterations_used"), 0
+                        ),
+                        "exhausted": cls._i(gauges.get("memory.extract.parse.exhausted"), 0),
+                    }
             summary["memory"] = memory_summary
 
         if cls._has_metric_prefix("resource", counters, gauges):

--- a/tests/session/test_extraction_parse_telemetry.py
+++ b/tests/session/test_extraction_parse_telemetry.py
@@ -159,3 +159,80 @@ def test_parse_stats_success_run_stays_clean():
     assert loop.parse_stats["iterations_used"] == 2
     assert loop.parse_stats["failure_kind"] is None
     assert loop.parse_stats["exhausted"] is False
+
+
+def _finished_summary_with_parse_stats(parse_stats: dict) -> dict:
+    """Drive the real OperationTelemetry → TelemetrySummaryBuilder path."""
+    from openviking.telemetry.operation import OperationTelemetry
+
+    t = OperationTelemetry(operation="session_commit", enabled=True)
+    t.set("memory.extract.parse.failure.parse_error", 1)
+    t.set("memory.extract.parse.format_retries_used", parse_stats.get("format_retries_used", 0))
+    t.set("memory.extract.parse.iterations_used", parse_stats.get("iterations_used", 0))
+    t.set("memory.extract.parse.exhausted", 1 if parse_stats.get("exhausted") else 0)
+    snapshot = t.finish()
+    assert snapshot is not None
+    return snapshot.summary
+
+
+def test_parse_stats_reach_finished_summary_contract():
+    summary = _finished_summary_with_parse_stats(
+        {"failure_kind": "parse_error", "format_retries_used": 1, "iterations_used": 4, "exhausted": True}
+    )
+    parse = summary["memory"]["extract"]["parse"]
+    assert parse == {
+        "failure_kind": "parse_error",
+        "format_retries_used": 1,
+        "iterations_used": 4,
+        "exhausted": 1,
+    }
+
+
+def test_parse_stats_bridge_maps_to_prometheus_counters():
+    from openviking.metrics.collectors.telemetry_bridge import TelemetryBridgeCollector
+    from openviking.metrics.core.registry import MetricRegistry
+    from openviking.metrics.datasources.base import EventMetricDataSource
+    from openviking.metrics.exporters.prometheus import PrometheusExporter
+
+    summary = _finished_summary_with_parse_stats(
+        {"failure_kind": "parse_error", "exhausted": True}
+    )
+    registry = MetricRegistry()
+    collector = TelemetryBridgeCollector()
+    captured = []
+
+    def _emit(event_name, payload):
+        captured.append((event_name, payload))
+
+    EventMetricDataSource._emit = staticmethod(_emit)
+    try:
+        from openviking.metrics.datasources.telemetry_bridge import (
+            TelemetryBridgeEventDataSource,
+        )
+
+        TelemetryBridgeEventDataSource.record_summary(summary)
+    finally:
+        del EventMetricDataSource._emit
+    for event_name, payload in captured:
+        collector.receive_hook(event_name, payload, registry)
+
+    text = PrometheusExporter(registry=registry).render()
+    assert 'failure_kind="parse_error"' in text
+    assert "openviking_memory_parse_failures_total" in text
+    assert "openviking_memory_parse_exhausted_total" in text
+
+
+def test_parse_stats_failure_then_recovery_clears_failure_kind():
+    """Attempt-level failure must not survive a successful parse (#4628 review)."""
+    loop = _bare_loop()
+    loop._record_parse_attempt(0, 3)
+    loop._record_parse_failure("parse_error")  # first attempt fails
+    loop._format_retry_count = 1
+    loop._record_format_retry()
+    loop._record_parse_attempt(1, 4)  # retry succeeds
+    loop._record_parse_recovery()
+
+    assert loop.parse_stats["failure_kind"] is None  # final response WAS parseable
+    assert loop.parse_stats["format_retries_used"] == 1  # retry usage still visible
+    assert loop.parse_stats["iterations_used"] == 2
+    assert loop.parse_stats["exhausted"] is False

--- a/tests/session/test_extraction_parse_telemetry.py
+++ b/tests/session/test_extraction_parse_telemetry.py
@@ -188,14 +188,19 @@ def test_parse_stats_reach_finished_summary_contract():
     }
 
 
-def test_parse_stats_bridge_maps_to_prometheus_counters():
+def test_parse_stats_bridge_maps_to_prometheus_counters(monkeypatch):
     from openviking.metrics.collectors.telemetry_bridge import TelemetryBridgeCollector
     from openviking.metrics.core.registry import MetricRegistry
     from openviking.metrics.datasources.base import EventMetricDataSource
     from openviking.metrics.exporters.prometheus import PrometheusExporter
 
     summary = _finished_summary_with_parse_stats(
-        {"failure_kind": "parse_error", "exhausted": True}
+        {
+            "failure_kind": "parse_error",
+            "format_retries_used": 1,
+            "iterations_used": 4,
+            "exhausted": True,
+        }
     )
     registry = MetricRegistry()
     collector = TelemetryBridgeCollector()
@@ -204,15 +209,15 @@ def test_parse_stats_bridge_maps_to_prometheus_counters():
     def _emit(event_name, payload):
         captured.append((event_name, payload))
 
-    EventMetricDataSource._emit = staticmethod(_emit)
-    try:
-        from openviking.metrics.datasources.telemetry_bridge import (
-            TelemetryBridgeEventDataSource,
-        )
+    # monkeypatch keeps the original staticmethod descriptor and restores it on
+    # teardown; assigning + `del` would permanently drop the production _emit.
+    monkeypatch.setattr(EventMetricDataSource, "_emit", staticmethod(_emit))
+    from openviking.metrics.datasources.telemetry_bridge import (
+        TelemetryBridgeEventDataSource,
+    )
 
-        TelemetryBridgeEventDataSource.record_summary(summary)
-    finally:
-        del EventMetricDataSource._emit
+    TelemetryBridgeEventDataSource.record_summary(summary)
+    assert EventMetricDataSource._emit is not None
     for event_name, payload in captured:
         collector.receive_hook(event_name, payload, registry)
 
@@ -220,6 +225,27 @@ def test_parse_stats_bridge_maps_to_prometheus_counters():
     assert 'failure_kind="parse_error"' in text
     assert "openviking_memory_parse_failures_total" in text
     assert "openviking_memory_parse_exhausted_total" in text
+    # aggregate-safe surfaces for "4 iterations used, 1 format retry"
+    assert "openviking_memory_parse_iterations_bucket" in text
+    assert "openviking_memory_parse_format_retries_bucket" in text
+    assert 'le="4.0"' in text  # 4-iteration observation lands in the le=4 bucket
+    assert 'le="1.0"' in text  # 1 format-retry observation lands in the le=1 bucket
+
+
+def test_bridge_emit_patch_restored_after_test(monkeypatch):
+    """The bridge test must not leak a stubbed _emit into later tests (review follow-up)."""
+    from openviking.metrics.datasources.base import EventMetricDataSource
+
+    original = EventMetricDataSource.__dict__.get("_emit")
+    assert original is not None, "production _emit must exist on the class"
+
+    def _stub(event_name, payload):
+        return None
+
+    monkeypatch.setattr(EventMetricDataSource, "_emit", staticmethod(_stub))
+    assert EventMetricDataSource.__dict__["_emit"] is not original
+    # monkeypatch teardown restores the original descriptor; the next test that
+    # calls record_summary() sees the production emitter again.
 
 
 def test_parse_stats_failure_then_recovery_clears_failure_kind():

--- a/tests/session/test_extraction_parse_telemetry.py
+++ b/tests/session/test_extraction_parse_telemetry.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Structured parse-failure telemetry for the extraction loop (RFC #4243 slice 1)."""
+
+import sys
+import types
+from types import SimpleNamespace
+
+_ark = types.ModuleType("volcenginesdkarkruntime")
+_ark_exc = types.ModuleType("volcenginesdkarkruntime._exceptions")
+
+
+class _ArkRateLimitError(Exception):
+    pass
+
+
+_ark_exc.ArkRateLimitError = _ArkRateLimitError
+_ark._exceptions = _ark_exc
+sys.modules.setdefault("volcenginesdkarkruntime", _ark)
+sys.modules.setdefault("volcenginesdkarkruntime._exceptions", _ark_exc)
+
+from openviking.session.compressor_v3 import _report_extraction_telemetry
+
+
+class _CaptureTelemetry:
+    def __init__(self):
+        self.values = {}
+
+    def set(self, name, value):
+        self.values[name] = value
+
+
+def _fake_result():
+    return SimpleNamespace(
+        written_uris=[],
+        edited_uris=[],
+        deleted_uris=[],
+        skipped_operations=[],
+        errors=[(
+            "viking://user/u/memories/entities/unknown.md",
+            "Final response could not be parsed as JSON operations "
+            "after 4 iterations (failure_kind=parse_error)",
+        )],
+    )
+
+
+def _fake_operations():
+    return SimpleNamespace(upsert_operations=[], delete_file_contents=[])
+
+
+def test_parse_stats_emitted_for_zero_extraction(monkeypatch):
+    captured = _CaptureTelemetry()
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.get_current_telemetry", lambda: captured
+    )
+    stats = {
+        "failure_kind": "parse_error",
+        "format_retries_used": 1,
+        "iterations_used": 4,
+        "max_iterations": 4,
+        "exhausted": True,
+    }
+
+    _report_extraction_telemetry(_fake_result(), _fake_operations(), stats)
+
+    assert captured.values["memory.extract.parse.failure.parse_error"] == 1
+    assert captured.values["memory.extract.parse.format_retries_used"] == 1
+    assert captured.values["memory.extract.parse.iterations_used"] == 4
+    assert captured.values["memory.extract.parse.exhausted"] == 1
+    # existing counters keep working for the zero-extraction shape
+    assert captured.values["memory.extract.failed"] == 1
+
+
+def test_parse_stats_absent_emits_nothing(monkeypatch):
+    captured = _CaptureTelemetry()
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.get_current_telemetry", lambda: captured
+    )
+
+    _report_extraction_telemetry(_fake_result(), _fake_operations())
+
+    assert not [k for k in captured.values if k.startswith("memory.extract.parse.")]
+
+
+def test_parse_stats_no_failure_kind_skips_kind_counter(monkeypatch):
+    captured = _CaptureTelemetry()
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.get_current_telemetry", lambda: captured
+    )
+    stats = {
+        "failure_kind": None,
+        "format_retries_used": 0,
+        "iterations_used": 2,
+        "max_iterations": 3,
+        "exhausted": False,
+    }
+
+    _report_extraction_telemetry(_fake_result(), _fake_operations(), stats)
+
+    assert "memory.extract.parse.failure.parse_error" not in captured.values
+    assert "memory.extract.parse.failure.refusal_text" not in captured.values
+    assert captured.values["memory.extract.parse.iterations_used"] == 2
+    assert captured.values["memory.extract.parse.exhausted"] == 0

--- a/tests/session/test_extraction_parse_telemetry.py
+++ b/tests/session/test_extraction_parse_telemetry.py
@@ -20,6 +20,7 @@ sys.modules.setdefault("volcenginesdkarkruntime", _ark)
 sys.modules.setdefault("volcenginesdkarkruntime._exceptions", _ark_exc)
 
 from openviking.session.compressor_v3 import _report_extraction_telemetry
+from openviking.session.memory.extract_loop import ExtractLoop
 
 
 class _CaptureTelemetry:
@@ -101,3 +102,60 @@ def test_parse_stats_no_failure_kind_skips_kind_counter(monkeypatch):
     assert "memory.extract.parse.failure.refusal_text" not in captured.values
     assert captured.values["memory.extract.parse.iterations_used"] == 2
     assert captured.values["memory.extract.parse.exhausted"] == 0
+
+
+def _bare_loop():
+    """Construct an ExtractLoop without its heavy dependencies.
+
+    Only the parse-stats state is initialized; the recorder methods under
+    test touch nothing else.
+    """
+    loop = ExtractLoop.__new__(ExtractLoop)
+    loop.parse_stats = {
+        "failure_kind": None,
+        "format_retries_used": 0,
+        "iterations_used": 0,
+        "max_iterations": 0,
+        "exhausted": False,
+    }
+    loop._format_retry_count = 0
+    return loop
+
+
+def test_parse_stats_initial_shape():
+    loop = _bare_loop()
+    assert loop.parse_stats == {
+        "failure_kind": None,
+        "format_retries_used": 0,
+        "iterations_used": 0,
+        "max_iterations": 0,
+        "exhausted": False,
+    }
+
+
+def test_parse_stats_full_failure_lifecycle():
+    """failure -> retry -> more attempts -> exhaustion mirrors a zero-extraction run."""
+    loop = _bare_loop()
+    loop._record_parse_attempt(0, 3)
+    loop._record_parse_failure("parse_error")
+    loop._format_retry_count = 1
+    loop._record_format_retry()
+    loop._record_parse_attempt(3, 4)  # retry extended max_iterations
+    loop._record_parse_failure("refusal_text")
+    loop._record_parse_exhausted()
+
+    assert loop.parse_stats == {
+        "failure_kind": "refusal_text",  # last failure wins
+        "format_retries_used": 1,
+        "iterations_used": 4,
+        "max_iterations": 4,
+        "exhausted": True,
+    }
+
+
+def test_parse_stats_success_run_stays_clean():
+    loop = _bare_loop()
+    loop._record_parse_attempt(1, 3)
+    assert loop.parse_stats["iterations_used"] == 2
+    assert loop.parse_stats["failure_kind"] is None
+    assert loop.parse_stats["exhausted"] is False


### PR DESCRIPTION
First slice of the RFC #4243 discussion, implementing exactly what @ranxi2001 proposed there: promote `failure_kind`, retry outcome, and iteration exhaustion into structured extraction telemetry, independent of any semantic annotations.

## Why

Zero-extraction reports (#4486, #4580, #1541) fail **before** an extracted-memory candidate exists: `ExtractLoop` records an unparseable final response as empty `ResolvedOperations` with a `failure_kind`, while extraction telemetry is emitted later from applied candidates and actions. With zero candidates there is nothing to segment — but the parse outcome itself is the diagnosable signal, and today it only lives in logs.

## What this adds

- `ExtractLoop.parse_stats`: `{failure_kind, format_retries_used, iterations_used, max_iterations, exhausted}`, updated at the existing failure/retry/exhaustion points in `run()` — no behavior change to the loop itself.
- `_report_extraction_telemetry(..., parse_stats=...)` emits:
  - `memory.extract.parse.failure.<kind>` (=1 when the final response was unparseable; `parse_error` / `refusal_text`)
  - `memory.extract.parse.format_retries_used`
  - `memory.extract.parse.iterations_used`
  - `memory.extract.parse.exhausted` (1 when max_iterations was reached without a parsable final response)

A zero-extraction session is now directly answerable from metrics ("4 iterations used, 1 format retry, final `parse_error`, exhausted") without touching extraction prompts or the persisted memory schema. Semantic annotations (`C/E/L/V + provenance_key`) remain a separate design decision per the RFC thread.

Note: this composes with #4619 (defensive `unknown` bucketing in the same telemetry function) rather than overlapping it.

## How verified

- 3 new conftest-free tests in `tests/session/test_extraction_parse_telemetry.py`: counters emitted for a zero-extraction shape with full stats; absent `parse_stats` emits no `memory.extract.parse.*`; missing `failure_kind` skips the kind counter while iteration/exhaustion counters still fire.
- `py_compile` on both touched modules; existing counters asserted unchanged (`memory.extract.failed` still counts errors).
