### PR TITLE
fix(pi): tolerate hosts without buildContextEntries

### DIFF
--- a/examples/pi-coding-agent-extension/index.ts
+++ b/examples/pi-coding-agent-extension/index.ts
@@ -181,13 +181,28 @@ export default async function (pi: ExtensionAPI) {
     // still receives current-query memory, without blocking user-message UI.
     await recall.searchPending();
 
-    // The context hook omits persisted entry ids, but its user messages are a
-    // deep copy of the active SessionManager context. Associate those objects
-    // with stable ids before takeover may filter the array; retained messages
-    // keep object identity through that transform.
-    const userEntryIds = ctx.sessionManager.buildContextEntries()
-      .filter((entry: any) => entry?.type === "message" && entry.message?.role === "user")
-      .map((entry: any) => entry.id as string);
+    // The entry IDs are an optional optimization for replaying the recall
+    // ledger. Compatible hosts may omit buildContextEntries(), so fail closed
+    // to nullable IDs rather than guessing from another SessionManager API.
+    const sessionManager = ctx.sessionManager;
+    const entries = typeof sessionManager?.buildContextEntries === "function"
+      ? sessionManager.buildContextEntries()
+      : [];
+    const userEntryIds = entries
+      .filter((entry: unknown): entry is { id?: unknown; type: "message"; message: { role: "user" } } => {
+        if (!entry || typeof entry !== "object") return false;
+        if (!("type" in entry) || !("message" in entry)) return false;
+        const type = entry.type;
+        const message = entry.message;
+        return type === "message" &&
+          !!message &&
+          typeof message === "object" &&
+          "role" in message &&
+          message.role === "user";
+      })
+      .map((entry): string | undefined =>
+        typeof entry.id === "string" ? entry.id : undefined
+      );
     const messageIds = new WeakMap<object, string>();
     let userIndex = 0;
     for (const message of event.messages as any[]) {


### PR DESCRIPTION
## Description

Make the OpenViking Pi extension tolerate compatible hosts whose `SessionManager` does not expose `buildContextEntries()`.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4652

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Feature-detect `SessionManager.buildContextEntries()`.
- Fall back to an empty positional ID mapping when the host omits that API.
- Preserve nullable IDs so missing IDs cannot shift later IDs onto the wrong user message.
- Keep `RecallManager`'s existing nullable-ID behavior; no IDs are guessed from another host API.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Tests run:

```shell
bun test examples/pi-coding-agent-extension/tests/*.test.mjs
# 58 pass, 0 fail
```

Also smoke-tested a real OMP 18.1.5 prompt on macOS against OpenViking 0.4.17.1 using the patched extension. The turn synced successfully and stderr contained no `buildContextEntries` or OpenViking extension error.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

The reported failure was on the pre-change upstream snapshot `a8380147a23d9fd97ee5457c109478d235eaded9`, at the unguarded call in `examples/pi-coding-agent-extension/index.ts` around lines 188-190. This PR is a graceful cross-runtime compatibility fix; the upstream Pi behavior remains unchanged when `buildContextEntries()` exists.
