### PR TITLE
fix(bot): forward actor_peer_id through openviking_connection

### DIFF
--- a/openviking/server/routers/bot.py
+++ b/openviking/server/routers/bot.py
@@ -92,6 +92,11 @@ def _build_openviking_connection(
     }
     if api_key:
         connection["api_key"] = api_key
+    # Preserve request-scoped actor peer so vikingbot does not fall back to
+    # body user_id / authenticated OpenViking user_id (#4649).
+    actor_peer_id = str(getattr(ctx, "actor_peer_id", None) or "").strip()
+    if actor_peer_id:
+        connection["actor_peer_id"] = actor_peer_id
     return connection
 
 

--- a/openviking/server/routers/bot.py
+++ b/openviking/server/routers/bot.py
@@ -94,7 +94,7 @@ def _build_openviking_connection(
         connection["api_key"] = api_key
     # Preserve request-scoped actor peer so vikingbot does not fall back to
     # body user_id / authenticated OpenViking user_id (#4649).
-    actor_peer_id = str(getattr(ctx, "actor_peer_id", None) or "").strip()
+    actor_peer_id = str(ctx.actor_peer_id or "").strip()
     if actor_peer_id:
         connection["actor_peer_id"] = actor_peer_id
     return connection

--- a/tests/server/test_bot_actor_peer_forward.py
+++ b/tests/server/test_bot_actor_peer_forward.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from openviking.server.identity import RequestContext, Role
+from openviking.server.routers.bot import _build_openviking_connection
+from openviking_cli.session.user_id import UserIdentifier
+
+
+def test_build_openviking_connection_forwards_actor_peer_id():
+    ctx = RequestContext(
+        user=UserIdentifier("acct", "alice"),
+        role=Role.USER,
+        actor_peer_id="peer-a",
+    )
+    connection = _build_openviking_connection(
+        api_key="user-key",
+        ctx=ctx,
+        effective_auth_mode="api_key",
+        server_url="http://127.0.0.1:1933",
+    )
+    body = {"message": "hello", "user_id": "peer-b", "openviking_connection": connection}
+    actual = body["openviking_connection"].get("actor_peer_id") or body["user_id"]
+    assert connection["actor_peer_id"] == "peer-a"
+    assert actual == "peer-a"
+
+
+def test_build_openviking_connection_omits_blank_actor_peer_id():
+    ctx = RequestContext(
+        user=UserIdentifier("acct", "alice"),
+        role=Role.USER,
+        actor_peer_id="  ",
+    )
+    connection = _build_openviking_connection(
+        api_key="user-key",
+        ctx=ctx,
+        effective_auth_mode="api_key",
+        server_url="http://127.0.0.1:1933",
+    )
+    assert "actor_peer_id" not in connection

--- a/tests/server/test_bot_actor_peer_forward.py
+++ b/tests/server/test_bot_actor_peer_forward.py
@@ -18,10 +18,8 @@ def test_build_openviking_connection_forwards_actor_peer_id():
         effective_auth_mode="api_key",
         server_url="http://127.0.0.1:1933",
     )
-    body = {"message": "hello", "user_id": "peer-b", "openviking_connection": connection}
-    actual = body["openviking_connection"].get("actor_peer_id") or body["user_id"]
+    # Assert the OpenViking-side forward only; vikingbot owns connection > body fallback.
     assert connection["actor_peer_id"] == "peer-a"
-    assert actual == "peer-a"
 
 
 def test_build_openviking_connection_omits_blank_actor_peer_id():


### PR DESCRIPTION
## Summary
`openviking-server --with-bot` builds `openviking_connection` from `RequestContext` but omitted `actor_peer_id`. VikingBot then falls back to body `user_id` (or the authenticated OV user), so `X-OpenViking-Actor-Peer` is ignored on the proxy path while the direct gateway path preserves it.

This copies a non-blank `ctx.actor_peer_id` into the forwarded connection (also used by `_bot_gateway_headers`).

Fixes #4649

## Test plan
- [x] Unit test mirrors the issue MRE (`tests/server/test_bot_actor_peer_forward.py`)
- [ ] Optional: curl `/bot/v1/chat` via proxy with `X-OpenViking-Actor-Peer: peer-a` and body `user_id: peer-b` — inbound `actor_peer_id` should be `peer-a`