### PR TITLE
feat(memory): make extract max_iterations configurable

### DIFF
--- a/docs/en/configuration/01-server.md
+++ b/docs/en/configuration/01-server.md
@@ -308,6 +308,7 @@ See [Encryption](../guides/08-encryption.md) for provider and key-management set
     "experimental_memory_switch": false,
     "eager_prefetch": true,
     "prefetch_search_topn": 5,
+    "extract_max_iterations": 3,
     "extraction_enabled": true,
     "session_skill_extraction_enabled": false,
     "link_enabled": false,
@@ -325,6 +326,7 @@ See [Encryption](../guides/08-encryption.md) for provider and key-management set
 | `experimental_memory_switch` | boolean | `false` | Enable experimental templates |
 | `eager_prefetch` | boolean | `true` | Search and read memories before extraction |
 | `prefetch_search_topn` | integer, `>= 1` | `5` | Results read during prefetch |
+| `extract_max_iterations` | integer, `>= 1` | `3` | Max ReAct iterations for session memory extraction |
 | `extraction_enabled` | boolean | `true` | Extract long-term memories on session commit |
 | `session_skill_extraction_enabled` | boolean | `false` | Also extract reusable skills |
 | `link_enabled` | boolean | `false` | Generate and resolve memory links |

--- a/docs/zh/configuration/01-server.md
+++ b/docs/zh/configuration/01-server.md
@@ -308,6 +308,7 @@ Provider 和密钥管理配置见[加密指南](../guides/08-encryption.md)。
     "experimental_memory_switch": false,
     "eager_prefetch": true,
     "prefetch_search_topn": 5,
+    "extract_max_iterations": 3,
     "extraction_enabled": true,
     "session_skill_extraction_enabled": false,
     "link_enabled": false,
@@ -325,6 +326,7 @@ Provider 和密钥管理配置见[加密指南](../guides/08-encryption.md)。
 | `experimental_memory_switch` | boolean | `false` | 是否启用实验性记忆模板 |
 | `eager_prefetch` | boolean | `true` | 是否在抽取前预取并读取记忆内容 |
 | `prefetch_search_topn` | integer，`>= 1` | `5` | 预取时读取的检索结果数量 |
+| `extract_max_iterations` | integer，`>= 1` | `3` | Session 记忆抽取的最大 ReAct 迭代次数 |
 | `extraction_enabled` | boolean | `true` | session commit 时是否抽取长期记忆 |
 | `session_skill_extraction_enabled` | boolean | `false` | 是否同时抽取可复用 Skill |
 | `link_enabled` | boolean | `false` | 是否生成和解析记忆链接 |

--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -281,6 +281,7 @@ class SessionCompressorV3:
         return ExtractLoop(
             vlm=vlm,
             viking_fs=viking_fs,
+            max_iterations=config.memory.extract_max_iterations,
             ctx=ctx,
             context_provider=context_provider,
             isolation_handler=isolation_handler,

--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -130,7 +130,7 @@ class ExtractLoop:
             vlm: VLM instance (from openviking.models.vlm.base)
             viking_fs: VikingFS instance for storage operations
             model: Model name to use
-            max_iterations: Maximum number of ReAct iterations (default: 5)
+            max_iterations: Maximum number of ReAct iterations (default: 3)
             ctx: Request context
             context_provider: ExtractContextProvider - 必须提供（由 provider 加载 schema）
             thinking: Whether to explicitly enable model thinking for this extraction loop.

--- a/openviking_cli/utils/config/memory_config.py
+++ b/openviking_cli/utils/config/memory_config.py
@@ -56,6 +56,15 @@ class MemoryConfig(BaseModel):
             "When multiple directories are searched, results are merged and top-N are read."
         ),
     )
+    extract_max_iterations: int = Field(
+        default=3,
+        ge=1,
+        description=(
+            "Maximum ReAct iterations for session memory extraction (compressor v3). "
+            "Raise when models need more tool-read rounds before writing memories; "
+            "streaming extraction keeps its own fixed budget."
+        ),
+    )
     extraction_enabled: bool = Field(
         default=True,
         description=(


### PR DESCRIPTION
## Summary
- Add `memory.extract_max_iterations` (default `3`, `>= 1`) to `MemoryConfig` / `ov.conf`
- Pass it into compressor v3 `ExtractLoop` so session extraction budget is tunable without code changes
- Document the field in EN/ZH server config; align `ExtractLoop` docstring default with the real constructor default

Streaming extraction keeps its fixed `max_iterations=1` path unchanged.

Related to #4486 (suggested fix 2; follow-up to #4633).

## Test plan
- [ ] Confirm default config still constructs `ExtractLoop` with `max_iterations=3`
- [ ] Set `memory.extract_max_iterations: 8` in `ov.conf` and verify extractor logs `ReAct iteration N/8`
- [ ] Reject `extract_max_iterations: 0` via pydantic validation