### PR TITLE
fix(dsh-plugin): run profile and recall in parallel on pre-step

### DIFF
--- a/examples/dsh-memory-plugin/index.mjs
+++ b/examples/dsh-memory-plugin/index.mjs
@@ -33,13 +33,17 @@ export function apply(ctx, input = {}) {
 
   // prepend: downstream waterfall listeners run first, so this plugin sees
   // the final claimed batch and appends after every other contributor.
+  // Profile + recall are independent after `next()`; run them concurrently so
+  // the agent/pre-step waterfall (which currently gates user/message push in
+  // dsh-agent-loop) spends less wall time (#4515).
   ctx.on("agent/pre-step", async ({ agent, messages, signal }, next) => {
     const decision = await next();
     if (skipMemory(agent.session)) return decision;
     if (decision.kind !== "enter" || signal.aborted) return decision;
-    const profile = await runtime.profileMessage(agent);
-    if (signal.aborted) return decision;
-    const recall = await runtime.recallMessage(agent, decision.messages);
+    const [profile, recall] = await Promise.all([
+      runtime.profileMessage(agent),
+      runtime.recallMessage(agent, decision.messages),
+    ]);
     if (signal.aborted) return decision;
     const additions = [profile, recall].filter(Boolean);
     return additions.length > 0


### PR DESCRIPTION
## Summary
`agent/pre-step` in `dsh-memory-plugin` awaited `profileMessage` then `recallMessage` sequentially. That waterfall still runs before `dsh-agent-loop` appends `user/message` (#4515), so serial OV work adds avoidable latency to the blank chat window.

Run profile + recall concurrently via `Promise.all` after `next()` (`ensureState` is already single-flight safe).

This is a mitigation inside OpenViking's plugin; a complete UX fix still needs `dsh-agent-loop` to push `user/message` before the pre-step waterfall.

Related to #4515

## Test plan
- [ ] `node --test examples/dsh-memory-plugin/index.test.mjs`
- [ ] With the plugin installed, send a message and confirm recall still injects; wall time of pre-step should drop when both profile and recall would have been slow