### PR TITLE
test(sdk): pin source_name forwarding in add_resource uploads (#4569)

### DIFF
--- a/sdk/python/tests/test_async_client_behaviors.py
+++ b/sdk/python/tests/test_async_client_behaviors.py
@@ -867,8 +867,34 @@ async def test_add_resource_uploads_local_file_even_when_url_is_localhost(tmp_pa
     fake_http.post.assert_awaited_once()
     payload = fake_http.post.await_args.kwargs["json"]
     assert payload["temp_file_id"] == "upload_resource.md"
+    assert payload["source_name"] == "demo.md"
     assert payload["watch_interval"] == 60
     assert "path" not in payload
+
+
+@pytest.mark.asyncio
+async def test_add_resource_uploads_local_directory_with_source_name(tmp_path):
+    resource_dir = tmp_path / "notes pack"
+    resource_dir.mkdir()
+    (resource_dir / "a.md").write_text("# A\n")
+
+    client = AsyncHTTPClient(url="http://127.0.0.1:1933")
+    fake_http = SimpleNamespace(post=AsyncMock(return_value=object()))
+    client._http = fake_http
+
+    async def fake_upload(_path: str) -> str:
+        return "upload_resource.zip"
+
+    client._upload_temp_file = fake_upload
+    client._handle_response_data = lambda _response: {
+        "result": {"root_uri": "viking://resources/notes"}
+    }
+
+    await client.add_resource(str(resource_dir))
+
+    payload = fake_http.post.await_args.kwargs["json"]
+    assert payload["temp_file_id"] == "upload_resource.zip"
+    assert payload["source_name"] == "notes pack"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
While diagnosing #4569 we traced the whole `source_name` chain on current main (API backfill → `AddResourceMsg` → `internal_kwargs` → parser layout) and found it intact — but the SDK upload layer, the first link, had **no regression coverage**: the existing `test_add_resource_uploads_local_file_even_when_url_is_localhost` asserts `temp_file_id` and option forwarding, not `source_name`. Deleting the two `request_data["source_name"] = ...` lines in `AsyncHTTPClient.add_resource` would pass the suite while reintroducing exactly the rename the issue describes (leaf named after the server-side temp upload).

This pins it:

- extends the file-upload test to assert `source_name == "demo.md"`;
- adds a directory-upload case asserting `source_name == "notes pack"` (directory name, spaces included — the compressed-directory path goes through the same field).

10/10 `add_resource` tests pass locally (`-o addopts=""` to bypass the coverage addopts); no production code touched.
