### PR TITLE
docs: fix broken internal links in READMEs and docs

### DIFF
--- a/bot/docs/zh/concepts/03-channels-and-gateway.md
+++ b/bot/docs/zh/concepts/03-channels-and-gateway.md
@@ -121,4 +121,4 @@ Gateway 使用多层安全边界：
 - [VikingBot 架构](./01-architecture.md)
 - [Agent 能力体系](./02-agent-capabilities.md)
 - [与 OpenViking 集成](./04-openviking-integration.md)
-- [渠道配置](../../CHANNEL.md)
+- [渠道配置](./05-channel.md)

--- a/openviking/eval/README.md
+++ b/openviking/eval/README.md
@@ -326,4 +326,4 @@ python -m openviking.eval.ragas.rag_eval --docs_dir ./docs --question_file ./que
 - 回放 CLI：[ragas/play_recorder.py](./ragas/play_recorder.py)
 - IO 录制器：[recorder/__init__.py](./recorder/__init__.py)
 - 示例数据：[datasets/local_doc_example_glm5.jsonl](./datasets/local_doc_example_glm5.jsonl)
-- 测试文件：[tests/eval/](../../tests/eval/)、[tests/storage/test_recorder.py](../../tests/storage/test_recorder.py)
+- 测试文件：[tests/eval/](../../tests/eval/)

--- a/openviking/parse/parsers/code/README.md
+++ b/openviking/parse/parsers/code/README.md
@@ -165,6 +165,6 @@ results = client.find(
 
 ## 相关文档
 
-*   [上下文类型](docs/zh/concepts/context-types.md)
-*   [Viking URI](docs/zh/concepts/viking-uri.md)
-*   [上下文层级](docs/zh/concepts/context-layers.md)
+*   [上下文类型](../../../../docs/zh/concepts/02-context-types.md)
+*   [Viking URI](../../../../docs/zh/concepts/04-viking-uri.md)
+*   [上下文层级](../../../../docs/zh/concepts/03-context-layers.md)

--- a/openviking/storage/observers/README.md
+++ b/openviking/storage/observers/README.md
@@ -75,6 +75,6 @@ print(client.observer.vikingdb())
 
 ## See Also
 
-- [QueueFS Documentation](../queuefs/README.md)
-- [Storage Documentation](../../docs/OpenViking存储.md)
-- [API Documentation](../../docs/OpenViking接口文档.md)
+- [QueueFS module](../queuefs/)
+- [Storage concepts](../../../docs/en/concepts/05-storage.md)
+- [Observer API](../../../docs/en/api/18-observer.md)

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,7 +26,7 @@ Set the `OPENVIKING_CONFIG_FILE` environment variable to point to your `ov.conf`
 export OPENVIKING_CONFIG_FILE="/path/to/ov.conf"
 ```
 
-See [docs/en/guides/configuration.md](../docs/en/guides/configuration.md) for the config file format.
+See [docs/en/guides/01-configuration.md](../docs/en/guides/01-configuration.md) for the config file format.
 
 ### Dependencies
 

--- a/web-studio/README.md
+++ b/web-studio/README.md
@@ -384,4 +384,3 @@ The API key is missing or invalid, the key belongs to a different server, or the
 
 - [Web Studio internationalization contribution guide](./CONTRIBUTING.md): translation ownership, dynamic server text, and the review checklist.
 - [OpenViking server deployment](../docs/en/guides/03-deployment.md): server-side deployment details.
-- [VikingBot validation with OpenViking Server](../bot/docs/vikingbot-phase1-validation-with-openviking-server.md): bot proxy validation flow.

--- a/web-studio/README_CN.md
+++ b/web-studio/README_CN.md
@@ -383,4 +383,3 @@ openviking-server --with-bot
 
 - [Web Studio 国际化贡献指南](./CONTRIBUTING_CN.md)：翻译归属、服务端动态文本和审查清单。
 - [OpenViking server deployment](../docs/en/guides/03-deployment.md)：服务端部署说明。
-- [VikingBot validation with OpenViking Server](../bot/docs/vikingbot-phase1-validation-with-openviking-server.md)：Bot proxy 验证流程。


### PR DESCRIPTION
## Summary

Fixes 12 broken relative links across 7 markdown files, found by scanning every `.md` in the repo for relative targets that no longer resolve. Each fix points at the current location of the referenced document.

## Changes

- `web-studio/README.md` + `README_CN.md`: removed the reference to `../bot/docs/vikingbot-phase1-validation-with-openviking-server.md`, which no longer exists in the tree.
- `openviking/parse/parsers/code/README.md`: `context-types`, `viking-uri` and `context-layers` links updated to the renumbered `docs/zh/concepts/02-context-types.md`, `04-viking-uri.md`, `03-context-layers.md`.
- `openviking/storage/observers/README.md`: dead `../queuefs/README.md` replaced with the QueueFS module directory; the removed `OpenViking存储.md` / `OpenViking接口文档.md` replaced with `docs/en/concepts/05-storage.md` and `docs/en/api/18-observer.md`.
- `openviking/eval/README.md`: dropped the removed `tests/storage/test_recorder.py` reference.
- `tests/README.md`: configuration guide link updated to `01-configuration.md`.
- `bot/docs/zh/concepts/03-channels-and-gateway.md`: `../../CHANNEL.md` replaced with the existing `05-channel.md`.

## Notes

- Remaining unresolved relative references were intentionally left alone: `viking://` example URIs, `<相对路径>` template placeholders in the api-doc-writing guide, and the skill-creator `FORMS.md`-style references that resolve in the skill's runtime directory.
- Docs-only change; no code or tests affected.