### PR TITLE
fix(session): batch Phase 2 extraction by auto-commit policy

### DIFF
--- a/openviking/session/extraction_batch.py
+++ b/openviking/session/extraction_batch.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Phase 2 extraction batches derived from a session's auto-commit policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, List, Optional
+
+from openviking.message import Message
+from openviking.session.auto_commit_policy import AutoCommitPolicy
+from openviking.session.retention import UserTurn, build_turns
+
+
+@dataclass(frozen=True)
+class ExtractionBatchLimits:
+    max_message_tokens: Optional[int] = None
+    max_messages: Optional[int] = None
+
+    @property
+    def enabled(self) -> bool:
+        return self.max_message_tokens is not None or self.max_messages is not None
+
+
+@dataclass(frozen=True)
+class ExtractionMessageBatch:
+    messages: tuple[Message, ...]
+    estimated_tokens: int
+    oversized: bool = False
+
+
+def resolve_extraction_batch_limits(auto_commit_policy: Any) -> ExtractionBatchLimits:
+    if not isinstance(auto_commit_policy, dict) or not auto_commit_policy:
+        return ExtractionBatchLimits()
+    policy = AutoCommitPolicy.from_dict(auto_commit_policy)
+    return ExtractionBatchLimits(
+        max_message_tokens=(
+            policy.pending_token_threshold if policy.pending_token_threshold > 0 else None
+        ),
+        max_messages=(
+            policy.message_count_threshold if policy.message_count_threshold > 0 else None
+        ),
+    )
+
+
+def estimate_extraction_message_tokens(messages: Iterable[Message]) -> int:
+    return sum(int(message.estimated_tokens or 0) for message in messages)
+
+
+def _exceeds_limits(
+    *,
+    message_count: int,
+    estimated_tokens: int,
+    limits: ExtractionBatchLimits,
+) -> bool:
+    return bool(
+        (limits.max_message_tokens is not None and estimated_tokens > limits.max_message_tokens)
+        or (limits.max_messages is not None and message_count > limits.max_messages)
+    )
+
+
+def _turn_units(turn: UserTurn, limits: ExtractionBatchLimits) -> List[List[Message]]:
+    messages = list(turn.messages)
+    if not _exceeds_limits(
+        message_count=len(messages),
+        estimated_tokens=estimate_extraction_message_tokens(messages),
+        limits=limits,
+    ):
+        return [messages]
+
+    units: List[List[Message]] = []
+    if turn.anchor is not None:
+        units.append([turn.anchor])
+    for step in turn.steps:
+        step_messages = list(step.messages)
+        if _exceeds_limits(
+            message_count=len(step_messages),
+            estimated_tokens=estimate_extraction_message_tokens(step_messages),
+            limits=limits,
+        ):
+            units.extend([[message] for message in step_messages])
+        elif step_messages:
+            units.append(step_messages)
+    return units or [messages]
+
+
+def plan_extraction_batches(
+    messages: List[Message],
+    limits: ExtractionBatchLimits,
+) -> List[ExtractionMessageBatch]:
+    if not messages:
+        return []
+    if not limits.enabled:
+        return [
+            ExtractionMessageBatch(
+                messages=tuple(messages),
+                estimated_tokens=estimate_extraction_message_tokens(messages),
+            )
+        ]
+
+    units = [unit for turn in build_turns(messages) for unit in _turn_units(turn, limits)]
+    batches: List[ExtractionMessageBatch] = []
+    current: List[Message] = []
+    current_tokens = 0
+
+    def flush() -> None:
+        nonlocal current, current_tokens
+        if not current:
+            return
+        batches.append(
+            ExtractionMessageBatch(
+                messages=tuple(current),
+                estimated_tokens=current_tokens,
+                oversized=_exceeds_limits(
+                    message_count=len(current),
+                    estimated_tokens=current_tokens,
+                    limits=limits,
+                ),
+            )
+        )
+        current = []
+        current_tokens = 0
+
+    for unit in units:
+        if not unit:
+            continue
+        unit_tokens = estimate_extraction_message_tokens(unit)
+        if current and _exceeds_limits(
+            message_count=len(current) + len(unit),
+            estimated_tokens=current_tokens + unit_tokens,
+            limits=limits,
+        ):
+            flush()
+        if _exceeds_limits(
+            message_count=len(unit),
+            estimated_tokens=unit_tokens,
+            limits=limits,
+        ):
+            flush()
+            batches.append(
+                ExtractionMessageBatch(
+                    messages=tuple(unit),
+                    estimated_tokens=unit_tokens,
+                    oversized=True,
+                )
+            )
+            continue
+        current.extend(unit)
+        current_tokens += unit_tokens
+
+    flush()
+    return batches
+
+
+__all__ = [
+    "ExtractionBatchLimits",
+    "ExtractionMessageBatch",
+    "estimate_extraction_message_tokens",
+    "plan_extraction_batches",
+    "resolve_extraction_batch_limits",
+]

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -2415,7 +2415,7 @@ class Session:
         archive_uri: str,
         extract_batch: Callable[[List[Message]], Awaitable[Any]],
         record_batch: Callable[
-            [str, List[Message], Callable[[], Awaitable[Any]]],
+            [str, str, List[Message], Callable[[], Awaitable[Any]]],
             Awaitable[Any],
         ],
     ) -> Any:
@@ -2426,6 +2426,7 @@ class Session:
             batch_messages = list(batches[0].messages)
             return await record_batch(
                 "long_term_memory_extraction",
+                "long_term",
                 batch_messages,
                 lambda: extract_batch(batch_messages),
             )
@@ -2489,6 +2490,7 @@ class Session:
 
             result = await record_batch(
                 f"long_term_memory_extraction_batch_{batch_number}",
+                "long_term",
                 batch_messages,
                 _extract_and_merge,
             )
@@ -2759,7 +2761,7 @@ class Session:
 
                         if self._session_compressor and long_term_has_work:
 
-                            async def _extract_long_term_batch(
+                            async def _run_long_term_memory_extraction(
                                 batch_messages: List[Message],
                             ) -> Any:
                                 return await self._session_compressor.extract_long_term_memories(
@@ -2778,25 +2780,13 @@ class Session:
                                     event_search_tags=event_search_tags,
                                 )
 
-                            async def _record_long_term_batch(
-                                operation_name: str,
-                                batch_messages: List[Message],
-                                fn: Callable[[], Awaitable[Any]],
-                            ) -> Any:
-                                return await _run_recorded_memory_step(
-                                    operation_name,
-                                    "long_term",
-                                    batch_messages,
-                                    fn,
-                                )
-
                             extraction_tasks.append(
                                 self._extract_long_term_memories_with_batching(
                                     messages=long_term_messages,
                                     limits=extraction_batch_limits,
                                     archive_uri=archive_uri,
-                                    extract_batch=_extract_long_term_batch,
-                                    record_batch=_record_long_term_batch,
+                                    extract_batch=_run_long_term_memory_extraction,
+                                    record_batch=_run_recorded_memory_step,
                                 )
                             )
                             extraction_labels.append("long_term")

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -25,6 +25,7 @@ from openviking.server.identity import RequestContext, Role
 from openviking.session.auto_commit_policy import AutoCommitPolicy
 from openviking.session.extraction_batch import (
     ExtractionBatchLimits,
+    ExtractionMessageBatch,
     estimate_extraction_message_tokens,
     plan_extraction_batches,
     resolve_extraction_batch_limits,
@@ -2600,11 +2601,21 @@ class Session:
                         }
                         if checkpoint_requests:
                             summary_kwargs["checkpoint_requests"] = checkpoint_requests
-                        generated = await self._generate_archive_summary_with_batching(
+                        summary_batches = plan_extraction_batches(
                             extraction_messages,
-                            limits=extraction_batch_limits,
-                            **summary_kwargs,
+                            extraction_batch_limits,
                         )
+                        if len(summary_batches) <= 1:
+                            generated = await self._generate_archive_summary_async(
+                                extraction_messages,
+                                **summary_kwargs,
+                            )
+                        else:
+                            generated = await self._generate_archive_summary_with_batching(
+                                summary_batches,
+                                limits=extraction_batch_limits,
+                                **summary_kwargs,
+                            )
                         summary_result = (
                             generated
                             if isinstance(generated, _ArchiveSummaryResult)
@@ -4327,21 +4338,14 @@ class Session:
 
     async def _generate_archive_summary_with_batching(
         self,
-        messages: List[Message],
+        batches: List[ExtractionMessageBatch],
         *,
         latest_archive_overview: str,
         checkpoint_requests: Optional[List[_CheckpointRequest]] = None,
         limits: ExtractionBatchLimits,
     ) -> str | _ArchiveSummaryResult:
-        batches = plan_extraction_batches(messages, limits)
+        messages = [message for batch in batches for message in batch.messages]
         requests = list(checkpoint_requests or [])
-        if len(batches) <= 1:
-            return await self._generate_archive_summary_async(
-                messages,
-                latest_archive_overview=latest_archive_overview,
-                checkpoint_requests=requests,
-            )
-
         vlm = get_openviking_config().vlm
         if not (vlm and vlm.is_available()):
             return await self._generate_archive_summary_async(

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -2607,7 +2607,7 @@ class Session:
                             extraction_messages,
                             extraction_batch_limits,
                         )
-                        if len(summary_batches) <= 1:
+                        if checkpoint_requests or len(summary_batches) <= 1:
                             generated = await self._generate_archive_summary_async(
                                 extraction_messages,
                                 **summary_kwargs,
@@ -4331,17 +4331,14 @@ class Session:
         batches: List[ExtractionMessageBatch],
         *,
         latest_archive_overview: str,
-        checkpoint_requests: Optional[List[_CheckpointRequest]] = None,
         limits: ExtractionBatchLimits,
-    ) -> str | _ArchiveSummaryResult:
+    ) -> str:
         messages = [message for batch in batches for message in batch.messages]
-        requests = list(checkpoint_requests or [])
         vlm = get_openviking_config().vlm
         if not (vlm and vlm.is_available()):
             return await self._generate_archive_summary_async(
                 messages,
                 latest_archive_overview=latest_archive_overview,
-                checkpoint_requests=requests,
             )
         try:
             _load_render_prompt()
@@ -4349,7 +4346,6 @@ class Session:
             return await self._generate_archive_summary_async(
                 messages,
                 latest_archive_overview=latest_archive_overview,
-                checkpoint_requests=requests,
             )
 
         logger.info(
@@ -4360,72 +4356,19 @@ class Session:
             limits.max_messages,
         )
         current_overview = latest_archive_overview
-        checkpoint_summaries: Dict[int, str] = {}
-        checkpoint_source_ids: Dict[int, List[str]] = {
-            index: list(request.previous_checkpoint_source_message_ids)
-            for index, request in enumerate(requests)
-        }
 
         for batch in batches:
             batch_messages = list(batch.messages)
-            batch_message_ids = {message.id for message in batch_messages}
-            batch_requests: List[_CheckpointRequest] = []
-            batch_request_indexes: List[int] = []
-            for index, request in enumerate(requests):
-                source_ids = tuple(
-                    message_id
-                    for message_id in request.source_message_ids
-                    if message_id in batch_message_ids
-                )
-                if not source_ids:
-                    continue
-                batch_requests.append(
-                    _CheckpointRequest(
-                        turn_anchor_message_id=request.turn_anchor_message_id,
-                        source_message_ids=source_ids,
-                        retained_message_token_budget=request.retained_message_token_budget,
-                        estimated_active_tokens=request.estimated_active_tokens,
-                        previous_checkpoint_abstract=checkpoint_summaries.get(
-                            index,
-                            request.previous_checkpoint_abstract,
-                        ),
-                        previous_checkpoint_source_message_ids=tuple(checkpoint_source_ids[index]),
-                    )
-                )
-                batch_request_indexes.append(index)
-
             generated = await self._generate_archive_summary_async(
                 batch_messages,
                 latest_archive_overview=current_overview,
-                checkpoint_requests=batch_requests,
             )
-            result = (
-                generated
+            current_overview = (
+                generated.overview
                 if isinstance(generated, _ArchiveSummaryResult)
-                else _ArchiveSummaryResult(overview=str(generated or ""))
+                else str(generated or "")
             )
-            current_overview = result.overview
-            if len(result.checkpoint_summaries) != len(batch_requests):
-                raise ValueError(
-                    "Working Memory batch returned an unexpected checkpoint summary count"
-                )
-            for request_index, batch_request, summary in zip(
-                batch_request_indexes,
-                batch_requests,
-                result.checkpoint_summaries,
-                strict=True,
-            ):
-                checkpoint_summaries[request_index] = summary
-                checkpoint_source_ids[request_index].extend(batch_request.source_message_ids)
-
-        if len(checkpoint_summaries) != len(requests):
-            raise ValueError("Working Memory batches did not cover every checkpoint request")
-        return _ArchiveSummaryResult(
-            overview=current_overview,
-            checkpoint_summaries=tuple(
-                checkpoint_summaries[index] for index in range(len(requests))
-            ),
-        )
+        return current_overview
 
     async def _generate_archive_summary_async(
         self,

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -2422,14 +2422,6 @@ class Session:
         batches = plan_extraction_batches(messages, limits)
         if not batches:
             return []
-        if len(batches) <= 1 and not limits.enabled:
-            batch_messages = list(batches[0].messages)
-            return await record_batch(
-                "long_term_memory_extraction",
-                "long_term",
-                batch_messages,
-                lambda: extract_batch(batch_messages),
-            )
 
         logger.info(
             "Processing Phase 2 long-term memory extraction in %s planned batches "
@@ -2762,10 +2754,14 @@ class Session:
                         if self._session_compressor and long_term_has_work:
 
                             async def _run_long_term_memory_extraction(
-                                batch_messages: List[Message],
+                                batch_messages: Optional[List[Message]] = None,
                             ) -> Any:
                                 return await self._session_compressor.extract_long_term_memories(
-                                    messages=batch_messages,
+                                    messages=(
+                                        long_term_messages
+                                        if batch_messages is None
+                                        else batch_messages
+                                    ),
                                     user=self.user,
                                     session_id=self.session_id,
                                     ctx=self.ctx,
@@ -2780,15 +2776,25 @@ class Session:
                                     event_search_tags=event_search_tags,
                                 )
 
-                            extraction_tasks.append(
-                                self._extract_long_term_memories_with_batching(
-                                    messages=long_term_messages,
-                                    limits=extraction_batch_limits,
-                                    archive_uri=archive_uri,
-                                    extract_batch=_run_long_term_memory_extraction,
-                                    record_batch=_run_recorded_memory_step,
+                            if extraction_batch_limits.enabled:
+                                extraction_tasks.append(
+                                    self._extract_long_term_memories_with_batching(
+                                        messages=long_term_messages,
+                                        limits=extraction_batch_limits,
+                                        archive_uri=archive_uri,
+                                        extract_batch=_run_long_term_memory_extraction,
+                                        record_batch=_run_recorded_memory_step,
+                                    )
                                 )
-                            )
+                            else:
+                                extraction_tasks.append(
+                                    _run_recorded_memory_step(
+                                        "long_term_memory_extraction",
+                                        "long_term",
+                                        long_term_messages,
+                                        _run_long_term_memory_extraction,
+                                    )
+                                )
                             extraction_labels.append("long_term")
 
                         _results = await asyncio.gather(

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -2406,7 +2406,7 @@ class Session:
         )
         return await reporter.extract_and_report(messages=messages, context=context)
 
-    async def _extract_long_term_memories_in_batches(
+    async def _extract_long_term_memories_with_batching(
         self,
         *,
         messages: List[Message],
@@ -2600,7 +2600,7 @@ class Session:
                         }
                         if checkpoint_requests:
                             summary_kwargs["checkpoint_requests"] = checkpoint_requests
-                        generated = await self._generate_archive_summary_in_batches(
+                        generated = await self._generate_archive_summary_with_batching(
                             extraction_messages,
                             limits=extraction_batch_limits,
                             **summary_kwargs,
@@ -2780,7 +2780,7 @@ class Session:
                                 )
 
                             extraction_tasks.append(
-                                self._extract_long_term_memories_in_batches(
+                                self._extract_long_term_memories_with_batching(
                                     messages=long_term_messages,
                                     limits=extraction_batch_limits,
                                     archive_uri=archive_uri,
@@ -4325,7 +4325,7 @@ class Session:
             )
         return tuple(raw)
 
-    async def _generate_archive_summary_in_batches(
+    async def _generate_archive_summary_with_batching(
         self,
         messages: List[Message],
         *,

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -112,6 +112,12 @@ def _redact_inline_images(text: str) -> str:
     return _B64_JSON_RE.sub(replace_b64_json, _INLINE_IMAGE_DATA_URL_RE.sub(replace_data_url, text))
 
 
+def _load_render_prompt() -> Callable[..., str]:
+    from openviking.prompts import render_prompt
+
+    return render_prompt
+
+
 def _redact_inline_images_from_tool_outputs(messages: List[Message]) -> List[Message]:
     for message in messages:
         for part in message.parts:
@@ -4329,7 +4335,23 @@ class Session:
     ) -> str | _ArchiveSummaryResult:
         batches = plan_extraction_batches(messages, limits)
         requests = list(checkpoint_requests or [])
-        if len(batches) <= 1 and not limits.enabled:
+        if len(batches) <= 1:
+            return await self._generate_archive_summary_async(
+                messages,
+                latest_archive_overview=latest_archive_overview,
+                checkpoint_requests=requests,
+            )
+
+        vlm = get_openviking_config().vlm
+        if not (vlm and vlm.is_available()):
+            return await self._generate_archive_summary_async(
+                messages,
+                latest_archive_overview=latest_archive_overview,
+                checkpoint_requests=requests,
+            )
+        try:
+            _load_render_prompt()
+        except Exception:
             return await self._generate_archive_summary_async(
                 messages,
                 latest_archive_overview=latest_archive_overview,
@@ -4463,7 +4485,7 @@ class Session:
             )
 
         try:
-            from openviking.prompts import render_prompt
+            render_prompt = _load_render_prompt()
         except Exception as e:
             if checkpoint_requests:
                 raise RuntimeError("Prompt module is required to generate checkpoints") from e

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -23,9 +23,15 @@ from openviking.pyagfs.exceptions import AGFSClientError, AGFSHTTPError, AGFSNot
 from openviking.server.config import ToolOutputExternalizationConfig
 from openviking.server.identity import RequestContext, Role
 from openviking.session.auto_commit_policy import AutoCommitPolicy
+from openviking.session.extraction_batch import (
+    ExtractionBatchLimits,
+    estimate_extraction_message_tokens,
+    plan_extraction_batches,
+    resolve_extraction_batch_limits,
+)
 from openviking.session.memory.constants import AGENT_EVOLUTION_MEMORY_TYPES
-from openviking.session.memory_policy import MemoryPolicy
 from openviking.session.memory.utils.language import resolve_output_language_from_conversation
+from openviking.session.memory_policy import MemoryPolicy
 from openviking.session.retention import (
     RETENTION_MODE_TURN_BUDGET,
     RetentionPlan,
@@ -2104,6 +2110,7 @@ class Session:
                 usage_uris=list(dict.fromkeys(u.uri for u in usage_snapshot if u.uri)),
                 record_auto_commit_success=record_auto_commit_success,
                 event_search_tags=list(effective_event_tags),
+                auto_commit_policy=dict(self._meta.auto_commit_policy or {}),
             )
             phase1_stage = "phase1_persist"
             try:
@@ -2367,6 +2374,7 @@ class Session:
             user_config_error=user_config_error,
             record_auto_commit_success=msg.record_auto_commit_success,
             event_search_tags=list(msg.event_search_tags or []),
+            auto_commit_policy=msg.auto_commit_policy,
         )
         return True
 
@@ -2392,6 +2400,101 @@ class Session:
         )
         return await reporter.extract_and_report(messages=messages, context=context)
 
+    async def _extract_long_term_memories_in_batches(
+        self,
+        *,
+        messages: List[Message],
+        limits: ExtractionBatchLimits,
+        archive_uri: str,
+        extract_batch: Callable[[List[Message]], Awaitable[Any]],
+        record_batch: Callable[
+            [str, List[Message], Callable[[], Awaitable[Any]]],
+            Awaitable[Any],
+        ],
+    ) -> Any:
+        batches = plan_extraction_batches(messages, limits)
+        if not batches:
+            return []
+        if len(batches) <= 1 and not limits.enabled:
+            batch_messages = list(batches[0].messages)
+            return await record_batch(
+                "long_term_memory_extraction",
+                batch_messages,
+                lambda: extract_batch(batch_messages),
+            )
+
+        logger.info(
+            "Processing Phase 2 long-term memory extraction in %s planned batches "
+            "for %s estimated tokens",
+            len(batches),
+            estimate_extraction_message_tokens(messages),
+        )
+        contexts: List[Any] = []
+        skills: List[Dict[str, Any]] = []
+        memory_diffs: List[Dict[str, Any]] = []
+        previous_diff_raw = ""
+        if self._viking_fs:
+            try:
+                previous_diff_raw = await self._viking_fs.read_file(
+                    f"{archive_uri}/memory_diff.json",
+                    ctx=self.ctx,
+                )
+                previous_diff = json.loads(previous_diff_raw or "{}")
+                if isinstance(previous_diff, dict):
+                    memory_diffs.append(previous_diff)
+            except Exception as exc:
+                if not _is_storage_not_found(exc):
+                    raise
+                previous_diff_raw = ""
+
+        for batch_number, batch in enumerate(batches, start=1):
+            batch_messages = list(batch.messages)
+
+            async def _extract_and_merge(
+                batch_messages: List[Message] = batch_messages,
+            ) -> Any:
+                nonlocal previous_diff_raw
+                result = await extract_batch(batch_messages)
+                if not self._viking_fs:
+                    return result
+                try:
+                    current_diff_raw = await self._viking_fs.read_file(
+                        f"{archive_uri}/memory_diff.json",
+                        ctx=self.ctx,
+                    )
+                    if current_diff_raw != previous_diff_raw:
+                        current_diff = json.loads(current_diff_raw or "{}")
+                        if isinstance(current_diff, dict):
+                            memory_diffs.append(current_diff)
+                            await self._session_compressor._write_final_memory_diff(
+                                archive_uri=archive_uri,
+                                ctx=self.ctx,
+                                memory_diffs=memory_diffs,
+                            )
+                            previous_diff_raw = await self._viking_fs.read_file(
+                                f"{archive_uri}/memory_diff.json",
+                                ctx=self.ctx,
+                            )
+                except Exception as exc:
+                    if not _is_storage_not_found(exc):
+                        raise
+                return result
+
+            result = await record_batch(
+                f"long_term_memory_extraction_batch_{batch_number}",
+                batch_messages,
+                _extract_and_merge,
+            )
+            if isinstance(result, dict):
+                contexts.extend(result.get("contexts", []))
+                skills.extend(result.get("session_skills", []))
+            else:
+                contexts.extend(result or [])
+
+        if skills:
+            return {"contexts": contexts, "session_skills": skills}
+        return contexts
+
     @tracer("session.commit.phase2", ignore_result=True, ignore_args=True)
     async def _run_memory_extraction(
         self,
@@ -2407,6 +2510,7 @@ class Session:
         user_config_error: Optional[str] = None,
         record_auto_commit_success: bool = False,
         event_search_tags: Optional[List[str]] = None,
+        auto_commit_policy: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Phase 2: Extract memories and enqueue semantic work in the background."""
         from openviking.service.task_tracker import get_task_tracker
@@ -2450,6 +2554,7 @@ class Session:
                 with bind_telemetry(telemetry):
                     ov_config = get_openviking_config()
                     effective_policy = MemoryPolicy.from_dict(memory_policy)
+                    extraction_batch_limits = resolve_extraction_batch_limits(auto_commit_policy)
                     working_memory_enabled = effective_policy.working_memory_enabled
                     checkpoint_requests = (
                         await self._collect_checkpoint_requests_for_phase2(
@@ -2489,8 +2594,9 @@ class Session:
                         }
                         if checkpoint_requests:
                             summary_kwargs["checkpoint_requests"] = checkpoint_requests
-                        generated = await self._generate_archive_summary_async(
+                        generated = await self._generate_archive_summary_in_batches(
                             extraction_messages,
+                            limits=extraction_batch_limits,
                             **summary_kwargs,
                         )
                         summary_result = (
@@ -2636,13 +2742,11 @@ class Session:
 
                         if self._session_compressor and long_term_has_work:
 
-                            async def _run_long_term_memory_extraction() -> Any:
-                                # strict_extract_errors=True lets transient failures
-                                # surface so _run_retryable_phase2_step can retry them
-                                # (and so a final failure is recorded as a skipped
-                                # archive instead of silently dropping the memory).
+                            async def _extract_long_term_batch(
+                                batch_messages: List[Message],
+                            ) -> Any:
                                 return await self._session_compressor.extract_long_term_memories(
-                                    messages=long_term_messages,
+                                    messages=batch_messages,
                                     user=self.user,
                                     session_id=self.session_id,
                                     ctx=self.ctx,
@@ -2657,12 +2761,25 @@ class Session:
                                     event_search_tags=event_search_tags,
                                 )
 
-                            extraction_tasks.append(
-                                _run_recorded_memory_step(
-                                    "long_term_memory_extraction",
+                            async def _record_long_term_batch(
+                                operation_name: str,
+                                batch_messages: List[Message],
+                                fn: Callable[[], Awaitable[Any]],
+                            ) -> Any:
+                                return await _run_recorded_memory_step(
+                                    operation_name,
                                     "long_term",
-                                    long_term_messages,
-                                    _run_long_term_memory_extraction,
+                                    batch_messages,
+                                    fn,
+                                )
+
+                            extraction_tasks.append(
+                                self._extract_long_term_memories_in_batches(
+                                    messages=long_term_messages,
+                                    limits=extraction_batch_limits,
+                                    archive_uri=archive_uri,
+                                    extract_batch=_extract_long_term_batch,
+                                    record_batch=_record_long_term_batch,
                                 )
                             )
                             extraction_labels.append("long_term")
@@ -4201,6 +4318,98 @@ class Session:
                 f"tool_call checkpoint_summaries must contain exactly {request_count} strings"
             )
         return tuple(raw)
+
+    async def _generate_archive_summary_in_batches(
+        self,
+        messages: List[Message],
+        *,
+        latest_archive_overview: str,
+        checkpoint_requests: Optional[List[_CheckpointRequest]] = None,
+        limits: ExtractionBatchLimits,
+    ) -> str | _ArchiveSummaryResult:
+        batches = plan_extraction_batches(messages, limits)
+        requests = list(checkpoint_requests or [])
+        if len(batches) <= 1 and not limits.enabled:
+            return await self._generate_archive_summary_async(
+                messages,
+                latest_archive_overview=latest_archive_overview,
+                checkpoint_requests=requests,
+            )
+
+        logger.info(
+            "Processing Phase 2 Working Memory extraction in %s planned batches "
+            "using auto-commit limits tokens=%s messages=%s",
+            len(batches),
+            limits.max_message_tokens,
+            limits.max_messages,
+        )
+        current_overview = latest_archive_overview
+        checkpoint_summaries: Dict[int, str] = {}
+        checkpoint_source_ids: Dict[int, List[str]] = {
+            index: list(request.previous_checkpoint_source_message_ids)
+            for index, request in enumerate(requests)
+        }
+
+        for batch in batches:
+            batch_messages = list(batch.messages)
+            batch_message_ids = {message.id for message in batch_messages}
+            batch_requests: List[_CheckpointRequest] = []
+            batch_request_indexes: List[int] = []
+            for index, request in enumerate(requests):
+                source_ids = tuple(
+                    message_id
+                    for message_id in request.source_message_ids
+                    if message_id in batch_message_ids
+                )
+                if not source_ids:
+                    continue
+                batch_requests.append(
+                    _CheckpointRequest(
+                        turn_anchor_message_id=request.turn_anchor_message_id,
+                        source_message_ids=source_ids,
+                        retained_message_token_budget=request.retained_message_token_budget,
+                        estimated_active_tokens=request.estimated_active_tokens,
+                        previous_checkpoint_abstract=checkpoint_summaries.get(
+                            index,
+                            request.previous_checkpoint_abstract,
+                        ),
+                        previous_checkpoint_source_message_ids=tuple(checkpoint_source_ids[index]),
+                    )
+                )
+                batch_request_indexes.append(index)
+
+            generated = await self._generate_archive_summary_async(
+                batch_messages,
+                latest_archive_overview=current_overview,
+                checkpoint_requests=batch_requests,
+            )
+            result = (
+                generated
+                if isinstance(generated, _ArchiveSummaryResult)
+                else _ArchiveSummaryResult(overview=str(generated or ""))
+            )
+            current_overview = result.overview
+            if len(result.checkpoint_summaries) != len(batch_requests):
+                raise ValueError(
+                    "Working Memory batch returned an unexpected checkpoint summary count"
+                )
+            for request_index, batch_request, summary in zip(
+                batch_request_indexes,
+                batch_requests,
+                result.checkpoint_summaries,
+                strict=True,
+            ):
+                checkpoint_summaries[request_index] = summary
+                checkpoint_source_ids[request_index].extend(batch_request.source_message_ids)
+
+        if len(checkpoint_summaries) != len(requests):
+            raise ValueError("Working Memory batches did not cover every checkpoint request")
+        return _ArchiveSummaryResult(
+            overview=current_overview,
+            checkpoint_summaries=tuple(
+                checkpoint_summaries[index] for index in range(len(requests))
+            ),
+        )
 
     async def _generate_archive_summary_async(
         self,

--- a/openviking/storage/queuefs/session_commit_msg.py
+++ b/openviking/storage/queuefs/session_commit_msg.py
@@ -21,6 +21,7 @@ class SessionCommitMsg:
     # Resolved custom scalar tags to attach to event memories extracted in this
     # commit. Already normalized by the producer; empty means "no tags".
     event_search_tags: List[str] = field(default_factory=list)
+    auto_commit_policy: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)

--- a/tests/session/test_session_commit.py
+++ b/tests/session/test_session_commit.py
@@ -115,6 +115,45 @@ class TestCommit:
         # Wait for semantic/embedding queues
         await service.resources.wait_processed(timeout=60.0)
 
+    async def test_phase2_splits_with_the_committed_auto_commit_policy(
+        self,
+        session_with_messages: Session,
+        monkeypatch,
+    ):
+        await session_with_messages.update_config(
+            auto_commit_policy={
+                "pending_token_threshold": 0,
+                "message_count_threshold": 1,
+            },
+            update_auto_commit_policy=True,
+        )
+        working_memory_batches = []
+
+        async def generate_summary(
+            _session,
+            messages,
+            latest_archive_overview="",
+            checkpoint_requests=None,
+        ):
+            del checkpoint_requests
+            working_memory_batches.append([message.id for message in messages])
+            return f"{latest_archive_overview}\n{messages[0].id}"
+
+        monkeypatch.setattr(Session, "_generate_archive_summary_async", generate_summary)
+        extract_long_term = AsyncMock(return_value=[])
+        session_with_messages._session_compressor.extract_long_term_memories = extract_long_term
+
+        result = await session_with_messages.commit_async()
+        task_result = await _wait_for_task(result["task_id"])
+
+        assert task_result["status"] == "completed"
+        assert len(working_memory_batches) == 4
+        assert all(len(batch) == 1 for batch in working_memory_batches)
+        assert extract_long_term.await_count == 4
+        assert all(len(call.kwargs["messages"]) == 1 for call in extract_long_term.await_args_list)
+        phase1 = await session_with_messages._read_phase1_meta(result["archive_uri"])
+        assert phase1["queue_message"]["auto_commit_policy"]["message_count_threshold"] == 1
+
     async def test_commit_task_reports_intentionally_skipped_memory_operations(
         self,
         session_with_messages: Session,

--- a/tests/unit/session/test_extraction_batch.py
+++ b/tests/unit/session/test_extraction_batch.py
@@ -100,10 +100,11 @@ async def test_working_memory_batches_carry_the_previous_summary_forward():
 
     session._generate_archive_summary_async = AsyncMock(side_effect=generate)
 
+    limits = ExtractionBatchLimits(max_messages=1)
     result = await session._generate_archive_summary_with_batching(
-        messages,
+        plan_extraction_batches(messages, limits),
         latest_archive_overview="previous",
-        limits=ExtractionBatchLimits(max_messages=1),
+        limits=limits,
     )
 
     assert isinstance(result, _ArchiveSummaryResult)
@@ -122,10 +123,11 @@ async def test_working_memory_no_vlm_fallback_uses_all_messages(monkeypatch):
     config = type("Config", (), {"vlm": None})()
     monkeypatch.setattr("openviking.session.session.get_openviking_config", lambda: config)
 
+    limits = ExtractionBatchLimits(max_messages=1)
     result = await session._generate_archive_summary_with_batching(
-        messages,
+        plan_extraction_batches(messages, limits),
         latest_archive_overview="",
-        limits=ExtractionBatchLimits(max_messages=1),
+        limits=limits,
     )
 
     assert result == "# Session Summary\n\n**Overview**: 3 turns, 3 messages"
@@ -144,10 +146,11 @@ async def test_working_memory_prompt_fallback_uses_all_messages(monkeypatch):
 
     monkeypatch.setattr("openviking.session.session._load_render_prompt", unavailable_prompt)
 
+    limits = ExtractionBatchLimits(max_messages=1)
     result = await session._generate_archive_summary_with_batching(
-        messages,
+        plan_extraction_batches(messages, limits),
         latest_archive_overview="",
-        limits=ExtractionBatchLimits(max_messages=1),
+        limits=limits,
     )
 
     assert result == "# Session Summary\n\n**Overview**: 3 turns, 3 messages"
@@ -181,11 +184,12 @@ async def test_working_memory_batches_accumulate_split_checkpoint_sources():
 
     session._generate_archive_summary_async = AsyncMock(side_effect=generate)
 
+    limits = ExtractionBatchLimits(max_messages=1)
     result = await session._generate_archive_summary_with_batching(
-        messages,
+        plan_extraction_batches(messages, limits),
         latest_archive_overview="previous",
         checkpoint_requests=[request],
-        limits=ExtractionBatchLimits(max_messages=1),
+        limits=limits,
     )
 
     assert isinstance(result, _ArchiveSummaryResult)

--- a/tests/unit/session/test_extraction_batch.py
+++ b/tests/unit/session/test_extraction_batch.py
@@ -100,7 +100,7 @@ async def test_working_memory_batches_carry_the_previous_summary_forward():
 
     session._generate_archive_summary_async = AsyncMock(side_effect=generate)
 
-    result = await session._generate_archive_summary_in_batches(
+    result = await session._generate_archive_summary_with_batching(
         messages,
         latest_archive_overview="previous",
         limits=ExtractionBatchLimits(max_messages=1),
@@ -122,7 +122,7 @@ async def test_working_memory_no_vlm_fallback_uses_all_messages(monkeypatch):
     config = type("Config", (), {"vlm": None})()
     monkeypatch.setattr("openviking.session.session.get_openviking_config", lambda: config)
 
-    result = await session._generate_archive_summary_in_batches(
+    result = await session._generate_archive_summary_with_batching(
         messages,
         latest_archive_overview="",
         limits=ExtractionBatchLimits(max_messages=1),
@@ -144,7 +144,7 @@ async def test_working_memory_prompt_fallback_uses_all_messages(monkeypatch):
 
     monkeypatch.setattr("openviking.session.session._load_render_prompt", unavailable_prompt)
 
-    result = await session._generate_archive_summary_in_batches(
+    result = await session._generate_archive_summary_with_batching(
         messages,
         latest_archive_overview="",
         limits=ExtractionBatchLimits(max_messages=1),
@@ -181,7 +181,7 @@ async def test_working_memory_batches_accumulate_split_checkpoint_sources():
 
     session._generate_archive_summary_async = AsyncMock(side_effect=generate)
 
-    result = await session._generate_archive_summary_in_batches(
+    result = await session._generate_archive_summary_with_batching(
         messages,
         latest_archive_overview="previous",
         checkpoint_requests=[request],
@@ -208,7 +208,7 @@ async def test_long_term_memory_batches_follow_the_planned_limit():
         recorded_batches.append((operation_name, [message.id for message in batch]))
         return result
 
-    result = await session._extract_long_term_memories_in_batches(
+    result = await session._extract_long_term_memories_with_batching(
         messages=messages,
         limits=ExtractionBatchLimits(max_messages=1),
         archive_uri="viking://user/default/sessions/s1/history/archive_001",

--- a/tests/unit/session/test_extraction_batch.py
+++ b/tests/unit/session/test_extraction_batch.py
@@ -116,6 +116,44 @@ async def test_working_memory_batches_carry_the_previous_summary_forward():
 
 
 @pytest.mark.asyncio
+async def test_working_memory_no_vlm_fallback_uses_all_messages(monkeypatch):
+    session = Session(viking_fs=None)
+    messages = [_message("u1"), _message("u2"), _message("u3")]
+    config = type("Config", (), {"vlm": None})()
+    monkeypatch.setattr("openviking.session.session.get_openviking_config", lambda: config)
+
+    result = await session._generate_archive_summary_in_batches(
+        messages,
+        latest_archive_overview="",
+        limits=ExtractionBatchLimits(max_messages=1),
+    )
+
+    assert result == "# Session Summary\n\n**Overview**: 3 turns, 3 messages"
+
+
+@pytest.mark.asyncio
+async def test_working_memory_prompt_fallback_uses_all_messages(monkeypatch):
+    session = Session(viking_fs=None)
+    messages = [_message("u1"), _message("u2"), _message("u3")]
+    vlm = type("VLM", (), {"is_available": lambda self: True})()
+    config = type("Config", (), {"vlm": vlm})()
+    monkeypatch.setattr("openviking.session.session.get_openviking_config", lambda: config)
+
+    def unavailable_prompt():
+        raise ImportError("prompt module unavailable")
+
+    monkeypatch.setattr("openviking.session.session._load_render_prompt", unavailable_prompt)
+
+    result = await session._generate_archive_summary_in_batches(
+        messages,
+        latest_archive_overview="",
+        limits=ExtractionBatchLimits(max_messages=1),
+    )
+
+    assert result == "# Session Summary\n\n**Overview**: 3 turns, 3 messages"
+
+
+@pytest.mark.asyncio
 async def test_working_memory_batches_accumulate_split_checkpoint_sources():
     session = Session(viking_fs=None)
     messages = [_message("u1"), _message("a1", "assistant"), _message("a2", "assistant")]

--- a/tests/unit/session/test_extraction_batch.py
+++ b/tests/unit/session/test_extraction_batch.py
@@ -207,9 +207,9 @@ async def test_long_term_memory_batches_follow_the_planned_limit():
     async def extract(batch):
         return [batch[0].id]
 
-    async def record(operation_name, batch, fn):
+    async def record(operation_name, step, batch, fn):
         result = await fn()
-        recorded_batches.append((operation_name, [message.id for message in batch]))
+        recorded_batches.append((operation_name, step, [message.id for message in batch]))
         return result
 
     result = await session._extract_long_term_memories_with_batching(
@@ -221,8 +221,9 @@ async def test_long_term_memory_batches_follow_the_planned_limit():
     )
 
     assert result == ["u1", "u2", "u3"]
-    assert [message_ids for _, message_ids in recorded_batches] == [
+    assert [message_ids for _, _, message_ids in recorded_batches] == [
         ["u1"],
         ["u2"],
         ["u3"],
     ]
+    assert all(step == "long_term" for _, step, _ in recorded_batches)

--- a/tests/unit/session/test_extraction_batch.py
+++ b/tests/unit/session/test_extraction_batch.py
@@ -11,7 +11,7 @@ from openviking.session.extraction_batch import (
     plan_extraction_batches,
     resolve_extraction_batch_limits,
 )
-from openviking.session.session import Session, _ArchiveSummaryResult, _CheckpointRequest
+from openviking.session.session import Session
 
 
 def _message(message_id: str, role: str = "user", text: str = "content") -> Message:
@@ -107,8 +107,7 @@ async def test_working_memory_batches_carry_the_previous_summary_forward():
         limits=limits,
     )
 
-    assert isinstance(result, _ArchiveSummaryResult)
-    assert result.overview == "previous|u1|u2|u3"
+    assert result == "previous|u1|u2|u3"
     assert [(ids, previous) for ids, previous, _ in calls] == [
         (["u1"], "previous"),
         (["u2"], "previous|u1"),
@@ -154,48 +153,6 @@ async def test_working_memory_prompt_fallback_uses_all_messages(monkeypatch):
     )
 
     assert result == "# Session Summary\n\n**Overview**: 3 turns, 3 messages"
-
-
-@pytest.mark.asyncio
-async def test_working_memory_batches_accumulate_split_checkpoint_sources():
-    session = Session(viking_fs=None)
-    messages = [_message("u1"), _message("a1", "assistant"), _message("a2", "assistant")]
-    request = _CheckpointRequest(
-        turn_anchor_message_id="u1",
-        source_message_ids=("a1", "a2"),
-        retained_message_token_budget=100,
-        estimated_active_tokens=10,
-        previous_checkpoint_abstract="older",
-        previous_checkpoint_source_message_ids=("a0",),
-    )
-    calls = []
-
-    async def generate(batch, latest_archive_overview="", checkpoint_requests=None):
-        batch_requests = list(checkpoint_requests or [])
-        calls.append(batch_requests)
-        summaries = tuple(
-            f"{item.previous_checkpoint_abstract}+{','.join(item.source_message_ids)}"
-            for item in batch_requests
-        )
-        return _ArchiveSummaryResult(
-            overview=f"{latest_archive_overview}|{batch[0].id}",
-            checkpoint_summaries=summaries,
-        )
-
-    session._generate_archive_summary_async = AsyncMock(side_effect=generate)
-
-    limits = ExtractionBatchLimits(max_messages=1)
-    result = await session._generate_archive_summary_with_batching(
-        plan_extraction_batches(messages, limits),
-        latest_archive_overview="previous",
-        checkpoint_requests=[request],
-        limits=limits,
-    )
-
-    assert isinstance(result, _ArchiveSummaryResult)
-    assert result.checkpoint_summaries == ("older+a1+a2",)
-    assert calls[1][0].previous_checkpoint_source_message_ids == ("a0",)
-    assert calls[2][0].previous_checkpoint_source_message_ids == ("a0", "a1")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/test_extraction_batch.py
+++ b/tests/unit/session/test_extraction_batch.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from openviking.message import Message, TextPart
+from openviking.session.extraction_batch import (
+    ExtractionBatchLimits,
+    plan_extraction_batches,
+    resolve_extraction_batch_limits,
+)
+from openviking.session.session import Session, _ArchiveSummaryResult, _CheckpointRequest
+
+
+def _message(message_id: str, role: str = "user", text: str = "content") -> Message:
+    return Message(id=message_id, role=role, parts=[TextPart(text)])
+
+
+def test_auto_commit_policy_resolves_phase2_batch_limits():
+    limits = resolve_extraction_batch_limits(
+        {
+            "pending_token_threshold": 8000,
+            "message_count_threshold": 40,
+        }
+    )
+
+    assert limits == ExtractionBatchLimits(max_message_tokens=8000, max_messages=40)
+    assert resolve_extraction_batch_limits(None).enabled is False
+    assert resolve_extraction_batch_limits({}).enabled is False
+
+
+def test_phase2_batches_split_an_oversized_batch_by_message_count():
+    messages = [_message(f"m{index}") for index in range(5)]
+
+    batches = plan_extraction_batches(
+        messages,
+        ExtractionBatchLimits(max_messages=2),
+    )
+
+    assert [[message.id for message in batch.messages] for batch in batches] == [
+        ["m0", "m1"],
+        ["m2", "m3"],
+        ["m4"],
+    ]
+
+
+def test_phase2_batches_split_an_oversized_batch_by_token_count():
+    messages = [_message(f"m{index}", text="word " * 80) for index in range(3)]
+    one_message_tokens = messages[0].estimated_tokens
+
+    batches = plan_extraction_batches(
+        messages,
+        ExtractionBatchLimits(max_message_tokens=one_message_tokens),
+    )
+
+    assert [[message.id for message in batch.messages] for batch in batches] == [
+        ["m0"],
+        ["m1"],
+        ["m2"],
+    ]
+    assert all(batch.estimated_tokens <= one_message_tokens for batch in batches)
+
+
+def test_phase2_batches_keep_a_turn_together_when_it_fits():
+    messages = [
+        _message("u1", text="question"),
+        _message("a1", role="assistant", text="answer"),
+        _message("u2", text="next"),
+        _message("a2", role="assistant", text="done"),
+    ]
+
+    batches = plan_extraction_batches(
+        messages,
+        ExtractionBatchLimits(max_messages=2),
+    )
+
+    assert [[message.id for message in batch.messages] for batch in batches] == [
+        ["u1", "a1"],
+        ["u2", "a2"],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_working_memory_batches_carry_the_previous_summary_forward():
+    session = Session(viking_fs=None)
+    messages = [_message("u1"), _message("u2"), _message("u3")]
+    calls = []
+
+    async def generate(batch, latest_archive_overview="", checkpoint_requests=None):
+        calls.append(
+            (
+                [message.id for message in batch],
+                latest_archive_overview,
+                list(checkpoint_requests or []),
+            )
+        )
+        return f"{latest_archive_overview}|{batch[0].id}"
+
+    session._generate_archive_summary_async = AsyncMock(side_effect=generate)
+
+    result = await session._generate_archive_summary_in_batches(
+        messages,
+        latest_archive_overview="previous",
+        limits=ExtractionBatchLimits(max_messages=1),
+    )
+
+    assert isinstance(result, _ArchiveSummaryResult)
+    assert result.overview == "previous|u1|u2|u3"
+    assert [(ids, previous) for ids, previous, _ in calls] == [
+        (["u1"], "previous"),
+        (["u2"], "previous|u1"),
+        (["u3"], "previous|u1|u2"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_working_memory_batches_accumulate_split_checkpoint_sources():
+    session = Session(viking_fs=None)
+    messages = [_message("u1"), _message("a1", "assistant"), _message("a2", "assistant")]
+    request = _CheckpointRequest(
+        turn_anchor_message_id="u1",
+        source_message_ids=("a1", "a2"),
+        retained_message_token_budget=100,
+        estimated_active_tokens=10,
+        previous_checkpoint_abstract="older",
+        previous_checkpoint_source_message_ids=("a0",),
+    )
+    calls = []
+
+    async def generate(batch, latest_archive_overview="", checkpoint_requests=None):
+        batch_requests = list(checkpoint_requests or [])
+        calls.append(batch_requests)
+        summaries = tuple(
+            f"{item.previous_checkpoint_abstract}+{','.join(item.source_message_ids)}"
+            for item in batch_requests
+        )
+        return _ArchiveSummaryResult(
+            overview=f"{latest_archive_overview}|{batch[0].id}",
+            checkpoint_summaries=summaries,
+        )
+
+    session._generate_archive_summary_async = AsyncMock(side_effect=generate)
+
+    result = await session._generate_archive_summary_in_batches(
+        messages,
+        latest_archive_overview="previous",
+        checkpoint_requests=[request],
+        limits=ExtractionBatchLimits(max_messages=1),
+    )
+
+    assert isinstance(result, _ArchiveSummaryResult)
+    assert result.checkpoint_summaries == ("older+a1+a2",)
+    assert calls[1][0].previous_checkpoint_source_message_ids == ("a0",)
+    assert calls[2][0].previous_checkpoint_source_message_ids == ("a0", "a1")
+
+
+@pytest.mark.asyncio
+async def test_long_term_memory_batches_follow_the_planned_limit():
+    session = Session(viking_fs=None)
+    messages = [_message("u1"), _message("u2"), _message("u3")]
+    recorded_batches = []
+
+    async def extract(batch):
+        return [batch[0].id]
+
+    async def record(operation_name, batch, fn):
+        result = await fn()
+        recorded_batches.append((operation_name, [message.id for message in batch]))
+        return result
+
+    result = await session._extract_long_term_memories_in_batches(
+        messages=messages,
+        limits=ExtractionBatchLimits(max_messages=1),
+        archive_uri="viking://user/default/sessions/s1/history/archive_001",
+        extract_batch=extract,
+        record_batch=record,
+    )
+
+    assert result == ["u1", "u2", "u3"]
+    assert [message_ids for _, message_ids in recorded_batches] == [
+        ["u1"],
+        ["u2"],
+        ["u3"],
+    ]

--- a/tests/unit/session/test_session_commit_resume.py
+++ b/tests/unit/session/test_session_commit_resume.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 
+import inspect
 import json
+from dataclasses import fields
 from unittest.mock import AsyncMock
 
 import pytest
@@ -49,6 +51,13 @@ class _MemoryVikingFS:
         self.files[uri] = content
 
 
+def test_phase2_auto_commit_policy_parameters_are_appended():
+    signature = inspect.signature(Session._run_memory_extraction)
+
+    assert list(signature.parameters)[-1] == "auto_commit_policy"
+    assert fields(SessionCommitMsg)[-1].name == "auto_commit_policy"
+
+
 @pytest.mark.asyncio
 async def test_resume_queued_commit_continues_phase2(monkeypatch):
     session_uri = "viking://user/default/sessions/session-1"
@@ -74,6 +83,7 @@ async def test_resume_queued_commit_continues_phase2(monkeypatch):
         archive_uri=archive_uri,
         user={"account_id": "default", "user_id": "default"},
         memory_policy={"memory_types": []},
+        auto_commit_policy={"pending_token_threshold": 8000},
     )
 
     try:
@@ -84,6 +94,9 @@ async def test_resume_queued_commit_continues_phase2(monkeypatch):
     session._run_memory_extraction.assert_awaited_once()
     assert session._run_memory_extraction.await_args.kwargs["task_id"] == "task-1"
     assert session._run_memory_extraction.await_args.kwargs["agent_evolution_enabled"] is True
+    assert session._run_memory_extraction.await_args.kwargs["auto_commit_policy"] == {
+        "pending_token_threshold": 8000
+    }
     assert [
         item.id for item in session._run_memory_extraction.await_args.kwargs["messages"]
     ] == ["archived"]
@@ -210,4 +223,5 @@ def test_session_commit_message_ignores_unknown_fields():
     )
 
     assert message.task_id == "task-1"
+    assert message.auto_commit_policy == {}
     assert "actor_peer_id" not in message.to_dict()


### PR DESCRIPTION
## Description

Prevent oversized batch message ingestion from sending the entire archived message set to each Phase 2 model call. A session still produces one commit and one archive, while Working Memory and long-term memory extraction are split using the session's committed auto-commit policy.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Snapshot the effective auto-commit policy in the durable Session Phase 2 queue message, with an empty default for compatibility with older queued payloads.
- Plan turn-aware extraction batches using `pending_token_threshold` and `message_count_threshold` while preserving the existing single-commit/single-archive behavior.
- Process ordinary Working Memory batches sequentially and carry the generated overview into the next batch; checkpoint requests keep the existing full-message path.
- Preserve the aggregate Working Memory fallback when no VLM or prompt renderer is available by bypassing model-oriented batching for those local fallback paths.
- Process long-term memory batches sequentially, persist completed message IDs for restart-safe recovery, and merge per-batch memory diffs.
- Add unit, resume-compatibility, and Session commit coverage for policy propagation and batching behavior.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands and results:

```bash
/Users/bytedance/myconda/envs/openviking/bin/python -m pytest -o addopts='' -q \
  tests/unit/session/test_extraction_batch.py \
  tests/unit/session/test_session_commit_resume.py
# 16 passed

/Users/bytedance/myconda/envs/openviking/bin/python -m ruff check \
  openviking/session/extraction_batch.py \
  openviking/session/session.py \
  openviking/storage/queuefs/session_commit_msg.py \
  tests/unit/session/test_extraction_batch.py \
  tests/unit/session/test_session_commit_resume.py \
  tests/session/test_session_commit.py
# All checks passed
```

Real HTTP Session flow on the local Conda deployment:

- Created a Session with `pending_token_threshold=100`, batch-added 20 messages totaling 200 estimated tokens, and triggered auto commit.
- Before the fix, both Phase 2 model paths received one 200-token message batch and failed against a controlled 150-token input limit.
- After the fix, both Working Memory and long-term memory extraction received two 100-token batches; the commit task completed and `archive_001` was readable.
- The same flow also completed against the configured real VLM, with server logs confirming two planned batches for both extraction paths.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- This change splits Phase 2 extraction work; it does not turn one oversized auto commit into multiple Session commits.
- Batch limits cover estimated message tokens and message count. Prompt templates, schemas, tool definitions, and multimodal provider accounting remain outside this estimate.
- `tests/session/test_session_commit.py` is currently blocked during the shared service fixture setup by a missing `/local/default/_system/setting.json`. The same failure reproduces on the latest `ov/main` without this PR, before any commit test executes.
