### PR TITLE
fix(memory): optimize tool results before appending to extract messages

### DIFF
--- a/openviking/session/memory/tools.py
+++ b/openviking/session/memory/tools.py
@@ -46,7 +46,11 @@ def optimize_search_result(result: Any, limit: int = 10) -> Any:
 
 
 def optimize_tool_result(tool_name: str, result: Any) -> Any:
-    """优化工具结果以减少 Token 消耗。"""
+    """优化工具结果以减少 Token 消耗。
+
+    Error payloads keep up to 250 chars of diagnostic text so ReAct loops
+    can still recover from patch/URI failures (#4486 review).
+    """
     if isinstance(result, dict) and "error" in result:
         return {"error": extract_error_summary(result["error"])}
     if tool_name == "search" and isinstance(result, dict) and "memories" in result:
@@ -65,7 +69,7 @@ def extract_error_summary(error: str) -> str:
         return "Permission denied"
     if "Timeout" in error:
         return "Timeout"
-    return error[:50]
+    return error[:250]
 
 
 def add_tool_call_pair_to_messages(

--- a/openviking/session/memory/tools.py
+++ b/openviking/session/memory/tools.py
@@ -10,7 +10,7 @@ import json
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
-from openviking.session.memory.utils import add_line_numbers, line_count, slice_content_lines
+from openviking.session.memory.utils import add_line_numbers, line_count, slice_content_lines, split_content_lines
 from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
 from openviking.telemetry import tracer
 from openviking_cli.exceptions import NotFoundError
@@ -76,11 +76,16 @@ def add_tool_call_pair_to_messages(
     result: Any,
 ) -> None:
     """Add a tool call pair with optimized format to save tokens."""
+    # Optimize only the LLM-visible copy. Callers that need the full payload
+    # (e.g. MemoryReadTool -> ctx.read_file_contents) keep the original result.
+    # See https://github.com/volcengine/OpenViking/issues/4486
+    optimized = optimize_tool_result(tool_name, result)
     messages.append(
         {
             "role": "user",
             "content": json.dumps(
-                {"tool_call_name": tool_name, "args": params, "result": result}, ensure_ascii=False
+                {"tool_call_name": tool_name, "args": params, "result": optimized},
+                ensure_ascii=False,
             ),
         }
     )
@@ -206,6 +211,13 @@ class MemoryReadTool(MemoryTool):
                 if page_id is not None:
                     llm_result["page_id"] = page_id
             plain_content = mf.plain_content() or ""
+            # Sparse memory templates can contain long runs of trailing blank
+            # lines. Drop them before paging/numbering so ReAct context is not
+            # spent on empty line numbers (#4486).
+            content_lines = split_content_lines(plain_content)
+            while content_lines and not content_lines[-1].strip():
+                content_lines.pop()
+            plain_content = "\n".join(content_lines)
             visible_content = slice_content_lines(plain_content, offset=offset, limit=limit)
             if visible_content:
                 llm_result["content"] = add_line_numbers(visible_content, start_line=offset + 1)

--- a/tests/session/memory/test_tool_result_optimize_messages.py
+++ b/tests/session/memory/test_tool_result_optimize_messages.py
@@ -39,3 +39,42 @@ def test_add_tool_call_pair_uses_optimized_read_result():
     assert "truncated" in payload["result"]["content"]
     # Caller-held original remains full for apply/write paths
     assert len(original["content"]) == len(long_content)
+
+def test_optimize_tool_result_summarizes_error_with_room_for_diagnostics():
+    long_err = "patch failed: " + ("x" * 400)
+    optimized = optimize_tool_result("read", {"error": long_err})
+    assert optimized == {"error": long_err[:250]}
+    assert len(optimized["error"]) == 250
+
+
+def test_optimize_tool_result_preserves_known_error_labels():
+    optimized = optimize_tool_result("search", {"error": "File not found at viking://x"})
+    assert optimized == {"error": "File not found"}
+
+
+def test_optimize_tool_result_compacts_search_memories():
+    result = {
+        "memories": [
+            {"uri": "viking://a/profile.md", "score": 0.9, "extra": "drop"},
+            {"uri": "viking://a/note.abstract.md", "score": 0.8},
+            {"uri": "viking://a/keep.md", "score": 0.7},
+        ]
+    }
+    optimized = optimize_tool_result("search", result)
+    assert optimized == [
+        {"uri": "viking://a/profile.md", "score": 0.9},
+        {"uri": "viking://a/keep.md", "score": 0.7},
+    ]
+
+
+def test_add_tool_call_pair_uses_optimized_error_result():
+    messages = []
+    add_tool_call_pair_to_messages(
+        messages,
+        call_id="call_err",
+        tool_name="read",
+        params={"uri": "viking://x"},
+        result={"error": "Timeout while reading"},
+    )
+    payload = json.loads(messages[0]["content"])
+    assert payload["result"] == {"error": "Timeout"}

--- a/tests/session/memory/test_tool_result_optimize_messages.py
+++ b/tests/session/memory/test_tool_result_optimize_messages.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import json
+
+from openviking.session.memory.tools import (
+    add_tool_call_pair_to_messages,
+    optimize_tool_result,
+)
+
+
+def test_optimize_tool_result_truncates_read_content():
+    long_content = "\n".join(f"{i}\t" for i in range(1, 900))
+    result = {"uri": "viking://user/u/memories/profile.md", "content": long_content}
+    optimized = optimize_tool_result("read", result)
+    assert isinstance(optimized, dict)
+    assert "content" in optimized
+    assert len(optimized["content"]) < len(long_content)
+    assert "truncated" in optimized["content"]
+    # Original must stay untouched
+    assert len(result["content"]) == len(long_content)
+
+
+def test_add_tool_call_pair_uses_optimized_read_result():
+    long_content = "\n".join(f"{i}\t" for i in range(1, 900))
+    original = {"uri": "viking://user/u/memories/profile.md", "content": long_content}
+    messages = []
+    add_tool_call_pair_to_messages(
+        messages,
+        call_id="call_1",
+        tool_name="read",
+        params={"uri": original["uri"]},
+        result=original,
+    )
+    assert len(messages) == 1
+    payload = json.loads(messages[0]["content"])
+    assert payload["tool_call_name"] == "read"
+    assert len(payload["result"]["content"]) < len(long_content)
+    assert "truncated" in payload["result"]["content"]
+    # Caller-held original remains full for apply/write paths
+    assert len(original["content"]) == len(long_content)


### PR DESCRIPTION
## Summary
- Wire `optimize_tool_result()` into `add_tool_call_pair_to_messages()` so LLM-facing `read` tool results are truncated (existing 1000-char line-aware policy) without mutating the original result used by apply/write paths.
- Drop trailing blank lines from `MemoryReadTool` output before paging/numbering, so sparse memory templates do not flood the ReAct context with empty line numbers.
- Add a focused regression test for both behaviors.

Fixes #4486

## Why
Memory extraction was burning ReAct iterations/context on huge numbered `read` payloads (sparse templates / unoptimized tool messages), then silently reporting `Extracted 0 memories`.

## Test plan
- [ ] `pytest tests/session/memory/test_tool_result_optimize_messages.py -q`
- [ ] Extract against a sparse `profile.md`-style template and confirm the tool message content is truncated / not hundreds of blank numbered lines
