### PR TITLE
feat(session): extract session skills even when no training cases are produced

### DIFF
--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -499,12 +499,14 @@ class SessionCompressorV3:
                         else "memory_types_filtered"
                     ),
                 }
-            # Evolution training only reaches skill extraction when cases exist.
-            # `skill_uris` missing means that path never ran; an empty list means it ran.
+            # Empty-cases training returns before skill extraction. Compensate
+            # only then; a swallowed training error keeps case_count > 0 and
+            # must not re-submit skills that may already be on disk.
             if (
                 agent_evolution_enabled
                 and session_skills_enabled
                 and allow_self_memory
+                and train_result.get("case_count") == 0
                 and "skill_uris" not in train_result
             ):
                 skill_result = await self.extract_session_skills(

--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -499,6 +499,27 @@ class SessionCompressorV3:
                         else "memory_types_filtered"
                     ),
                 }
+            # Evolution training only reaches skill extraction when cases exist.
+            # `skill_uris` missing means that path never ran; an empty list means it ran.
+            if (
+                agent_evolution_enabled
+                and session_skills_enabled
+                and allow_self_memory
+                and "skill_uris" not in train_result
+            ):
+                skill_result = await self.extract_session_skills(
+                    messages=message_list,
+                    ctx=ctx,
+                    archive_uri=archive_uri or "",
+                    strict_extract_errors=strict_extract_errors,
+                )
+                train_result = {
+                    **train_result,
+                    "skill_submitted": skill_result.get("skill_submitted", 0),
+                    "skill_uris": list(skill_result.get("skill_uris") or []),
+                }
+                if skill_result.get("memory_diff") is not None:
+                    train_result["memory_diff"] = skill_result["memory_diff"]
             await self._write_final_memory_diff(
                 archive_uri=archive_uri or "",
                 ctx=ctx,

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -396,6 +396,56 @@ async def test_v3_does_not_reextract_session_skills_when_training_already_did(
 
 
 @pytest.mark.asyncio
+async def test_v3_does_not_reextract_session_skills_when_training_swallowed_an_error(
+    monkeypatch,
+):
+    # train_from_extracted_cases swallows mid-loop failures and returns
+    # case_count > 0 without skill_uris. Skills may already be on disk.
+    config = SimpleNamespace(
+        memory=SimpleNamespace(session_skill_extraction_enabled=True),
+    )
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.get_viking_fs",
+        lambda: SimpleNamespace(),
+    )
+    compressor = SessionCompressorV3(
+        vikingdb=None,
+        skill_processor=SimpleNamespace(),
+    )
+    compressor._extract_user_memories = AsyncMock(
+        return_value=SimpleNamespace(
+            contexts=[],
+            cases=[_training_case()],
+            memory_diff={"operations": {}},
+            case_uri_by_name={},
+        )
+    )
+    compressor.train_from_extracted_cases = AsyncMock(
+        return_value={
+            "case_count": 1,
+            "submitted": 0,
+            "error": "Commit streaming train failed",
+        }
+    )
+    compressor.extract_session_skills = AsyncMock()
+    compressor._write_final_memory_diff = AsyncMock()
+
+    result = await compressor.extract_long_term_memories(
+        messages=_messages(),
+        ctx=_ctx(),
+        agent_evolution_enabled=True,
+    )
+
+    compressor.train_from_extracted_cases.assert_awaited_once()
+    compressor.extract_session_skills.assert_not_awaited()
+    assert result == []
+
+
+@pytest.mark.asyncio
 async def test_v3_skill_only_extraction_submits_gradients_without_agent_memories(monkeypatch):
     from openviking.session.train import PatchSemanticGradient
 

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -286,6 +286,116 @@ async def test_v3_extracts_session_skills_when_agent_evolution_is_disabled(monke
 
 
 @pytest.mark.asyncio
+async def test_v3_extracts_session_skills_when_agent_evolution_has_no_cases(
+    monkeypatch,
+):
+    config = SimpleNamespace(
+        memory=SimpleNamespace(session_skill_extraction_enabled=True),
+    )
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.get_viking_fs",
+        lambda: SimpleNamespace(),
+    )
+    compressor = SessionCompressorV3(
+        vikingdb=None,
+        skill_processor=SimpleNamespace(),
+    )
+    compressor._extract_user_memories = AsyncMock(
+        return_value=SimpleNamespace(
+            contexts=[],
+            cases=[],
+            memory_diff={"operations": {}},
+            case_uri_by_name={},
+        )
+    )
+    compressor.train_from_extracted_cases = AsyncMock(
+        return_value={"case_count": 0, "submitted": 0},
+    )
+    compressor.extract_session_skills = AsyncMock(
+        return_value={
+            "case_count": 0,
+            "submitted": 0,
+            "skill_submitted": 1,
+            "skill_uris": ["viking://user/u/skills/code-review/SKILL.md"],
+        }
+    )
+    compressor._write_final_memory_diff = AsyncMock()
+
+    result = await compressor.extract_long_term_memories(
+        messages=_messages(),
+        ctx=_ctx(),
+        agent_evolution_enabled=True,
+    )
+
+    compressor.train_from_extracted_cases.assert_awaited_once()
+    compressor.extract_session_skills.assert_awaited_once()
+    assert result["session_skills"] == [
+        {
+            "uri": "viking://user/u/skills/code-review/SKILL.md",
+            "archive_uri": "",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_v3_does_not_reextract_session_skills_when_training_already_did(
+    monkeypatch,
+):
+    config = SimpleNamespace(
+        memory=SimpleNamespace(session_skill_extraction_enabled=True),
+    )
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.get_viking_fs",
+        lambda: SimpleNamespace(),
+    )
+    compressor = SessionCompressorV3(
+        vikingdb=None,
+        skill_processor=SimpleNamespace(),
+    )
+    compressor._extract_user_memories = AsyncMock(
+        return_value=SimpleNamespace(
+            contexts=[],
+            cases=[_training_case()],
+            memory_diff={"operations": {}},
+            case_uri_by_name={},
+        )
+    )
+    compressor.train_from_extracted_cases = AsyncMock(
+        return_value={
+            "case_count": 1,
+            "submitted": 1,
+            "skill_submitted": 1,
+            "skill_uris": ["viking://user/u/skills/code-review/SKILL.md"],
+        }
+    )
+    compressor.extract_session_skills = AsyncMock()
+    compressor._write_final_memory_diff = AsyncMock()
+
+    result = await compressor.extract_long_term_memories(
+        messages=_messages(),
+        ctx=_ctx(),
+        agent_evolution_enabled=True,
+    )
+
+    compressor.train_from_extracted_cases.assert_awaited_once()
+    compressor.extract_session_skills.assert_not_awaited()
+    assert result["session_skills"] == [
+        {
+            "uri": "viking://user/u/skills/code-review/SKILL.md",
+            "archive_uri": "",
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_v3_skill_only_extraction_submits_gradients_without_agent_memories(monkeypatch):
     from openviking.session.train import PatchSemanticGradient
 


### PR DESCRIPTION
## Description

With Agent Evolution on (the default), `memory.session_skill_extraction_enabled=true` did not extract skills unless the same commit also produced training cases.

Root cause: `extract_long_term_memories` only called `train_from_extracted_cases` on that path. That function returns on empty `cases` before it reads the skill flag. The standalone `extract_session_skills` path ran only when Evolution was off.

After this change, if the skill flag is on and training did not run skill extraction (`skill_uris` absent from `train_result`), commit calls existing `extract_session_skills`. If training already set `skill_uris` (including `[]`), it is not called again.

Default (flag off) is unchanged. No API/config/migration impact. Inferred from the dispatcher and unit tests, not reproduced on a live server.

Entrypoint: `SessionCompressorV3.extract_long_term_memories`. Module: `openviking/session`.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4655

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- After the Evolution branch in `extract_long_term_memories`, call `extract_session_skills` when the flag is on and `skill_uris` is missing from `train_result`.
- Tests for: Evolution on + no cases → extract; training already returned `skill_uris` → do not extract again.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

```
.venv/bin/python -m pytest -q --no-cov \
  tests/session/test_compressor_v3.py::test_v3_extracts_session_skills_when_agent_evolution_is_disabled \
  tests/session/test_compressor_v3.py::test_v3_extracts_session_skills_when_agent_evolution_has_no_cases \
  tests/session/test_compressor_v3.py::test_v3_does_not_reextract_session_skills_when_training_already_did
```

All three passed. Other failures in `test_compressor_v3.py` also fail on unmodified `origin/main` (missing local server config) and are not claimed here.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
