### PR TITLE
fix(opencode-plugin): fall back to config peerId when shared credentials define none

### DIFF
--- a/examples/opencode-plugin/README.md
+++ b/examples/opencode-plugin/README.md
@@ -164,7 +164,11 @@ with an explicit actor peer so one person's memories are not recalled into
 another person's session.
 
 `OPENVIKING_API_KEY`, `OPENVIKING_ACCOUNT`, `OPENVIKING_USER`,
-and `OPENVIKING_PEER_ID` take precedence over values in this file.
+and `OPENVIKING_PEER_ID` take precedence over values in this file. The config
+file's `peerId` still applies whenever shared credentials (ovcli.conf or
+environment variables) do not carry a peer of their own, so an authenticated
+setup keeps writing peer-scoped data instead of dropping into the shared user
+tree.
 
 For advanced setups, `OPENVIKING_PLUGIN_CONFIG` can point to another config file path.
 

--- a/examples/opencode-plugin/lib/config.mjs
+++ b/examples/opencode-plugin/lib/config.mjs
@@ -294,7 +294,11 @@ export function loadConfig(pluginRoot, projectDirectory) {
   config.apiKey = creds.apiKey
   config.account = creds.account
   config.user = creds.user
-  config.peerId = creds.peerId
+  // Shared credentials only carry a peer when ovcli.conf sets actor_peer_id
+  // (or OPENVIKING_PEER_ID is exported); without one the project config's
+  // peerId still applies so authenticated setups keep writing peer-scoped
+  // data instead of silently dropping into the shared user tree (#4487).
+  config.peerId = creds.peerId || str(fileConfig.peerId, "")
   config.mcpUrl = creds.mcpUrl
   config.credentialSource = creds.credentialSource
   config.credentialPath = creds.cliPath || creds.ovPath || ""

--- a/examples/opencode-plugin/tests/config.test.mjs
+++ b/examples/opencode-plugin/tests/config.test.mjs
@@ -267,3 +267,95 @@ test("loadConfig defaults an invalid commit keep recent count", async () => {
     }
   })
 })
+
+test("loadConfig falls back to config peerId when shared credentials define none (#4487)", async () => {
+  const snapshot = { ...process.env }
+  await withTempDir("ov-oc-peer-fallback-", async (dir) => {
+    try {
+      for (const key of Object.keys(process.env)) {
+        if (key.startsWith("OPENVIKING_")) delete process.env[key]
+      }
+      const ovcli = join(dir, "ovcli.conf")
+      const project = join(dir, "project")
+      await mkdir(join(project, ".opencode"), { recursive: true })
+      await writeFile(ovcli, JSON.stringify({
+        url: "https://cli.example.com",
+        api_key: "cli-key",
+        account: "cli-account",
+        user: "cli-user",
+      }))
+      await writeFile(join(project, ".opencode", "openviking-config.json"), JSON.stringify({
+        enabled: true,
+        peerId: "atomic-city",
+        workspacePeer: false,
+        recallPeerScope: "actor",
+      }))
+      process.env.OPENVIKING_CLI_CONFIG_FILE = ovcli
+
+      const cfg = loadConfig(dir, project)
+      assert.equal(cfg.peerId, "atomic-city")
+      assert.deepEqual(cfg.effectivePeer, { peerId: "atomic-city", source: "explicit" })
+      assert.equal(cfg.legacyCredentialsUsed, false)
+    } finally {
+      restoreOpenVikingEnv(snapshot)
+    }
+  })
+})
+
+test("loadConfig keeps ovcli actor_peer_id over config peerId", async () => {
+  const snapshot = { ...process.env }
+  await withTempDir("ov-oc-peer-cli-wins-", async (dir) => {
+    try {
+      for (const key of Object.keys(process.env)) {
+        if (key.startsWith("OPENVIKING_")) delete process.env[key]
+      }
+      const ovcli = join(dir, "ovcli.conf")
+      const project = join(dir, "project")
+      await mkdir(join(project, ".opencode"), { recursive: true })
+      await writeFile(ovcli, JSON.stringify({
+        url: "https://cli.example.com",
+        api_key: "cli-key",
+        actor_peer_id: "cli-peer",
+      }))
+      await writeFile(join(project, ".opencode", "openviking-config.json"), JSON.stringify({
+        peerId: "config-peer",
+      }))
+      process.env.OPENVIKING_CLI_CONFIG_FILE = ovcli
+
+      const cfg = loadConfig(dir, project)
+      assert.equal(cfg.peerId, "cli-peer")
+      assert.deepEqual(cfg.effectivePeer, { peerId: "cli-peer", source: "explicit" })
+    } finally {
+      restoreOpenVikingEnv(snapshot)
+    }
+  })
+})
+
+test("loadConfig keeps env peer over config peerId when ovcli has none", async () => {
+  const snapshot = { ...process.env }
+  await withTempDir("ov-oc-peer-env-wins-", async (dir) => {
+    try {
+      for (const key of Object.keys(process.env)) {
+        if (key.startsWith("OPENVIKING_")) delete process.env[key]
+      }
+      const ovcli = join(dir, "ovcli.conf")
+      const project = join(dir, "project")
+      await mkdir(join(project, ".opencode"), { recursive: true })
+      await writeFile(ovcli, JSON.stringify({
+        url: "https://cli.example.com",
+        api_key: "cli-key",
+      }))
+      await writeFile(join(project, ".opencode", "openviking-config.json"), JSON.stringify({
+        peerId: "config-peer",
+      }))
+      process.env.OPENVIKING_CLI_CONFIG_FILE = ovcli
+      process.env.OPENVIKING_PEER_ID = "env-peer"
+
+      const cfg = loadConfig(dir, project)
+      assert.equal(cfg.peerId, "env-peer")
+      assert.deepEqual(cfg.effectivePeer, { peerId: "env-peer", source: "explicit" })
+    } finally {
+      restoreOpenVikingEnv(snapshot)
+    }
+  })
+})


### PR DESCRIPTION
Fixes #4487

## Problem

`@openviking/opencode-plugin` silently ignores the `peerId` set in the project's `openviking-config.json` whenever shared credentials exist (ovcli.conf or environment variables). The effective peer falls back to empty (with `workspacePeer: false`), so no peer id is sent at all: sessions and memories are written to the shared user space (`viking://user/<user>/...`) instead of a peer-scoped tree (`viking://user/<user>/peers/<peerId>/...`).

## Root cause

In `loadConfig()` (examples/opencode-plugin/lib/config.mjs):

1. `config.peerId = creds.peerId` is assigned unconditionally from resolved shared credentials.
2. `applyLegacyConnection()` — the only code path that reads the config file's `peerId` — is skipped whenever shared credentials exist (`mayUseLegacyCredentials` is false when `credentialSource` is `ovcli`/`env` or any credential field is set).
3. When ovcli.conf authenticates without `actor_peer_id`, `creds.peerId` is empty and the file config's `peerId` is never applied → `resolveEffectivePeerId()` sees an empty explicit peer → `workspacePeer: false` → `source: "none"`.

The config-file `peerId` only worked in the legacy no-credentials path, which is backwards: the common authenticated path (ovcli.conf) is exactly where it never worked.

## Fix

Apply the file config's `peerId` as a fallback when shared credentials carry no peer of their own:

```js
config.peerId = creds.peerId || str(fileConfig.peerId, "")
```

Resulting precedence (matches the Pi extension design in #3653, and the suggestion in the issue):

1. shared credentials peer — `OPENVIKING_PEER_ID` > ovcli.conf `actor_peer_id`/`peer_id`
2. extension config `peerId` (this PR makes it actually apply when authenticated)
3. workspace-derived peer (unchanged `workspacePeer` behavior)
4. none

## Tests

Three new cases in `tests/config.test.mjs` (11/11 pass, full plugin suite 29/29):

- ovcli.conf with credentials but no `actor_peer_id` + project config `peerId` + `workspacePeer: false` → `effectivePeer = { peerId: "atomic-city", source: "explicit" }` (the issue's exact scenario)
- ovcli.conf `actor_peer_id` wins over config `peerId`
- `OPENVIKING_PEER_ID` wins over config `peerId` when ovcli has no peer

Existing tests unaffected (they cover the credentials-present-with-peer paths, which short-circuit the fallback).

## Compatibility

- Non-breaking: nothing changes when shared credentials already carry a peer, or when no config-file `peerId` is set.
- README updated to state the fallback explicitly (the docs previously implied config `peerId` always applied).
- Same defect class as #3649 (Pi extension); this PR covers the OpenCode plugin only.
