### PR TITLE
fix(storage): allow '#' in write URIs and tighten chunk detection

### DIFF
--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -442,15 +442,25 @@ def _mcp_uri_suffix(uri: str) -> str:
 
 
 def _is_mcp_image_uri(uri: str) -> bool:
-    return _mcp_uri_suffix(uri) in _MCP_IMAGE_EXTENSIONS
+    return _mcp_uri_matches_extension(uri, _MCP_IMAGE_EXTENSIONS)
 
 
 def _is_mcp_audio_uri(uri: str) -> bool:
-    return _mcp_uri_suffix(uri) in _MCP_AUDIO_EXTENSIONS
+    return _mcp_uri_matches_extension(uri, _MCP_AUDIO_EXTENSIONS)
 
 
 def _is_mcp_video_uri(uri: str) -> bool:
-    return _mcp_uri_suffix(uri) in _MCP_VIDEO_EXTENSIONS
+    return _mcp_uri_matches_extension(uri, _MCP_VIDEO_EXTENSIONS)
+
+
+def _mcp_uri_matches_extension(uri: str, extensions: set[str]) -> bool:
+    """Two-stage extension match: the literal path suffix wins ('#' in a real
+    filename keeps its meaning), with a fallback to the pre-'#' portion so a
+    media-fragment reference like 'video.mp4#t=5' keeps its extension."""
+    if _mcp_uri_suffix(uri) in extensions:
+        return True
+    head = uri.split("#", 1)[0]
+    return head != uri and _mcp_uri_suffix(head) in extensions
 
 
 def _sniff_mcp_image_mime_type(data: bytes) -> Optional[str]:
@@ -473,16 +483,15 @@ def _mcp_image_content(data: bytes, mime_type: str) -> ImageContent:
 
 def _sniff_mcp_audio_mime_type(data: bytes, uri: str) -> Optional[str]:
     """Recognize audio formats represented by MCP AudioContent."""
-    suffix = _mcp_uri_suffix(uri)
     if data.startswith(b"RIFF") and len(data) >= 12 and data[8:12] == b"WAVE":
         return "audio/wav"
     if data.startswith(b"fLaC"):
         return "audio/flac"
-    if data.startswith(b"OggS") and suffix in {".oga", ".ogg"}:
+    if data.startswith(b"OggS") and _mcp_uri_matches_extension(uri, {".oga", ".ogg"}):
         return "audio/ogg"
     if data.startswith(b"ID3") or (len(data) >= 2 and data[0] == 0xFF and data[1] & 0xE0 == 0xE0):
         return "audio/mpeg"
-    if len(data) >= 12 and data[4:8] == b"ftyp" and suffix == ".m4a":
+    if len(data) >= 12 and data[4:8] == b"ftyp" and _mcp_uri_matches_extension(uri, {".m4a"}):
         return "audio/mp4"
     return None
 

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -65,6 +65,7 @@ from openviking.server.local_input_guard import (
 from openviking.server.resource_ingest import ingest_temp_upload
 from openviking.server.temp_upload_store import TempUploadStore
 from openviking.server.upload_token_store import upload_token_store
+from openviking.utils.chunk_uri import strip_chunk_suffix
 from openviking.utils.search_filters import SearchContextTypeInput, merge_search_filter
 from openviking_cli.exceptions import (
     InvalidArgumentError,
@@ -430,10 +431,14 @@ _MCP_VIDEO_EXTENSIONS = {".avi", ".m4v", ".mkv", ".mov", ".mp4", ".webm"}
 _MCP_MEDIA_MAX_BYTES = 3_932_160
 
 
+def _mcp_uri_path(uri: str) -> str:
+    """Path portion of a URI, ignoring any query and a trailing chunk suffix."""
+    return strip_chunk_suffix(uri.split("?", 1)[0])
+
+
 def _mcp_uri_suffix(uri: str) -> str:
-    """Lowercased file extension of a URI, ignoring any query or fragment."""
-    path = uri.split("#", 1)[0].split("?", 1)[0]
-    return PurePosixPath(path).suffix.lower()
+    """Lowercased file extension of a URI, ignoring any query and a trailing chunk suffix."""
+    return PurePosixPath(_mcp_uri_path(uri)).suffix.lower()
 
 
 def _is_mcp_image_uri(uri: str) -> bool:
@@ -489,8 +494,7 @@ def _mcp_audio_content(data: bytes, mime_type: str) -> AudioContent:
 
 def _mcp_media_download_hint(uri: str) -> str:
     """Return actionable fallbacks when media cannot be inlined."""
-    path = uri.split("#", 1)[0].split("?", 1)[0]
-    filename = PurePosixPath(path).name or "download"
+    filename = PurePosixPath(_mcp_uri_path(uri)).name or "download"
     encoded_uri = quote(uri, safe="")
     return (
         f'Use `ov get "{uri}" "./{filename}"` or GET '

--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -37,6 +37,7 @@ from openviking.storage.queuefs.semantic_processor import SemanticProcessor
 from openviking.storage.viking_fs import get_viking_fs
 from openviking.telemetry import get_current_telemetry
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
+from openviking.utils.chunk_uri import chunk_base_uri, make_chunk_uri
 from openviking.utils.embedding_input import truncate_embedding_input
 from openviking.utils.embedding_utils import (
     _apply_ingest_options,
@@ -680,11 +681,14 @@ class ReindexExecutor:
                 if not records:
                     break
 
+                chunk_cache: dict[str, tuple[_PruneSourceRead, Optional[set[str]]]] = {}
                 for record in records:
                     counters.scanned_records += 1
                     if not self._is_supported_prune_record(record, counters):
                         continue
-                    if not await self._is_orphan_vector_record(record, counters=counters, ctx=ctx):
+                    if not await self._is_orphan_vector_record(
+                        record, counters=counters, ctx=ctx, chunk_cache=chunk_cache
+                    ):
                         continue
 
                     if dry_run:
@@ -782,6 +786,7 @@ class ReindexExecutor:
         *,
         counters: _ReindexCounters,
         ctx: RequestContext,
+        chunk_cache: Optional[dict[str, tuple[_PruneSourceRead, Optional[set[str]]]]] = None,
     ) -> bool:
         uri = str(record["uri"])
         level = int(record.get("_prune_level", record["level"]))
@@ -846,25 +851,40 @@ class ReindexExecutor:
                 )
             return True
 
-        if "#" in uri:
-            if context_type == ContextType.MEMORY.value and "#chunk_" in uri:
-                base_uri = uri.split("#chunk_", 1)[0]
+        # Chunk suffixes only exist in the memory namespace; a resource/skill
+        # record whose literal name happens to end in '#chunk_NNNN' is a real
+        # file and must fall through to the exists-based prune below.
+        base_uri = (
+            chunk_base_uri(uri) if context_type == ContextType.MEMORY.value else None
+        )
+        if base_uri is not None:
+            # All chunks of one base share the same source read and expected
+            # set; memoize so a heavily-chunked base costs one read, not N.
+            if chunk_cache is not None and base_uri in chunk_cache:
+                base, expected = chunk_cache[base_uri]
+            else:
                 base = await self._read_prune_source(base_uri, ctx=owner_ctx)
-                if base.error:
-                    self._record_prune_source_error(
-                        counters=counters,
-                        uri=uri,
-                        source_uri=base_uri,
-                        error=base.error,
-                    )
-                    return False
-                if not base.exists:
-                    return True
-                expected = {
-                    chunk_uri for chunk_uri, _chunk in self._chunk_memory_body(base_uri, base.text)
-                }
-                return uri not in expected
-            return False
+                expected = (
+                    {
+                        chunk_uri
+                        for chunk_uri, _chunk in self._chunk_memory_body(base_uri, base.text)
+                    }
+                    if base.exists and not base.error
+                    else None
+                )
+                if chunk_cache is not None:
+                    chunk_cache[base_uri] = (base, expected)
+            if base.error:
+                self._record_prune_source_error(
+                    counters=counters,
+                    uri=uri,
+                    source_uri=base_uri,
+                    error=base.error,
+                )
+                return False
+            if not base.exists:
+                return True
+            return uri not in expected
 
         if self._is_hidden_meta_file(uri):
             return False
@@ -1635,7 +1655,11 @@ class ReindexExecutor:
                 file_counters.warnings.append(f"No memory source found for {file_uri}")
                 return file_counters
 
-            parent_uri = VikingURI(file_uri.split("#", 1)[0]).parent.uri
+            # No '#' split here: '#' has no fragment semantics in Viking URIs, and
+            # stripping at the first '#' would misparent names/directories that
+            # legitimately contain it (real chunk URIs keep the '#' inside the
+            # final path segment, so parent is unaffected either way).
+            parent_uri = VikingURI(file_uri).parent.uri
             if body:
                 detail_abstract = self._prefer_non_empty(abstract, memory_content, body)
                 try:
@@ -1966,7 +1990,9 @@ class ReindexExecutor:
             if start >= len(body):
                 break
 
-        return [(f"{uri}#chunk_{idx:04d}", chunk) for idx, chunk in enumerate(chunks) if chunk]
+        return [
+            (make_chunk_uri(uri, idx), chunk) for idx, chunk in enumerate(chunks) if chunk
+        ]
 
     def _best_non_empty(self, *values: str) -> str:
         for value in values:

--- a/openviking/storage/vector_migration.py
+++ b/openviking/storage/vector_migration.py
@@ -19,6 +19,7 @@ from openviking.storage.abstract_overview import (
 )
 from openviking.storage.expr import And, Contains, Eq, Or, PathScope
 from openviking.storage.vector_ids import vector_record_id
+from openviking.utils.chunk_uri import CHUNK_MARKER, chunk_base_uri
 from openviking.utils.time_utils import get_current_timestamp
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils.uri import VikingURI
@@ -82,13 +83,20 @@ def _has_vector_payload(record: dict[str, Any]) -> bool:
     return False
 
 
+def _is_chunk_of(uri: str, base_uri: str) -> bool:
+    # Only an exact chunk suffix ({base}#chunk_{idx:04d}) counts, so a sibling
+    # whose own name contains '#' (accepted by add/write) is never treated as
+    # a chunk of the base URI.
+    return chunk_base_uri(uri) == base_uri
+
+
 def uri_in_transfer_scope(uri: str, scope_uri: str, *, recursive: bool) -> bool:
     """Return whether *uri* belongs to a file or recursive directory transfer."""
     scope_uri = _normalize_uri(scope_uri)
     return (
         uri == scope_uri
-        or uri.startswith(scope_uri + "#")
         or (recursive and uri.startswith(scope_uri + "/"))
+        or _is_chunk_of(uri, scope_uri)
     )
 
 
@@ -98,7 +106,7 @@ def rewrite_transfer_uri(uri: str, source_uri: str, target_uri: str) -> str:
     target_uri = _normalize_uri(target_uri)
     if uri == source_uri:
         return target_uri
-    if uri.startswith(source_uri + "/") or uri.startswith(source_uri + "#"):
+    if uri.startswith(source_uri + "/") or _is_chunk_of(uri, source_uri):
         return target_uri + uri[len(source_uri) :]
     return uri
 
@@ -180,7 +188,10 @@ async def _records_in_scope(
         if parent is not None and parent.uri != "viking://":
             filters.append(PathScope("uri", parent.uri, depth=1))
     else:
-        filters.append(Contains("uri", uri + "#"))
+        # Cheap pre-filter for chunk records ahead of the exact suffix check in
+        # uri_in_transfer_scope; real files whose name merely contains
+        # CHUNK_MARKER are fetched too and dropped there.
+        filters.append(Contains("uri", uri + CHUNK_MARKER))
 
     ctx = _root_ctx(account_id)
     records = await vector_store.filter(

--- a/openviking/storage/vector_migration.py
+++ b/openviking/storage/vector_migration.py
@@ -11,6 +11,7 @@ from openviking.core.namespace import context_type_for_uri, owner_fields_for_uri
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.expr import And, Contains, Eq, Or, PathScope
 from openviking.storage.vector_ids import vector_record_id
+from openviking.utils.chunk_uri import CHUNK_MARKER, chunk_base_uri
 from openviking.utils.time_utils import get_current_timestamp
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils.uri import VikingURI
@@ -70,18 +71,25 @@ def _has_vector_payload(record: dict[str, Any]) -> bool:
     return False
 
 
+def _is_chunk_of(uri: str, base_uri: str) -> bool:
+    # Only an exact chunk suffix ({base}#chunk_{idx:04d}) counts, so a sibling
+    # whose own name contains '#' (accepted by add/write) is never treated as
+    # a chunk of the base URI.
+    return chunk_base_uri(uri) == base_uri
+
+
 def _uri_in_scope(uri: str, scope_uri: str, *, recursive: bool) -> bool:
     return (
         uri == scope_uri
-        or uri.startswith(scope_uri + "#")
         or (recursive and uri.startswith(scope_uri + "/"))
+        or _is_chunk_of(uri, scope_uri)
     )
 
 
 def _rewrite_uri(uri: str, source_uri: str, target_uri: str) -> str:
     if uri == source_uri:
         return target_uri
-    if uri.startswith(source_uri + "/") or uri.startswith(source_uri + "#"):
+    if uri.startswith(source_uri + "/") or _is_chunk_of(uri, source_uri):
         return target_uri + uri[len(source_uri) :]
     return uri
 
@@ -101,7 +109,10 @@ async def _records_in_scope(
         if parent is not None and parent.uri != "viking://":
             filters.append(PathScope("uri", parent.uri, depth=1))
     else:
-        filters.append(Contains("uri", uri + "#"))
+        # Cheap pre-filter for chunk records ahead of the exact suffix check in
+        # _uri_in_scope; real files whose name merely contains CHUNK_MARKER are
+        # fetched too and dropped there.
+        filters.append(Contains("uri", uri + CHUNK_MARKER))
 
     ctx = _root_ctx(account_id)
     records = await vector_store.filter(

--- a/openviking/utils/chunk_uri.py
+++ b/openviking/utils/chunk_uri.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Helpers for memory chunk URI suffixes.
+
+Real chunk URIs are ``{base_uri}#chunk_{idx:04d}`` (see
+``ReindexExecutor._chunk_memory_body``): the chunk marker is always the
+final segment of the URI. A '#' elsewhere is a literal path character
+(accepted by add-resource and write), never a fragment.
+
+Production (``make_chunk_uri``), recognition (``chunk_base_uri``), and
+query pre-filtering (``CHUNK_MARKER``) all derive from this module so the
+format has a single source of truth.
+"""
+
+import re
+from typing import Optional
+
+CHUNK_MARKER = "#chunk_"
+
+_CHUNK_SUFFIX_RE = re.compile(rf"{re.escape(CHUNK_MARKER)}\d+$")
+
+
+def make_chunk_uri(base_uri: str, index: int) -> str:
+    """Return the chunk URI for *index* of *base_uri*."""
+    return f"{base_uri}{CHUNK_MARKER}{index:04d}"
+
+
+def chunk_base_uri(uri: str) -> Optional[str]:
+    """Return the base URI when *uri* ends with a chunk suffix, else None."""
+    match = _CHUNK_SUFFIX_RE.search(uri)
+    return uri[: match.start()] if match else None
+
+
+def strip_chunk_suffix(uri: str) -> str:
+    """Return *uri* with a trailing chunk suffix removed, if present."""
+    base = chunk_base_uri(uri)
+    return uri if base is None else base

--- a/openviking/utils/path_safety.py
+++ b/openviking/utils/path_safety.py
@@ -45,7 +45,11 @@ def sanitize_relative_viking_path(rel_path: str) -> str:
 def validate_safe_viking_uri_path(uri: str) -> str:
     """Reject ambiguous or traversal-bearing path syntax in a Viking URI."""
     normalized = VikingURI(uri.strip()).uri.rstrip("/")
-    if "?" in normalized or "#" in normalized:
+    # '?' is stripped as a query separator by core.namespace.uri_parts, so a
+    # '?' in the path would not read back. '#' has no fragment semantics in
+    # Viking URIs (add-resource targets and the read paths already accept it),
+    # so it is allowed as a literal path character.
+    if "?" in normalized:
         raise ValueError(f"Unsafe Viking URI path rejected: {uri}")
     path = normalized[len(f"{VikingURI.SCHEME}://") :]
     if not path:

--- a/tests/server/test_admin_rebuild_api.py
+++ b/tests/server/test_admin_rebuild_api.py
@@ -1107,6 +1107,114 @@ async def test_prune_orphans_skips_memory_chunks_when_base_read_fails(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_prune_orphans_keeps_real_file_whose_name_looks_like_a_chunk(monkeypatch):
+    """A memory file literally named `x#chunk_0000.md` is a file, not a chunk
+    of `x` — write URIs accept '#', so the prune check must match the exact
+    chunk suffix instead of any '#chunk_' substring."""
+    from openviking.service.reindex_executor import ReindexExecutor, _ReindexCounters
+
+    base_uri = "viking://user/bob/memories/notes/meeting.md"
+    hash_named_file = "viking://user/bob/memories/notes/meeting#chunk_0000.md"
+
+    class FakeVikingFS:
+        async def exists(self, uri, ctx=None):
+            return uri in {base_uri, hash_named_file}
+
+        async def read_file(self, uri, ctx=None):
+            assert uri == base_uri
+            return "memory body"
+
+    class FakeVikingDB:
+        async def filter(self, *, filter, limit, output_fields, ctx):
+            return [
+                {
+                    "id": "keep_hash_named_file",
+                    "uri": hash_named_file,
+                    "level": 2,
+                    "context_type": "memory",
+                    "account_id": "acct",
+                    "owner_user_id": "bob",
+                }
+            ]
+
+        async def delete(self, ids, *, ctx):
+            raise AssertionError("existing files must not be pruned as orphan chunks")
+
+    fake_service = type("Svc", (), {"vikingdb_manager": FakeVikingDB()})()
+    monkeypatch.setattr("openviking.service.reindex_executor.get_service", lambda: fake_service)
+    monkeypatch.setattr("openviking.service.reindex_executor.get_viking_fs", lambda: FakeVikingFS())
+
+    counters = _ReindexCounters()
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="acct", user_id="admin"),
+        role=Role.ROOT,
+    )
+
+    await ReindexExecutor()._prune_orphan_vectors(
+        uri="viking://user/bob/memories",
+        object_type="memory",
+        dry_run=False,
+        counters=counters,
+        ctx=ctx,
+    )
+
+    assert counters.deleted_records == 0
+    assert counters.failed_records == 0
+
+
+@pytest.mark.asyncio
+async def test_prune_orphans_prunes_resource_record_named_like_a_chunk(monkeypatch):
+    """A resource/skill record whose literal name ends in '#chunk_0000' is a
+    real file: the chunk-prune shortcut must not shield it from the ordinary
+    exists-based prune when the file is gone."""
+    from openviking.service.reindex_executor import ReindexExecutor, _ReindexCounters
+
+    hash_named_file = "viking://resources/demo/notes#chunk_0000"
+    deleted = {}
+
+    class FakeVikingFS:
+        async def exists(self, uri, ctx=None):
+            return False
+
+    class FakeVikingDB:
+        async def filter(self, *, filter, limit, output_fields, ctx):
+            return [
+                {
+                    "id": "delete_hash_named_resource",
+                    "uri": hash_named_file,
+                    "level": 2,
+                    "context_type": "resource",
+                    "account_id": "test",
+                }
+            ]
+
+        async def delete(self, ids, *, ctx):
+            deleted["ids"] = ids
+            return len(ids)
+
+    fake_service = type("Svc", (), {"vikingdb_manager": FakeVikingDB()})()
+    monkeypatch.setattr("openviking.service.reindex_executor.get_service", lambda: fake_service)
+    monkeypatch.setattr("openviking.service.reindex_executor.get_viking_fs", lambda: FakeVikingFS())
+
+    counters = _ReindexCounters()
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="test", user_id="admin"),
+        role=Role.ROOT,
+    )
+
+    await ReindexExecutor()._prune_orphan_vectors(
+        uri="viking://resources/demo",
+        object_type="resource",
+        dry_run=False,
+        counters=counters,
+        ctx=ctx,
+    )
+
+    assert deleted["ids"] == ["delete_hash_named_resource"]
+    assert counters.deleted_records == 1
+
+
+@pytest.mark.asyncio
 async def test_prune_orphans_deletes_missing_file_with_string_level(monkeypatch):
     from openviking.service.reindex_executor import ReindexExecutor, _ReindexCounters
 

--- a/tests/server/test_api_content_write.py
+++ b/tests/server/test_api_content_write.py
@@ -370,3 +370,45 @@ async def test_set_tags_discards_invalid_kv_tag(client_with_resource):
     body = resp.json()
     assert body["status"] == "ok"
     assert body["result"]["tags"] == ["team=search"]
+
+
+async def test_write_accepts_hash_in_uri(client):
+    """'#' is a literal path character: add-resource already accepts it, so
+    write must too (regression for resources that could not be updated)."""
+    uri = "viking://user/default/memories/notes#1.md"
+
+    write_resp = await client.post(
+        "/api/v1/content/write",
+        json={
+            "uri": uri,
+            "content": "# Notes\n\nHash in the file name.",
+            "mode": "create",
+            "wait": True,
+        },
+    )
+    assert write_resp.status_code == 200
+    body = write_resp.json()
+    assert body["status"] == "ok"
+    assert body["result"]["uri"] == uri
+
+    read_resp = await client.get("/api/v1/content/read", params={"uri": uri})
+    assert read_resp.status_code == 200
+    assert read_resp.json()["result"] == "# Notes\n\nHash in the file name."
+
+
+async def test_write_rejects_query_separator_in_uri(client):
+    """'?' is still rejected: uri_parts strips it as a query separator, so the
+    path would not read back."""
+    resp = await client.post(
+        "/api/v1/content/write",
+        json={
+            "uri": "viking://user/default/memories/notes?draft=1.md",
+            "content": "content",
+            "mode": "create",
+            "wait": True,
+        },
+    )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["status"] == "error"
+    assert body["error"]["code"] == "INVALID_ARGUMENT"

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -632,6 +632,8 @@ async def test_read_delegates_to_visible_read(monkeypatch):
         ("viking://resources/result.jpg", b"\xff\xd8\xffimage", "image/jpeg"),
         ("viking://resources/result.gif", b"GIF89aimage", "image/gif"),
         ("viking://resources/result.webp", b"RIFF\x00\x00\x00\x00WEBPimage", "image/webp"),
+        # media-fragment reference falls back to the pre-'#' extension
+        ("viking://resources/img.png#section", b"\x89PNG\r\n\x1a\nimage", "image/png"),
     ],
 )
 async def test_read_image_returns_native_mcp_content(monkeypatch, uri, image_bytes, mime_type):
@@ -704,6 +706,9 @@ async def test_read_mixed_batch_preserves_source_order(monkeypatch):
         ("viking://resources/song#1.mp3", b"ID3audio", "audio/mpeg"),
         ("viking://resources/clip.mp3#chunk_0000", b"ID3audio", "audio/mpeg"),
         ("viking://resources/clip.mp3#chunk_0000?v=2", b"ID3audio", "audio/mpeg"),
+        # media-fragment references fall back to the pre-'#' extension
+        ("viking://resources/clip.ogg#t=5", b"OggSaudio", "audio/ogg"),
+        ("viking://resources/clip.m4a#t=10,20", b"\x00\x00\x00\x18ftypM4A audio", "audio/mp4"),
     ],
 )
 async def test_read_audio_returns_native_mcp_content(monkeypatch, uri, audio_bytes, mime_type):
@@ -772,6 +777,53 @@ async def test_read_video_hash_named_file_keeps_full_download_filename(monkeypat
     result = await read("viking://resources/demo#1.mp4")
 
     assert 'ov get "viking://resources/demo#1.mp4" "./demo#1.mp4"' in result
+
+
+async def test_read_video_media_fragment_keeps_download_hint(monkeypatch):
+    """A '#t=...' suffix still recognizes the pre-'#' video extension and gets
+    the download hint instead of falling through to a text read."""
+    stat = AsyncMock(return_value={"size": 1024, "isDir": False})
+    read_visible = AsyncMock()
+    monkeypatch.setattr(
+        mcp_endpoint,
+        "get_service",
+        lambda: SimpleNamespace(
+            fs=SimpleNamespace(
+                read_file_bytes=AsyncMock(),
+                read_visible=read_visible,
+                stat=stat,
+            )
+        ),
+    )
+
+    result = await read("viking://resources/demo.mp4#t=5")
+
+    assert "no standard VideoContent" in result
+    assert 'ov get "viking://resources/demo.mp4#t=5" "./demo.mp4#t=5"' in result
+    read_visible.assert_not_awaited()
+
+
+async def test_read_fragment_like_text_name_stays_text(monkeypatch):
+    """A file literally named 'notes#t=5.md' matches no media extension in
+    either stage and keeps going through the visible-text read path."""
+    read_visible = AsyncMock(return_value="text body")
+    read_file_bytes = AsyncMock()
+    monkeypatch.setattr(
+        mcp_endpoint,
+        "get_service",
+        lambda: SimpleNamespace(
+            fs=SimpleNamespace(
+                read_file_bytes=read_file_bytes,
+                read_visible=read_visible,
+            )
+        ),
+    )
+
+    result = await read("viking://resources/notes#t=5.md")
+
+    assert result == "text body"
+    read_visible.assert_awaited_once_with("viking://resources/notes#t=5.md", ctx=DEFAULT_CTX)
+    read_file_bytes.assert_not_awaited()
 
 
 async def test_read_video_nonexistent_uri_preserves_not_found(monkeypatch):

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -700,6 +700,10 @@ async def test_read_mixed_batch_preserves_source_order(monkeypatch):
         ("viking://resources/clip.m4a", b"\x00\x00\x00\x18ftypM4A audio", "audio/mp4"),
         # suffix sniffing must ignore a query string, like the extension gate does
         ("viking://resources/clip.ogg?v=2", b"OggSaudio", "audio/ogg"),
+        # '#' is a literal path character; only a trailing chunk suffix is stripped
+        ("viking://resources/song#1.mp3", b"ID3audio", "audio/mpeg"),
+        ("viking://resources/clip.mp3#chunk_0000", b"ID3audio", "audio/mpeg"),
+        ("viking://resources/clip.mp3#chunk_0000?v=2", b"ID3audio", "audio/mpeg"),
     ],
 )
 async def test_read_audio_returns_native_mcp_content(monkeypatch, uri, audio_bytes, mime_type):
@@ -748,6 +752,26 @@ async def test_read_video_returns_unsupported_hint(monkeypatch):
     assert 'ov get "viking://resources/demo.mp4" "./demo.mp4"' in result
     stat.assert_awaited_once_with("viking://resources/demo.mp4", ctx=DEFAULT_CTX)
     read_visible.assert_not_awaited()
+
+
+async def test_read_video_hash_named_file_keeps_full_download_filename(monkeypatch):
+    stat = AsyncMock(return_value={"size": 1024, "isDir": False})
+    read_visible = AsyncMock()
+    monkeypatch.setattr(
+        mcp_endpoint,
+        "get_service",
+        lambda: SimpleNamespace(
+            fs=SimpleNamespace(
+                read_file_bytes=AsyncMock(),
+                read_visible=read_visible,
+                stat=stat,
+            )
+        ),
+    )
+
+    result = await read("viking://resources/demo#1.mp4")
+
+    assert 'ov get "viking://resources/demo#1.mp4" "./demo#1.mp4"' in result
 
 
 async def test_read_video_nonexistent_uri_preserves_not_found(monkeypatch):

--- a/tests/storage/test_vector_migration.py
+++ b/tests/storage/test_vector_migration.py
@@ -285,3 +285,95 @@ async def test_delete_vector_records_deletes_records_in_scope_only():
 
     assert result.deleted == 2
     assert store.deleted_ids == ["old-dir", "old-file"]
+
+
+@pytest.mark.asyncio
+async def test_copy_vector_records_leaves_hash_named_sibling_untouched():
+    """A sibling whose own name contains '#' is a file, not a chunk of the base."""
+    store = FakeVectorStore(
+        [
+            {
+                "id": "old-file",
+                "uri": "viking://user/alice/memories/notes/meeting.md",
+                "account_id": "acct",
+                "context_type": "memory",
+                "level": 2,
+                "abstract": "meeting",
+                "vector": [0.1, 0.2],
+            },
+            {
+                "id": "old-chunk",
+                "uri": "viking://user/alice/memories/notes/meeting.md#chunk_0000",
+                "account_id": "acct",
+                "context_type": "memory",
+                "level": 2,
+                "abstract": "chunk",
+                "vector": [0.3, 0.4],
+            },
+            {
+                "id": "old-hash-sibling",
+                "uri": "viking://user/alice/memories/notes/meeting.md#1.md",
+                "account_id": "acct",
+                "context_type": "memory",
+                "level": 2,
+                "abstract": "separate file",
+                "vector": [0.5, 0.6],
+            },
+        ]
+    )
+
+    result = await copy_vector_records(
+        store,
+        account_id="acct",
+        source_uri="viking://user/alice/memories/notes/meeting.md",
+        target_uri="viking://user/alice/memories/notes/archived.md",
+        recursive=False,
+    )
+
+    assert result.copied == 2
+    assert {record["uri"] for record in store.upserts} == {
+        "viking://user/alice/memories/notes/archived.md",
+        "viking://user/alice/memories/notes/archived.md#chunk_0000",
+    }
+
+
+@pytest.mark.asyncio
+async def test_delete_vector_records_keeps_hash_named_sibling():
+    store = FakeVectorStore(
+        [
+            {
+                "id": "old-file",
+                "uri": "viking://user/alice/memories/notes/meeting.md",
+                "account_id": "acct",
+                "vector": [0.1, 0.2],
+            },
+            {
+                "id": "old-chunk",
+                "uri": "viking://user/alice/memories/notes/meeting.md#chunk_0000",
+                "account_id": "acct",
+                "vector": [0.3, 0.4],
+            },
+            {
+                "id": "old-hash-sibling",
+                "uri": "viking://user/alice/memories/notes/meeting.md#1.md",
+                "account_id": "acct",
+                "vector": [0.5, 0.6],
+            },
+            {
+                # Unicode digits pass str.isdigit() but are not \d chunk indices
+                "id": "old-unicode-digit-sibling",
+                "uri": "viking://user/alice/memories/notes/meeting.md#chunk_²",
+                "account_id": "acct",
+                "vector": [0.7, 0.8],
+            },
+        ]
+    )
+
+    result = await delete_vector_records(
+        store,
+        account_id="acct",
+        uri="viking://user/alice/memories/notes/meeting.md",
+    )
+
+    assert result.deleted == 2
+    assert sorted(store.deleted_ids) == ["old-chunk", "old-file"]

--- a/tests/storage/test_vector_migration.py
+++ b/tests/storage/test_vector_migration.py
@@ -162,3 +162,95 @@ async def test_delete_vector_records_deletes_records_in_scope_only():
 
     assert result.deleted == 2
     assert store.deleted_ids == ["old-dir", "old-file"]
+
+
+@pytest.mark.asyncio
+async def test_copy_vector_records_leaves_hash_named_sibling_untouched():
+    """A sibling whose own name contains '#' is a file, not a chunk of the base."""
+    store = FakeVectorStore(
+        [
+            {
+                "id": "old-file",
+                "uri": "viking://user/alice/memories/notes/meeting.md",
+                "account_id": "acct",
+                "context_type": "memory",
+                "level": 2,
+                "abstract": "meeting",
+                "vector": [0.1, 0.2],
+            },
+            {
+                "id": "old-chunk",
+                "uri": "viking://user/alice/memories/notes/meeting.md#chunk_0000",
+                "account_id": "acct",
+                "context_type": "memory",
+                "level": 2,
+                "abstract": "chunk",
+                "vector": [0.3, 0.4],
+            },
+            {
+                "id": "old-hash-sibling",
+                "uri": "viking://user/alice/memories/notes/meeting.md#1.md",
+                "account_id": "acct",
+                "context_type": "memory",
+                "level": 2,
+                "abstract": "separate file",
+                "vector": [0.5, 0.6],
+            },
+        ]
+    )
+
+    result = await copy_vector_records(
+        store,
+        account_id="acct",
+        source_uri="viking://user/alice/memories/notes/meeting.md",
+        target_uri="viking://user/alice/memories/notes/archived.md",
+        recursive=False,
+    )
+
+    assert result.copied == 2
+    assert {record["uri"] for record in store.upserts} == {
+        "viking://user/alice/memories/notes/archived.md",
+        "viking://user/alice/memories/notes/archived.md#chunk_0000",
+    }
+
+
+@pytest.mark.asyncio
+async def test_delete_vector_records_keeps_hash_named_sibling():
+    store = FakeVectorStore(
+        [
+            {
+                "id": "old-file",
+                "uri": "viking://user/alice/memories/notes/meeting.md",
+                "account_id": "acct",
+                "vector": [0.1, 0.2],
+            },
+            {
+                "id": "old-chunk",
+                "uri": "viking://user/alice/memories/notes/meeting.md#chunk_0000",
+                "account_id": "acct",
+                "vector": [0.3, 0.4],
+            },
+            {
+                "id": "old-hash-sibling",
+                "uri": "viking://user/alice/memories/notes/meeting.md#1.md",
+                "account_id": "acct",
+                "vector": [0.5, 0.6],
+            },
+            {
+                # Unicode digits pass str.isdigit() but are not \d chunk indices
+                "id": "old-unicode-digit-sibling",
+                "uri": "viking://user/alice/memories/notes/meeting.md#chunk_²",
+                "account_id": "acct",
+                "vector": [0.7, 0.8],
+            },
+        ]
+    )
+
+    result = await delete_vector_records(
+        store,
+        account_id="acct",
+        uri="viking://user/alice/memories/notes/meeting.md",
+    )
+
+    assert result.deleted == 2
+    assert sorted(store.deleted_ids) == ["old-chunk", "old-file"]

--- a/tests/unit/test_path_safety.py
+++ b/tests/unit/test_path_safety.py
@@ -3,7 +3,11 @@
 
 import pytest
 
-from openviking.utils.path_safety import safe_join_viking_uri, sanitize_relative_viking_path
+from openviking.utils.path_safety import (
+    safe_join_viking_uri,
+    sanitize_relative_viking_path,
+    validate_safe_viking_uri_path,
+)
 
 
 def test_sanitize_relative_viking_path_normalizes_windows_separators():
@@ -73,3 +77,28 @@ def test_safe_join_viking_uri_preserves_posix_relative_path():
         )
         == "viking://user/default/skills/pdf/scripts/check_bounding_boxes.py"
     )
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "viking://resources/proj/notes#1.md",
+        "viking://user/u/memories/notes/meeting.md#chunk_0000",
+        "viking://resources/proj/dir#1/b.md",
+    ],
+)
+def test_validate_safe_viking_uri_path_allows_hash(uri):
+    assert validate_safe_viking_uri_path(uri) == uri
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "viking://resources/proj/notes?draft=1",
+        "viking://resources/proj/../secret.md",
+        "viking://resources/proj/%2e%2e/secret.md",
+    ],
+)
+def test_validate_safe_viking_uri_path_rejects_unsafe_uri(uri):
+    with pytest.raises(ValueError):
+        validate_safe_viking_uri_path(uri)


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

资源 URI 中 # 字符的处理在写入与读取链路之间存在不一致：

  - add 链路: 显式 to 目标不拒绝 #
  - write 链路: 对包含 # 的 URI 一律抛异常

目前出现能加不能改情况

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- 放开 write 对 URI 中 `#` 的拒绝:`validate_safe_viking_uri_path` 仅拒绝 `?`, write/batch-write/set_tags 与 add-resource 行为对齐,可更新带 `#` 名字的资源。
- 新增 `openviking/utils/chunk_uri.py` 作为 chunk URI 格式(`{base}#chunk_{idx:04d}`)的单一事实来源:生成、识别、查询预过滤均从同一模块派生。
- 将 prune 孤儿判定、parent_uri 计算、向量迁移 scope/改写、MCP 媒体后缀识别中的"含 `#` 即 chunk" 启发式收紧为结尾精确匹配 `#chunk_\d+`,消除文件名含 `#` 时的向量误删、parent 错算与媒体识别失效。

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

## Checklist

- [x] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
