### PR TITLE
feat(compile-cli): load endpoint from ovcli.conf

### DIFF
--- a/.github/workflows/compile-cli-release.yml
+++ b/.github/workflows/compile-cli-release.yml
@@ -112,7 +112,7 @@ jobs:
           sed -i.bak "s/^version = \"0.0.0\"/version = \"$VERSION\"/" crates/ov_cli/Cargo.toml
           rm -f crates/ov_cli/Cargo.toml.bak
 
-      - name: Build read-only CLI
+      - name: Build compile CLI
         shell: bash
         run: |
           if [[ "${{ runner.os }}" == "Linux" ]]; then
@@ -140,7 +140,7 @@ jobs:
             const pkg = {
               name: '@openviking-compile/${{ matrix.npm_pkg }}',
               version: process.env.VERSION,
-              description: 'Read-only OpenViking CLI binary for ${{ matrix.npm_os }}-${{ matrix.npm_cpu }}',
+              description: 'OpenViking retrieval and content-write CLI binary for ${{ matrix.npm_os }}-${{ matrix.npm_cpu }}',
               os: ['${{ matrix.npm_os }}'],
               cpu: ['${{ matrix.npm_cpu }}'],
               files: ['bin'],

--- a/.github/workflows/compile-cli-release.yml
+++ b/.github/workflows/compile-cli-release.yml
@@ -1,0 +1,243 @@
+name: Compile CLI Build and Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "crates/ov_cli/**"
+      - "npm/compile-cli/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/compile-cli-release.yml"
+    tags:
+      - "compile-cli@*"
+  pull_request:
+    branches: [main]
+    paths:
+      - "crates/ov_cli/**"
+      - "npm/compile-cli/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/compile-cli-release.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+            npm_pkg: cli-linux-x64
+            npm_os: linux
+            npm_cpu: x64
+          - os: ubuntu-24.04
+            target: aarch64-unknown-linux-musl
+            npm_pkg: cli-linux-arm64
+            npm_os: linux
+            npm_cpu: arm64
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+            npm_pkg: cli-darwin-x64
+            npm_os: darwin
+            npm_cpu: x64
+          - os: macos-14
+            target: aarch64-apple-darwin
+            npm_pkg: cli-darwin-arm64
+            npm_os: darwin
+            npm_cpu: arm64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            npm_pkg: cli-win32-x64
+            npm_os: win32
+            npm_cpu: x64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
+      - name: Install Zig and cargo-zigbuild
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          ZIG_VERSION=0.13.0
+          ZIG_DIR="$RUNNER_TEMP/zig-$ZIG_VERSION"
+          mkdir -p "$ZIG_DIR"
+          curl -fsSL "https://ziglang.org/download/$ZIG_VERSION/zig-linux-x86_64-$ZIG_VERSION.tar.xz" \
+            | tar -xJ --strip-components=1 -C "$ZIG_DIR"
+          echo "$ZIG_DIR" >> "$GITHUB_PATH"
+          cargo install --locked cargo-zigbuild
+
+      - name: Cache Cargo files
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target
+          key: ${{ runner.os }}-compile-cli-${{ matrix.target }}-${{ hashFiles('Cargo.lock', 'crates/**/*.rs') }}
+          restore-keys: |
+            ${{ runner.os }}-compile-cli-${{ matrix.target }}-
+            ${{ runner.os }}-compile-cli-
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/compile-cli@}"
+          if [[ "$VERSION" == "$GITHUB_REF" ]]; then
+            VERSION="0.0.0-dev"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Inject release version
+        if: startsWith(github.ref, 'refs/tags/compile-cli@')
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          sed -i.bak "s/^version = \"0.0.0\"/version = \"$VERSION\"/" crates/ov_cli/Cargo.toml
+          rm -f crates/ov_cli/Cargo.toml.bak
+
+      - name: Build read-only CLI
+        shell: bash
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            cargo zigbuild --release --target ${{ matrix.target }} -p ov_cli --features compile-cli
+          else
+            cargo build --release --target ${{ matrix.target }} -p ov_cli --features compile-cli
+          fi
+
+      - name: Package native npm module
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          PKG_DIR="npm-pkg"
+          mkdir -p "$PKG_DIR/bin"
+
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            cp "target/${{ matrix.target }}/release/ov.exe" "$PKG_DIR/bin/ov.exe"
+          else
+            cp "target/${{ matrix.target }}/release/ov" "$PKG_DIR/bin/ov"
+            chmod +x "$PKG_DIR/bin/ov"
+          fi
+
+          node -e "
+            const pkg = {
+              name: '@openviking-compile/${{ matrix.npm_pkg }}',
+              version: process.env.VERSION,
+              description: 'Read-only OpenViking CLI binary for ${{ matrix.npm_os }}-${{ matrix.npm_cpu }}',
+              os: ['${{ matrix.npm_os }}'],
+              cpu: ['${{ matrix.npm_cpu }}'],
+              files: ['bin'],
+              license: 'Apache-2.0',
+              repository: {
+                type: 'git',
+                url: 'git+https://github.com/fujiajie666/OpenViking_Vaka.git'
+              },
+              publishConfig: { access: 'public' }
+            };
+            require('fs').writeFileSync(
+              '$PKG_DIR/package.json',
+              JSON.stringify(pkg, null, 2) + '\n'
+            );
+          "
+
+      - name: Upload native npm module
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.npm_pkg }}
+          path: npm-pkg/
+
+  npm-publish:
+    name: Publish @openviking-compile/cli
+    runs-on: ubuntu-24.04
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/compile-cli@')
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: echo "version=${GITHUB_REF#refs/tags/compile-cli@}" >> "$GITHUB_OUTPUT"
+
+      - name: Download native npm modules
+        uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+
+      - name: Configure npm authentication
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -n "${NPM_TOKEN:-}" ]; then
+            npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
+          else
+            echo "NPM_TOKEN is not set; npm Trusted Publishing must already be configured."
+          fi
+
+      - name: Publish native npm modules
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          for pkg_dir in artifacts/cli-*/; do
+            pkg_name=$(basename "$pkg_dir")
+            package="@openviking-compile/$pkg_name"
+            if npm view "$package@$VERSION" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+              echo "Skipping $package@$VERSION; already published."
+              continue
+            fi
+
+            chmod +x "$pkg_dir/bin/ov" 2>/dev/null || true
+            (cd "$pkg_dir" && npm publish --access public --provenance)
+          done
+
+      - name: Publish wrapper npm module
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          cd npm/compile-cli
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.version = process.env.VERSION;
+            for (const dependency of Object.keys(pkg.optionalDependencies || {})) {
+              pkg.optionalDependencies[dependency] = process.env.VERSION;
+            }
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+          if npm view "@openviking-compile/cli@$VERSION" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "Skipping @openviking-compile/cli@$VERSION; already published."
+            exit 0
+          fi
+
+          npm pack --dry-run
+          npm publish --access public --provenance

--- a/.github/workflows/compile-cli-release.yml
+++ b/.github/workflows/compile-cli-release.yml
@@ -33,27 +33,27 @@ jobs:
         include:
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-musl
-            npm_pkg: cli-linux-x64
+            npm_pkg: compile-linux-x64
             npm_os: linux
             npm_cpu: x64
           - os: ubuntu-24.04
             target: aarch64-unknown-linux-musl
-            npm_pkg: cli-linux-arm64
+            npm_pkg: compile-linux-arm64
             npm_os: linux
             npm_cpu: arm64
           - os: macos-15-intel
             target: x86_64-apple-darwin
-            npm_pkg: cli-darwin-x64
+            npm_pkg: compile-darwin-x64
             npm_os: darwin
             npm_cpu: x64
           - os: macos-14
             target: aarch64-apple-darwin
-            npm_pkg: cli-darwin-arm64
+            npm_pkg: compile-darwin-arm64
             npm_os: darwin
             npm_cpu: arm64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            npm_pkg: cli-win32-x64
+            npm_pkg: compile-win32-x64
             npm_os: win32
             npm_cpu: x64
 
@@ -138,7 +138,7 @@ jobs:
 
           node -e "
             const pkg = {
-              name: '@openviking-compile/${{ matrix.npm_pkg }}',
+              name: '@openviking/${{ matrix.npm_pkg }}',
               version: process.env.VERSION,
               description: 'OpenViking retrieval and content-write CLI binary for ${{ matrix.npm_os }}-${{ matrix.npm_cpu }}',
               os: ['${{ matrix.npm_os }}'],
@@ -147,7 +147,7 @@ jobs:
               license: 'Apache-2.0',
               repository: {
                 type: 'git',
-                url: 'git+https://github.com/fujiajie666/OpenViking_Vaka.git'
+                url: 'git+https://github.com/volcengine/openviking.git'
               },
               publishConfig: { access: 'public' }
             };
@@ -164,7 +164,7 @@ jobs:
           path: npm-pkg/
 
   npm-publish:
-    name: Publish @openviking-compile/cli
+    name: Publish @openviking/compile
     runs-on: ubuntu-24.04
     needs: build
     if: startsWith(github.ref, 'refs/tags/compile-cli@')
@@ -207,9 +207,9 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          for pkg_dir in artifacts/cli-*/; do
+          for pkg_dir in artifacts/compile-*/; do
             pkg_name=$(basename "$pkg_dir")
-            package="@openviking-compile/$pkg_name"
+            package="@openviking/$pkg_name"
             if npm view "$package@$VERSION" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
               echo "Skipping $package@$VERSION; already published."
               continue
@@ -234,8 +234,8 @@ jobs:
             fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
 
-          if npm view "@openviking-compile/cli@$VERSION" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
-            echo "Skipping @openviking-compile/cli@$VERSION; already published."
+          if npm view "@openviking/compile@$VERSION" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "Skipping @openviking/compile@$VERSION; already published."
             exit 0
           fi
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4369,6 +4369,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.37",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",

--- a/crates/ov_cli/Cargo.toml
+++ b/crates/ov_cli/Cargo.toml
@@ -17,7 +17,17 @@ compile-cli = []
 
 [dependencies]
 clap = { version = "4.5", features = ["derive", "env"] }
-reqwest = { version = "0.12", features = ["json", "multipart", "rustls-tls", "gzip"], default-features = false }
+reqwest = {
+    version = "0.12",
+    features = [
+        "json",
+        "multipart",
+        "rustls-tls-webpki-roots",
+        "rustls-tls-native-roots",
+        "gzip",
+    ],
+    default-features = false,
+}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_yaml = "0.9"

--- a/crates/ov_cli/Cargo.toml
+++ b/crates/ov_cli/Cargo.toml
@@ -11,6 +11,10 @@ license = "Apache-2.0"
 name = "ov"
 path = "src/main.rs"
 
+[features]
+default = []
+compile-cli = []
+
 [dependencies]
 clap = { version = "4.5", features = ["derive", "env"] }
 reqwest = { version = "0.12", features = ["json", "multipart", "rustls-tls", "gzip"], default-features = false }

--- a/crates/ov_cli/src/compile_cli.rs
+++ b/crates/ov_cli/src/compile_cli.rs
@@ -1,0 +1,532 @@
+use std::ffi::OsString;
+
+use clap::{ArgAction, Parser, Subcommand, ValueEnum};
+
+use crate::{
+    CliContext,
+    config::Config,
+    error::{Error, Result},
+    error_ui, handlers,
+    output::OutputFormat,
+};
+
+const OPENVIKING_COMPILE_URL: &str = "https://api.vikingdb.cn-beijing.volces.com/openviking";
+const OPENVIKING_API_KEY_ENV: &str = "OPENVIKING_API_KEY";
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum OutputArg {
+    Table,
+    Json,
+}
+
+impl From<OutputArg> for OutputFormat {
+    fn from(value: OutputArg) -> Self {
+        match value {
+            OutputArg::Table => Self::Table,
+            OutputArg::Json => Self::Json,
+        }
+    }
+}
+
+/// Read-only OpenViking CLI for cloud agents.
+#[derive(Parser)]
+#[command(name = "ov")]
+#[command(about = "Read-only OpenViking CLI for cloud agents")]
+#[command(version = env!("OPENVIKING_CLI_VERSION"))]
+#[command(arg_required_else_help = true)]
+struct CompileCli {
+    /// Choose human-readable table output or machine-readable JSON.
+    #[arg(short, long, value_enum, global = true, default_value = "table")]
+    output: OutputArg,
+
+    /// Use compact output rendering.
+    #[arg(
+        long,
+        global = true,
+        default_value = "true",
+        default_missing_value = "true",
+        hide = true,
+        num_args = 0..=1,
+        require_equals = true,
+        action = ArgAction::Set,
+        value_name = "bool"
+    )]
+    compact: bool,
+
+    #[command(subcommand)]
+    command: ReadOnlyCommand,
+}
+
+#[derive(Subcommand)]
+enum ReadOnlyCommand {
+    /// Read full file content (Level 2).
+    Read {
+        /// Viking URI.
+        #[arg(value_name = "uri")]
+        uri: String,
+    },
+
+    /// Search file content with a regular expression.
+    Grep {
+        /// Target URI. Root-level grep is rejected to protect the service.
+        #[arg(short, long, default_value = "viking://", value_name = "uri")]
+        uri: String,
+        /// Excluded URI prefix.
+        #[arg(short = 'x', long = "exclude-uri", value_name = "uri")]
+        exclude_uri: Option<String>,
+        /// Search pattern.
+        #[arg(value_name = "pattern")]
+        pattern: String,
+        /// Match without case sensitivity.
+        #[arg(short, long)]
+        ignore_case: bool,
+        /// Maximum number of results.
+        #[arg(
+            short = 'n',
+            long = "node-limit",
+            alias = "limit",
+            default_value = "256",
+            value_parser = clap::value_parser!(i32).range(0..),
+            value_name = "n"
+        )]
+        node_limit: i32,
+        /// Maximum traversal depth.
+        #[arg(
+            short = 'L',
+            long = "level-limit",
+            default_value = "10",
+            value_name = "n"
+        )]
+        level_limit: i32,
+    },
+
+    /// Search file names with a glob pattern.
+    Glob {
+        /// Glob pattern.
+        #[arg(value_name = "pattern")]
+        pattern: String,
+        /// Search root URI.
+        #[arg(short, long, default_value = "viking://", value_name = "uri")]
+        uri: String,
+        /// Maximum number of results.
+        #[arg(
+            short = 'n',
+            long = "node-limit",
+            alias = "limit",
+            default_value = "256",
+            value_parser = clap::value_parser!(i32).range(0..),
+            value_name = "n"
+        )]
+        node_limit: i32,
+    },
+
+    /// List directory contents.
+    Ls {
+        /// Viking URI to list.
+        #[arg(default_value = "viking://", value_name = "uri")]
+        uri: String,
+        /// Print paths only.
+        #[arg(short, long)]
+        simple: bool,
+        /// List subdirectories recursively.
+        #[arg(short, long)]
+        recursive: bool,
+        /// Abstract content limit.
+        #[arg(
+            long = "abs-limit",
+            short = 'l',
+            default_value = "256",
+            value_name = "n"
+        )]
+        abs_limit: i32,
+        /// Include hidden files.
+        #[arg(short, long)]
+        all: bool,
+        /// Maximum number of nodes.
+        #[arg(
+            short = 'n',
+            long = "node-limit",
+            alias = "limit",
+            default_value = "256",
+            value_parser = clap::value_parser!(i32).range(0..),
+            value_name = "n"
+        )]
+        node_limit: i32,
+    },
+
+    /// Print a directory tree.
+    Tree {
+        /// Viking URI to traverse.
+        #[arg(value_name = "uri")]
+        uri: String,
+        /// Abstract content limit.
+        #[arg(
+            long = "abs-limit",
+            short = 'l',
+            default_value = "128",
+            value_name = "n"
+        )]
+        abs_limit: i32,
+        /// Include hidden files.
+        #[arg(short, long)]
+        all: bool,
+        /// Maximum number of nodes.
+        #[arg(
+            short = 'n',
+            long = "node-limit",
+            alias = "limit",
+            default_value = "256",
+            value_parser = clap::value_parser!(i32).range(0..),
+            value_name = "n"
+        )]
+        node_limit: i32,
+        /// Maximum traversal depth.
+        #[arg(
+            short = 'L',
+            long = "level-limit",
+            default_value = "3",
+            value_name = "n"
+        )]
+        level_limit: i32,
+    },
+
+    /// Run semantic retrieval.
+    Find {
+        /// Search query.
+        #[arg(value_name = "query")]
+        query: Option<String>,
+        /// Image query: local path, data URI, HTTP URL, or viking:// URI.
+        #[arg(long = "image", value_name = "path|uri")]
+        image: Option<String>,
+        /// Target URI.
+        #[arg(short, long, default_value = "", value_name = "uri")]
+        uri: String,
+        /// Maximum final results returned.
+        #[arg(
+            short = 'n',
+            long = "node-limit",
+            alias = "limit",
+            default_value = "10",
+            value_parser = clap::value_parser!(i32).range(0..),
+            value_name = "n"
+        )]
+        node_limit: i32,
+        /// Score threshold.
+        #[arg(short, long, value_name = "score")]
+        threshold: Option<f64>,
+        /// Only include results on or after this time.
+        #[arg(long = "after", value_name = "time")]
+        after: Option<String>,
+        /// Only include results on or before this time.
+        #[arg(long = "before", value_name = "time")]
+        before: Option<String>,
+        /// Only include specific levels (0=abstract, 1=overview, 2=file).
+        #[arg(
+            short = 'L',
+            long = "level",
+            value_delimiter = ',',
+            value_name = "0,1,2"
+        )]
+        level: Option<Vec<i32>>,
+        /// Only include specific context types.
+        #[arg(long = "context-type", value_delimiter = ',', value_name = "type")]
+        context_type: Option<Vec<String>>,
+        /// Only include results matching all tags.
+        #[arg(long = "tags", value_delimiter = ',')]
+        tags: Option<Vec<String>>,
+    },
+
+    /// Run context-aware retrieval.
+    Search {
+        /// Search query.
+        #[arg(value_name = "query")]
+        query: Option<String>,
+        /// Image query: local path, data URI, HTTP URL, or viking:// URI.
+        #[arg(long = "image", value_name = "path|uri")]
+        image: Option<String>,
+        /// Target URI.
+        #[arg(short, long, default_value = "", value_name = "uri")]
+        uri: String,
+        /// Session ID for context-aware search.
+        #[arg(long, value_name = "id")]
+        session_id: Option<String>,
+        /// Maximum results per search pass.
+        #[arg(
+            short = 'n',
+            long = "node-limit",
+            alias = "limit",
+            default_value = "10",
+            value_parser = clap::value_parser!(i32).range(0..),
+            value_name = "n"
+        )]
+        node_limit: i32,
+        /// Score threshold.
+        #[arg(short, long, value_name = "score")]
+        threshold: Option<f64>,
+        /// Only include results on or after this time.
+        #[arg(long = "after", value_name = "time")]
+        after: Option<String>,
+        /// Only include results on or before this time.
+        #[arg(long = "before", value_name = "time")]
+        before: Option<String>,
+        /// Only include specific levels (0=abstract, 1=overview, 2=file).
+        #[arg(
+            short = 'L',
+            long = "level",
+            value_delimiter = ',',
+            value_name = "0,1,2"
+        )]
+        level: Option<Vec<i32>>,
+        /// Only include specific context types.
+        #[arg(long = "context-type", value_delimiter = ',', value_name = "type")]
+        context_type: Option<Vec<String>>,
+        /// Only include results matching all tags.
+        #[arg(long = "tags", value_delimiter = ',')]
+        tags: Option<Vec<String>>,
+    },
+}
+
+pub(super) async fn run() {
+    let args: Vec<OsString> = std::env::args_os().collect();
+    let command_display = error_ui::display_command(&args);
+    let cli = match CompileCli::try_parse_from(&args) {
+        Ok(cli) => cli,
+        Err(error) => error.exit(),
+    };
+
+    let output_format = OutputFormat::from(cli.output);
+    let config = match runtime_config(std::env::var(OPENVIKING_API_KEY_ENV).ok()) {
+        Ok(config) => config,
+        Err(error) => {
+            print_compile_error(&command_display, &error, output_format, cli.compact);
+            std::process::exit(2);
+        }
+    };
+    let ctx = CliContext::from_config(
+        config,
+        output_format,
+        cli.compact,
+        None,
+        None,
+        None,
+        false,
+        None,
+        None,
+        None,
+    );
+
+    let result = match cli.command {
+        ReadOnlyCommand::Read { uri } => handlers::handle_read(uri, ctx).await,
+        ReadOnlyCommand::Grep {
+            uri,
+            exclude_uri,
+            pattern,
+            ignore_case,
+            node_limit,
+            level_limit,
+        } => {
+            handlers::handle_grep(
+                uri,
+                exclude_uri,
+                pattern,
+                ignore_case,
+                node_limit,
+                level_limit,
+                ctx,
+            )
+            .await
+        }
+        ReadOnlyCommand::Glob {
+            pattern,
+            uri,
+            node_limit,
+        } => handlers::handle_glob(pattern, uri, node_limit, ctx).await,
+        ReadOnlyCommand::Ls {
+            uri,
+            simple,
+            recursive,
+            abs_limit,
+            all,
+            node_limit,
+        } => handlers::handle_ls(uri, simple, recursive, abs_limit, all, node_limit, ctx).await,
+        ReadOnlyCommand::Tree {
+            uri,
+            abs_limit,
+            all,
+            node_limit,
+            level_limit,
+        } => handlers::handle_tree(uri, abs_limit, all, node_limit, level_limit, ctx).await,
+        ReadOnlyCommand::Find {
+            query,
+            image,
+            uri,
+            node_limit,
+            threshold,
+            after,
+            before,
+            level,
+            context_type,
+            tags,
+        } => {
+            handlers::handle_find(
+                query,
+                uri,
+                image,
+                node_limit,
+                threshold,
+                after,
+                before,
+                level,
+                context_type,
+                tags,
+                ctx,
+            )
+            .await
+        }
+        ReadOnlyCommand::Search {
+            query,
+            image,
+            uri,
+            session_id,
+            node_limit,
+            threshold,
+            after,
+            before,
+            level,
+            context_type,
+            tags,
+        } => {
+            handlers::handle_search(
+                query,
+                uri,
+                image,
+                session_id,
+                node_limit,
+                threshold,
+                after,
+                before,
+                level,
+                context_type,
+                tags,
+                ctx,
+            )
+            .await
+        }
+    };
+
+    if let Err(error) = result {
+        print_compile_error(&command_display, &error, output_format, cli.compact);
+        std::process::exit(1);
+    }
+}
+
+fn print_compile_error(command: &str, error: &Error, output_format: OutputFormat, compact: bool) {
+    let message = match error {
+        Error::Api { message, .. } => message.clone(),
+        _ => error.to_string(),
+    };
+
+    if matches!(output_format, OutputFormat::Json) {
+        let mut error_body = serde_json::json!({
+            "code": error.code(),
+            "message": message,
+        });
+        if let Error::Api {
+            details: Some(details),
+            ..
+        } = error
+        {
+            error_body["details"] = details.clone();
+        }
+        let body = serde_json::json!({"ok": false, "error": error_body});
+        if compact {
+            eprintln!("{body}");
+        } else {
+            eprintln!(
+                "{}",
+                serde_json::to_string_pretty(&body).unwrap_or_else(|_| body.to_string())
+            );
+        }
+        return;
+    }
+
+    eprintln!("{command}\n\nError [{}]: {message}", error.code());
+    if matches!(error, Error::Config(_)) {
+        eprintln!("\nSet the key with: export {OPENVIKING_API_KEY_ENV}=\"<your-api-key>\"");
+    }
+}
+
+fn runtime_config(api_key: Option<String>) -> Result<Config> {
+    let api_key = api_key
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            Error::Config(format!(
+                "{OPENVIKING_API_KEY_ENV} is required. Export it before running ov."
+            ))
+        })?;
+    api_key
+        .parse::<reqwest::header::HeaderValue>()
+        .map_err(|_| Error::Config(format!("{OPENVIKING_API_KEY_ENV} is not a valid API key")))?;
+
+    Ok(Config {
+        url: OPENVIKING_COMPILE_URL.to_string(),
+        api_key: Some(api_key),
+        echo_command: false,
+        ..Config::default()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn exposes_only_the_seven_read_only_commands() {
+        let names = CompileCli::command()
+            .get_subcommands()
+            .map(|command| command.get_name().to_string())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            names,
+            ["read", "grep", "glob", "ls", "tree", "find", "search"]
+        );
+    }
+
+    #[test]
+    fn rejects_mutating_commands() {
+        assert!(CompileCli::try_parse_from(["ov", "rm", "viking://resources/a"]).is_err());
+        assert!(CompileCli::try_parse_from(["ov", "write", "viking://resources/a"]).is_err());
+        assert!(CompileCli::try_parse_from(["ov", "config"]).is_err());
+        assert!(CompileCli::try_parse_from(["ov", "list"]).is_err());
+    }
+
+    #[test]
+    fn runtime_config_uses_only_the_fixed_service_and_supplied_key() {
+        let config = runtime_config(Some("  secret  ".to_string())).expect("valid config");
+
+        assert_eq!(config.url, OPENVIKING_COMPILE_URL);
+        assert_eq!(config.api_key.as_deref(), Some("secret"));
+        assert!(config.root_api_key.is_none());
+        assert!(config.account.is_none());
+        assert!(config.user.is_none());
+        assert!(!config.echo_command);
+    }
+
+    #[test]
+    fn runtime_config_requires_a_non_empty_api_key() {
+        for value in [None, Some(String::new()), Some("  ".to_string())] {
+            let error = runtime_config(value).expect_err("missing key must fail");
+            assert!(error.to_string().contains(OPENVIKING_API_KEY_ENV));
+        }
+    }
+
+    #[test]
+    fn runtime_config_rejects_a_key_that_cannot_be_sent_as_an_http_header() {
+        let error =
+            runtime_config(Some("bad\nkey".to_string())).expect_err("invalid key must fail");
+        assert!(error.to_string().contains(OPENVIKING_API_KEY_ENV));
+    }
+}

--- a/crates/ov_cli/src/compile_cli.rs
+++ b/crates/ov_cli/src/compile_cli.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::ffi::OsString;
 
 use clap::{ArgAction, Parser, Subcommand, ValueEnum};
@@ -465,13 +466,18 @@ fn runtime_config(api_key: Option<String>) -> Result<Config> {
                 "{OPENVIKING_API_KEY_ENV} is required. Export it before running ov."
             ))
         })?;
-    api_key
+    let authorization = format!("Bearer {api_key}");
+    authorization
         .parse::<reqwest::header::HeaderValue>()
         .map_err(|_| Error::Config(format!("{OPENVIKING_API_KEY_ENV} is not a valid API key")))?;
 
     Ok(Config {
         url: OPENVIKING_COMPILE_URL.to_string(),
-        api_key: Some(api_key),
+        api_key: None,
+        extra_headers: Some(HashMap::from([(
+            reqwest::header::AUTHORIZATION.as_str().to_string(),
+            authorization,
+        )])),
         echo_command: false,
         ..Config::default()
     })
@@ -508,11 +514,44 @@ mod tests {
         let config = runtime_config(Some("  secret  ".to_string())).expect("valid config");
 
         assert_eq!(config.url, OPENVIKING_COMPILE_URL);
-        assert_eq!(config.api_key.as_deref(), Some("secret"));
+        assert!(config.api_key.is_none());
+        assert_eq!(
+            config
+                .extra_headers
+                .as_ref()
+                .and_then(|headers| headers.get(reqwest::header::AUTHORIZATION.as_str()))
+                .map(String::as_str),
+            Some("Bearer secret")
+        );
         assert!(config.root_api_key.is_none());
         assert!(config.account.is_none());
         assert!(config.user.is_none());
         assert!(!config.echo_command);
+    }
+
+    #[test]
+    fn runtime_config_preserves_vault_placeholder_in_bearer_header() {
+        let config = runtime_config(Some("ARK_SECRET_PLACEHOLDER".to_string()))
+            .expect("Vault placeholder should be accepted");
+        let client = crate::base_client::BaseClient::new(
+            &config.url,
+            config.api_key.clone(),
+            config.account.clone(),
+            config.user.clone(),
+            config.actor_peer_id.clone(),
+            config.timeout,
+            config.profile,
+            config.extra_headers.clone(),
+        );
+        let headers = client.build_headers();
+
+        assert_eq!(
+            headers
+                .get(reqwest::header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer ARK_SECRET_PLACEHOLDER")
+        );
+        assert!(!headers.contains_key("X-API-Key"));
     }
 
     #[test]

--- a/crates/ov_cli/src/compile_cli.rs
+++ b/crates/ov_cli/src/compile_cli.rs
@@ -446,6 +446,7 @@ pub(super) async fn run() {
                 level,
                 context_type,
                 tags,
+                false, // The restricted CLI does not inline matched content in retrieval results.
                 ctx,
             )
             .await
@@ -475,6 +476,7 @@ pub(super) async fn run() {
                 level,
                 context_type,
                 tags,
+                false, // The restricted CLI does not inline matched content in retrieval results.
                 ctx,
             )
             .await
@@ -556,7 +558,10 @@ mod tests {
 
     #[test]
     fn exposes_only_retrieval_and_content_write_commands() {
-        let names = CompileCli::command()
+        let command = CompileCli::command();
+        assert_eq!(command.get_name(), "ov");
+
+        let names = command
             .get_subcommands()
             .map(|command| command.get_name().to_string())
             .collect::<Vec<_>>();

--- a/crates/ov_cli/src/compile_cli.rs
+++ b/crates/ov_cli/src/compile_cli.rs
@@ -29,10 +29,10 @@ impl From<OutputArg> for OutputFormat {
     }
 }
 
-/// Read-only OpenViking CLI for cloud agents.
+/// OpenViking retrieval and content-write CLI for cloud agents.
 #[derive(Parser)]
 #[command(name = "ov")]
-#[command(about = "Read-only OpenViking CLI for cloud agents")]
+#[command(about = "OpenViking retrieval and content-write CLI for cloud agents")]
 #[command(version = env!("OPENVIKING_CLI_VERSION"))]
 #[command(arg_required_else_help = true)]
 struct CompileCli {
@@ -55,16 +55,53 @@ struct CompileCli {
     compact: bool,
 
     #[command(subcommand)]
-    command: ReadOnlyCommand,
+    command: CompileCommand,
 }
 
+/// Commands exposed by the compile CLI; mutations are limited to writing text content.
 #[derive(Subcommand)]
-enum ReadOnlyCommand {
+enum CompileCommand {
     /// Read full file content (Level 2).
     Read {
         /// Viking URI.
         #[arg(value_name = "uri")]
         uri: String,
+    },
+
+    /// Write text content.
+    Write {
+        /// Viking URI.
+        #[arg(value_name = "uri")]
+        uri: String,
+        /// Content to write.
+        #[arg(long, conflicts_with = "from_file", value_name = "text")]
+        content: Option<String>,
+        /// Read content from a local file.
+        #[arg(long = "from-file", conflicts_with = "content", value_name = "path")]
+        from_file: Option<String>,
+        /// Append instead of replacing the file.
+        #[arg(long)]
+        append: bool,
+        /// Write mode: replace, append, or create (default: replace).
+        #[arg(long, value_name = "replace|append|create", conflicts_with = "append")]
+        mode: Option<String>,
+        /// Wait for async processing to finish.
+        #[arg(long, default_value = "false")]
+        wait: bool,
+        /// Content post-write processing mode.
+        #[arg(
+            long = "processing-mode",
+            default_value = "semantic_and_vectors",
+            value_parser = ["semantic_and_vectors", "vectors_only"]
+        )]
+        processing_mode: String,
+        /// Optional wait timeout in seconds.
+        #[arg(
+            long,
+            value_parser = crate::config::parse_positive_timeout,
+            value_name = "seconds"
+        )]
+        timeout: Option<f64>,
     },
 
     /// Search file content with a regular expression.
@@ -317,8 +354,37 @@ pub(super) async fn run() {
     );
 
     let result = match cli.command {
-        ReadOnlyCommand::Read { uri } => handlers::handle_read(uri, ctx).await,
-        ReadOnlyCommand::Grep {
+        CompileCommand::Read { uri } => handlers::handle_read(uri, ctx).await,
+        CompileCommand::Write {
+            uri,
+            content,
+            from_file,
+            append,
+            mode,
+            wait,
+            processing_mode,
+            timeout,
+        } => {
+            let effective_mode = if let Some(mode) = mode {
+                mode
+            } else if append {
+                "append".to_string()
+            } else {
+                "replace".to_string()
+            };
+            handlers::handle_write(
+                uri,
+                content,
+                from_file,
+                effective_mode,
+                wait,
+                timeout,
+                processing_mode,
+                ctx,
+            )
+            .await
+        }
+        CompileCommand::Grep {
             uri,
             exclude_uri,
             pattern,
@@ -337,12 +403,12 @@ pub(super) async fn run() {
             )
             .await
         }
-        ReadOnlyCommand::Glob {
+        CompileCommand::Glob {
             pattern,
             uri,
             node_limit,
         } => handlers::handle_glob(pattern, uri, node_limit, ctx).await,
-        ReadOnlyCommand::Ls {
+        CompileCommand::Ls {
             uri,
             simple,
             recursive,
@@ -350,14 +416,14 @@ pub(super) async fn run() {
             all,
             node_limit,
         } => handlers::handle_ls(uri, simple, recursive, abs_limit, all, node_limit, ctx).await,
-        ReadOnlyCommand::Tree {
+        CompileCommand::Tree {
             uri,
             abs_limit,
             all,
             node_limit,
             level_limit,
         } => handlers::handle_tree(uri, abs_limit, all, node_limit, level_limit, ctx).await,
-        ReadOnlyCommand::Find {
+        CompileCommand::Find {
             query,
             image,
             uri,
@@ -384,7 +450,7 @@ pub(super) async fn run() {
             )
             .await
         }
-        ReadOnlyCommand::Search {
+        CompileCommand::Search {
             query,
             image,
             uri,
@@ -489,7 +555,7 @@ mod tests {
     use clap::CommandFactory;
 
     #[test]
-    fn exposes_only_the_seven_read_only_commands() {
+    fn exposes_only_retrieval_and_content_write_commands() {
         let names = CompileCli::command()
             .get_subcommands()
             .map(|command| command.get_name().to_string())
@@ -497,14 +563,57 @@ mod tests {
 
         assert_eq!(
             names,
-            ["read", "grep", "glob", "ls", "tree", "find", "search"]
+            [
+                "read", "write", "grep", "glob", "ls", "tree", "find", "search"
+            ]
         );
     }
 
     #[test]
-    fn rejects_mutating_commands() {
+    fn parses_the_full_write_command_contract() {
+        let cli = CompileCli::try_parse_from([
+            "ov",
+            "write",
+            "viking://resources/a.md",
+            "--content",
+            "hello",
+            "--mode",
+            "create",
+            "--wait",
+            "--processing-mode",
+            "vectors_only",
+            "--timeout",
+            "12.5",
+        ])
+        .expect("write command should parse");
+
+        match cli.command {
+            CompileCommand::Write {
+                uri,
+                content,
+                from_file,
+                append,
+                mode,
+                wait,
+                processing_mode,
+                timeout,
+            } => {
+                assert_eq!(uri, "viking://resources/a.md");
+                assert_eq!(content.as_deref(), Some("hello"));
+                assert!(from_file.is_none());
+                assert!(!append);
+                assert_eq!(mode.as_deref(), Some("create"));
+                assert!(wait);
+                assert_eq!(processing_mode, "vectors_only");
+                assert_eq!(timeout, Some(12.5));
+            }
+            _ => panic!("expected write command"),
+        }
+    }
+
+    #[test]
+    fn rejects_other_mutating_and_administration_commands() {
         assert!(CompileCli::try_parse_from(["ov", "rm", "viking://resources/a"]).is_err());
-        assert!(CompileCli::try_parse_from(["ov", "write", "viking://resources/a"]).is_err());
         assert!(CompileCli::try_parse_from(["ov", "config"]).is_err());
         assert!(CompileCli::try_parse_from(["ov", "list"]).is_err());
     }

--- a/crates/ov_cli/src/compile_cli.rs
+++ b/crates/ov_cli/src/compile_cli.rs
@@ -333,7 +333,15 @@ pub(super) async fn run() {
     };
 
     let output_format = OutputFormat::from(cli.output);
-    let config = match runtime_config(std::env::var(OPENVIKING_API_KEY_ENV).ok()) {
+    let configured_url = match Config::load_required() {
+        Ok(config) => Some(config.url),
+        Err(Error::MissingConfig) => None,
+        Err(error) => {
+            print_compile_error(&command_display, &error, output_format, cli.compact);
+            std::process::exit(2);
+        }
+    };
+    let config = match runtime_config(std::env::var(OPENVIKING_API_KEY_ENV).ok(), configured_url) {
         Ok(config) => config,
         Err(error) => {
             print_compile_error(&command_display, &error, output_format, cli.compact);
@@ -380,6 +388,8 @@ pub(super) async fn run() {
                 wait,
                 timeout,
                 processing_mode,
+                Vec::new(),
+                "replace".to_string(),
                 ctx,
             )
             .await
@@ -399,6 +409,8 @@ pub(super) async fn run() {
                 ignore_case,
                 node_limit,
                 level_limit,
+                Vec::new(),
+                None,
                 ctx,
             )
             .await
@@ -407,7 +419,7 @@ pub(super) async fn run() {
             pattern,
             uri,
             node_limit,
-        } => handlers::handle_glob(pattern, uri, node_limit, ctx).await,
+        } => handlers::handle_glob(pattern, uri, node_limit, false, None, Vec::new(), ctx).await,
         CompileCommand::Ls {
             uri,
             simple,
@@ -415,14 +427,40 @@ pub(super) async fn run() {
             abs_limit,
             all,
             node_limit,
-        } => handlers::handle_ls(uri, simple, recursive, abs_limit, all, node_limit, ctx).await,
+        } => {
+            handlers::handle_ls(
+                uri,
+                simple,
+                recursive,
+                abs_limit,
+                all,
+                node_limit,
+                None,
+                Vec::new(),
+                ctx,
+            )
+            .await
+        }
         CompileCommand::Tree {
             uri,
             abs_limit,
             all,
             node_limit,
             level_limit,
-        } => handlers::handle_tree(uri, abs_limit, all, node_limit, level_limit, ctx).await,
+        } => {
+            handlers::handle_tree(
+                uri,
+                abs_limit,
+                all,
+                node_limit,
+                level_limit,
+                false,
+                None,
+                Vec::new(),
+                ctx,
+            )
+            .await
+        }
         CompileCommand::Find {
             query,
             image,
@@ -520,12 +558,12 @@ fn print_compile_error(command: &str, error: &Error, output_format: OutputFormat
     }
 
     eprintln!("{command}\n\nError [{}]: {message}", error.code());
-    if matches!(error, Error::Config(_)) {
+    if matches!(error, Error::Config(message) if message.contains(OPENVIKING_API_KEY_ENV)) {
         eprintln!("\nSet the key with: export {OPENVIKING_API_KEY_ENV}=\"<your-api-key>\"");
     }
 }
 
-fn runtime_config(api_key: Option<String>) -> Result<Config> {
+fn runtime_config(api_key: Option<String>, service_url: Option<String>) -> Result<Config> {
     let api_key = api_key
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
@@ -539,8 +577,24 @@ fn runtime_config(api_key: Option<String>) -> Result<Config> {
         .parse::<reqwest::header::HeaderValue>()
         .map_err(|_| Error::Config(format!("{OPENVIKING_API_KEY_ENV} is not a valid API key")))?;
 
+    let service_url = service_url
+        .map(|value| value.trim().trim_end_matches('/').to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| OPENVIKING_COMPILE_URL.to_string());
+    let parsed_url = reqwest::Url::parse(&service_url)
+        .map_err(|_| Error::Config("ovcli.conf contains an invalid URL".to_string()))?;
+    if !matches!(parsed_url.scheme(), "http" | "https")
+        || parsed_url.host_str().is_none()
+        || parsed_url.query().is_some()
+        || parsed_url.fragment().is_some()
+    {
+        return Err(Error::Config(
+            "ovcli.conf URL must be an HTTP(S) base URL without a query or fragment".to_string(),
+        ));
+    }
+
     Ok(Config {
-        url: OPENVIKING_COMPILE_URL.to_string(),
+        url: service_url,
         api_key: None,
         extra_headers: Some(HashMap::from([(
             reqwest::header::AUTHORIZATION.as_str().to_string(),
@@ -624,10 +678,14 @@ mod tests {
     }
 
     #[test]
-    fn runtime_config_uses_only_the_fixed_service_and_supplied_key() {
-        let config = runtime_config(Some("  secret  ".to_string())).expect("valid config");
+    fn runtime_config_uses_configured_service_or_default_and_vault_key() {
+        let config = runtime_config(
+            Some("  secret  ".to_string()),
+            Some(" https://stg.example.com/openviking/ ".to_string()),
+        )
+        .expect("valid config");
 
-        assert_eq!(config.url, OPENVIKING_COMPILE_URL);
+        assert_eq!(config.url, "https://stg.example.com/openviking");
         assert!(config.api_key.is_none());
         assert_eq!(
             config
@@ -641,11 +699,15 @@ mod tests {
         assert!(config.account.is_none());
         assert!(config.user.is_none());
         assert!(!config.echo_command);
+
+        let default_config =
+            runtime_config(Some("secret".to_string()), None).expect("valid config");
+        assert_eq!(default_config.url, OPENVIKING_COMPILE_URL);
     }
 
     #[test]
     fn runtime_config_preserves_vault_placeholder_in_bearer_header() {
-        let config = runtime_config(Some("ARK_SECRET_PLACEHOLDER".to_string()))
+        let config = runtime_config(Some("ARK_SECRET_PLACEHOLDER".to_string()), None)
             .expect("Vault placeholder should be accepted");
         let client = crate::base_client::BaseClient::new(
             &config.url,
@@ -671,7 +733,7 @@ mod tests {
     #[test]
     fn runtime_config_requires_a_non_empty_api_key() {
         for value in [None, Some(String::new()), Some("  ".to_string())] {
-            let error = runtime_config(value).expect_err("missing key must fail");
+            let error = runtime_config(value, None).expect_err("missing key must fail");
             assert!(error.to_string().contains(OPENVIKING_API_KEY_ENV));
         }
     }
@@ -679,7 +741,7 @@ mod tests {
     #[test]
     fn runtime_config_rejects_a_key_that_cannot_be_sent_as_an_http_header() {
         let error =
-            runtime_config(Some("bad\nkey".to_string())).expect_err("invalid key must fail");
+            runtime_config(Some("bad\nkey".to_string()), None).expect_err("invalid key must fail");
         assert!(error.to_string().contains(OPENVIKING_API_KEY_ENV));
     }
 }

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -1,7 +1,11 @@
+#![cfg_attr(feature = "compile-cli", allow(dead_code, unused_imports))]
+
 mod base_client;
 mod cli_arg_scan;
 mod client;
 mod commands;
+#[cfg(feature = "compile-cli")]
+mod compile_cli;
 mod config;
 mod config_agent;
 mod config_command_ui;
@@ -2977,6 +2981,13 @@ fn render_pre_language_help_request(args: &[OsString]) -> Option<String> {
     help_ui::render_command_help_request(args).or_else(|| Some(error.to_string()))
 }
 
+#[cfg(feature = "compile-cli")]
+#[tokio::main]
+async fn main() {
+    compile_cli::run().await;
+}
+
+#[cfg(not(feature = "compile-cli"))]
 #[tokio::main]
 async fn main() {
     let args = preprocess_cli_args(std::env::args_os().collect());

--- a/npm/compile-cli/README.md
+++ b/npm/compile-cli/README.md
@@ -18,6 +18,12 @@ The CLI reads its API key only from `OPENVIKING_API_KEY`:
 export OPENVIKING_API_KEY="<your-api-key>"
 ```
 
+The value is sent unchanged as a Bearer credential in the `Authorization`
+header. This is compatible with sandbox Vaults that expose a placeholder in
+the environment and replace it at the network egress. The native CLI trusts
+both Mozilla public roots and certificates installed in the operating
+system's trust store, including sandbox egress gateway CAs.
+
 The API endpoint is compiled into the binary and cannot be overridden:
 
 ```text

--- a/npm/compile-cli/README.md
+++ b/npm/compile-cli/README.md
@@ -1,6 +1,6 @@
 # @openviking-compile/cli
 
-Read-only OpenViking CLI for cloud agents. The package installs an `ov` command with seven retrieval commands and no mutation or administration commands.
+OpenViking retrieval and content-write CLI for cloud agents. The package installs an `ov` command with seven retrieval commands plus `write`; other mutation and administration commands are not included.
 
 ## Install
 
@@ -37,6 +37,7 @@ The CLI does not read `~/.openviking/ovcli.conf` or `OPENVIKING_CLI_CONFIG_FILE`
 | Command | Purpose |
 | --- | --- |
 | `ov read <uri>` | Read full file content |
+| `ov write <uri> --content <text>` | Replace, append, or create text content |
 | `ov grep --uri <uri> <pattern>` | Search file content with a regular expression |
 | `ov glob <pattern>` | Search file names with a glob pattern |
 | `ov ls [uri]` | List directory contents |
@@ -45,6 +46,16 @@ The CLI does not read `~/.openviking/ovcli.conf` or `OPENVIKING_CLI_CONFIG_FILE`
 | `ov search <query>` | Run context-aware retrieval |
 
 Run `ov <command> --help` for command-specific options. Add `--output json` for machine-readable output.
+
+`write` accepts inline text or a local UTF-8 text file:
+
+```bash
+ov write viking://resources/notes.md --content "updated text"
+ov write viking://resources/notes.md --from-file ./notes.md --append
+ov write viking://resources/new.md --content "new text" --mode create --wait
+```
+
+The write modes are `replace` (default), `append`, and `create`. Use `--processing-mode vectors_only` to skip semantic processing while updating vectors.
 
 ## Supported platforms
 

--- a/npm/compile-cli/README.md
+++ b/npm/compile-cli/README.md
@@ -28,13 +28,24 @@ the environment and replace it at the network egress. The native CLI trusts
 both Mozilla public roots and certificates installed in the operating
 system's trust store, including sandbox egress gateway CAs.
 
-The API endpoint is compiled into the binary and cannot be overridden:
+The API endpoint defaults to:
 
 ```text
 https://api.vikingdb.cn-beijing.volces.com/openviking
 ```
 
-The CLI does not read `~/.openviking/ovcli.conf` or `OPENVIKING_CLI_CONFIG_FILE`.
+To use another OpenViking data-plane endpoint, write its URL to
+`~/.openviking/ovcli.conf`:
+
+```json
+{
+  "url": "https://openviking.example.com/openviking"
+}
+```
+
+Only the URL is read from this file. Authentication still comes exclusively
+from `OPENVIKING_API_KEY`; credentials in `ovcli.conf` are ignored. Set
+`OPENVIKING_CLI_CONFIG_FILE` to select a different config file.
 
 ## Commands
 

--- a/npm/compile-cli/README.md
+++ b/npm/compile-cli/README.md
@@ -1,14 +1,18 @@
-# @openviking-compile/cli
+# @openviking/compile
 
 OpenViking retrieval and content-write CLI for cloud agents. The package installs an `ov` command with seven retrieval commands plus `write`; other mutation and administration commands are not included.
 
 ## Install
 
 ```bash
-npm i -g @openviking-compile/cli
+npm i -g @openviking/compile
 ```
 
-Do not install this package globally alongside `@openviking/cli`; both packages provide an executable named `ov`.
+Do not install this package globally alongside `@openviking/cli`; both packages provide an executable named `ov`. Install one package globally, or run this restricted distribution in an isolated project with `npm exec`.
+
+```bash
+npm exec --yes --package=@openviking/compile -- ov --help
+```
 
 ## Authentication
 

--- a/npm/compile-cli/README.md
+++ b/npm/compile-cli/README.md
@@ -1,0 +1,53 @@
+# @openviking-compile/cli
+
+Read-only OpenViking CLI for cloud agents. The package installs an `ov` command with seven retrieval commands and no mutation or administration commands.
+
+## Install
+
+```bash
+npm i -g @openviking-compile/cli
+```
+
+Do not install this package globally alongside `@openviking/cli`; both packages provide an executable named `ov`.
+
+## Authentication
+
+The CLI reads its API key only from `OPENVIKING_API_KEY`:
+
+```bash
+export OPENVIKING_API_KEY="<your-api-key>"
+```
+
+The API endpoint is compiled into the binary and cannot be overridden:
+
+```text
+https://api.vikingdb.cn-beijing.volces.com/openviking
+```
+
+The CLI does not read `~/.openviking/ovcli.conf` or `OPENVIKING_CLI_CONFIG_FILE`.
+
+## Commands
+
+| Command | Purpose |
+| --- | --- |
+| `ov read <uri>` | Read full file content |
+| `ov grep --uri <uri> <pattern>` | Search file content with a regular expression |
+| `ov glob <pattern>` | Search file names with a glob pattern |
+| `ov ls [uri]` | List directory contents |
+| `ov tree <uri>` | Print a directory tree |
+| `ov find <query>` | Run semantic retrieval |
+| `ov search <query>` | Run context-aware retrieval |
+
+Run `ov <command> --help` for command-specific options. Add `--output json` for machine-readable output.
+
+## Supported platforms
+
+| Platform | Architecture |
+| --- | --- |
+| Linux | x64, ARM64 |
+| macOS | Apple Silicon, Intel |
+| Windows | x64 |
+
+## License
+
+Apache-2.0

--- a/npm/compile-cli/bin/ov.mjs
+++ b/npm/compile-cli/bin/ov.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+const require = createRequire(import.meta.url);
+const platforms = {
+  "darwin-arm64": "@openviking-compile/cli-darwin-arm64",
+  "darwin-x64": "@openviking-compile/cli-darwin-x64",
+  "linux-arm64": "@openviking-compile/cli-linux-arm64",
+  "linux-x64": "@openviking-compile/cli-linux-x64",
+  "win32-x64": "@openviking-compile/cli-win32-x64"
+};
+
+const key = `${process.platform}-${process.arch}`;
+const packageName = platforms[key];
+if (!packageName) {
+  console.error(`Unsupported platform: ${key}`);
+  process.exit(1);
+}
+
+let packageJson;
+try {
+  packageJson = require.resolve(`${packageName}/package.json`);
+} catch {
+  console.error(
+    `Native package ${packageName} is missing. Reinstall without --omit=optional.`
+  );
+  process.exit(1);
+}
+
+const extension = process.platform === "win32" ? ".exe" : "";
+const binary = join(packageJson, "..", "bin", `ov${extension}`);
+
+try {
+  execFileSync(binary, process.argv.slice(2), { stdio: "inherit" });
+} catch (error) {
+  process.exit(error.status ?? 1);
+}

--- a/npm/compile-cli/bin/ov.mjs
+++ b/npm/compile-cli/bin/ov.mjs
@@ -5,11 +5,11 @@ import { join } from "node:path";
 
 const require = createRequire(import.meta.url);
 const platforms = {
-  "darwin-arm64": "@openviking-compile/cli-darwin-arm64",
-  "darwin-x64": "@openviking-compile/cli-darwin-x64",
-  "linux-arm64": "@openviking-compile/cli-linux-arm64",
-  "linux-x64": "@openviking-compile/cli-linux-x64",
-  "win32-x64": "@openviking-compile/cli-win32-x64"
+  "darwin-arm64": "@openviking/compile-darwin-arm64",
+  "darwin-x64": "@openviking/compile-darwin-x64",
+  "linux-arm64": "@openviking/compile-linux-arm64",
+  "linux-x64": "@openviking/compile-linux-x64",
+  "win32-x64": "@openviking/compile-win32-x64"
 };
 
 const key = `${process.platform}-${process.arch}`;

--- a/npm/compile-cli/bin/postinstall.mjs
+++ b/npm/compile-cli/bin/postinstall.mjs
@@ -8,6 +8,7 @@ Set the API key before use:
 
 Available commands:
   ov read <uri>
+  ov write <uri> --content <text>
   ov grep --uri <uri> <pattern>
   ov glob <pattern> [--uri <uri>]
   ov ls [uri]

--- a/npm/compile-cli/bin/postinstall.mjs
+++ b/npm/compile-cli/bin/postinstall.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 process.stderr.write(`
-@openviking-compile/cli installed.
+@openviking/compile installed.
 
 Set the API key before use:
   export OPENVIKING_API_KEY="<your-api-key>"

--- a/npm/compile-cli/bin/postinstall.mjs
+++ b/npm/compile-cli/bin/postinstall.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+process.stderr.write(`
+@openviking-compile/cli installed.
+
+Set the API key before use:
+  export OPENVIKING_API_KEY="<your-api-key>"
+
+Available commands:
+  ov read <uri>
+  ov grep --uri <uri> <pattern>
+  ov glob <pattern> [--uri <uri>]
+  ov ls [uri]
+  ov tree <uri>
+  ov find <query> [--uri <uri>]
+  ov search <query> [--uri <uri>]
+
+The service endpoint is fixed in the binary.
+`);

--- a/npm/compile-cli/package.json
+++ b/npm/compile-cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@openviking-compile/cli",
+  "name": "@openviking/compile",
   "version": "0.0.0",
   "description": "OpenViking retrieval and content-write CLI for cloud agents",
   "bin": {
@@ -14,11 +14,11 @@
     "README.md"
   ],
   "optionalDependencies": {
-    "@openviking-compile/cli-darwin-arm64": "0.0.0",
-    "@openviking-compile/cli-darwin-x64": "0.0.0",
-    "@openviking-compile/cli-linux-arm64": "0.0.0",
-    "@openviking-compile/cli-linux-x64": "0.0.0",
-    "@openviking-compile/cli-win32-x64": "0.0.0"
+    "@openviking/compile-darwin-arm64": "0.0.0",
+    "@openviking/compile-darwin-x64": "0.0.0",
+    "@openviking/compile-linux-arm64": "0.0.0",
+    "@openviking/compile-linux-x64": "0.0.0",
+    "@openviking/compile-win32-x64": "0.0.0"
   },
   "keywords": [
     "openviking",
@@ -30,7 +30,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fujiajie666/OpenViking_Vaka.git"
+    "url": "git+https://github.com/volcengine/openviking.git"
   },
   "publishConfig": {
     "access": "public"

--- a/npm/compile-cli/package.json
+++ b/npm/compile-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openviking-compile/cli",
   "version": "0.0.0",
-  "description": "Read-only OpenViking CLI for cloud agents",
+  "description": "OpenViking retrieval and content-write CLI for cloud agents",
   "bin": {
     "ov": "bin/ov.mjs"
   },
@@ -24,8 +24,8 @@
     "openviking",
     "cli",
     "agent",
-    "read-only",
-    "search"
+    "search",
+    "write"
   ],
   "license": "Apache-2.0",
   "repository": {

--- a/npm/compile-cli/package.json
+++ b/npm/compile-cli/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@openviking-compile/cli",
+  "version": "0.0.0",
+  "description": "Read-only OpenViking CLI for cloud agents",
+  "bin": {
+    "ov": "bin/ov.mjs"
+  },
+  "scripts": {
+    "postinstall": "node bin/postinstall.mjs"
+  },
+  "type": "module",
+  "files": [
+    "bin",
+    "README.md"
+  ],
+  "optionalDependencies": {
+    "@openviking-compile/cli-darwin-arm64": "0.0.0",
+    "@openviking-compile/cli-darwin-x64": "0.0.0",
+    "@openviking-compile/cli-linux-arm64": "0.0.0",
+    "@openviking-compile/cli-linux-x64": "0.0.0",
+    "@openviking-compile/cli-win32-x64": "0.0.0"
+  },
+  "keywords": [
+    "openviking",
+    "cli",
+    "agent",
+    "read-only",
+    "search"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fujiajie666/OpenViking_Vaka.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
## Description

The restricted Compile CLI currently hardcodes the production OpenViking endpoint, so a Managed Agent created for STG or another deployment reads and writes the wrong collection even when its Vault API key belongs to that deployment.

After this change, `@openviking/compile` reads only `url` from the standard `ovcli.conf`; when no config file exists it keeps the current production endpoint as the default. Authentication remains isolated: the CLI ignores credentials from the file and continues to use only the Vault-provided `OPENVIKING_API_KEY`.

Example: with the same `ov read viking://resources/source/file.md` command, `{"url":"https://stg.example.com/openviking"}` routes the request to STG, while no config file routes it to `https://api.vikingdb.cn-beijing.volces.com/openviking`.

This PR also brings the already published restricted CLI source onto current `main` and supplies empty values for newer optional handler arguments, without exposing additional commands or options.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Supports the external Compile integration in [PR #4436](https://github.com/volcengine/OpenViking/pull/4436).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Load the Compile data-plane URL from `ovcli.conf`, with the existing production URL as the fallback.
- Keep API key ownership in `OPENVIKING_API_KEY` and ignore authentication fields from the config file.
- Align the restricted wrapper with current handler signatures while preserving its existing command surface.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The Base Server counterpart writes an URL-only `ovcli.conf` during Managed Agent Environment setup and keeps the API key in the Vault credential.
