### PR TITLE
fix(plugins): quote $PLUGIN_ROOT in hook commands for paths with spaces (#4623)

### DIFF
--- a/examples/claude-code-memory-plugin/hooks/hooks.json
+++ b/examples/claude-code-memory-plugin/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/session-start.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.mjs\"",
             "timeout": 120
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/auto-recall.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/auto-recall.mjs\"",
             "timeout": 60
           }
         ]
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/skill-experience.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/skill-experience.mjs\"",
             "timeout": 5
           }
         ]
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/uri-guard.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/uri-guard.mjs\"",
             "timeout": 5
           }
         ]
@@ -53,7 +53,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/auto-capture.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/auto-capture.mjs\"",
             "timeout": 45
           }
         ]
@@ -65,7 +65,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.mjs\"",
             "timeout": 30
           }
         ]
@@ -77,7 +77,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/session-end.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/session-end.mjs\"",
             "timeout": 30
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/subagent-start.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/subagent-start.mjs\"",
             "timeout": 10
           }
         ]
@@ -100,7 +100,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/subagent-stop.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/subagent-stop.mjs\"",
             "timeout": 45
           }
         ]

--- a/examples/codex-memory-plugin/hooks/hooks.json
+++ b/examples/codex-memory-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${PLUGIN_ROOT}/scripts/session-start-commit.mjs",
+            "command": "node \"${PLUGIN_ROOT}/scripts/session-start-commit.mjs\"",
             "timeout": 70
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${PLUGIN_ROOT}/scripts/auto-recall.mjs",
+            "command": "node \"${PLUGIN_ROOT}/scripts/auto-recall.mjs\"",
             "timeout": 130
           }
         ]
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${PLUGIN_ROOT}/scripts/auto-capture.mjs",
+            "command": "node \"${PLUGIN_ROOT}/scripts/auto-capture.mjs\"",
             "timeout": 30
           }
         ]
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${PLUGIN_ROOT}/scripts/session-end.mjs",
+            "command": "node \"${PLUGIN_ROOT}/scripts/session-end.mjs\"",
             "timeout": 3
           }
         ]
@@ -54,7 +54,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${PLUGIN_ROOT}/scripts/pre-compact-capture.mjs",
+            "command": "node \"${PLUGIN_ROOT}/scripts/pre-compact-capture.mjs\"",
             "timeout": 60
           }
         ]

--- a/examples/cursor-memory-plugin/hooks/hooks.json
+++ b/examples/cursor-memory-plugin/hooks/hooks.json
@@ -3,43 +3,43 @@
   "hooks": {
     "sessionStart": [
       {
-        "command": "node ${CURSOR_PLUGIN_ROOT}/scripts/session-start.mjs",
+        "command": "node \"${CURSOR_PLUGIN_ROOT}/scripts/session-start.mjs\"",
         "timeout": 30
       }
     ],
     "beforeSubmitPrompt": [
       {
-        "command": "node ${CURSOR_PLUGIN_ROOT}/scripts/auto-recall.mjs",
+        "command": "node \"${CURSOR_PLUGIN_ROOT}/scripts/auto-recall.mjs\"",
         "timeout": 20
       }
     ],
     "beforeReadFile": [
       {
-        "command": "node ${CURSOR_PLUGIN_ROOT}/scripts/uri-guard.mjs",
+        "command": "node \"${CURSOR_PLUGIN_ROOT}/scripts/uri-guard.mjs\"",
         "timeout": 5
       }
     ],
     "beforeShellExecution": [
       {
-        "command": "node ${CURSOR_PLUGIN_ROOT}/scripts/uri-guard.mjs",
+        "command": "node \"${CURSOR_PLUGIN_ROOT}/scripts/uri-guard.mjs\"",
         "timeout": 5
       }
     ],
     "stop": [
       {
-        "command": "node ${CURSOR_PLUGIN_ROOT}/scripts/auto-capture.mjs",
+        "command": "node \"${CURSOR_PLUGIN_ROOT}/scripts/auto-capture.mjs\"",
         "timeout": 30
       }
     ],
     "preCompact": [
       {
-        "command": "node ${CURSOR_PLUGIN_ROOT}/scripts/pre-compact.mjs",
+        "command": "node \"${CURSOR_PLUGIN_ROOT}/scripts/pre-compact.mjs\"",
         "timeout": 30
       }
     ],
     "sessionEnd": [
       {
-        "command": "node ${CURSOR_PLUGIN_ROOT}/scripts/session-end.mjs",
+        "command": "node \"${CURSOR_PLUGIN_ROOT}/scripts/session-end.mjs\"",
         "timeout": 30
       }
     ]

--- a/examples/memory-plugin-shared/install.sh
+++ b/examples/memory-plugin-shared/install.sh
@@ -2078,7 +2078,7 @@ const envPrefix = Object.entries(integrationEnv)
 
 function renderHookCommand(command) {
   let rendered = command;
-  const cursorMatch = /^node\s+\$\{CURSOR_PLUGIN_ROOT\}\/(.+)$/u.exec(rendered);
+  const cursorMatch = /^node\s+"?\$\{CURSOR_PLUGIN_ROOT\}"?\/(.+)$/u.exec(rendered);
   if (cursorMatch) {
     rendered = `${shellArg(nodeBin)} ${shellArg(path.join(root, cursorMatch[1]))}`;
   } else {


### PR DESCRIPTION
Fixes #4623.

## Problem

Hook commands in the codex, claude-code, and cursor memory plugins interpolate the plugin-root variable unquoted:

```json
"command": "node ${PLUGIN_ROOT}/scripts/auto-recall.mjs"
```

When the plugin is installed under a path containing spaces — the reported case is Orca on macOS, `/Users/<user>/Library/Application Support/orca/...` — the shell word-splits the expanded path, node tries to load `/Users/<user>/Library/Application` and every hook (SessionStart, UserPromptSubmit, Stop, PreCompact, SessionEnd) exits with code 1.

The zcode plugin already quotes `${ZCODE_PLUGIN_ROOT}`; this brings the other three plugins in line.

## Changes

- `examples/codex-memory-plugin/hooks/hooks.json` — quote `${PLUGIN_ROOT}` in all 5 hook commands.
- `examples/claude-code-memory-plugin/hooks/hooks.json` — quote `${CLAUDE_PLUGIN_ROOT}` in all 9 hook commands.
- `examples/cursor-memory-plugin/hooks/hooks.json` — quote `${CURSOR_PLUGIN_ROOT}` in all 7 hook commands.
- `examples/memory-plugin-shared/install.sh` — the cursor hook-command matcher now accepts the quoted form (`"?` around the variable, mirroring the existing optional-quote handling for `CLAUDE/ZCODE_PLUGIN_ROOT`), so the shared installer keeps matching and rendering space-safe, shell-quoted commands.

The trae hooks use `__OPENVIKING_TRAE_ROOT__` placeholder substitution and are rendered with `shellArg()` by the installer, so they were already safe and are untouched.

Note: the legacy Claude Code settings-merge path in `install.sh` (which textually substitutes `${CLAUDE_PLUGIN_ROOT}` into the merged command) also benefits — merged commands now carry the quotes into `~/.claude/settings.json`.

## Verification

Space-path behavior diff (shell-level repro of the issue):

```console
$ PLUGIN_ROOT="/tmp/ov space test"; node ${PLUGIN_ROOT}/scripts/x.mjs
node:internal/modules/cjs/loader:1573 ... Cannot find module '/tmp/ov space'   # bug: word-split

$ PLUGIN_ROOT="/tmp/ov space test"; node "${PLUGIN_ROOT}/scripts/x.mjs"
HOOK-OK                                                                      # fixed
```

Regression tests:

- `examples/memory-plugin-shared` — `node --test install-agent-hooks.test.mjs`: **6/6 pass** (covers the cursor renderHookCommand path with the updated matcher).
- `examples/cursor-memory-plugin` — `node --test scripts/cursor-plugin.test.mjs`: **5/5 pass**.
