### PR TITLE
perf(acl): batch filesystem access checks

### DIFF
--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -388,18 +388,13 @@ async def _format_search_result(result, *, service, ctx, read_content: bool = Fa
 
     contents: dict[str, str] = {}
     if read_content:
-        import asyncio
-
-        semaphore = asyncio.Semaphore(10)
-
-        async def _read(uri: str) -> None:
-            async with semaphore:
-                try:
-                    contents[uri] = await service.fs.read_visible(uri, ctx=ctx)
-                except Exception:
-                    pass
-
-        await asyncio.gather(*(_read(m.uri) for _, m in items))
+        uris = [m.uri for _, m in items]
+        read_results = await service.fs.read_visible_many(uris, ctx=ctx)
+        contents = {
+            uri: content
+            for uri, content in zip(uris, read_results, strict=True)
+            if isinstance(content, str)
+        }
 
     lines = []
     for ctx_type, m in items:
@@ -567,6 +562,16 @@ async def read(uris: str | list[str]) -> str | list[ContentBlock]:
                 media_total += size
         checked.append((resolved_uri, size, error))
 
+    preloaded_text: dict[str, str | Exception] = {}
+    text_uris = [
+        resolved_uri
+        for resolved_uri, size, error in checked
+        if error is None and size is None
+    ]
+    if len(text_uris) > 1:
+        text_results = await service.fs.read_visible_many(text_uris, ctx=ctx)
+        preloaded_text = dict(zip(text_uris, text_results, strict=True))
+
     async def _read_one(
         uri: str, prepared: tuple[str, Optional[int], Optional[str]]
     ) -> str | ContentBlock:
@@ -597,6 +602,13 @@ async def read(uris: str | list[str]) -> str | list[ContentBlock]:
                     if is_image:
                         return _mcp_image_content(data, mime_type)
                     return _mcp_audio_content(data, mime_type)
+                if resolved_uri in preloaded_text:
+                    preloaded = preloaded_text[resolved_uri]
+                    if isinstance(preloaded, OpenVikingError):
+                        return str(preloaded)
+                    if isinstance(preloaded, Exception):
+                        raise preloaded
+                    return preloaded
                 content = await service.fs.read_visible(resolved_uri, ctx=ctx)
                 return content
             except OpenVikingError as exc:

--- a/openviking/server/routers/search.py
+++ b/openviking/server/routers/search.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Search endpoints for OpenViking HTTP Server."""
 
-import asyncio
 import math
 from typing import Any, Dict, List, Literal, Optional, Sequence, Union
 
@@ -250,16 +249,11 @@ async def _inline_read_content(
         for hit in result.get(category, [])
         if isinstance(hit, dict) and isinstance(hit.get("uri"), str)
     ]
-    semaphore = asyncio.Semaphore(10)
-
-    async def _read(hit: Dict[str, Any]) -> None:
-        async with semaphore:
-            try:
-                hit["content"] = await service.fs.read_visible(hit["uri"], ctx=ctx)
-            except Exception:
-                pass
-
-    await asyncio.gather(*(_read(hit) for hit in hits))
+    uris = [hit["uri"] for hit in hits]
+    contents = await service.fs.read_visible_many(uris, ctx=ctx)
+    for hit, content in zip(hits, contents, strict=True):
+        if isinstance(content, str):
+            hit["content"] = content
     return result
 
 

--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -8,7 +8,7 @@ Provides file system operations: ls, mkdir, rm, mv, tree, stat, read, abstract, 
 
 import asyncio
 from collections.abc import Coroutine
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 
 from openviking.core.context import ContextLevel
 from openviking.core.namespace import classify_uri, context_type_for_uri, uri_leaf_name
@@ -27,7 +27,7 @@ from openviking.storage.abstract_overview import (
     plan_abstract_overview_refresh,
     render_abstract_overview,
 )
-from openviking.storage.acl import CreatorAclGrant
+from openviking.storage.acl import AclAction, CreatorAclGrant
 from openviking.storage.content_write import ContentWriteCoordinator
 from openviking.storage.expr import And, Eq, In, Or
 from openviking.storage.queuefs import SemanticMsg, get_queue_manager
@@ -41,7 +41,11 @@ from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.telemetry.resource_summary import build_queue_status_payload
 from openviking.utils.embedding_utils import vectorize_directory_meta
 from openviking.utils.tags import normalize_search_tags
-from openviking_cli.exceptions import DeadlineExceededError, NotInitializedError
+from openviking_cli.exceptions import (
+    DeadlineExceededError,
+    NotInitializedError,
+    PermissionDeniedError,
+)
 from openviking_cli.utils import VikingURI, get_logger
 from openviking_cli.utils.config import get_openviking_config
 
@@ -872,12 +876,24 @@ class FSService:
     async def read(self, uri: str, ctx: RequestContext, offset: int = 0, limit: int = -1) -> str:
         """Read file content. Accepts a Viking URI or a 32-char hex vector record id."""
         viking_fs = self._ensure_initialized()
-        # Resolve ids to URIs so that downstream helpers (get_skill_name_from_uri)
-        # always see a real viking:// URI. VikingFS.read_file also resolves, which
-        # is harmless defense-in-depth when the input was already a URI.
         resolved_uri = await self._resolve_uri(uri, ctx)
         content = await viking_fs.read_file(resolved_uri, ctx=ctx)
-        skill_name = get_skill_name_from_uri(resolved_uri)
+        content = await self._apply_read_privacy(resolved_uri, content, ctx)
+
+        if offset == 0 and limit == -1:
+            return content
+        lines = content.splitlines(keepends=True)
+        sliced = lines[offset:] if limit == -1 else lines[offset : offset + limit]
+        return "".join(sliced)
+
+    async def _apply_read_privacy(
+        self,
+        uri: str,
+        content: str,
+        ctx: RequestContext,
+    ) -> str:
+        """Restore configured private skill values before public visibility filtering."""
+        skill_name = get_skill_name_from_uri(uri)
         if skill_name and self._privacy_config_service:
             current = await self._privacy_config_service.get_current(
                 ctx=ctx,
@@ -886,12 +902,46 @@ class FSService:
             )
             if current:
                 content = restore_skill_content(content, skill_name, current.values)
+        return content
 
-        if offset == 0 and limit == -1:
-            return content
-        lines = content.splitlines(keepends=True)
-        sliced = lines[offset:] if limit == -1 else lines[offset : offset + limit]
-        return "".join(sliced)
+    async def read_visible_many(
+        self,
+        uris: List[str],
+        ctx: RequestContext,
+    ) -> List[Union[str, Exception]]:
+        """Read visible content with one batched READ authorization.
+
+        Results preserve input order. Per-item failures are returned as exception
+        objects so callers can preserve partial-success behavior.
+        """
+        if not uris:
+            return []
+
+        viking_fs = self._ensure_initialized()
+        unique_uris = list(dict.fromkeys(uris))
+        try:
+            access = await viking_fs._can_access_many(unique_uris, ctx, action=AclAction.READ)
+        except Exception as exc:
+            return [exc for _ in uris]
+
+        semaphore = asyncio.Semaphore(10)
+
+        async def _read_one(uri: str) -> Union[str, Exception]:
+            if not access.get(uri, False):
+                return PermissionDeniedError(f"Access denied for {uri}", resource=uri)
+            try:
+                async with semaphore:
+                    content = await viking_fs._read_file_authorized(uri, ctx=ctx)
+                    content = await self._apply_read_privacy(uri, content, ctx)
+                    if classify_uri(uri).is_memory:
+                        content = visible_content(content, uri=uri)
+                    return content
+            except Exception as exc:
+                return exc
+
+        unique_results = await asyncio.gather(*(_read_one(uri) for uri in unique_uris))
+        result_by_uri = dict(zip(unique_uris, unique_results, strict=True))
+        return [result_by_uri[uri] for uri in uris]
 
     async def read_visible(
         self,

--- a/openviking/storage/viking_fs/_access.py
+++ b/openviking/storage/viking_fs/_access.py
@@ -552,6 +552,7 @@ class _AccessMixin:
             raw_limit = max(node_limit * self._TREE_OVERFETCH_FACTOR, node_limit)
         acl_enabled = self._acl_enabled(real_ctx)
 
+        access_by_uri: Dict[str, bool] = {}
         while True:
             raw_entries = await self._async_agfs.tree_directory(
                 path,
@@ -584,9 +585,12 @@ class _AccessMixin:
             if not acl_enabled:
                 visible = candidates
             else:
-                access = await self._can_access_many(
-                    [entry_uri for _, entry_uri in candidates], real_ctx
-                )
+                pending_uris = [
+                    entry_uri for _, entry_uri in candidates if entry_uri not in access_by_uri
+                ]
+                if pending_uris:
+                    access_by_uri.update(await self._can_access_many(pending_uris, real_ctx))
+                access = access_by_uri
                 if expose_resource_names:
                     denied_directories = {
                         entry["path"].rstrip("/")

--- a/openviking/storage/viking_fs/_grep.py
+++ b/openviking/storage/viking_fs/_grep.py
@@ -60,10 +60,10 @@ class _GrepMixin:
         Returns:
             Dict with matches, count, match_count, files_scanned
         """
-        await self._ensure_access(uri, ctx)
         # Skip vector_store.count() — the count field is not needed for grep,
-        # and avoiding it saves one VikingDB API call.
-        await self.stat(uri, ctx=ctx, skip_count=True)
+        # and avoiding it saves one VikingDB API call. stat() also owns the
+        # root READ check, so grep must not check the same URI first.
+        root_stat = await self.stat(uri, ctx=ctx, skip_count=True)
 
         # Read engine and threshold from grep_config (ov.conf)
         engine = self.grep_config.engine if self.grep_config else "auto"
@@ -114,6 +114,7 @@ class _GrepMixin:
                 ctx=ctx,
                 content_transform=content_transform,
                 allowed_uris=allowed_uris,
+                root_is_dir=bool(root_stat.get("isDir", False)),
             )
         else:  # "vikingdb_then_fs"
             result = await self._grep_vikingdb_then_fs(
@@ -233,6 +234,7 @@ class _GrepMixin:
         ctx,
         content_transform=None,
         allowed_uris=None,
+        root_is_dir: Optional[bool] = None,
     ):
         """Filesystem grep path: prefer native agfs grep and fall back if unavailable."""
         if content_transform is None and allowed_uris is None:
@@ -259,6 +261,7 @@ class _GrepMixin:
             ctx=ctx,
             content_transform=content_transform,
             allowed_uris=allowed_uris,
+            root_is_dir=root_is_dir,
         )
 
     async def _grep_vikingdb_then_fs(
@@ -424,14 +427,17 @@ class _GrepMixin:
         """Execute regex matching in specified file list (vikingdb_then_fs Step 2)."""
         flags = re.IGNORECASE if case_insensitive else 0
         compiled = re.compile(pattern, flags)
+        access = await self._can_access_many(file_uris, ctx)
 
         results = []
         files_scanned = 0
 
         for file_uri in file_uris:
+            if not access.get(file_uri, False):
+                continue
             files_scanned += 1
             try:
-                content_bytes = await self.read(file_uri, ctx=ctx)
+                content_bytes = await self._read_authorized(file_uri, ctx=ctx)
                 content = content_bytes.decode("utf-8", errors="replace")
             except Exception:
                 continue
@@ -510,6 +516,14 @@ class _GrepMixin:
             raise
 
         matches = result.get("matches", [])
+        match_uris = []
+        for match in matches:
+            match_file = match.get("file", "")
+            if not match_file:
+                continue
+            match_path = self._resolve_grep_match_agfs_path(path, match_file)
+            match_uris.append(self._path_to_uri(match_path, ctx=ctx))
+        access = await self._can_access_many(match_uris, ctx)
         results = []
         files_scanned_set = set()
         real_ctx = self._ctx_or_default(ctx)
@@ -522,7 +536,7 @@ class _GrepMixin:
             agfs_file_path = self._resolve_grep_match_agfs_path(path, match_file)
 
             file_uri = self._path_to_uri(agfs_file_path, ctx=ctx)
-            if not self._is_accessible(file_uri, real_ctx):
+            if not access.get(file_uri, False):
                 continue
 
             files_scanned_set.add(file_uri)
@@ -566,6 +580,7 @@ class _GrepMixin:
         ctx: Optional[RequestContext] = None,
         content_transform: Optional[Callable[[str, str], str]] = None,
         allowed_uris: Optional[Set[str]] = None,
+        root_is_dir: Optional[bool] = None,
     ) -> Dict:
         """Grep implementation for encrypted files.
 
@@ -596,6 +611,7 @@ class _GrepMixin:
             level_limit=level_limit,
             ctx=ctx,
             allowed_uris=allowed_uris,
+            root_is_dir=root_is_dir,
         )
         results, files_scanned = await self._grep_files_parallel(
             file_uris,
@@ -619,6 +635,7 @@ class _GrepMixin:
         level_limit: int,
         ctx: Optional[RequestContext] = None,
         allowed_uris: Optional[Set[str]] = None,
+        root_is_dir: Optional[bool] = None,
     ) -> List[str]:
         file_uris: List[str] = []
 
@@ -640,6 +657,8 @@ class _GrepMixin:
                 return
 
             for entry in entries:
+                if entry.get("access") == "denied":
+                    continue
                 entry_uri = f"{normalized_current_uri.rstrip('/')}/{entry['name']}"
                 if excluded_prefix and (
                     entry_uri == excluded_prefix or entry_uri.startswith(excluded_prefix + "/")
@@ -658,11 +677,13 @@ class _GrepMixin:
         ):
             logger.debug(f"Skipping excluded uri during grep: {normalized_uri}")
             return file_uris
-        try:
-            root_stat = await self.stat(normalized_uri, ctx=ctx)
-        except Exception:
-            return file_uris
-        if not root_stat.get("isDir", False):
+        if root_is_dir is None:
+            try:
+                root_stat = await self.stat(normalized_uri, ctx=ctx, skip_count=True)
+            except Exception:
+                return file_uris
+            root_is_dir = bool(root_stat.get("isDir", False))
+        if not root_is_dir:
             if allowed_uris is None or normalized_uri in allowed_uris:
                 file_uris.append(normalized_uri)
             return file_uris
@@ -710,7 +731,7 @@ class _GrepMixin:
         content_transform: Optional[Callable[[str, str], str]] = None,
     ) -> tuple[List[Dict[str, Any]], int]:
         try:
-            content = await self.read(entry_uri, ctx=ctx)
+            content = await self._read_authorized(entry_uri, ctx=ctx)
             if isinstance(content, bytes):
                 content = content.decode("utf-8", errors="replace")
             if content_transform is not None:

--- a/openviking/storage/viking_fs/_ops.py
+++ b/openviking/storage/viking_fs/_ops.py
@@ -85,6 +85,17 @@ class _OpsMixin:
         real_ctx = self._ctx_or_default(ctx)
         uri = await self.resolve_uri(uri, real_ctx)
         await self._ensure_access(uri, ctx)
+        return await self._read_authorized(uri, offset=offset, size=size, ctx=ctx)
+
+    async def _read_authorized(
+        self,
+        uri: str,
+        offset: int = 0,
+        size: int = -1,
+        ctx: Optional[RequestContext] = None,
+    ) -> bytes:
+        """Read a file URI whose READ access was already established by the caller."""
+        real_ctx = self._ctx_or_default(ctx)
         primary_path = self._uri_to_path(uri, ctx=ctx)
 
         # Decryption + offset/size slicing now happen inside the ragfs encryption layer
@@ -595,8 +606,7 @@ class _OpsMixin:
         acl_enabled = self._acl_enabled(ctx)
         guard_ctx = replace(self._ctx_or_default(ctx), bypass_acl=True)
         await self._ensure_access(old_uri, guard_ctx, action=AclAction.MANAGE)
-        await self._ensure_access(old_uri, ctx, action=AclAction.WRITE)
-        await self._ensure_access(new_uri, ctx, action=AclAction.WRITE)
+        await self._ensure_access_many([old_uri, new_uri], ctx, action=AclAction.WRITE)
         old_scope = old_uri.rstrip("/")
         new_scope = new_uri.rstrip("/")
         if old_scope == new_scope:
@@ -995,10 +1005,10 @@ class _OpsMixin:
         ctx: Optional[RequestContext] = None,
         lease_ref: Dict[str, Any] | None = None,
     ) -> None:
-        """Copy one file through VikingFS read/write hooks without deleting source."""
-        content_bytes = await self.read_file_bytes(from_uri, ctx=ctx)
+        """Copy one file after the caller authorized source and destination."""
+        content_bytes = await self._read_file_bytes_authorized(from_uri, ctx=ctx)
         if lease_ref is None:
-            await self.write_file_bytes(to_uri, content_bytes, ctx=ctx)
+            await self._write_file_bytes_authorized(to_uri, content_bytes, ctx=ctx)
             return
 
         child_path = self._uri_to_path(to_uri, ctx=ctx)
@@ -1007,7 +1017,9 @@ class _OpsMixin:
             owner_lease_ref=lease_ref,
         )
         try:
-            await self.write_file_bytes(to_uri, content_bytes, ctx=ctx, lease_ref=child_lease)
+            await self._write_file_bytes_authorized(
+                to_uri, content_bytes, ctx=ctx, lease_ref=child_lease
+            )
         finally:
             await self._async_agfs.pathlock_release(child_lease)
 
@@ -1244,11 +1256,11 @@ class _OpsMixin:
         abs_limit: int,
         ctx: Optional[RequestContext] = None,
     ) -> None:
-        """Batch fetch abstracts for entries using a fixed-size worker pool.
+        """Fetch abstracts for already-authorized entries with a worker pool.
 
         Non-directory entries receive an empty abstract immediately.
-        Directory entries are processed concurrently via a worker pool,
-        using _read_abstract_for_known_dir to skip redundant stat() calls.
+        Directory entries are processed concurrently without repeating the
+        access and stat checks already completed while listing the entries.
 
         Args:
             entries: List of entries to fetch abstracts for
@@ -1544,6 +1556,23 @@ class _OpsMixin:
         concurrently (e.g. unique-per-request shared upload directories).
         """
         await self._ensure_access(uri, ctx, action=AclAction.WRITE)
+        await self._write_file_authorized(
+            uri,
+            content,
+            ctx=ctx,
+            lease_ref=lease_ref,
+            auto_pathlock=auto_pathlock,
+        )
+
+    async def _write_file_authorized(
+        self,
+        uri: str,
+        content: Union[str, bytes],
+        ctx: Optional[RequestContext] = None,
+        lease_ref: Dict[str, Any] | None = None,
+        auto_pathlock: bool = True,
+    ) -> None:
+        """Write a file URI whose WRITE access was already established by the caller."""
         path = self._uri_to_path(uri, ctx=ctx)
         await self._ensure_parent_dirs(path, ctx=ctx, lease_ref=lease_ref)
 
@@ -1577,6 +1606,17 @@ class _OpsMixin:
         real_ctx = self._ctx_or_default(ctx)
         uri = await self.resolve_uri(uri, real_ctx)
         await self._ensure_access(uri, ctx)
+        return await self._read_file_authorized(uri, offset=offset, limit=limit, ctx=ctx)
+
+    async def _read_file_authorized(
+        self,
+        uri: str,
+        offset: int = 0,
+        limit: int = -1,
+        ctx: Optional[RequestContext] = None,
+    ) -> str:
+        """Read a text file URI whose READ access was already established by the caller."""
+        real_ctx = self._ctx_or_default(ctx)
         primary_path = self._uri_to_path(uri, ctx=ctx)
         # Verify the file exists before reading, because AGFS read returns
         # empty bytes for non-existent files instead of raising an error.
@@ -1628,6 +1668,15 @@ class _OpsMixin:
         real_ctx = self._ctx_or_default(ctx)
         uri = await self.resolve_uri(uri, real_ctx)
         await self._ensure_access(uri, ctx)
+        return await self._read_file_bytes_authorized(uri, ctx=ctx)
+
+    async def _read_file_bytes_authorized(
+        self,
+        uri: str,
+        ctx: Optional[RequestContext] = None,
+    ) -> bytes:
+        """Read a binary file whose READ access was established by the caller."""
+        real_ctx = self._ctx_or_default(ctx)
         primary_path = self._uri_to_path(uri, ctx=ctx)
         last_not_found: Optional[Exception] = None
         for path in self._read_paths(uri, ctx=ctx):
@@ -1669,6 +1718,23 @@ class _OpsMixin:
         concurrently (e.g. unique-per-request shared upload directories).
         """
         await self._ensure_access(uri, ctx, action=AclAction.WRITE)
+        await self._write_file_bytes_authorized(
+            uri,
+            content,
+            ctx=ctx,
+            lease_ref=lease_ref,
+            auto_pathlock=auto_pathlock,
+        )
+
+    async def _write_file_bytes_authorized(
+        self,
+        uri: str,
+        content: bytes,
+        ctx: Optional[RequestContext] = None,
+        lease_ref: Dict[str, Any] | None = None,
+        auto_pathlock: bool = True,
+    ) -> None:
+        """Write bytes to a URI whose WRITE access was established by the caller."""
         path = self._uri_to_path(uri, ctx=ctx)
         await self._ensure_parent_dirs(path, ctx=ctx, lease_ref=lease_ref)
 
@@ -2030,8 +2096,7 @@ class _OpsMixin:
         ctx: Optional[RequestContext] = None,
     ) -> None:
         """Move file."""
-        await self._ensure_access(from_uri, ctx, action=AclAction.WRITE)
-        await self._ensure_access(to_uri, ctx, action=AclAction.WRITE)
+        await self._ensure_access_many([from_uri, to_uri], ctx, action=AclAction.WRITE)
         from_path = self._uri_to_path(from_uri, ctx=ctx)
 
         await self._copy_file_through_vikingfs(from_uri, to_uri, ctx=ctx)

--- a/openviking/storage/viking_fs/_semantic.py
+++ b/openviking/storage/viking_fs/_semantic.py
@@ -56,10 +56,10 @@ class _SemanticMixin:
     ) -> str:
         """Read .abstract.md for a directory that is already known to be a directory.
 
-        Bypasses stat() and isDir check. Caller (i.e. _batch_fetch_abstracts)
-        must guarantee that the URI points to a directory.
+        Bypasses access, stat(), and isDir checks. Caller (i.e.
+        _batch_fetch_abstracts) must guarantee that the URI is accessible and
+        points to a directory.
         """
-        await self._ensure_access(uri, ctx)
         real_ctx = self._ctx_or_default(ctx)
         primary_path = self._uri_to_path(uri, ctx=ctx)
         for path in self._read_paths(uri, ctx=ctx):
@@ -440,25 +440,13 @@ class _SemanticMixin:
     ) -> None:
         """Write context to AGFS (L0/L1/L2)."""
 
-        await self._ensure_access(uri, ctx, action=AclAction.WRITE)
-        path = self._uri_to_path(uri, ctx=ctx)
-
-        try:
-            await self._ensure_parent_dirs(path, ctx=ctx)
-            try:
-                await self._async_agfs.mkdir(path)
-            except Exception as e:
-                if "exist" not in str(e).lower():
-                    raise
-
-            if content:
-                content_uri = f"{uri}/{content_filename}"
-                await self.write_file(content_uri, content, ctx=ctx)
-
-            if abstract:
-                abstract_uri = f"{uri}/.abstract.md"
-                await self.write_file(
-                    abstract_uri,
+        writes: List[tuple[str, Union[str, bytes]]] = []
+        if content:
+            writes.append((f"{uri}/{content_filename}", content))
+        if abstract:
+            writes.append(
+                (
+                    f"{uri}/.abstract.md",
                     render_abstract_overview(
                         ContextLevel.ABSTRACT,
                         uri,
@@ -470,13 +458,12 @@ class _SemanticMixin:
                             }
                         },
                     ),
-                    ctx=ctx,
                 )
-
-            if overview:
-                overview_uri = f"{uri}/.overview.md"
-                await self.write_file(
-                    overview_uri,
+            )
+        if overview:
+            writes.append(
+                (
+                    f"{uri}/.overview.md",
                     render_abstract_overview(
                         ContextLevel.OVERVIEW,
                         uri,
@@ -488,8 +475,26 @@ class _SemanticMixin:
                             }
                         },
                     ),
-                    ctx=ctx,
                 )
+            )
+
+        await self._ensure_access_many(
+            [uri, *(target_uri for target_uri, _ in writes)],
+            ctx,
+            action=AclAction.WRITE,
+        )
+        path = self._uri_to_path(uri, ctx=ctx)
+
+        try:
+            await self._ensure_parent_dirs(path, ctx=ctx)
+            try:
+                await self._async_agfs.mkdir(path)
+            except Exception as e:
+                if "exist" not in str(e).lower():
+                    raise
+
+            for target_uri, value in writes:
+                await self._write_file_authorized(target_uri, value, ctx=ctx)
 
         except Exception as e:
             logger.error(f"[VikingFS] Failed to write {uri}: {e}")

--- a/tests/misc/test_vikingfs_uri_guard.py
+++ b/tests/misc/test_vikingfs_uri_guard.py
@@ -313,6 +313,7 @@ class TestVikingFSURITraversalGuard:
         fs = _make_viking_fs()
         fs._encryptor = None
         fs._ensure_access = AsyncMock()
+        fs.stat = AsyncMock(return_value={"isDir": True})
         fs._grep_with_agfs = AsyncMock(side_effect=AGFSInvalidOperationError("invalid regex"))
         fs._grep_encrypted = AsyncMock(
             return_value={"matches": [], "count": 0, "match_count": 0, "files_scanned": 0}

--- a/tests/server/test_api_search.py
+++ b/tests/server/test_api_search.py
@@ -62,9 +62,9 @@ async def test_find_basic(client_with_resource):
 async def test_search_endpoints_inline_visible_content_when_requested(
     client: httpx.AsyncClient, service, monkeypatch, endpoint: str
 ):
-    async def fake_read_visible(uri, *, ctx):
+    async def fake_read_visible_many(uris, *, ctx):
         assert ctx is not None
-        return f"visible content for {uri}"
+        return [f"visible content for {uri}" for uri in uris]
 
     async def fake_search(**kwargs):
         del kwargs
@@ -79,7 +79,7 @@ async def test_search_endpoints_inline_visible_content_when_requested(
             skills=[],
         )
 
-    monkeypatch.setattr(service.fs, "read_visible", fake_read_visible)
+    monkeypatch.setattr(service.fs, "read_visible_many", fake_read_visible_many)
     monkeypatch.setattr(
         service.search, "find" if endpoint.endswith("/find") else "search", fake_search
     )
@@ -111,8 +111,8 @@ async def test_find_omits_content_when_read_is_not_requested(
     monkeypatch.setattr(service.search, "find", fake_search)
     monkeypatch.setattr(
         service.fs,
-        "read_visible",
-        lambda *args, **kwargs: pytest.fail("read_visible must not be called"),
+        "read_visible_many",
+        lambda *args, **kwargs: pytest.fail("read_visible_many must not be called"),
     )
 
     response = await client.post("/api/v1/search/find", json={"query": "visible"})
@@ -124,9 +124,9 @@ async def test_find_omits_content_when_read_is_not_requested(
 async def test_find_keeps_hit_without_content_when_read_fails(
     client: httpx.AsyncClient, service, monkeypatch
 ):
-    async def fake_read_visible(uri, *, ctx):
-        del uri, ctx
-        raise RuntimeError("unavailable")
+    async def fake_read_visible_many(uris, *, ctx):
+        del ctx
+        return [RuntimeError("unavailable") for _ in uris]
 
     async def fake_find(**kwargs):
         del kwargs
@@ -141,7 +141,7 @@ async def test_find_keeps_hit_without_content_when_read_fails(
             skills=[],
         )
 
-    monkeypatch.setattr(service.fs, "read_visible", fake_read_visible)
+    monkeypatch.setattr(service.fs, "read_visible_many", fake_read_visible_many)
     monkeypatch.setattr(service.search, "find", fake_find)
 
     response = await client.post(

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -323,13 +323,13 @@ async def test_find_tool_inlines_visible_content_when_requested(service, monkeyp
             skills=[],
         )
 
-    async def fake_read_visible(uri, *, ctx):
-        assert uri == "viking://resources/visible.md"
+    async def fake_read_visible_many(uris, *, ctx):
+        assert uris == ["viking://resources/visible.md"]
         assert ctx == DEFAULT_CTX
-        return "full visible content"
+        return ["full visible content"]
 
     monkeypatch.setattr(service.search, "find", fake_find)
-    monkeypatch.setattr(service.fs, "read_visible", fake_read_visible)
+    monkeypatch.setattr(service.fs, "read_visible_many", fake_read_visible_many)
 
     result = await mcp_endpoint.find(query="visible", read_content=True)
 

--- a/tests/service/test_fs_service.py
+++ b/tests/service/test_fs_service.py
@@ -11,6 +11,7 @@ import pytest
 
 from openviking.server.identity import RequestContext, Role
 from openviking.service.fs_service import FSService
+from openviking.storage.acl import AclAction
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -205,12 +206,26 @@ def request_context():
 @pytest.mark.asyncio
 async def test_read_visible_strips_memory_metadata_before_slicing(request_context):
     raw = 'line one\nline two\n\n<!-- MEMORY_FIELDS\n{"secret":"hidden"}\n-->'
-    viking_fs = SimpleNamespace(read_file=AsyncMock(return_value=raw))
-    service = FSService(viking_fs=viking_fs)
     uri = "viking://user/ryoma/memories/notes/private.md"
+    second_uri = "viking://user/ryoma/memories/notes/second.md"
+    viking_fs = SimpleNamespace(
+        read_file=AsyncMock(return_value=raw),
+        _can_access_many=AsyncMock(return_value={uri: True, second_uri: True}),
+        _read_file_authorized=AsyncMock(return_value=raw),
+    )
+    service = FSService(viking_fs=viking_fs)
 
     assert await service.read_visible(uri, ctx=request_context, offset=3, limit=1) == ""
     viking_fs.read_file.assert_awaited_once_with(uri, ctx=request_context)
+
+    assert await service.read_visible_many([uri, second_uri], ctx=request_context) == [
+        "line one\nline two",
+        "line one\nline two",
+    ]
+    viking_fs._can_access_many.assert_awaited_once_with(
+        [uri, second_uri], request_context, action=AclAction.READ
+    )
+    assert viking_fs._read_file_authorized.await_count == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/storage/test_viking_fs_grep.py
+++ b/tests/storage/test_viking_fs_grep.py
@@ -361,6 +361,7 @@ async def test_grep_preserves_dfs_order_and_node_limit(monkeypatch):
                 {"name": "dir_b", "isDir": True},
             ],
             "viking://resources/dir_a": [
+                {"name": "denied.md", "isDir": False, "access": "denied"},
                 {"name": "a1.md", "isDir": False},
                 {"name": "a2.md", "isDir": False},
             ],
@@ -602,7 +603,7 @@ async def test_grep_stops_scheduling_later_batches_after_node_limit(monkeypatch)
 
     assert result["count"] == 2
     assert result["files_scanned"] == 1
-    assert read_paths == ["/resources/file0.md", "/resources/file1.md"]
+    assert set(read_paths) == {"/resources/file0.md", "/resources/file1.md"}
 
 
 @pytest.mark.asyncio

--- a/tests/storage/test_viking_fs_tree.py
+++ b/tests/storage/test_viking_fs_tree.py
@@ -347,21 +347,22 @@ async def test_iter_visible_tree_entries_node_limit_after_acl(monkeypatch, fs):
 @pytest.mark.asyncio
 async def test_iter_visible_tree_entries_refetch_when_under_limit(monkeypatch, fs):
     """PY-ITER-004: when ACL filtering leaves too few visible entries and Rust
-    returned a full page, the raw limit is doubled and re-fetched (zero-regression
-    bounded over-fetch)."""
+    returned a full page, the raw limit is doubled without rechecking entries
+    already authorized in the first page."""
     factor = fs._TREE_OVERFETCH_FACTOR
     node_limit = 2
     # First page (size == raw_limit) is entirely invisible; second page after
     # doubling contains the visible entries.
     invisible = [
-        make_entry(f"/local/test_account/resources/h{i}/x", "x", is_dir=False)
+        make_entry(f"/local/test_account/user/default/h{i}/x", "x", is_dir=False)
         for i in range(node_limit * factor)
     ]
     visible = [
-        make_entry(f"/local/test_account/resources/v{i}", f"v{i}", is_dir=False)
+        make_entry(f"/local/test_account/user/default/v{i}", f"v{i}", is_dir=False)
         for i in range(node_limit)
     ]
     captured_limits = []
+    access_batches = []
 
     async def fake_tree_directory(_path, **kwargs):
         raw_limit = kwargs.get("node_limit")
@@ -372,15 +373,22 @@ async def test_iter_visible_tree_entries_refetch_when_under_limit(monkeypatch, f
             return invisible[:raw_limit]
         return invisible + visible
 
-    def fake_is_accessible(uri, _ctx):
-        # Entries under an "hN" directory are invisible (ACL denied).
-        return "/h" not in uri
+    async def fake_can_access_many(uris, _ctx):
+        access_batches.append(list(uris))
+        return {uri: "/h" not in uri for uri in uris}
 
-    patch_tree_env(monkeypatch, fs, fake_tree_directory, is_accessible=fake_is_accessible)
+    patch_tree_env(
+        monkeypatch,
+        fs,
+        fake_tree_directory,
+        uri_to_path="/local/test_account/user/default",
+    )
+    fs.acl_manager = SimpleNamespace(is_enabled=lambda _account_id: True)
+    monkeypatch.setattr(fs, "_can_access_many", fake_can_access_many)
 
     results = []
     async for entry, _uri in fs._iter_visible_tree_entries(
-        "viking://resources", node_limit=node_limit, ctx=_default_ctx()
+        "viking://user/default", node_limit=node_limit, ctx=_default_ctx()
     ):
         results.append(entry)
 
@@ -388,6 +396,10 @@ async def test_iter_visible_tree_entries_refetch_when_under_limit(monkeypatch, f
     # Re-fetch happened: first raw_limit = node_limit*factor, then doubled.
     assert captured_limits[0] == node_limit * factor
     assert captured_limits[1] == node_limit * factor * 2
+    assert access_batches == [
+        [f"viking://user/default/h{i}/x" for i in range(node_limit * factor)],
+        [f"viking://user/default/v{i}" for i in range(node_limit)],
+    ]
 
 
 @pytest.mark.asyncio
@@ -661,19 +673,34 @@ async def test_ls_agent_modtime_is_raw_utc_iso(monkeypatch, fs):
 
 @pytest.mark.asyncio
 async def test_tree_agent_abs_limit_truncation(monkeypatch, fs):
-    """PY-AGENT-005: abstract is truncated when exceeding abs_limit."""
+    """PY-AGENT-005: reuse batched access and truncate long abstracts."""
     entries = [make_entry("/local/test_account/resources/sub", "sub", is_dir=True)]
+    access_batches = []
 
-    async def fake_batch_fetch(entries_arg, abs_limit, **_kwargs):
-        for entry in entries_arg:
-            abstract = "x" * (abs_limit + 10) if entry.get("isDir") else ""
-            if len(abstract) > abs_limit:
-                abstract = abstract[: abs_limit - 3] + "..."
-            entry["abstract"] = abstract
+    async def fake_can_access_many(uris, _ctx):
+        access_batches.append(list(uris))
+        return dict.fromkeys(uris, True)
 
-    patch_tree_env(monkeypatch, fs, entries, batch_fetch=fake_batch_fetch)
+    async def always_visible(*_args, **_kwargs):
+        return True
+
+    async def fake_read_abstract_file(*_args, **_kwargs):
+        return "x" * 20
+
+    patch_tree_env(monkeypatch, fs, entries)
+    fs.acl_manager = SimpleNamespace(is_enabled=lambda _account_id: True)
+    monkeypatch.setattr(fs, "_can_access_many", fake_can_access_many)
+    monkeypatch.setattr(
+        fs,
+        "_read_paths",
+        lambda _uri, **_kwargs: ["/local/test_account/resources/sub"],
+    )
+    monkeypatch.setattr(fs, "_read_path_visible", always_visible)
+    monkeypatch.setattr(fs, "_agfs_path_exists", always_visible)
+    monkeypatch.setattr(fs, "_read_abstract_file", fake_read_abstract_file)
 
     result = await fs._tree_agent("viking://resources", abs_limit=10, ctx=_default_ctx())
+    assert access_batches == [["viking://resources/sub"]]
     assert len(result[0]["abstract"]) <= 10
     assert result[0]["abstract"].endswith("...")
 


### PR DESCRIPTION
## Description

ACL 引入后，多资源操作虽然是一个用户请求，但每个文件会各自重新做一次权限解析，导致 vector backend 请求量被结果数放大。

### Before

同一个 `find` 请求：`limit=10`、`read_content=true`，返回 10 个不同 URI 时，会逐个调用 `read_visible()`，产生最多 10 次独立 ACL backend 查询。MCP 批量 `read`、grep 候选文件读取、tree/ls 摘要读取也存在类似的重复校验。

流程：`find -> N 次 read_visible -> N 次单 URI ACL 查询 -> N 次文件读取`

### After

同一个请求先对去重后的 URI 做一次 `_can_access_many()`，随后只对已授权项读取内容，不再在每个文件读取时重复访问 ACL backend。

流程：`find -> 1 次 read_visible_many -> 1 次批量 ACL 查询 -> N 次文件读取`

这次改动不在 `RequestContext` 中增加 ACL cache。公开读写入口仍然自行校验权限；只有已经完成批量校验的内部路径才使用 authorized helper。

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

相关 ACL 实现：[PR #3213](https://github.com/volcengine/OpenViking/pull/3213)

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made

- `find/search` 的 `read_content=true` 和 MCP 多文件 `read` 改为批量 READ 校验，并保持原有逐项失败语义和最多 10 个并发读取。
- tree/ls 复用列表阶段的权限结果；tree 扩容重取时只校验新增 URI；grep 对候选和 native match URI 统一批量校验。
- mv、move_file 和 semantic context 写入合并 WRITE/MANAGE 校验，已授权的内部读写不再重复查询 ACL backend。

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

验证结果：

- 160 个 ACL、FSService、tree、grep、mv、locking 和 record ID 测试通过
- 7 个 HTTP find/search 与 MCP read 聚焦测试通过
- Python 语法检查、Ruff 和 `git diff --check` 通过

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

本 PR 只合并同一次操作内已知 URI 的权限查询，不改变 ACL 判定规则、find 召回逻辑或公开 API 返回结构。
