### PR TITLE
fix(pi-extension): bound takeover queue drain for offline resilience

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,6 +66,7 @@ jobs:
             examples/memory-plugin-shared/setup-wizard.test.mjs \
             examples/memory-plugin-shared/sync.test.mjs \
             examples/memory-plugin-shared/mcp-proxy-config.test.mjs \
+            examples/memory-plugin-shared/pending-queue.test.mjs \
             examples/memory-plugin-shared/recall-compress-core.test.mjs \
             examples/memory-plugin-shared/recall-core.test.mjs \
             examples/memory-plugin-shared/workspace-peer.test.mjs \

--- a/examples/claude-code-memory-plugin/scripts/shared/pending-queue.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/pending-queue.mjs
@@ -258,6 +258,37 @@ export async function listPending() {
   return entries;
 }
 
+async function countPendingMessagesForSession(sessionId) {
+  const dir = getPendingDir();
+  let unresolved = 0;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    let files;
+    try {
+      files = await readdir(dir);
+    } catch {
+      return unresolved;
+    }
+
+    let count = 0;
+    unresolved = 0;
+    for (const filename of files) {
+      if (!filename.endsWith(".json") && !filename.endsWith(".processing")) continue;
+      try {
+        const entry = await readEntry(dir, filename);
+        if (entry?.type === "addMessage" && entry.sessionId === sessionId) count++;
+      } catch (err) {
+        // Queue claims and retry writes rename files atomically. Re-scan after
+        // ENOENT so the inventory observes the new name. If names keep moving,
+        // conservatively keep the takeover barrier closed for this pass.
+        if (err?.code === "ENOENT") unresolved++;
+      }
+    }
+    if (unresolved === 0) return count;
+    if (attempt === 1) return count + unresolved;
+  }
+  return unresolved;
+}
+
 /**
  * Atomically claim a pending file for replay. Only the process that successfully
  * renames the file may send the HTTP replay.
@@ -341,6 +372,109 @@ export async function cleanStale() {
     }
   }
   return cleaned;
+}
+
+/**
+ * Replay queued addMessage entries for one session within a bounded pass.
+ * Each entry from the initial snapshot is considered at most once, so a
+ * retryable failure cannot consume multiple retries during one call.
+ *
+ * @param {Function} fetchJSON - the configured fetchJSON from makeFetchJSON
+ * @param {Function} log - logger function
+ * @param {string} sessionId - session whose addMessage entries should drain
+ * @param {object} options
+ * @param {number} options.maxItems - maximum snapshot entries examined
+ * @param {number} options.timeBudgetMs - maximum elapsed time before starting more work
+ * @returns {{ replayed: number, failed: number, skipped: number, deferred: number, remaining: number }}
+ */
+export async function drainPendingForSession(fetchJSON, log, sessionId, options = {}) {
+  if (typeof sessionId !== "string" || !sessionId) {
+    throw new TypeError("sessionId is required");
+  }
+
+  const pending = (await listPending()).filter(
+    ({ entry }) => entry?.type === "addMessage" && entry.sessionId === sessionId,
+  );
+  const configuredMaxItems = Number(options.maxItems);
+  const maxItems = options.maxItems === undefined
+    ? getReplayLimit()
+    : Math.max(0, Number.isFinite(configuredMaxItems) ? Math.floor(configuredMaxItems) : 0);
+  const configuredTimeBudget = Number(options.timeBudgetMs);
+  const timeBudgetMs = options.timeBudgetMs === undefined
+    ? Infinity
+    : Math.max(0, Number.isFinite(configuredTimeBudget) ? configuredTimeBudget : 0);
+  const startedAt = Date.now();
+
+  let replayed = 0;
+  let failed = 0;
+  let skipped = 0;
+  let deferred = 0;
+
+  log("pending-queue", {
+    action: "session-drain-start",
+    sessionId,
+    count: pending.length,
+    maxItems,
+    timeBudgetMs: Number.isFinite(timeBudgetMs) ? timeBudgetMs : undefined,
+  });
+
+  for (let index = 0; index < pending.length; index++) {
+    if (index >= maxItems || Date.now() - startedAt >= timeBudgetMs) {
+      deferred += pending.length - index;
+      break;
+    }
+
+    const { filename, entry } = pending[index];
+
+    if ((entry.retries || 0) >= getMaxRetries()) {
+      await dequeue(filename);
+      skipped++;
+      continue;
+    }
+
+    const claimedFilename = await claimForReplay(filename);
+    if (!claimedFilename) {
+      skipped++;
+      continue;
+    }
+
+    let res;
+    try {
+      const encodedSid = encodeURIComponent(entry.sessionId);
+      res = await fetchJSON(`/api/v1/sessions/${encodedSid}/messages`, {
+        method: "POST",
+        body: JSON.stringify(entry.payload),
+      });
+    } catch {
+      res = { ok: false };
+    }
+
+    if (res?.ok) {
+      await dequeue(claimedFilename);
+      replayed++;
+    } else if (!isRetryableReplayFailure(res)) {
+      await dequeue(claimedFilename);
+      skipped++;
+    } else {
+      await incrementRetry(claimedFilename, entry);
+      failed++;
+      deferred += pending.length - index - 1;
+      break;
+    }
+  }
+
+  const remaining = await countPendingMessagesForSession(sessionId);
+  log("pending-queue", {
+    action: "session-drain-done",
+    sessionId,
+    replayed,
+    failed,
+    skipped,
+    deferred,
+    remaining,
+  });
+
+  return { replayed, failed, skipped, deferred, remaining };
 }
 
 /**

--- a/examples/codex-memory-plugin/scripts/shared/pending-queue.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/pending-queue.mjs
@@ -258,6 +258,37 @@ export async function listPending() {
   return entries;
 }
 
+async function countPendingMessagesForSession(sessionId) {
+  const dir = getPendingDir();
+  let unresolved = 0;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    let files;
+    try {
+      files = await readdir(dir);
+    } catch {
+      return unresolved;
+    }
+
+    let count = 0;
+    unresolved = 0;
+    for (const filename of files) {
+      if (!filename.endsWith(".json") && !filename.endsWith(".processing")) continue;
+      try {
+        const entry = await readEntry(dir, filename);
+        if (entry?.type === "addMessage" && entry.sessionId === sessionId) count++;
+      } catch (err) {
+        // Queue claims and retry writes rename files atomically. Re-scan after
+        // ENOENT so the inventory observes the new name. If names keep moving,
+        // conservatively keep the takeover barrier closed for this pass.
+        if (err?.code === "ENOENT") unresolved++;
+      }
+    }
+    if (unresolved === 0) return count;
+    if (attempt === 1) return count + unresolved;
+  }
+  return unresolved;
+}
+
 /**
  * Atomically claim a pending file for replay. Only the process that successfully
  * renames the file may send the HTTP replay.
@@ -341,6 +372,109 @@ export async function cleanStale() {
     }
   }
   return cleaned;
+}
+
+/**
+ * Replay queued addMessage entries for one session within a bounded pass.
+ * Each entry from the initial snapshot is considered at most once, so a
+ * retryable failure cannot consume multiple retries during one call.
+ *
+ * @param {Function} fetchJSON - the configured fetchJSON from makeFetchJSON
+ * @param {Function} log - logger function
+ * @param {string} sessionId - session whose addMessage entries should drain
+ * @param {object} options
+ * @param {number} options.maxItems - maximum snapshot entries examined
+ * @param {number} options.timeBudgetMs - maximum elapsed time before starting more work
+ * @returns {{ replayed: number, failed: number, skipped: number, deferred: number, remaining: number }}
+ */
+export async function drainPendingForSession(fetchJSON, log, sessionId, options = {}) {
+  if (typeof sessionId !== "string" || !sessionId) {
+    throw new TypeError("sessionId is required");
+  }
+
+  const pending = (await listPending()).filter(
+    ({ entry }) => entry?.type === "addMessage" && entry.sessionId === sessionId,
+  );
+  const configuredMaxItems = Number(options.maxItems);
+  const maxItems = options.maxItems === undefined
+    ? getReplayLimit()
+    : Math.max(0, Number.isFinite(configuredMaxItems) ? Math.floor(configuredMaxItems) : 0);
+  const configuredTimeBudget = Number(options.timeBudgetMs);
+  const timeBudgetMs = options.timeBudgetMs === undefined
+    ? Infinity
+    : Math.max(0, Number.isFinite(configuredTimeBudget) ? configuredTimeBudget : 0);
+  const startedAt = Date.now();
+
+  let replayed = 0;
+  let failed = 0;
+  let skipped = 0;
+  let deferred = 0;
+
+  log("pending-queue", {
+    action: "session-drain-start",
+    sessionId,
+    count: pending.length,
+    maxItems,
+    timeBudgetMs: Number.isFinite(timeBudgetMs) ? timeBudgetMs : undefined,
+  });
+
+  for (let index = 0; index < pending.length; index++) {
+    if (index >= maxItems || Date.now() - startedAt >= timeBudgetMs) {
+      deferred += pending.length - index;
+      break;
+    }
+
+    const { filename, entry } = pending[index];
+
+    if ((entry.retries || 0) >= getMaxRetries()) {
+      await dequeue(filename);
+      skipped++;
+      continue;
+    }
+
+    const claimedFilename = await claimForReplay(filename);
+    if (!claimedFilename) {
+      skipped++;
+      continue;
+    }
+
+    let res;
+    try {
+      const encodedSid = encodeURIComponent(entry.sessionId);
+      res = await fetchJSON(`/api/v1/sessions/${encodedSid}/messages`, {
+        method: "POST",
+        body: JSON.stringify(entry.payload),
+      });
+    } catch {
+      res = { ok: false };
+    }
+
+    if (res?.ok) {
+      await dequeue(claimedFilename);
+      replayed++;
+    } else if (!isRetryableReplayFailure(res)) {
+      await dequeue(claimedFilename);
+      skipped++;
+    } else {
+      await incrementRetry(claimedFilename, entry);
+      failed++;
+      deferred += pending.length - index - 1;
+      break;
+    }
+  }
+
+  const remaining = await countPendingMessagesForSession(sessionId);
+  log("pending-queue", {
+    action: "session-drain-done",
+    sessionId,
+    replayed,
+    failed,
+    skipped,
+    deferred,
+    remaining,
+  });
+
+  return { replayed, failed, skipped, deferred, remaining };
 }
 
 /**

--- a/examples/dsh-memory-plugin/shared/pending-queue.mjs
+++ b/examples/dsh-memory-plugin/shared/pending-queue.mjs
@@ -258,6 +258,37 @@ export async function listPending() {
   return entries;
 }
 
+async function countPendingMessagesForSession(sessionId) {
+  const dir = getPendingDir();
+  let unresolved = 0;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    let files;
+    try {
+      files = await readdir(dir);
+    } catch {
+      return unresolved;
+    }
+
+    let count = 0;
+    unresolved = 0;
+    for (const filename of files) {
+      if (!filename.endsWith(".json") && !filename.endsWith(".processing")) continue;
+      try {
+        const entry = await readEntry(dir, filename);
+        if (entry?.type === "addMessage" && entry.sessionId === sessionId) count++;
+      } catch (err) {
+        // Queue claims and retry writes rename files atomically. Re-scan after
+        // ENOENT so the inventory observes the new name. If names keep moving,
+        // conservatively keep the takeover barrier closed for this pass.
+        if (err?.code === "ENOENT") unresolved++;
+      }
+    }
+    if (unresolved === 0) return count;
+    if (attempt === 1) return count + unresolved;
+  }
+  return unresolved;
+}
+
 /**
  * Atomically claim a pending file for replay. Only the process that successfully
  * renames the file may send the HTTP replay.
@@ -341,6 +372,109 @@ export async function cleanStale() {
     }
   }
   return cleaned;
+}
+
+/**
+ * Replay queued addMessage entries for one session within a bounded pass.
+ * Each entry from the initial snapshot is considered at most once, so a
+ * retryable failure cannot consume multiple retries during one call.
+ *
+ * @param {Function} fetchJSON - the configured fetchJSON from makeFetchJSON
+ * @param {Function} log - logger function
+ * @param {string} sessionId - session whose addMessage entries should drain
+ * @param {object} options
+ * @param {number} options.maxItems - maximum snapshot entries examined
+ * @param {number} options.timeBudgetMs - maximum elapsed time before starting more work
+ * @returns {{ replayed: number, failed: number, skipped: number, deferred: number, remaining: number }}
+ */
+export async function drainPendingForSession(fetchJSON, log, sessionId, options = {}) {
+  if (typeof sessionId !== "string" || !sessionId) {
+    throw new TypeError("sessionId is required");
+  }
+
+  const pending = (await listPending()).filter(
+    ({ entry }) => entry?.type === "addMessage" && entry.sessionId === sessionId,
+  );
+  const configuredMaxItems = Number(options.maxItems);
+  const maxItems = options.maxItems === undefined
+    ? getReplayLimit()
+    : Math.max(0, Number.isFinite(configuredMaxItems) ? Math.floor(configuredMaxItems) : 0);
+  const configuredTimeBudget = Number(options.timeBudgetMs);
+  const timeBudgetMs = options.timeBudgetMs === undefined
+    ? Infinity
+    : Math.max(0, Number.isFinite(configuredTimeBudget) ? configuredTimeBudget : 0);
+  const startedAt = Date.now();
+
+  let replayed = 0;
+  let failed = 0;
+  let skipped = 0;
+  let deferred = 0;
+
+  log("pending-queue", {
+    action: "session-drain-start",
+    sessionId,
+    count: pending.length,
+    maxItems,
+    timeBudgetMs: Number.isFinite(timeBudgetMs) ? timeBudgetMs : undefined,
+  });
+
+  for (let index = 0; index < pending.length; index++) {
+    if (index >= maxItems || Date.now() - startedAt >= timeBudgetMs) {
+      deferred += pending.length - index;
+      break;
+    }
+
+    const { filename, entry } = pending[index];
+
+    if ((entry.retries || 0) >= getMaxRetries()) {
+      await dequeue(filename);
+      skipped++;
+      continue;
+    }
+
+    const claimedFilename = await claimForReplay(filename);
+    if (!claimedFilename) {
+      skipped++;
+      continue;
+    }
+
+    let res;
+    try {
+      const encodedSid = encodeURIComponent(entry.sessionId);
+      res = await fetchJSON(`/api/v1/sessions/${encodedSid}/messages`, {
+        method: "POST",
+        body: JSON.stringify(entry.payload),
+      });
+    } catch {
+      res = { ok: false };
+    }
+
+    if (res?.ok) {
+      await dequeue(claimedFilename);
+      replayed++;
+    } else if (!isRetryableReplayFailure(res)) {
+      await dequeue(claimedFilename);
+      skipped++;
+    } else {
+      await incrementRetry(claimedFilename, entry);
+      failed++;
+      deferred += pending.length - index - 1;
+      break;
+    }
+  }
+
+  const remaining = await countPendingMessagesForSession(sessionId);
+  log("pending-queue", {
+    action: "session-drain-done",
+    sessionId,
+    replayed,
+    failed,
+    skipped,
+    deferred,
+    remaining,
+  });
+
+  return { replayed, failed, skipped, deferred, remaining };
 }
 
 /**

--- a/examples/memory-plugin-shared/lib/pending-queue.mjs
+++ b/examples/memory-plugin-shared/lib/pending-queue.mjs
@@ -257,6 +257,37 @@ export async function listPending() {
   return entries;
 }
 
+async function countPendingMessagesForSession(sessionId) {
+  const dir = getPendingDir();
+  let unresolved = 0;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    let files;
+    try {
+      files = await readdir(dir);
+    } catch {
+      return unresolved;
+    }
+
+    let count = 0;
+    unresolved = 0;
+    for (const filename of files) {
+      if (!filename.endsWith(".json") && !filename.endsWith(".processing")) continue;
+      try {
+        const entry = await readEntry(dir, filename);
+        if (entry?.type === "addMessage" && entry.sessionId === sessionId) count++;
+      } catch (err) {
+        // Queue claims and retry writes rename files atomically. Re-scan after
+        // ENOENT so the inventory observes the new name. If names keep moving,
+        // conservatively keep the takeover barrier closed for this pass.
+        if (err?.code === "ENOENT") unresolved++;
+      }
+    }
+    if (unresolved === 0) return count;
+    if (attempt === 1) return count + unresolved;
+  }
+  return unresolved;
+}
+
 /**
  * Atomically claim a pending file for replay. Only the process that successfully
  * renames the file may send the HTTP replay.
@@ -340,6 +371,109 @@ export async function cleanStale() {
     }
   }
   return cleaned;
+}
+
+/**
+ * Replay queued addMessage entries for one session within a bounded pass.
+ * Each entry from the initial snapshot is considered at most once, so a
+ * retryable failure cannot consume multiple retries during one call.
+ *
+ * @param {Function} fetchJSON - the configured fetchJSON from makeFetchJSON
+ * @param {Function} log - logger function
+ * @param {string} sessionId - session whose addMessage entries should drain
+ * @param {object} options
+ * @param {number} options.maxItems - maximum snapshot entries examined
+ * @param {number} options.timeBudgetMs - maximum elapsed time before starting more work
+ * @returns {{ replayed: number, failed: number, skipped: number, deferred: number, remaining: number }}
+ */
+export async function drainPendingForSession(fetchJSON, log, sessionId, options = {}) {
+  if (typeof sessionId !== "string" || !sessionId) {
+    throw new TypeError("sessionId is required");
+  }
+
+  const pending = (await listPending()).filter(
+    ({ entry }) => entry?.type === "addMessage" && entry.sessionId === sessionId,
+  );
+  const configuredMaxItems = Number(options.maxItems);
+  const maxItems = options.maxItems === undefined
+    ? getReplayLimit()
+    : Math.max(0, Number.isFinite(configuredMaxItems) ? Math.floor(configuredMaxItems) : 0);
+  const configuredTimeBudget = Number(options.timeBudgetMs);
+  const timeBudgetMs = options.timeBudgetMs === undefined
+    ? Infinity
+    : Math.max(0, Number.isFinite(configuredTimeBudget) ? configuredTimeBudget : 0);
+  const startedAt = Date.now();
+
+  let replayed = 0;
+  let failed = 0;
+  let skipped = 0;
+  let deferred = 0;
+
+  log("pending-queue", {
+    action: "session-drain-start",
+    sessionId,
+    count: pending.length,
+    maxItems,
+    timeBudgetMs: Number.isFinite(timeBudgetMs) ? timeBudgetMs : undefined,
+  });
+
+  for (let index = 0; index < pending.length; index++) {
+    if (index >= maxItems || Date.now() - startedAt >= timeBudgetMs) {
+      deferred += pending.length - index;
+      break;
+    }
+
+    const { filename, entry } = pending[index];
+
+    if ((entry.retries || 0) >= getMaxRetries()) {
+      await dequeue(filename);
+      skipped++;
+      continue;
+    }
+
+    const claimedFilename = await claimForReplay(filename);
+    if (!claimedFilename) {
+      skipped++;
+      continue;
+    }
+
+    let res;
+    try {
+      const encodedSid = encodeURIComponent(entry.sessionId);
+      res = await fetchJSON(`/api/v1/sessions/${encodedSid}/messages`, {
+        method: "POST",
+        body: JSON.stringify(entry.payload),
+      });
+    } catch {
+      res = { ok: false };
+    }
+
+    if (res?.ok) {
+      await dequeue(claimedFilename);
+      replayed++;
+    } else if (!isRetryableReplayFailure(res)) {
+      await dequeue(claimedFilename);
+      skipped++;
+    } else {
+      await incrementRetry(claimedFilename, entry);
+      failed++;
+      deferred += pending.length - index - 1;
+      break;
+    }
+  }
+
+  const remaining = await countPendingMessagesForSession(sessionId);
+  log("pending-queue", {
+    action: "session-drain-done",
+    sessionId,
+    replayed,
+    failed,
+    skipped,
+    deferred,
+    remaining,
+  });
+
+  return { replayed, failed, skipped, deferred, remaining };
 }
 
 /**

--- a/examples/memory-plugin-shared/pending-queue.test.mjs
+++ b/examples/memory-plugin-shared/pending-queue.test.mjs
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  claimForReplay,
+  drainPendingForSession,
+  enqueue,
+  listPending,
+} from "./lib/pending-queue.mjs";
+
+const originalEnv = {
+  dir: process.env.OPENVIKING_PENDING_DIR,
+  maxRetries: process.env.OPENVIKING_PENDING_MAX_RETRIES,
+  replayLimit: process.env.OPENVIKING_PENDING_REPLAY_LIMIT,
+  ttlDays: process.env.OPENVIKING_PENDING_TTL_DAYS,
+};
+
+async function withPendingDir(fn) {
+  const dir = await mkdtemp(join(tmpdir(), "openviking-shared-pending-test-"));
+  process.env.OPENVIKING_PENDING_DIR = dir;
+  process.env.OPENVIKING_PENDING_MAX_RETRIES = "3";
+  process.env.OPENVIKING_PENDING_REPLAY_LIMIT = "50";
+  process.env.OPENVIKING_PENDING_TTL_DAYS = "7";
+  try {
+    return await fn(dir);
+  } finally {
+    for (const [key, envName] of [
+      ["dir", "OPENVIKING_PENDING_DIR"],
+      ["maxRetries", "OPENVIKING_PENDING_MAX_RETRIES"],
+      ["replayLimit", "OPENVIKING_PENDING_REPLAY_LIMIT"],
+      ["ttlDays", "OPENVIKING_PENDING_TTL_DAYS"],
+    ]) {
+      if (originalEnv[key] === undefined) delete process.env[envName];
+      else process.env[envName] = originalEnv[key];
+    }
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("session drain bypasses an older retryable failure from another session", async () => {
+  await withPendingDir(async () => {
+    await enqueue("addMessage", "other-session", { content: "other" }, { createdAt: 1 });
+    await enqueue("addMessage", "takeover-session", { content: "current" }, { createdAt: 2 });
+
+    const calls = [];
+    const result = await drainPendingForSession(async (path) => {
+      calls.push(path);
+      return { ok: true };
+    }, () => {}, "takeover-session");
+
+    assert.deepEqual(calls, ["/api/v1/sessions/takeover-session/messages"]);
+    assert.deepEqual(result, {
+      replayed: 1,
+      failed: 0,
+      skipped: 0,
+      deferred: 0,
+      remaining: 0,
+    });
+    const pending = await listPending();
+    assert.equal(pending.length, 1);
+    assert.equal(pending[0].entry.sessionId, "other-session");
+  });
+});
+
+test("session drain reports messages left by its item budget", async () => {
+  await withPendingDir(async () => {
+    for (let i = 0; i < 3; i++) {
+      await enqueue("addMessage", "takeover-session", { content: `message-${i}` }, { createdAt: i + 1 });
+    }
+
+    let calls = 0;
+    const result = await drainPendingForSession(async () => {
+      calls++;
+      return { ok: true };
+    }, () => {}, "takeover-session", { maxItems: 1 });
+
+    assert.equal(calls, 1);
+    assert.equal(result.replayed, 1);
+    assert.equal(result.deferred, 2);
+    assert.equal(result.remaining, 2);
+  });
+});
+
+test("session drain item budget also bounds entries skipped without HTTP", async () => {
+  await withPendingDir(async () => {
+    process.env.OPENVIKING_PENDING_MAX_RETRIES = "0";
+    await enqueue("addMessage", "takeover-session", { content: "expired" }, { createdAt: 1 });
+    await enqueue("addMessage", "takeover-session", { content: "deferred" }, { createdAt: 2 });
+
+    let calls = 0;
+    const result = await drainPendingForSession(async () => {
+      calls++;
+      return { ok: true };
+    }, () => {}, "takeover-session", { maxItems: 1 });
+
+    assert.equal(calls, 0);
+    assert.equal(result.skipped, 1);
+    assert.equal(result.deferred, 1);
+    assert.equal(result.remaining, 1);
+  });
+});
+
+test("session drain starts no work after its elapsed-time budget is exhausted", async () => {
+  await withPendingDir(async () => {
+    await enqueue("addMessage", "takeover-session", { content: "later" }, { createdAt: 1 });
+
+    let calls = 0;
+    const result = await drainPendingForSession(async () => {
+      calls++;
+      return { ok: true };
+    }, () => {}, "takeover-session", { timeBudgetMs: 0 });
+
+    assert.equal(calls, 0);
+    assert.equal(result.deferred, 1);
+    assert.equal(result.remaining, 1);
+  });
+});
+
+test("session drain attempts a retryable message at most once per invocation", async () => {
+  await withPendingDir(async () => {
+    await enqueue("addMessage", "takeover-session", { content: "blocked" }, { createdAt: 1 });
+    await enqueue("addMessage", "takeover-session", { content: "after" }, { createdAt: 2 });
+
+    let calls = 0;
+    const result = await drainPendingForSession(async () => {
+      calls++;
+      return { ok: false, status: 500 };
+    }, () => {}, "takeover-session", { maxItems: 50 });
+
+    assert.equal(calls, 1);
+    assert.equal(result.failed, 1);
+    assert.equal(result.deferred, 1);
+    assert.equal(result.remaining, 2);
+    const pending = await listPending();
+    assert.deepEqual(pending.map(({ entry }) => entry.retries), [1, 0]);
+  });
+});
+
+test("session drain leaves queued commits to the normal replay path", async () => {
+  await withPendingDir(async () => {
+    await enqueue("commitSession", "takeover-session", { keep_recent_count: 1 }, { createdAt: 1 });
+
+    let calls = 0;
+    const result = await drainPendingForSession(async () => {
+      calls++;
+      return { ok: true };
+    }, () => {}, "takeover-session");
+
+    assert.equal(calls, 0);
+    assert.equal(result.remaining, 0);
+    assert.equal((await listPending()).length, 1);
+  });
+});
+
+test("session drain keeps the barrier closed for a claimed in-flight message", async () => {
+  await withPendingDir(async () => {
+    await enqueue("addMessage", "takeover-session", { content: "in flight" }, { createdAt: 1 });
+    const [{ filename }] = await listPending();
+    assert.match(await claimForReplay(filename), /\.processing$/);
+
+    const result = await drainPendingForSession(async () => {
+      assert.fail("an already claimed message must not be replayed twice");
+    }, () => {}, "takeover-session");
+
+    assert.equal(result.replayed, 0);
+    assert.equal(result.remaining, 1);
+  });
+});
+
+test("session drain conservatively counts a queue filename that changes during inventory", async () => {
+  await withPendingDir(async (dir) => {
+    await symlink(join(dir, "already-renamed.processing"), join(dir, "raced_0.json"));
+
+    const result = await drainPendingForSession(async () => {
+      assert.fail("an unresolved inventory entry must not be replayed");
+    }, () => {}, "takeover-session");
+
+    assert.equal(result.remaining, 1);
+  });
+});

--- a/examples/opencode-plugin/lib/shared/pending-queue.mjs
+++ b/examples/opencode-plugin/lib/shared/pending-queue.mjs
@@ -258,6 +258,37 @@ export async function listPending() {
   return entries;
 }
 
+async function countPendingMessagesForSession(sessionId) {
+  const dir = getPendingDir();
+  let unresolved = 0;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    let files;
+    try {
+      files = await readdir(dir);
+    } catch {
+      return unresolved;
+    }
+
+    let count = 0;
+    unresolved = 0;
+    for (const filename of files) {
+      if (!filename.endsWith(".json") && !filename.endsWith(".processing")) continue;
+      try {
+        const entry = await readEntry(dir, filename);
+        if (entry?.type === "addMessage" && entry.sessionId === sessionId) count++;
+      } catch (err) {
+        // Queue claims and retry writes rename files atomically. Re-scan after
+        // ENOENT so the inventory observes the new name. If names keep moving,
+        // conservatively keep the takeover barrier closed for this pass.
+        if (err?.code === "ENOENT") unresolved++;
+      }
+    }
+    if (unresolved === 0) return count;
+    if (attempt === 1) return count + unresolved;
+  }
+  return unresolved;
+}
+
 /**
  * Atomically claim a pending file for replay. Only the process that successfully
  * renames the file may send the HTTP replay.
@@ -341,6 +372,109 @@ export async function cleanStale() {
     }
   }
   return cleaned;
+}
+
+/**
+ * Replay queued addMessage entries for one session within a bounded pass.
+ * Each entry from the initial snapshot is considered at most once, so a
+ * retryable failure cannot consume multiple retries during one call.
+ *
+ * @param {Function} fetchJSON - the configured fetchJSON from makeFetchJSON
+ * @param {Function} log - logger function
+ * @param {string} sessionId - session whose addMessage entries should drain
+ * @param {object} options
+ * @param {number} options.maxItems - maximum snapshot entries examined
+ * @param {number} options.timeBudgetMs - maximum elapsed time before starting more work
+ * @returns {{ replayed: number, failed: number, skipped: number, deferred: number, remaining: number }}
+ */
+export async function drainPendingForSession(fetchJSON, log, sessionId, options = {}) {
+  if (typeof sessionId !== "string" || !sessionId) {
+    throw new TypeError("sessionId is required");
+  }
+
+  const pending = (await listPending()).filter(
+    ({ entry }) => entry?.type === "addMessage" && entry.sessionId === sessionId,
+  );
+  const configuredMaxItems = Number(options.maxItems);
+  const maxItems = options.maxItems === undefined
+    ? getReplayLimit()
+    : Math.max(0, Number.isFinite(configuredMaxItems) ? Math.floor(configuredMaxItems) : 0);
+  const configuredTimeBudget = Number(options.timeBudgetMs);
+  const timeBudgetMs = options.timeBudgetMs === undefined
+    ? Infinity
+    : Math.max(0, Number.isFinite(configuredTimeBudget) ? configuredTimeBudget : 0);
+  const startedAt = Date.now();
+
+  let replayed = 0;
+  let failed = 0;
+  let skipped = 0;
+  let deferred = 0;
+
+  log("pending-queue", {
+    action: "session-drain-start",
+    sessionId,
+    count: pending.length,
+    maxItems,
+    timeBudgetMs: Number.isFinite(timeBudgetMs) ? timeBudgetMs : undefined,
+  });
+
+  for (let index = 0; index < pending.length; index++) {
+    if (index >= maxItems || Date.now() - startedAt >= timeBudgetMs) {
+      deferred += pending.length - index;
+      break;
+    }
+
+    const { filename, entry } = pending[index];
+
+    if ((entry.retries || 0) >= getMaxRetries()) {
+      await dequeue(filename);
+      skipped++;
+      continue;
+    }
+
+    const claimedFilename = await claimForReplay(filename);
+    if (!claimedFilename) {
+      skipped++;
+      continue;
+    }
+
+    let res;
+    try {
+      const encodedSid = encodeURIComponent(entry.sessionId);
+      res = await fetchJSON(`/api/v1/sessions/${encodedSid}/messages`, {
+        method: "POST",
+        body: JSON.stringify(entry.payload),
+      });
+    } catch {
+      res = { ok: false };
+    }
+
+    if (res?.ok) {
+      await dequeue(claimedFilename);
+      replayed++;
+    } else if (!isRetryableReplayFailure(res)) {
+      await dequeue(claimedFilename);
+      skipped++;
+    } else {
+      await incrementRetry(claimedFilename, entry);
+      failed++;
+      deferred += pending.length - index - 1;
+      break;
+    }
+  }
+
+  const remaining = await countPendingMessagesForSession(sessionId);
+  log("pending-queue", {
+    action: "session-drain-done",
+    sessionId,
+    replayed,
+    failed,
+    skipped,
+    deferred,
+    remaining,
+  });
+
+  return { replayed, failed, skipped, deferred, remaining };
 }
 
 /**

--- a/examples/pi-coding-agent-extension/lib/takeover-core.mjs
+++ b/examples/pi-coding-agent-extension/lib/takeover-core.mjs
@@ -266,6 +266,7 @@ export class TakeoverCore {
       const flushed = await this.io.flush();
       if (!flushed) {
         this.log("takeover: flush failed; commit postponed");
+        this.pendingTokens = 0;
         return false;
       }
 

--- a/examples/pi-coding-agent-extension/shared/pending-queue.d.mts
+++ b/examples/pi-coding-agent-extension/shared/pending-queue.d.mts
@@ -1,5 +1,11 @@
 export function enqueue(type: string, sessionId: string, payload: Record<string, any>): Promise<{ ok: boolean; path?: string; error?: string }>;
 export function listPending(): Promise<Array<{ filename: string; entry: Record<string, any> }>>;
+export function drainPendingForSession(
+  fetchJSON: (path: string, init?: any) => Promise<{ ok: boolean; status?: number; result?: any; error?: any }>,
+  log: (stage: string, data?: any) => void,
+  sessionId: string,
+  options?: { maxItems?: number; timeBudgetMs?: number },
+): Promise<{ replayed: number; failed: number; skipped: number; deferred: number; remaining: number }>;
 export function replayPending(
   fetchJSON: (path: string, init?: any) => Promise<{ ok: boolean; status?: number; result?: any; error?: any }>,
   log: (stage: string, data?: any) => void,

--- a/examples/pi-coding-agent-extension/shared/pending-queue.mjs
+++ b/examples/pi-coding-agent-extension/shared/pending-queue.mjs
@@ -258,6 +258,37 @@ export async function listPending() {
   return entries;
 }
 
+async function countPendingMessagesForSession(sessionId) {
+  const dir = getPendingDir();
+  let unresolved = 0;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    let files;
+    try {
+      files = await readdir(dir);
+    } catch {
+      return unresolved;
+    }
+
+    let count = 0;
+    unresolved = 0;
+    for (const filename of files) {
+      if (!filename.endsWith(".json") && !filename.endsWith(".processing")) continue;
+      try {
+        const entry = await readEntry(dir, filename);
+        if (entry?.type === "addMessage" && entry.sessionId === sessionId) count++;
+      } catch (err) {
+        // Queue claims and retry writes rename files atomically. Re-scan after
+        // ENOENT so the inventory observes the new name. If names keep moving,
+        // conservatively keep the takeover barrier closed for this pass.
+        if (err?.code === "ENOENT") unresolved++;
+      }
+    }
+    if (unresolved === 0) return count;
+    if (attempt === 1) return count + unresolved;
+  }
+  return unresolved;
+}
+
 /**
  * Atomically claim a pending file for replay. Only the process that successfully
  * renames the file may send the HTTP replay.
@@ -341,6 +372,109 @@ export async function cleanStale() {
     }
   }
   return cleaned;
+}
+
+/**
+ * Replay queued addMessage entries for one session within a bounded pass.
+ * Each entry from the initial snapshot is considered at most once, so a
+ * retryable failure cannot consume multiple retries during one call.
+ *
+ * @param {Function} fetchJSON - the configured fetchJSON from makeFetchJSON
+ * @param {Function} log - logger function
+ * @param {string} sessionId - session whose addMessage entries should drain
+ * @param {object} options
+ * @param {number} options.maxItems - maximum snapshot entries examined
+ * @param {number} options.timeBudgetMs - maximum elapsed time before starting more work
+ * @returns {{ replayed: number, failed: number, skipped: number, deferred: number, remaining: number }}
+ */
+export async function drainPendingForSession(fetchJSON, log, sessionId, options = {}) {
+  if (typeof sessionId !== "string" || !sessionId) {
+    throw new TypeError("sessionId is required");
+  }
+
+  const pending = (await listPending()).filter(
+    ({ entry }) => entry?.type === "addMessage" && entry.sessionId === sessionId,
+  );
+  const configuredMaxItems = Number(options.maxItems);
+  const maxItems = options.maxItems === undefined
+    ? getReplayLimit()
+    : Math.max(0, Number.isFinite(configuredMaxItems) ? Math.floor(configuredMaxItems) : 0);
+  const configuredTimeBudget = Number(options.timeBudgetMs);
+  const timeBudgetMs = options.timeBudgetMs === undefined
+    ? Infinity
+    : Math.max(0, Number.isFinite(configuredTimeBudget) ? configuredTimeBudget : 0);
+  const startedAt = Date.now();
+
+  let replayed = 0;
+  let failed = 0;
+  let skipped = 0;
+  let deferred = 0;
+
+  log("pending-queue", {
+    action: "session-drain-start",
+    sessionId,
+    count: pending.length,
+    maxItems,
+    timeBudgetMs: Number.isFinite(timeBudgetMs) ? timeBudgetMs : undefined,
+  });
+
+  for (let index = 0; index < pending.length; index++) {
+    if (index >= maxItems || Date.now() - startedAt >= timeBudgetMs) {
+      deferred += pending.length - index;
+      break;
+    }
+
+    const { filename, entry } = pending[index];
+
+    if ((entry.retries || 0) >= getMaxRetries()) {
+      await dequeue(filename);
+      skipped++;
+      continue;
+    }
+
+    const claimedFilename = await claimForReplay(filename);
+    if (!claimedFilename) {
+      skipped++;
+      continue;
+    }
+
+    let res;
+    try {
+      const encodedSid = encodeURIComponent(entry.sessionId);
+      res = await fetchJSON(`/api/v1/sessions/${encodedSid}/messages`, {
+        method: "POST",
+        body: JSON.stringify(entry.payload),
+      });
+    } catch {
+      res = { ok: false };
+    }
+
+    if (res?.ok) {
+      await dequeue(claimedFilename);
+      replayed++;
+    } else if (!isRetryableReplayFailure(res)) {
+      await dequeue(claimedFilename);
+      skipped++;
+    } else {
+      await incrementRetry(claimedFilename, entry);
+      failed++;
+      deferred += pending.length - index - 1;
+      break;
+    }
+  }
+
+  const remaining = await countPendingMessagesForSession(sessionId);
+  log("pending-queue", {
+    action: "session-drain-done",
+    sessionId,
+    replayed,
+    failed,
+    skipped,
+    deferred,
+    remaining,
+  });
+
+  return { replayed, failed, skipped, deferred, remaining };
 }
 
 /**

--- a/examples/pi-coding-agent-extension/sync.ts
+++ b/examples/pi-coding-agent-extension/sync.ts
@@ -3,9 +3,11 @@ import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import type { OVConfig } from "./config.js";
 import { deriveHarnessSessionId } from "./shared/session-model.mjs";
-import { enqueue, listPending, replayPending } from "./shared/pending-queue.mjs";
+import { drainPendingForSession, enqueue, replayPending } from "./shared/pending-queue.mjs";
 import { extractBranchCapturePayloads } from "./lib/capture-adapter.mjs";
-import { countUndeliveredForSession, estimatePayloadTokens } from "./lib/takeover-core.mjs";
+import { estimatePayloadTokens } from "./lib/takeover-core.mjs";
+
+const TAKEOVER_DRAIN_TIME_BUDGET_MS = 1000;
 
 // --- SyncManager ---
 
@@ -69,9 +71,15 @@ export class SyncManager {
 
   async flushForTakeover(): Promise<boolean> {
     if (!this.ovSessionId) return false;
-    await this.replayPending();
-    const pending = await listPending();
-    return countUndeliveredForSession(pending, this.ovSessionId) === 0;
+    if (!this.client.connected) return false;
+    const result = await drainPendingForSession(
+      (path: string, init?: any) => this.client.fetchJSON(path, init, 10000),
+      (stage: string, data: unknown) =>
+        debugLog(`${stage}: ${JSON.stringify(data)}`),
+      this.ovSessionId,
+      { timeBudgetMs: TAKEOVER_DRAIN_TIME_BUDGET_MS },
+    );
+    return result.remaining === 0;
   }
 
   async syncBranch(branch: any[]): Promise<SyncBranchResult> {

--- a/examples/pi-coding-agent-extension/tests/sync-barrier.test.mjs
+++ b/examples/pi-coding-agent-extension/tests/sync-barrier.test.mjs
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { SyncManager } from "../sync.ts";
 import { enqueue, listPending } from "../shared/pending-queue.mjs";
+import { createTakeoverManager } from "../takeover.ts";
 
 function config(overrides = {}) {
   return {
@@ -33,14 +34,25 @@ function client(overrides = {}) {
 }
 
 async function withPendingDir(fn) {
-  const previous = process.env.OPENVIKING_PENDING_DIR;
+  const previousDir = process.env.OPENVIKING_PENDING_DIR;
+  const previousReplayLimit = process.env.OPENVIKING_PENDING_REPLAY_LIMIT;
+  const previousMaxRetries = process.env.OPENVIKING_PENDING_MAX_RETRIES;
+  const previousTtlDays = process.env.OPENVIKING_PENDING_TTL_DAYS;
   const dir = await mkdtemp(join(tmpdir(), "ov-pi-pending-"));
   process.env.OPENVIKING_PENDING_DIR = dir;
+  process.env.OPENVIKING_PENDING_MAX_RETRIES = "3";
+  process.env.OPENVIKING_PENDING_TTL_DAYS = "7";
   try {
     return await fn(dir);
   } finally {
-    if (previous === undefined) delete process.env.OPENVIKING_PENDING_DIR;
-    else process.env.OPENVIKING_PENDING_DIR = previous;
+    if (previousDir === undefined) delete process.env.OPENVIKING_PENDING_DIR;
+    else process.env.OPENVIKING_PENDING_DIR = previousDir;
+    if (previousReplayLimit === undefined) delete process.env.OPENVIKING_PENDING_REPLAY_LIMIT;
+    else process.env.OPENVIKING_PENDING_REPLAY_LIMIT = previousReplayLimit;
+    if (previousMaxRetries === undefined) delete process.env.OPENVIKING_PENDING_MAX_RETRIES;
+    else process.env.OPENVIKING_PENDING_MAX_RETRIES = previousMaxRetries;
+    if (previousTtlDays === undefined) delete process.env.OPENVIKING_PENDING_TTL_DAYS;
+    else process.env.OPENVIKING_PENDING_TTL_DAYS = previousTtlDays;
     await rm(dir, { recursive: true, force: true });
   }
 }
@@ -144,6 +156,57 @@ test("queued addMessage makes takeover flush barrier false until replay succeeds
   });
 });
 
+test("replay-limit backlog does not make takeover retry on a sub-threshold turn (#4504)", async () => {
+  await withPendingDir(async () => {
+    process.env.OPENVIKING_PENDING_REPLAY_LIMIT = "1";
+    let committed = 0;
+    let replayRequests = 0;
+    const c = client({
+      addMessagePayload: async () => false,
+      fetchJSON: async () => {
+        replayRequests++;
+        return { ok: true, status: 200, result: {} };
+      },
+      commitSessionResponse: async () => {
+        committed++;
+        return { result: { task_id: "t-1", archive_uri: "viking://archive/1" } };
+      },
+      getSessionContext: async () => ({ latest_archive_overview: "overview ready" }),
+    });
+    const cfg = config({
+      takeoverTokenThreshold: 100,
+      takeoverKeepRecentTurns: 1,
+      takeoverOverviewBudget: 1000,
+      takeoverOverviewPollMs: 0,
+      takeoverOverviewPollMax: 1,
+    });
+    const sync = new SyncManager(c, cfg);
+    await sync.ensureSession("pi-session");
+    await sync.addPayload({ role: "user", content: "queued one" });
+    await sync.addPayload({ role: "user", content: "queued two" });
+    const queuedBeforeTakeover = (await listPending()).length;
+
+    const takeover = createTakeoverManager({ pi: {}, client: c, sync, config: cfg });
+    takeover.transformContext([
+      { role: "user", content: "one" },
+      { role: "user", content: "two" },
+    ]);
+
+    const firstAttempt = await takeover.onTurnSynced(120);
+    const pendingAfterFirst = (await listPending()).length;
+    const commitsAfterFirst = committed;
+    const smallTurn = await takeover.onTurnSynced(10);
+
+    assert.equal(queuedBeforeTakeover, 2);
+    assert.equal(firstAttempt, false);
+    assert.equal(replayRequests, 1);
+    assert.equal(pendingAfterFirst, 1);
+    assert.equal(commitsAfterFirst, 0);
+    assert.equal(smallTurn, false);
+    assert.equal(committed, commitsAfterFirst);
+  });
+});
+
 test("current-session addMessage 500 remains queued and keeps barrier closed", async () => {
   await withPendingDir(async () => {
     const c = client({
@@ -160,6 +223,29 @@ test("current-session addMessage 500 remains queued and keeps barrier closed", a
     assert.equal(pending.length, 1);
     assert.equal(pending[0].entry.type, "addMessage");
     assert.equal(pending[0].entry.sessionId, sync.sessionId);
+  });
+});
+
+test("disconnected takeover does not consume a queued message retry", async () => {
+  await withPendingDir(async () => {
+    let calls = 0;
+    const c = client({
+      connected: false,
+      addMessagePayload: async () => false,
+      fetchJSON: async () => {
+        calls++;
+        return { ok: false, status: 500 };
+      },
+    });
+    const sync = new SyncManager(c, config());
+    await sync.ensureSession("pi-session");
+    await sync.addPayload({ role: "user", content: "Keep this queued while offline." });
+
+    assert.equal(await sync.flushForTakeover(), false);
+    assert.equal(calls, 0);
+    const pending = await listPending();
+    assert.equal(pending.length, 1);
+    assert.equal(pending[0].entry.retries, 0);
   });
 });
 

--- a/examples/pi-coding-agent-extension/tests/takeover-core.test.mjs
+++ b/examples/pi-coding-agent-extension/tests/takeover-core.test.mjs
@@ -249,11 +249,20 @@ test("commitAndAdvance advances boundary and persists after overview is ready", 
   assert.equal(calls.persisted[0].type, TAKEOVER_ENTRY_TYPE);
 });
 
-test("commitAndAdvance keeps pending tokens when flush fails", async () => {
+test("flush failure delays takeover retry until new token pressure crosses the threshold (#4504)", async () => {
   const { core, calls } = makeCore({ flushResult: false });
   core.transformContext([user("one"), user("two")]);
-  assert.equal(await core.onTurnSynced(120), false);
-  assert.equal(core.state.pendingTokens, 120);
+
+  const firstAttempt = await core.onTurnSynced(120);
+  const smallTurn = await core.onTurnSynced(10);
+  const flushesBeforeNewThreshold = calls.flushed;
+  const nextThreshold = await core.onTurnSynced(100);
+
+  assert.equal(firstAttempt, false);
+  assert.equal(smallTurn, false);
+  assert.equal(flushesBeforeNewThreshold, 1);
+  assert.equal(nextThreshold, false);
+  assert.equal(calls.flushed, 2);
   assert.equal(calls.committed, 0);
   assert.equal(calls.persisted.length, 0);
 });

--- a/examples/zcode-memory-plugin/scripts/shared/pending-queue.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/pending-queue.mjs
@@ -258,6 +258,37 @@ export async function listPending() {
   return entries;
 }
 
+async function countPendingMessagesForSession(sessionId) {
+  const dir = getPendingDir();
+  let unresolved = 0;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    let files;
+    try {
+      files = await readdir(dir);
+    } catch {
+      return unresolved;
+    }
+
+    let count = 0;
+    unresolved = 0;
+    for (const filename of files) {
+      if (!filename.endsWith(".json") && !filename.endsWith(".processing")) continue;
+      try {
+        const entry = await readEntry(dir, filename);
+        if (entry?.type === "addMessage" && entry.sessionId === sessionId) count++;
+      } catch (err) {
+        // Queue claims and retry writes rename files atomically. Re-scan after
+        // ENOENT so the inventory observes the new name. If names keep moving,
+        // conservatively keep the takeover barrier closed for this pass.
+        if (err?.code === "ENOENT") unresolved++;
+      }
+    }
+    if (unresolved === 0) return count;
+    if (attempt === 1) return count + unresolved;
+  }
+  return unresolved;
+}
+
 /**
  * Atomically claim a pending file for replay. Only the process that successfully
  * renames the file may send the HTTP replay.
@@ -341,6 +372,109 @@ export async function cleanStale() {
     }
   }
   return cleaned;
+}
+
+/**
+ * Replay queued addMessage entries for one session within a bounded pass.
+ * Each entry from the initial snapshot is considered at most once, so a
+ * retryable failure cannot consume multiple retries during one call.
+ *
+ * @param {Function} fetchJSON - the configured fetchJSON from makeFetchJSON
+ * @param {Function} log - logger function
+ * @param {string} sessionId - session whose addMessage entries should drain
+ * @param {object} options
+ * @param {number} options.maxItems - maximum snapshot entries examined
+ * @param {number} options.timeBudgetMs - maximum elapsed time before starting more work
+ * @returns {{ replayed: number, failed: number, skipped: number, deferred: number, remaining: number }}
+ */
+export async function drainPendingForSession(fetchJSON, log, sessionId, options = {}) {
+  if (typeof sessionId !== "string" || !sessionId) {
+    throw new TypeError("sessionId is required");
+  }
+
+  const pending = (await listPending()).filter(
+    ({ entry }) => entry?.type === "addMessage" && entry.sessionId === sessionId,
+  );
+  const configuredMaxItems = Number(options.maxItems);
+  const maxItems = options.maxItems === undefined
+    ? getReplayLimit()
+    : Math.max(0, Number.isFinite(configuredMaxItems) ? Math.floor(configuredMaxItems) : 0);
+  const configuredTimeBudget = Number(options.timeBudgetMs);
+  const timeBudgetMs = options.timeBudgetMs === undefined
+    ? Infinity
+    : Math.max(0, Number.isFinite(configuredTimeBudget) ? configuredTimeBudget : 0);
+  const startedAt = Date.now();
+
+  let replayed = 0;
+  let failed = 0;
+  let skipped = 0;
+  let deferred = 0;
+
+  log("pending-queue", {
+    action: "session-drain-start",
+    sessionId,
+    count: pending.length,
+    maxItems,
+    timeBudgetMs: Number.isFinite(timeBudgetMs) ? timeBudgetMs : undefined,
+  });
+
+  for (let index = 0; index < pending.length; index++) {
+    if (index >= maxItems || Date.now() - startedAt >= timeBudgetMs) {
+      deferred += pending.length - index;
+      break;
+    }
+
+    const { filename, entry } = pending[index];
+
+    if ((entry.retries || 0) >= getMaxRetries()) {
+      await dequeue(filename);
+      skipped++;
+      continue;
+    }
+
+    const claimedFilename = await claimForReplay(filename);
+    if (!claimedFilename) {
+      skipped++;
+      continue;
+    }
+
+    let res;
+    try {
+      const encodedSid = encodeURIComponent(entry.sessionId);
+      res = await fetchJSON(`/api/v1/sessions/${encodedSid}/messages`, {
+        method: "POST",
+        body: JSON.stringify(entry.payload),
+      });
+    } catch {
+      res = { ok: false };
+    }
+
+    if (res?.ok) {
+      await dequeue(claimedFilename);
+      replayed++;
+    } else if (!isRetryableReplayFailure(res)) {
+      await dequeue(claimedFilename);
+      skipped++;
+    } else {
+      await incrementRetry(claimedFilename, entry);
+      failed++;
+      deferred += pending.length - index - 1;
+      break;
+    }
+  }
+
+  const remaining = await countPendingMessagesForSession(sessionId);
+  log("pending-queue", {
+    action: "session-drain-done",
+    sessionId,
+    replayed,
+    failed,
+    skipped,
+    deferred,
+    remaining,
+  });
+
+  return { replayed, failed, skipped, deferred, remaining };
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes #4504.

A takeover livelock: while the OpenViking server is unreachable (or the pending
queue exceeds the replay limit), the takeover commit path could never flush, yet
its token counter kept climbing — so every later turn re-triggered a doomed
takeover commit attempt and `pendingTokens` grew without bound (observed at
14,493,633 in the issue).

**Root cause:** in `examples/pi-coding-agent-extension/lib/takeover-core.mjs`,
`commitAndAdvance()` reset token pressure when the archive overview was "not
ready", but *not* when the flush failed. That asymmetry meant a postponed commit
left `pendingTokens` above the takeover threshold forever, and `onTurnSynced()`
re-entered the commit path on every subsequent turn.

**Behavior before:** flush failure → tokens retained above threshold → each new
turn re-attempts takeover commit (and each replay pass re-hits the queue).

**Behavior after:** a failed flush clears the token pressure (mirroring the
overview-not-ready branch), so takeover waits for the next threshold crossing;
the flush gate now drains a bounded per-session backlog and only admits takeover
when the session's undelivered messages reach zero; while disconnected the gate
returns false without consuming a queued retry, so offline backlogs are preserved
until the server is reachable again.

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4504

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **shared pending queue** (`examples/memory-plugin-shared/lib/pending-queue.mjs`):
  add `drainPendingForSession` — a bounded, per-session replay pass. Each entry
  from the snapshot is attempted at most once per invocation, so a retryable
  failure cannot consume multiple retries in a single call; `maxItems` and
  `timeBudgetMs` cap how much new work one drain starts. Regenerated the
  `pending-queue.mjs` copies across all plugin examples (claude-code, codex,
  dsh, opencode, pi, zcode) and wired the source tests into CI.
- **pi takeover flush gate** (`sync.ts`): `flushForTakeover()` now drains the
  current session via `drainPendingForSession` and reports success only when
  nothing remains; it returns `false` immediately while disconnected so queued
  retries are not burned offline.
- **pi takeover core** (`lib/takeover-core.mjs`): clear `pendingTokens` on the
  flush-failed branch, matching the existing overview-not-ready behavior, so a
  postponed commit does not retry on every turn.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Validation commands run:

```bash
cd examples/pi-coding-agent-extension
node --test tests/takeover-core.test.mjs tests/sync-barrier.test.mjs   # 29 pass

cd examples/memory-plugin-shared
node --test pending-queue.test.mjs                                     # 8 pass
node sync.mjs                                                           # no drift
```

New tests:
- `tests/takeover-core.test.mjs`: a failed flush must not cause takeover to
  retry on a sub-threshold turn; only a fresh threshold crossing may re-attempt.
- `tests/sync-barrier.test.mjs`: a replay-limit backlog drains without takeover
  retrying on every turn; a disconnected client does not consume a queued retry.
- `pending-queue.test.mjs`: session drain isolation, item/time budgets, single
  retry opportunity per invocation, conservative in-flight accounting.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Diff Size / Review Scope

Total diff is 14 files / +1243 −11, but most of it is generated copies of a
single file, not hand-written change:

- ~940 lines are the `pending-queue.mjs` generated copies synced from
  `examples/memory-plugin-shared/lib` into the six plugin examples (claude-code,
  codex, dsh, opencode, pi, zcode) via `node sync.mjs`. Per CONTRIBUTING, these
  generated files are excluded from change-size assessment and the real review
  surface is the hand-written delta below.
- Hand-written delta is ~440 lines:
  - `examples/memory-plugin-shared/lib/pending-queue.mjs` +134 (new shared
    `drainPendingForSession`)
  - `examples/memory-plugin-shared/pending-queue.test.mjs` +183 (8 drain edge
    cases requested in review: backlog > replay window, budgets, retry-at-most-
    once, in-flight accounting)
  - pi tests +101, pi implementation `sync.ts` +13, plus 1-line
    `takeover-core.mjs`, +6 `pending-queue.d.mts`, +1 CI wiring

The larger hand-written portion is a new shared API plus its contract tests (the
direction requested in review), not a modification of existing logic, so it does
not fit the ≤200-line "small focused change" bucket.

## Additional Notes

Generated copies of `pending-queue.mjs` are produced from
`examples/memory-plugin-shared/lib` via `node sync.mjs`; the pi-extension and
plugin copies in this PR are in sync with the source (verified byte-identical
modulo the generated header).

