### PR TITLE
feat(session): add opt-in disk retention GC for sessions and commit archives

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1293,6 +1293,39 @@ Notes:
   - It does not perform a dedicated startup recovery sweep; idle detection happens only on periodic scans
 - Token- and message-count auto commit run inline after message writes, do not depend on the scheduler, and are unaffected by this switch.
 
+##### Session Disk GC Configuration
+
+`memory.session_gc` controls opt-in disk retention (garbage collection) for session directories and commit archives. It is disabled by default: when `enabled=false` (the default), no GC scheduler is registered and no retention action ever runs.
+
+```json
+{
+  "memory": {
+    "session_gc": {
+      "enabled": false,
+      "max_idle_days": 0.0,
+      "archive_max_age_days": 0.0,
+      "dry_run": false,
+      "interval_secs": 3600.0
+    }
+  }
+}
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `enabled` | bool | Master switch. When `false`, the disk-GC scheduler is not started and nothing is ever deleted | `false` |
+| `max_idle_days` | float | Delete a whole session after this many days without any write (session `.meta.json`, session directory, or archive mtimes). `0` disables whole-session deletion | `0.0` |
+| `archive_max_age_days` | float | Delete `history/archive_NNN` directories older than this many days. `0` disables archive deletion. The highest-numbered archive of each session is always kept | `0.0` |
+| `dry_run` | bool | Log planned deletions without executing them. Useful to validate thresholds before enabling real deletion | `false` |
+| `interval_secs` | float | Interval between GC scans in seconds. Must be greater than `0` | `3600.0` |
+
+Notes:
+
+- All deletions go through `VikingFS.rm(recursive=True)`, so vector index entries are removed in lockstep with the filesystem. GC never deletes storage directly.
+- Sessions with a running server-side commit task are skipped entirely for that scan.
+- Archives with unparsable or missing mtimes are conservatively kept.
+- Each run logs the scan/deletion counts before and after execution, both in dry-run and real mode.
+
 ###### Per-session Auto Commit Policy
 
 When a session carries an `auto_commit_policy`, any field you omit falls back to the recommended default below. Sessions without a stored policy keep auto commit disabled. Values are clamped into `[0, max]`, and unknown keys are rejected with `InvalidArgumentError`. See [Sessions API](../api/05-sessions.md#create_session) for how to set and view it.
@@ -1581,6 +1614,7 @@ For memory-related settings, add a `memory` section in `ov.conf`:
 | `session_skill_extraction_enabled` | Whether session commit also extracts reusable skills into the current user's skill directory. | `false` |
 | `link_enabled` | Whether memory extraction writes and resolves memory links. | `false` |
 | `session_auto_commit` | Server-wide automatic session commit controls. This belongs under `memory`, not under `server`; see [Session Auto Commit Configuration](#session-auto-commit-configuration). | See section above |
+| `session_gc` | Opt-in disk retention (GC) controls for session directories and commit archives. Disabled by default; see [Session Disk GC Configuration](#session-disk-gc-configuration). | See section above |
 
 ### ovcli.conf
 

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1268,6 +1268,39 @@ RAGFS 默认使用 Rust binding 模式，通过 Rust 实现直接访问文件系
   - 不会做单独的启动恢复扫描，idle 检查只发生在周期扫描时
 - token 和 message-count 自动触发在消息写入后内联执行，不依赖 scheduler，也不受这个开关影响。
 
+##### Session 磁盘 GC 配置
+
+`memory.session_gc` 控制 opt-in 的 session 目录与 commit archives 磁盘保留策略（GC）。默认关闭：`enabled=false`（默认值）时不注册 GC 调度器，也不会发生任何保留/删除行为。
+
+```json
+{
+  "memory": {
+    "session_gc": {
+      "enabled": false,
+      "max_idle_days": 0.0,
+      "archive_max_age_days": 0.0,
+      "dry_run": false,
+      "interval_secs": 3600.0
+    }
+  }
+}
+```
+
+| 参数 | 类型 | 说明 | 默认值 |
+|------|------|------|--------|
+| `enabled` | bool | 总开关。为 `false` 时不启动磁盘 GC 调度器，任何内容都不会被删除 | `false` |
+| `max_idle_days` | float | session 超过该天数没有任何写入（session `.meta.json`、session 目录或 archive 的 mtime）后整体删除。`0` 表示禁用整 session 删除 | `0.0` |
+| `archive_max_age_days` | float | 删除超过该天数的 `history/archive_NNN` 目录。`0` 表示禁用 archive 删除。每个 session 编号最大的 archive 始终保留 | `0.0` |
+| `dry_run` | bool | 只记录计划删除的日志、不实际执行。适合在真正开启删除前验证阈值 | `false` |
+| `interval_secs` | float | GC 扫描间隔，单位秒，必须大于 `0` | `3600.0` |
+
+说明：
+
+- 所有删除均通过 `VikingFS.rm(recursive=True)` 执行，向量索引会与文件系统同步清理，GC 不会绕过存储层直接删除。
+- 当次扫描中存在进行中服务端 commit 任务的 session 会被整体跳过。
+- mtime 缺失或无法解析的 archive 会保守保留。
+- 每次运行（dry-run 与真实模式）都会在删除前后记录扫描/删除计数日志。
+
 ###### 单 session 自动 commit 策略
 
 当 session 带有 `auto_commit_policy` 时，未传的字段会回退到下方推荐默认值。没有存储 policy 的 session 保持 auto commit 关闭。取值会被 clamp 到 `[0, 上限]`，未知字段会以 `InvalidArgumentError` 拒绝。设置和查看方式见 [Sessions API](../api/05-sessions.md#create_session)。
@@ -1553,6 +1586,7 @@ openviking-server --config /path/to/ov.conf
 | `session_skill_extraction_enabled` | session commit 时是否同时抽取可复用 skill 到当前用户的 skill 目录。 | `false` |
 | `link_enabled` | 记忆抽取是否写入和解析 memory links。 | `false` |
 | `session_auto_commit` | 服务端 session 自动 commit 的全局控制项。该配置属于 `memory` 段，不属于 `server` 段；详见 [Session Auto Commit 配置](#session-auto-commit-配置)。 | 见上文 |
+| `session_gc` | opt-in 的 session 目录与 commit archives 磁盘保留策略（GC）。默认关闭；详见 [Session 磁盘 GC 配置](#session-磁盘-gc-配置)。 | 见上文 |
 
 ### ovcli.conf
 

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -28,6 +28,7 @@ from openviking.service.resource_memory_link_service import ResourceMemoryLinkSe
 from openviking.service.resource_service import ResourceService
 from openviking.service.search_service import SearchService
 from openviking.service.session_auto_commit import SessionAutoCommitScheduler
+from openviking.service.session_disk_gc import SessionDiskGcScheduler
 from openviking.service.session_service import SessionService
 from openviking.service.task_tracker import get_task_tracker, set_task_tracker
 from openviking.session import create_session_compressor
@@ -50,7 +51,7 @@ from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import get_logger
 from openviking_cli.utils.config import OPENVIKING_ENABLE_RECORDER_ENV, get_openviking_config
 from openviking_cli.utils.config.git_config import GitConfig
-from openviking_cli.utils.config.memory_config import SessionAutoCommitConfig
+from openviking_cli.utils.config.memory_config import SessionAutoCommitConfig, SessionDiskGcConfig
 from openviking_cli.utils.config.open_viking_config import initialize_openviking_config
 from openviking_cli.utils.config.storage_config import StorageConfig
 
@@ -99,6 +100,7 @@ class OpenVikingService:
         self._uri_mutation_coordinator = UriMutationCoordinator()
         self._watch_scheduler: Optional[WatchScheduler] = None
         self._session_auto_commit_scheduler: Optional[SessionAutoCommitScheduler] = None
+        self._session_disk_gc_scheduler: Optional[SessionDiskGcScheduler] = None
         self._encryptor: Optional[Any] = None
         self._privacy_config_service: Optional[UserPrivacyConfigService] = None
         self._data_dir_lock_acquired = False
@@ -457,6 +459,19 @@ class OpenVikingService:
             await self._session_auto_commit_scheduler.start()
         else:
             self._session_auto_commit_scheduler = None
+        try:
+            session_gc_config = get_openviking_config().memory.session_gc
+        except Exception:
+            session_gc_config = SessionDiskGcConfig()
+        if session_gc_config.enabled:
+            self._session_disk_gc_scheduler = SessionDiskGcScheduler(
+                self._session_service,
+                session_gc_config,
+                interval_secs=session_gc_config.interval_secs,
+            )
+            await self._session_disk_gc_scheduler.start()
+        else:
+            self._session_disk_gc_scheduler = None
         self._debug_service.set_dependencies(
             vikingdb=self._vikingdb_manager,
             config=self._config,
@@ -544,6 +559,11 @@ class OpenVikingService:
             await self._session_auto_commit_scheduler.stop()
             self._session_auto_commit_scheduler = None
             logger.info("SessionAutoCommitScheduler stopped")
+
+        if self._session_disk_gc_scheduler:
+            await self._session_disk_gc_scheduler.stop()
+            self._session_disk_gc_scheduler = None
+            logger.info("SessionDiskGcScheduler stopped")
 
         if self._queue_manager:
             await asyncio.to_thread(self._queue_manager.stop)

--- a/openviking/service/session_disk_gc.py
+++ b/openviking/service/session_disk_gc.py
@@ -1,0 +1,342 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Scheduler and executor for opt-in session disk retention (GC).
+
+Periodically scans the canonical per-user session roots, plans deletions
+with :mod:`openviking.session.disk_gc`, and executes them exclusively via
+``VikingFS.rm(recursive=True)`` so vector index entries are cleaned up in
+lockstep with the filesystem. Everything is opt-in and disabled by
+default; see ``memory.session_gc`` in the OpenViking config.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+
+from openviking.pyagfs import AsyncAGFSClient
+from openviking.server.error_mapping import is_not_found_error
+from openviking.server.identity import RequestContext, Role
+from openviking.session.disk_gc import (
+    ARCHIVE_DIR_RE,
+    REASON_ARCHIVE_OVER_AGE,
+    REASON_SESSION_IDLE_EXPIRED,
+    ArchiveInfo,
+    SessionDiskState,
+    plan_disk_gc,
+)
+from openviking.utils.time_utils import parse_iso_datetime
+from openviking_cli.session.user_id import UserIdentifier
+from openviking_cli.utils import get_logger
+
+logger = get_logger(__name__)
+
+AGFS_SCAN_ROOT = "/local"
+DEFAULT_INTERVAL_SECS = 3600.0
+
+# (account_id, user_id, session_id) -> bool; awaited before planning.
+ActivityChecker = Callable[[str, str, str], Awaitable[bool]]
+
+
+def _parse_modtime(entry: Dict[str, Any]) -> Optional[datetime]:
+    """Best-effort parse of an AGFS entry ``modTime`` into aware UTC."""
+    raw = entry.get("modTime", entry.get("mtime", ""))
+    if isinstance(raw, (int, float)):
+        return datetime.fromtimestamp(float(raw), tz=timezone.utc)
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        parsed = parse_iso_datetime(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+async def _default_activity_checker(account_id: str, user_id: str, session_id: str) -> bool:
+    """Treat a session as active while a server-side commit is running."""
+    try:
+        from openviking.service.task_tracker import get_task_tracker
+
+        return await get_task_tracker().has_running(
+            "session_commit",
+            session_id,
+            account_id=account_id,
+            user_id=user_id,
+        )
+    except Exception:
+        # Cannot prove the session is idle -> conservatively treat as active.
+        return True
+
+
+class SessionDiskGcScheduler:
+    """Background disk-GC scheduler.
+
+    Mirrors the lifecycle conventions of ``SessionAutoCommitScheduler``
+    (start/stop + asyncio task loop) so operators see one consistent
+    pattern for periodic session maintenance jobs.
+    """
+
+    def __init__(
+        self,
+        session_service: Any,
+        config: Any,
+        *,
+        interval_secs: Optional[float] = None,
+        sleep: Any = asyncio.sleep,
+        activity_checker: Optional[ActivityChecker] = None,
+    ):
+        self._session_service = session_service
+        self._config = config
+        self._interval = DEFAULT_INTERVAL_SECS if interval_secs is None else float(interval_secs)
+        self._sleep = sleep
+        self._is_active = activity_checker or _default_activity_checker
+        self._running = False
+        self._task: Optional[asyncio.Task] = None
+        self._agfs_client: Optional[AsyncAGFSClient] = None
+        self._owners: Dict[str, Tuple[str, str]] = {}
+
+    @property
+    def _viking_fs(self) -> Any:
+        return self._session_service.viking_fs
+
+    def _get_agfs_client(self) -> AsyncAGFSClient:
+        if self._agfs_client is None:
+            self._agfs_client = AsyncAGFSClient(self._viking_fs.agfs)
+        return self._agfs_client
+
+    async def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        logger.info(
+            "SessionDiskGcScheduler started with interval %.3fs dry_run=%s",
+            self._interval,
+            bool(getattr(self._config, "dry_run", False)),
+        )
+        self._task = asyncio.create_task(self._run_loop())
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    async def _run_loop(self) -> None:
+        while self._running:
+            try:
+                await self._sleep(self._interval)
+            except asyncio.CancelledError:
+                break
+
+            try:
+                if getattr(self._config, "enabled", False):
+                    await self.scan_once()
+            except Exception as exc:
+                logger.error("Session disk-GC scheduler loop failed: %s", exc, exc_info=True)
+
+    async def scan_once(self) -> Dict[str, int]:
+        """Run one plan-and-execute pass. Also usable as a manual trigger."""
+        now = datetime.now(timezone.utc)
+        states = await self._collect_session_states()
+        plan = plan_disk_gc(
+            states,
+            now=now,
+            archive_max_age_days=float(getattr(self._config, "archive_max_age_days", 0.0) or 0.0),
+            max_idle_days=float(getattr(self._config, "max_idle_days", 0.0) or 0.0),
+        )
+        dry_run = bool(getattr(self._config, "dry_run", False))
+        archives_planned = sum(1 for a in plan if a.reason == REASON_ARCHIVE_OVER_AGE)
+        sessions_planned = sum(1 for a in plan if a.reason == REASON_SESSION_IDLE_EXPIRED)
+        logger.info(
+            "SessionDiskGc plan: sessions_scanned=%d archives_planned=%d "
+            "sessions_planned=%d dry_run=%s",
+            len(states),
+            archives_planned,
+            sessions_planned,
+            dry_run,
+        )
+
+        deleted = 0
+        failed = 0
+        if dry_run:
+            for action in plan:
+                logger.info("SessionDiskGc dry-run would delete %s (%s)", action.uri, action.reason)
+        else:
+            for action in plan:
+                ctx = self._ctx_for(action.uri)
+                if ctx is None:
+                    failed += 1
+                    logger.warning(
+                        "SessionDiskGc skipped %s (%s): owner unknown", action.uri, action.reason
+                    )
+                    continue
+                try:
+                    await self._viking_fs.rm(action.uri, recursive=True, ctx=ctx)
+                    deleted += 1
+                    logger.info("SessionDiskGc deleted %s (%s)", action.uri, action.reason)
+                except Exception as exc:
+                    failed += 1
+                    logger.warning(
+                        "SessionDiskGc failed to delete %s (%s): %s",
+                        action.uri,
+                        action.reason,
+                        exc,
+                    )
+        logger.info("SessionDiskGc run finished: deleted=%d failed=%d", deleted, failed)
+        return {
+            "sessions_scanned": len(states),
+            "archives_planned": archives_planned,
+            "sessions_planned": sessions_planned,
+            "deleted": deleted,
+            "failed": failed,
+            "dry_run": 1 if dry_run else 0,
+        }
+
+    def _ctx_for(self, uri: str) -> Optional[RequestContext]:
+        owner = self._owners.get(uri)
+        if owner is None:
+            # Archive actions live under the owning session URI.
+            for session_uri, candidate in self._owners.items():
+                if uri.startswith(session_uri + "/"):
+                    owner = candidate
+                    break
+        if owner is None:
+            return None
+        account_id, user_id = owner
+        return RequestContext(
+            user=UserIdentifier(account_id=account_id, user_id=user_id),
+            role=Role.USER,
+        )
+
+    async def _collect_session_states(self) -> List[SessionDiskState]:
+        agfs = self._get_agfs_client()
+        self._owners = {}
+        states: List[SessionDiskState] = []
+        try:
+            account_entries = await agfs.ls(AGFS_SCAN_ROOT)
+        except Exception:
+            logger.warning("SessionDiskGc failed to scan AGFS tree", exc_info=True)
+            return states
+
+        for account_entry in account_entries:
+            account_id = str(account_entry.get("name") or "").strip()
+            if not account_id or account_id == "_system":
+                continue
+            if not account_entry.get("isDir", False):
+                continue
+            try:
+                user_entries = await agfs.ls(f"/local/{account_id}/user")
+            except Exception as exc:
+                if not is_not_found_error(exc):
+                    logger.warning(
+                        "SessionDiskGc failed to scan users under /local/%s",
+                        account_id,
+                        exc_info=True,
+                    )
+                continue
+
+            for user_entry in user_entries:
+                user_id = str(user_entry.get("name") or "").strip()
+                if not user_id or not user_entry.get("isDir", False):
+                    continue
+                sessions_root = f"/local/{account_id}/user/{user_id}/sessions"
+                try:
+                    session_entries = await agfs.ls(sessions_root)
+                except Exception as exc:
+                    if not is_not_found_error(exc):
+                        logger.warning(
+                            "SessionDiskGc failed to scan sessions: %s",
+                            sessions_root,
+                            exc_info=True,
+                        )
+                    continue
+
+                for session_entry in session_entries:
+                    session_id = str(session_entry.get("name") or "").strip()
+                    if not session_id or not session_entry.get("isDir", False):
+                        continue
+                    state = await self._collect_session_state(
+                        agfs, account_id, user_id, session_id, session_entry
+                    )
+                    if state is None:
+                        continue
+                    states.append(state)
+                    self._owners[state.uri] = (account_id, user_id)
+        return states
+
+    async def _collect_session_state(
+        self,
+        agfs: AsyncAGFSClient,
+        account_id: str,
+        user_id: str,
+        session_id: str,
+        session_entry: Dict[str, Any],
+    ) -> Optional[SessionDiskState]:
+        session_uri = f"viking://user/{user_id}/sessions/{session_id}"
+        session_path = f"/local/{account_id}/user/{user_id}/sessions/{session_id}"
+
+        times = []
+        session_mod = _parse_modtime(session_entry)
+        if session_mod is not None:
+            times.append(session_mod)
+
+        meta_mod = await self._stat_modtime(agfs, f"{session_path}/.meta.json")
+        if meta_mod is not None:
+            times.append(meta_mod)
+
+        archives: List[ArchiveInfo] = []
+        try:
+            history_entries = await agfs.ls(f"{session_path}/history")
+        except Exception as exc:
+            if not is_not_found_error(exc):
+                logger.debug(
+                    "SessionDiskGc failed to list history: %s", session_path, exc_info=True
+                )
+            history_entries = []
+        for entry in history_entries:
+            name = str(entry.get("name") or "").strip()
+            if not name or not ARCHIVE_DIR_RE.fullmatch(name):
+                continue
+            if not entry.get("isDir", False):
+                continue
+            archive = ArchiveInfo(name=name, mtime=_parse_modtime(entry))
+            archives.append(archive)
+            if archive.mtime is not None:
+                times.append(archive.mtime)
+
+        last_activity = max(times) if times else None
+        try:
+            activity = self._is_active(account_id, user_id, session_id)
+            if asyncio.iscoroutine(activity):
+                activity = await activity
+            is_active = bool(activity)
+        except Exception:
+            # Cannot prove the session is idle -> conservatively keep it.
+            is_active = True
+
+        return SessionDiskState(
+            uri=session_uri,
+            session_id=session_id,
+            last_activity=last_activity,
+            is_active=is_active,
+            archives=tuple(archives),
+        )
+
+    @staticmethod
+    async def _stat_modtime(agfs: AsyncAGFSClient, path: str) -> Optional[datetime]:
+        try:
+            entry = await agfs.stat(path)
+        except Exception as exc:
+            if not is_not_found_error(exc):
+                logger.debug("SessionDiskGc stat failed: %s", path, exc_info=True)
+            return None
+        if not isinstance(entry, dict):
+            return None
+        return _parse_modtime(entry)

--- a/openviking/session/disk_gc.py
+++ b/openviking/session/disk_gc.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Pure planning logic for opt-in session disk retention (GC).
+
+This module owns only the decision layer: given a disk-side snapshot of
+sessions (URIs, last-activity timestamps, archive mtimes) it produces a
+conservative list of deletion candidates. Execution happens elsewhere and
+must go through ``VikingFS.rm(recursive=True)`` so vector index entries
+are cleaned up in lockstep with the filesystem.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Iterable, List, Optional
+
+# Commit archives live under ``<session>/history/archive_NNN``.
+ARCHIVE_DIR_RE = re.compile(r"archive_(\d+)")
+
+REASON_ARCHIVE_OVER_AGE = "archive_over_age"
+REASON_SESSION_IDLE_EXPIRED = "session_idle_expired"
+
+
+@dataclass(frozen=True)
+class ArchiveInfo:
+    """One ``history/archive_NNN`` directory inside a session."""
+
+    name: str
+    mtime: Optional[datetime] = None
+
+    @property
+    def index(self) -> Optional[int]:
+        match = ARCHIVE_DIR_RE.fullmatch(self.name)
+        return int(match.group(1)) if match else None
+
+
+@dataclass(frozen=True)
+class SessionDiskState:
+    """Disk-side snapshot of one session, gathered by the GC executor."""
+
+    uri: str
+    session_id: str
+    last_activity: Optional[datetime] = None
+    is_active: bool = False
+    archives: tuple = ()
+
+
+@dataclass(frozen=True)
+class GcAction:
+    """One deletion candidate produced by :func:`plan_disk_gc`."""
+
+    uri: str
+    session_id: str
+    reason: str
+
+
+def plan_disk_gc(
+    sessions: Iterable[SessionDiskState],
+    *,
+    now: datetime,
+    archive_max_age_days: float = 0.0,
+    max_idle_days: float = 0.0,
+) -> List[GcAction]:
+    """Plan conservative disk-retention deletions for the given sessions.
+
+    Rules (all opt-in; a threshold of ``0`` disables that rule):
+
+    - Sessions flagged ``is_active`` are skipped entirely.
+    - When ``max_idle_days`` is positive and ``last_activity`` is known, a
+      session idle for longer than the threshold is planned for whole
+      deletion. Its archives are then not listed separately.
+    - When ``archive_max_age_days`` is positive, archives with a known mtime
+      older than the threshold are planned for deletion, except the
+      highest-numbered archive which is always kept so a session never loses
+      its most recent commit context.
+    - Anything not explicitly covered above (unknown mtime, active session,
+      fresh data) is left untouched.
+    """
+    actions: List[GcAction] = []
+    archive_cutoff = timedelta(days=archive_max_age_days) if archive_max_age_days > 0 else None
+    idle_cutoff = timedelta(days=max_idle_days) if max_idle_days > 0 else None
+
+    for session in sessions:
+        if session.is_active:
+            continue
+
+        if (
+            idle_cutoff is not None
+            and session.last_activity is not None
+            and (now - session.last_activity) > idle_cutoff
+        ):
+            actions.append(
+                GcAction(
+                    uri=session.uri,
+                    session_id=session.session_id,
+                    reason=REASON_SESSION_IDLE_EXPIRED,
+                )
+            )
+            continue
+
+        if archive_cutoff is None:
+            continue
+
+        indexes = [a.index for a in session.archives if a.index is not None]
+        newest_index = max(indexes) if indexes else None
+        for archive in session.archives:
+            if archive.index is None or archive.mtime is None:
+                # Unclassifiable -> keep, never guess from missing metadata.
+                continue
+            if archive.index == newest_index:
+                continue
+            if (now - archive.mtime) > archive_cutoff:
+                actions.append(
+                    GcAction(
+                        uri=f"{session.uri.rstrip('/')}/history/{archive.name}",
+                        session_id=session.session_id,
+                        reason=REASON_ARCHIVE_OVER_AGE,
+                    )
+                )
+    return actions

--- a/openviking_cli/utils/config/memory_config.py
+++ b/openviking_cli/utils/config/memory_config.py
@@ -21,6 +21,27 @@ class SessionAutoCommitConfig(BaseModel):
     model_config = {"extra": "forbid"}
 
 
+class SessionDiskGcConfig(BaseModel):
+    """Opt-in disk retention (GC) for session directories and commit archives.
+
+    Disabled by default: when ``enabled`` is False (the default), no GC
+    scheduler is registered and no retention action ever runs.
+    """
+
+    enabled: bool = False
+    # Delete whole idle sessions after this many days of inactivity; 0 disables.
+    max_idle_days: float = Field(default=0.0, ge=0)
+    # Delete session history/archive_NNN directories older than this many days;
+    # 0 disables. The newest archive of each session is always kept.
+    archive_max_age_days: float = Field(default=0.0, ge=0)
+    # Log planned deletions without executing them.
+    dry_run: bool = False
+    # Interval between GC scans when enabled.
+    interval_secs: float = Field(default=3600.0, gt=0)
+
+    model_config = {"extra": "forbid"}
+
+
 class MemoryConfig(BaseModel):
     """Memory configuration for OpenViking."""
 
@@ -84,6 +105,10 @@ class MemoryConfig(BaseModel):
     session_auto_commit: SessionAutoCommitConfig = Field(
         default_factory=SessionAutoCommitConfig,
         description="Server-wide controls for automatic session commits.",
+    )
+    session_gc: SessionDiskGcConfig = Field(
+        default_factory=SessionDiskGcConfig,
+        description="Opt-in disk retention (GC) for session directories and commit archives.",
     )
 
     model_config = {"extra": "forbid"}

--- a/tests/unit/service/test_session_disk_gc.py
+++ b/tests/unit/service/test_session_disk_gc.py
@@ -1,0 +1,384 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for opt-in session disk retention (GC).
+
+Covers the pure planning layer (``openviking.session.disk_gc``), the
+executor (``openviking.service.session_disk_gc``), and the
+disabled-by-default contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+try:  # Keep imports working in envs without the Ark runtime SDK.
+    import volcenginesdkarkruntime  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover
+    import sys
+    from types import ModuleType
+
+    sys.modules["volcenginesdkarkruntime"] = ModuleType("volcenginesdkarkruntime")
+
+from openviking.server.identity import RequestContext
+from openviking.service.session_disk_gc import SessionDiskGcScheduler
+from openviking.session.disk_gc import (
+    ArchiveInfo,
+    GcAction,
+    SessionDiskState,
+    plan_disk_gc,
+)
+from openviking_cli.utils.config.memory_config import MemoryConfig, SessionDiskGcConfig
+
+NOW = datetime(2026, 9, 3, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _days_ago(days: float) -> datetime:
+    return NOW - timedelta(days=days)
+
+
+# ---------------------------------------------------------------------------
+# Pure policy tests
+# ---------------------------------------------------------------------------
+
+
+def test_plan_deletes_over_age_archives_but_keeps_newest():
+    session = SessionDiskState(
+        uri="viking://user/u/sessions/s1",
+        session_id="s1",
+        last_activity=_days_ago(1),
+        archives=(
+            ArchiveInfo("archive_001", _days_ago(40)),
+            ArchiveInfo("archive_002", _days_ago(35)),
+            ArchiveInfo("archive_003", _days_ago(3)),
+        ),
+    )
+    actions = plan_disk_gc([session], now=NOW, archive_max_age_days=30, max_idle_days=0)
+    assert [(a.uri, a.reason) for a in actions] == [
+        ("viking://user/u/sessions/s1/history/archive_001", "archive_over_age"),
+        ("viking://user/u/sessions/s1/history/archive_002", "archive_over_age"),
+    ]
+
+
+def test_plan_keeps_fresh_archives():
+    session = SessionDiskState(
+        uri="viking://user/u/sessions/s1",
+        session_id="s1",
+        last_activity=_days_ago(1),
+        archives=(ArchiveInfo("archive_001", _days_ago(2)),),
+    )
+    assert plan_disk_gc([session], now=NOW, archive_max_age_days=30) == []
+
+
+def test_plan_keeps_archive_at_exact_age_boundary():
+    session = SessionDiskState(
+        uri="viking://user/u/sessions/s1",
+        session_id="s1",
+        last_activity=_days_ago(1),
+        archives=(ArchiveInfo("archive_001", _days_ago(10)),),
+    )
+    assert plan_disk_gc([session], now=NOW, archive_max_age_days=10) == []
+
+
+def test_plan_idle_session_deleted_whole_and_archives_not_listed():
+    session = SessionDiskState(
+        uri="viking://user/u/sessions/s1",
+        session_id="s1",
+        last_activity=_days_ago(90),
+        archives=(ArchiveInfo("archive_001", _days_ago(80)),),
+    )
+    actions = plan_disk_gc([session], now=NOW, archive_max_age_days=30, max_idle_days=30)
+    assert actions == [
+        GcAction(
+            uri="viking://user/u/sessions/s1",
+            session_id="s1",
+            reason="session_idle_expired",
+        )
+    ]
+
+
+def test_plan_skips_active_sessions_entirely():
+    session = SessionDiskState(
+        uri="viking://user/u/sessions/s1",
+        session_id="s1",
+        last_activity=_days_ago(90),
+        is_active=True,
+        archives=(ArchiveInfo("archive_001", _days_ago(80)),),
+    )
+    assert plan_disk_gc([session], now=NOW, archive_max_age_days=30, max_idle_days=30) == []
+
+
+def test_plan_disabled_thresholds_is_noop():
+    session = SessionDiskState(
+        uri="viking://user/u/sessions/s1",
+        session_id="s1",
+        last_activity=_days_ago(365),
+        archives=(ArchiveInfo("archive_001", _days_ago(300)),),
+    )
+    assert plan_disk_gc([session], now=NOW) == []
+
+
+def test_plan_keeps_archives_with_unknown_mtime():
+    session = SessionDiskState(
+        uri="viking://user/u/sessions/s1",
+        session_id="s1",
+        last_activity=_days_ago(1),
+        archives=(
+            ArchiveInfo("archive_001", None),
+            ArchiveInfo("archive_002", _days_ago(40)),
+            ArchiveInfo("archive_003", None),
+        ),
+    )
+    actions = plan_disk_gc([session], now=NOW, archive_max_age_days=30)
+    assert [a.uri for a in actions] == ["viking://user/u/sessions/s1/history/archive_002"]
+
+
+def test_plan_skips_session_with_unknown_last_activity_for_idle_rule():
+    session = SessionDiskState(
+        uri="viking://user/u/sessions/s1", session_id="s1", last_activity=None
+    )
+    assert plan_disk_gc([session], now=NOW, max_idle_days=1) == []
+
+
+# ---------------------------------------------------------------------------
+# Fake stack for executor tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeAgfs:
+    """Sync AGFS surface; AsyncAGFSClient wraps it via to_thread."""
+
+    def __init__(
+        self,
+        tree: Dict[str, List[Dict[str, Any]]],
+        stats: Dict[str, Dict[str, Any]],
+        errors: Optional[Dict[str, BaseException]] = None,
+    ) -> None:
+        self._tree = tree
+        self._stats = stats
+        self._errors = errors or {}
+        self.ls_calls: List[str] = []
+
+    def ls(self, path: str, ctx: Any = None) -> List[Dict[str, Any]]:
+        self.ls_calls.append(path)
+        if path in self._errors:
+            raise self._errors[path]
+        entries = self._tree.get(path)
+        if entries is None:
+            raise FileNotFoundError(path)
+        return [dict(entry) for entry in entries]
+
+    def stat(self, path: str, ctx: Any = None) -> Dict[str, Any]:
+        if path in self._errors:
+            raise self._errors[path]
+        if path not in self._stats:
+            raise FileNotFoundError(path)
+        return dict(self._stats[path])
+
+
+class _FakeVikingFS:
+    def __init__(self, agfs: _FakeAgfs) -> None:
+        self.agfs = agfs
+        self.rm_calls: List[Tuple[str, bool, Any]] = []
+
+    async def rm(self, uri: str, recursive: bool = False, ctx: Any = None, **kwargs: Any):
+        self.rm_calls.append((uri, recursive, ctx))
+        return {"estimated_deleted_count": 1}
+
+
+class _FakeSessionService:
+    def __init__(self, viking_fs: _FakeVikingFS) -> None:
+        self.viking_fs = viking_fs
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def _build_fake_stack() -> Tuple[_FakeSessionService, _FakeAgfs, _FakeVikingFS]:
+    sessions_root = "/local/acct_a/user/user_b/sessions"
+    idle_root = f"{sessions_root}/sess_idle"
+    live_root = f"{sessions_root}/sess_live"
+    tree: Dict[str, List[Dict[str, Any]]] = {
+        "/local": [
+            {"name": "acct_a", "isDir": True},
+            {"name": "_system", "isDir": True},
+        ],
+        "/local/acct_a/user": [{"name": "user_b", "isDir": True}],
+        sessions_root: [
+            {"name": "sess_idle", "isDir": True, "modTime": _iso(_days_ago(90))},
+            {"name": "sess_live", "isDir": True, "modTime": _iso(_days_ago(1))},
+        ],
+        f"{idle_root}/history": [
+            {"name": "archive_001", "isDir": True, "modTime": _iso(_days_ago(100))},
+            {"name": "archive_002", "isDir": True, "modTime": _iso(_days_ago(90))},
+        ],
+        f"{live_root}/history": [
+            {"name": "archive_001", "isDir": True, "modTime": _iso(_days_ago(90))},
+            {"name": "archive_002", "isDir": True, "modTime": _iso(_days_ago(85))},
+            {"name": "not_an_archive", "isDir": True, "modTime": _iso(_days_ago(90))},
+        ],
+    }
+    stats = {
+        f"{idle_root}/.meta.json": {"modTime": _iso(_days_ago(90))},
+        f"{live_root}/.meta.json": {"modTime": _iso(_days_ago(0.5))},
+    }
+    agfs = _FakeAgfs(tree, stats)
+    viking_fs = _FakeVikingFS(agfs)
+    return _FakeSessionService(viking_fs), agfs, viking_fs
+
+
+def _gc_config(**overrides: Any) -> SessionDiskGcConfig:
+    values: Dict[str, Any] = {
+        "enabled": True,
+        "max_idle_days": 30,
+        "archive_max_age_days": 30,
+        "dry_run": False,
+    }
+    values.update(overrides)
+    return SessionDiskGcConfig(**values)
+
+
+async def _idle_checker(account_id: str, user_id: str, session_id: str) -> bool:
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Executor tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scan_once_executes_plan_via_viking_fs_rm():
+    service, agfs, viking_fs = _build_fake_stack()
+    scheduler = SessionDiskGcScheduler(service, _gc_config(), activity_checker=_idle_checker)
+    result = await scheduler.scan_once()
+
+    # sess_idle is idle beyond max_idle_days -> whole-session delete only.
+    # sess_live stays, but its over-age archive_001 goes; archive_002 is the
+    # newest archive so it is always kept.
+    assert sorted(call[0] for call in viking_fs.rm_calls) == [
+        "viking://user/user_b/sessions/sess_idle",
+        "viking://user/user_b/sessions/sess_live/history/archive_001",
+    ]
+    assert all(call[1] is True for call in viking_fs.rm_calls)
+    ctxs = [call[2] for call in viking_fs.rm_calls]
+    assert all(isinstance(ctx, RequestContext) for ctx in ctxs)
+    assert all(ctx.user.account_id == "acct_a" for ctx in ctxs)
+    assert all(ctx.user.user_id == "user_b" for ctx in ctxs)
+    assert result == {
+        "sessions_scanned": 2,
+        "archives_planned": 1,
+        "sessions_planned": 1,
+        "deleted": 2,
+        "failed": 0,
+        "dry_run": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_scan_once_dry_run_does_not_delete():
+    service, agfs, viking_fs = _build_fake_stack()
+    scheduler = SessionDiskGcScheduler(
+        service, _gc_config(dry_run=True), activity_checker=_idle_checker
+    )
+    result = await scheduler.scan_once()
+    assert viking_fs.rm_calls == []
+    assert result["dry_run"] == 1
+    assert result["deleted"] == 0
+    assert result["archives_planned"] == 1
+    assert result["sessions_planned"] == 1
+
+
+@pytest.mark.asyncio
+async def test_scan_once_skips_active_sessions():
+    service, agfs, viking_fs = _build_fake_stack()
+
+    async def always_active(account_id: str, user_id: str, session_id: str) -> bool:
+        return True
+
+    scheduler = SessionDiskGcScheduler(service, _gc_config(), activity_checker=always_active)
+    result = await scheduler.scan_once()
+    assert viking_fs.rm_calls == []
+    assert result["deleted"] == 0
+    assert result["archives_planned"] == 0
+    assert result["sessions_planned"] == 0
+
+
+@pytest.mark.asyncio
+async def test_scan_once_continues_when_single_delete_fails():
+    service, agfs, viking_fs = _build_fake_stack()
+    original_rm = viking_fs.rm
+
+    async def flaky_rm(uri: str, recursive: bool = False, ctx: Any = None, **kw: Any):
+        if uri.endswith("sess_idle"):
+            raise RuntimeError("locked")
+        return await original_rm(uri, recursive=recursive, ctx=ctx, **kw)
+
+    viking_fs.rm = flaky_rm
+    scheduler = SessionDiskGcScheduler(service, _gc_config(), activity_checker=_idle_checker)
+    result = await scheduler.scan_once()
+    assert result["failed"] == 1
+    assert result["deleted"] == 1
+    assert sorted(call[0] for call in viking_fs.rm_calls) == [
+        "viking://user/user_b/sessions/sess_live/history/archive_001"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_scan_once_handles_missing_history_and_meta():
+    sessions_root = "/local/acct_a/user/user_b/sessions"
+    tree: Dict[str, List[Dict[str, Any]]] = {
+        "/local": [{"name": "acct_a", "isDir": True}],
+        "/local/acct_a/user": [{"name": "user_b", "isDir": True}],
+        sessions_root: [{"name": "sess_bare", "isDir": True, "modTime": _iso(_days_ago(200))}],
+    }
+    agfs = _FakeAgfs(tree, stats={})
+    viking_fs = _FakeVikingFS(agfs)
+    scheduler = SessionDiskGcScheduler(
+        _FakeSessionService(viking_fs),
+        _gc_config(),
+        activity_checker=_idle_checker,
+    )
+    result = await scheduler.scan_once()
+    # Session dir mtime alone (200d) still proves idleness.
+    assert result["sessions_scanned"] == 1
+    assert result["sessions_planned"] == 1
+    assert result["deleted"] == 1
+    assert viking_fs.rm_calls[0][0] == "viking://user/user_b/sessions/sess_bare"
+
+
+# ---------------------------------------------------------------------------
+# Disabled-by-default contract
+# ---------------------------------------------------------------------------
+
+
+def test_default_config_is_disabled():
+    assert SessionDiskGcConfig().enabled is False
+    assert MemoryConfig().session_gc.enabled is False
+    assert SessionDiskGcConfig().interval_secs == 3600.0
+    assert SessionDiskGcConfig().max_idle_days == 0.0
+    assert SessionDiskGcConfig().archive_max_age_days == 0.0
+    assert SessionDiskGcConfig().dry_run is False
+
+
+@pytest.mark.asyncio
+async def test_run_loop_skips_scan_when_disabled():
+    service, agfs, viking_fs = _build_fake_stack()
+    scheduler = SessionDiskGcScheduler(service, SessionDiskGcConfig(), interval_secs=0.01)
+    calls: List[int] = []
+    original_scan = scheduler.scan_once
+
+    async def counting_scan() -> Dict[str, int]:
+        calls.append(1)
+        return await original_scan()
+
+    scheduler.scan_once = counting_scan  # type: ignore[method-assign]
+    await scheduler.start()
+    await asyncio.sleep(0.05)
+    await scheduler.stop()
+    assert calls == []
+    assert viking_fs.rm_calls == []


### PR DESCRIPTION

- **Branch**: `feat/iss-4029-session-disk-gc` (based on `upstream/main` @ f6d9dec6)
- **Fork push**: `now-ing/OpenViking` @ `7d7ffb181666d5a4b6a06449dc9000218a6fb5bd`
- **Closes**: #4029

## Summary

Session directories and their `history/archive_NNN` commits currently grow without bound: `auto_commit_policy` archives context on every commit but never deletes old archives, and sessions are only ever removed through explicit `SessionService.delete()` calls. For long-running agent deployments, session history and tool results quickly become the dominant storage consumers.

This PR adds a conservative, **opt-in, disabled-by-default** disk retention (GC) layer:

- New `memory.session_gc` config: `enabled` (false), `max_idle_days` (0 = off), `archive_max_age_days` (0 = off), `dry_run` (false), `interval_secs` (3600.0). With no configuration there is zero behavior change.
- `openviking/session/disk_gc.py` — pure planning module: given session disk snapshots (uri, last-activity, archive mtimes) it produces a deletion plan (list of `{uri, reason}`). No I/O, trivially testable.
- `openviking/service/session_disk_gc.py` — `SessionDiskGcScheduler` mirroring the existing `SessionAutoCommitScheduler` lifecycle (start/stop + asyncio loop), registered in `OpenVikingService.initialize()` only when `session_gc.enabled` is true, torn down in `close()`.
- Configuration docs added to both `docs/en/guides/01-configuration.md` and `docs/zh/guides/01-configuration.md`.

## Design

**Decision layer (pure)** — `plan_disk_gc()` rules, all opt-in, a threshold of `0` disables the rule:

1. Sessions flagged active are skipped entirely (no archive deletion either).
2. `max_idle_days` > 0 and last activity known and older than the threshold → whole-session deletion. Its archives are then not listed separately.
3. `archive_max_age_days` > 0 → delete archives with known mtime older than the threshold, **except the highest-numbered archive**, which is always kept so a session never loses its most recent commit context.
4. Anything not explicitly covered (unknown/unparsable mtime, active session, fresh data) is kept.

**Executor** — `SessionDiskGcScheduler.scan_once()`:

- Scans the canonical per-user session roots by walking AGFS `/local/{account}/user/{user}/sessions` (same traversal pattern as the idle auto-commit scanner; `_system` skipped, missing dirs tolerated).
- Last activity = max of session `.meta.json` stat mtime, session directory mtime, and archive mtimes.
- Active check = task tracker `has_running("session_commit", ...)` (cross-worker safe); if the check itself errors, the session is conservatively treated as active and skipped.
- **All deletions go through `VikingFS.rm(uri, recursive=True, ctx=owner_ctx)`** so vector index entries are cleaned up in lockstep; nothing bypasses the storage layer. Owner contexts are built from the scanned account/user ids.
- Per-run observability: plan counts logged before execution (`sessions_scanned/archives_planned/sessions_planned/dry_run`), per-deletion logs, and a `deleted/failed` summary after. `dry_run` logs the full plan without touching storage. Single-target failures are isolated and counted.

## Testing

`tests/unit/service/test_session_disk_gc.py` (15 tests, run with `--noconftest -o addopts=""`; Ark SDK stubbed at module top when absent):

- Policy: over-age archives deleted while newest is kept; fresh archives kept; exact-boundary age kept; idle session deleted whole (archives not double-listed); active sessions skipped; disabled thresholds are a no-op; unknown-mtime archives kept; unknown last activity disables the idle rule.
- Executor: plan executed via `VikingFS.rm` with correct URIs, `recursive=True`, and owner-scoped `RequestContext`; `dry_run` never calls `rm`; active sessions produce no deletions; single delete failure isolated (deleted/failed counts); sessions missing history/`.meta.json` handled (dir mtime still proves idleness).
- Default-off contract: `SessionDiskGcConfig()`/`MemoryConfig().session_gc` disabled defaults; `_run_loop` never calls `scan_once` while `enabled=false`.
- Regression: `tests/unit/service/test_session_auto_commit.py` 22/22 pass; `ruff check` + `ruff format --check` clean on all touched files.

## Notes for reviewers

- Deliberately conservative first version: no per-user overrides, no size-based quotas, no retention of extracted memories (memories live outside the session tree and are untouched). All natural follow-ups if this lands.
- `scan_once()` is public and side-effect-bounded, so an explicit manual trigger (CLI/API) can be layered on top later without reworking the scheduler.
