### PR TITLE
fix(memory): warn when extract loop exhausts iterations

### DIFF
--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -711,6 +711,12 @@ class SessionCompressorV3:
             tracer.info("[v3_patch_merge] No memory operations generated")
             return _V3ExtractionResult()
 
+        if operations.has_errors():
+            logger.warning(
+                "Memory extraction completed with errors (may look like Extracted 0): %s",
+                operations.errors,
+            )
+
         # Attach caller-provided custom scalar tags to event memories so they
         # ride the same first write into the vector index (人填标量).
         _apply_event_search_tags(operations, event_search_tags)

--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -409,8 +409,13 @@ The final output of the model must strictly follow the JSON Schema format shown 
                     f"after {max_iterations} iterations — treating as no operations "
                     f"failure_kind={failure_kind} response_preview={failure_preview!r}"
                 )
+                # Prefer application logs for operator visibility; keep tracer as a
+                # short breadcrumb to avoid duplicate full lines in shared backends.
                 logger.warning(msg)
-                tracer.error(msg)
+                tracer.error(
+                    "Memory extraction exhausted iterations without parseable operations "
+                    f"failure_kind={failure_kind}"
+                )
                 final_operations = ResolvedOperations(
                     upsert_operations=[],
                     delete_file_contents=[],

--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -402,11 +402,15 @@ The final output of the model must strictly follow the JSON Schema format shown 
                         console=True,
                     )
                     break
-                tracer.info(
+                # Surface exhaustion as a warning so silent "Extracted 0" is not
+                # indistinguishable from a healthy empty extraction (#4486).
+                msg = (
                     "Memory extraction final response could not be parsed as JSON operations "
                     f"after {max_iterations} iterations — treating as no operations "
                     f"failure_kind={failure_kind} response_preview={failure_preview!r}"
                 )
+                logger.warning(msg)
+                tracer.error(msg)
                 final_operations = ResolvedOperations(
                     upsert_operations=[],
                     delete_file_contents=[],

--- a/tests/session/memory/test_memory_react.py
+++ b/tests/session/memory/test_memory_react.py
@@ -4,7 +4,7 @@
 Tests for memory ExtractLoop orchestrator.
 """
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import BaseModel, Field
@@ -503,3 +503,82 @@ class TestExtractLoopFinalJsonRetry:
         assert "only if every substantive fact is in scope" in initial_system_prompt
         assert "otherwise MUST use DELETE blocks" in initial_system_prompt
         assert "not inferring scope from the file name/topic" in initial_system_prompt
+
+    @pytest.mark.asyncio
+    async def test_exhaustion_warns_with_failure_kind_and_short_tracer(self):
+        """Lock #4486 visibility: full warning + short tracer breadcrumb on exhaustion."""
+
+        class FakeVLM:
+            model = "test-model"
+
+            async def get_completion_async(self, **kwargs):
+                return "this is not json"
+
+        class FakeContextProvider:
+            read_file_contents = {}
+
+            def get_memory_schemas(self, ctx):
+                return [
+                    MemoryTypeSchema(
+                        memory_type="preferences",
+                        description="Preferences",
+                        directory="viking://user/{user_space}/memories/preferences",
+                        filename_template="{topic}.md",
+                        fields=[],
+                    )
+                ]
+
+            def get_tools(self):
+                return []
+
+            def get_extract_context(self):
+                return MagicMock()
+
+            def get_output_language(self):
+                return "en"
+
+            def instruction(self):
+                return "Extract memory operations."
+
+            async def prefetch(self):
+                return []
+
+        extract_loop = ExtractLoop(
+            vlm=FakeVLM(),
+            viking_fs=MagicMock(),
+            context_provider=FakeContextProvider(),
+            max_iterations=1,
+        )
+
+        with (
+            patch("openviking.session.memory.extract_loop.logger") as mock_logger,
+            patch("openviking.session.memory.extract_loop.tracer") as mock_tracer,
+        ):
+            result, _ = await extract_loop.run()
+
+        assert result is not None
+        assert result.errors
+        assert any("failure_kind=" in err for err in result.errors)
+
+        warning_msgs = [
+            str(call.args[0]) for call in mock_logger.warning.call_args_list if call.args
+        ]
+        assert any(
+            "after" in msg
+            and "iterations" in msg
+            and "failure_kind=" in msg
+            and "response_preview=" in msg
+            for msg in warning_msgs
+        ), warning_msgs
+
+        tracer_error_msgs = [
+            str(call.args[0]) for call in mock_tracer.error.call_args_list if call.args
+        ]
+        exhaustion_breadcrumbs = [
+            msg
+            for msg in tracer_error_msgs
+            if "exhausted iterations without parseable operations" in msg
+        ]
+        assert exhaustion_breadcrumbs
+        assert all("response_preview=" not in msg for msg in exhaustion_breadcrumbs)
+        assert all("failure_kind=" in msg for msg in exhaustion_breadcrumbs)


### PR DESCRIPTION
## Summary
- When the ReAct extract loop exhausts `max_iterations` and falls back to empty operations, emit `logger.warning` + `tracer.error` instead of `tracer.info`
- After `orchestrator.run()`, warn if `ResolvedOperations.errors` is non-empty (the silent Extracted-0 case)

Related to #4486 (suggested fix 3). Complements #4628 / #4633 / #4636.

## Test plan
- [ ] Force an unparseable final extract response and confirm a WARNING/ERROR appears in logs (not only info)
- [ ] Healthy empty extraction (no `errors`) stays quiet