### PR TITLE
fix(models): 统一模型重试与队列失败边界

### DIFF
--- a/bot/vikingbot/providers/vlm_adapter.py
+++ b/bot/vikingbot/providers/vlm_adapter.py
@@ -5,7 +5,6 @@ LLMProvider interface, so that bot.agents.provider / bot.agents.model
 configuration semantics are consistent with openviking server's vlm section.
 """
 
-import asyncio
 import json
 import re
 import time
@@ -16,7 +15,7 @@ from typing import Any
 from loguru import logger
 
 from openviking.models.vlm.backends.volcengine_vlm import build_volcengine_request_headers
-from openviking.utils.model_retry import is_retryable_rate_limit_error, rate_limit_retry_delay
+from openviking.utils.model_retry import retry_async_iterator
 from openviking.utils.multimodal import redact_image_data_urls
 from vikingbot.integrations.langfuse import LangfuseClient
 from vikingbot.providers.base import (
@@ -283,31 +282,15 @@ class VLMProviderAdapter(LLMProvider):
                         )
 
             # --- Call VLM backend ---
-            attempt = 1
             # An explicit empty list asks VLM backends for a structured response
             # without exposing tools, so per-response usage is preserved.
             response_tools = tools if tools is not None else []
-            while True:
-                try:
-                    result = await self._vlm.get_completion_async(
-                        messages=messages,
-                        thinking=getattr(self._vlm, "thinking", None),
-                        tools=response_tools,
-                        tool_choice="auto" if response_tools else None,
-                    )
-                    break
-                except Exception as e:
-                    if not is_retryable_rate_limit_error(e):
-                        raise
-                    delay = rate_limit_retry_delay(attempt)
-                    logger.warning(
-                        "VLM adapter chat rate limited; retrying attempt={} delay={:.1f}s error={}",
-                        attempt,
-                        delay,
-                        e,
-                    )
-                    await asyncio.sleep(delay)
-                    attempt += 1
+            result = await self._vlm.get_completion_async(
+                messages=messages,
+                thinking=getattr(self._vlm, "thinking", None),
+                tools=response_tools,
+                tool_choice="auto" if response_tools else None,
+            )
 
             llm_response = self._convert_response(result)
 
@@ -350,13 +333,15 @@ class VLMProviderAdapter(LLMProvider):
         try:
             stream_with_failover = getattr(self._vlm, "stream_with_failover", None)
             if callable(stream_with_failover):
-                async for event in self._chat_stream_failover_with_retry(
-                    stream_with_failover,
-                    messages=messages,
-                    tools=tools,
-                    model=model,
-                    max_tokens=max_tokens,
-                    temperature=temperature,
+                async for event in stream_with_failover(
+                    lambda vlm: self._chat_stream_with_retry(
+                        vlm,
+                        messages=messages,
+                        tools=tools,
+                        model=model,
+                        max_tokens=max_tokens,
+                        temperature=temperature,
+                    )
                 ):
                     yield event
                 return
@@ -425,47 +410,6 @@ class VLMProviderAdapter(LLMProvider):
             getattr(vlm, "get_async_client", None)
         )
 
-    async def _chat_stream_failover_with_retry(
-        self,
-        stream_with_failover: Any,
-        *,
-        messages: list[dict[str, Any]],
-        tools: list[dict[str, Any]] | None,
-        model: str | None,
-        max_tokens: int | None,
-        temperature: float,
-    ) -> AsyncIterator[LLMStreamEvent]:
-        attempt = 1
-        while True:
-            emitted = False
-            try:
-                async for event in stream_with_failover(
-                    lambda vlm: self._chat_stream_backend(
-                        vlm,
-                        messages=messages,
-                        tools=tools,
-                        model=model,
-                        max_tokens=max_tokens,
-                        temperature=temperature,
-                    )
-                ):
-                    emitted = True
-                    yield event
-                return
-            except Exception as exc:
-                if emitted or not is_retryable_rate_limit_error(exc):
-                    raise
-                delay = rate_limit_retry_delay(attempt)
-                logger.warning(
-                    "VLM credential stream rate limited; retrying attempt={} "
-                    "delay={:.1f}s error={}",
-                    attempt,
-                    delay,
-                    exc,
-                )
-                await asyncio.sleep(delay)
-                attempt += 1
-
     async def _chat_stream_with_retry(
         self,
         vlm: Any,
@@ -475,33 +419,20 @@ class VLMProviderAdapter(LLMProvider):
         max_tokens: int | None,
         temperature: float,
     ) -> AsyncIterator[LLMStreamEvent]:
-        attempt = 1
-        while True:
-            emitted = False
-            try:
-                async for event in self._chat_stream_backend(
-                    vlm,
-                    messages=messages,
-                    tools=tools,
-                    model=model,
-                    max_tokens=max_tokens,
-                    temperature=temperature,
-                ):
-                    emitted = True
-                    yield event
-                return
-            except Exception as exc:
-                if emitted or not is_retryable_rate_limit_error(exc):
-                    raise
-                delay = rate_limit_retry_delay(attempt)
-                logger.warning(
-                    "VLM adapter stream rate limited; retrying attempt={} delay={:.1f}s error={}",
-                    attempt,
-                    delay,
-                    exc,
-                )
-                await asyncio.sleep(delay)
-                attempt += 1
+        async for event in retry_async_iterator(
+            lambda: self._chat_stream_backend(
+                vlm,
+                messages=messages,
+                tools=tools,
+                model=model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            ),
+            max_retries=int(getattr(vlm, "max_retries", 0)),
+            logger=logger,
+            operation_name="VLM adapter stream",
+        ):
+            yield event
 
     async def _chat_stream_backend(
         self,

--- a/bot/vikingbot/tests/unit/test_bot_vlm_streaming.py
+++ b/bot/vikingbot/tests/unit/test_bot_vlm_streaming.py
@@ -119,6 +119,7 @@ async def test_vlm_adapter_streams_with_credential_failover_before_first_delta()
             "provider": "volcengine",
             "model": "primary-model",
             "api_key": "primary-key",
+            "max_retries": 0,
         }
     )
     backup = VolcEngineVLM(

--- a/openviking/models/embedder/base.py
+++ b/openviking/models/embedder/base.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0
 import asyncio
 import logging
-import random
 import time
 import weakref
 from abc import ABC, abstractmethod
@@ -558,71 +557,6 @@ class CompositeHybridEmbedder(HybridEmbedderBase):
     def close(self):
         self.dense_embedder.close()
         self.sparse_embedder.close()
-
-
-def exponential_backoff_retry(
-    func: Callable[[], T],
-    max_wait: float = 10.0,
-    base_delay: float = 0.5,
-    max_delay: float = 2.0,
-    jitter: bool = True,
-    is_retryable: Optional[Callable[[Exception], bool]] = None,
-    logger=None,
-) -> T:
-    """
-    指数退避重试函数
-
-    Args:
-        func: 要执行的函数
-        max_wait: 最大总等待时间（秒）
-        base_delay: 基础延迟时间（秒）
-        max_delay: 单次最大延迟时间（秒）
-        jitter: 是否添加随机抖动
-        is_retryable: 判断异常是否可重试的函数
-        logger: 日志记录器
-
-    Returns:
-        函数执行结果
-
-    Raises:
-        最后一次尝试的异常
-    """
-    start_time = time.time()
-    attempt = 0
-
-    while True:
-        try:
-            return func()
-        except Exception as e:
-            attempt += 1
-            elapsed = time.time() - start_time
-
-            if elapsed >= max_wait:
-                if logger:
-                    logger.error(
-                        f"Exceeded max wait time ({max_wait}s) after {attempt} attempts, giving up"
-                    )
-                raise
-
-            if is_retryable and not is_retryable(e):
-                if logger:
-                    logger.error(f"Non-retryable error after {attempt} attempts: {e}")
-                raise
-
-            delay = min(base_delay * (2 ** (attempt - 1)), max_delay)
-
-            if jitter:
-                delay = delay * (0.5 + random.random())
-
-            remaining_time = max_wait - elapsed
-            delay = min(delay, remaining_time)
-
-            if logger:
-                logger.info(
-                    f"Retry attempt {attempt}, waiting {delay:.2f}s before next try (elapsed: {elapsed:.2f}s)"
-                )
-
-            time.sleep(delay)
 
 
 class FailoverEmbedder(EmbedderBase):

--- a/openviking/models/embedder/cohere_embedders.py
+++ b/openviking/models/embedder/cohere_embedders.py
@@ -135,7 +135,11 @@ class CohereDenseEmbedder(DenseEmbedderBase):
     def embed(self, text: str, is_query: bool = False) -> EmbedResult:
         input_type = "search_query" if is_query else "search_document"
         try:
-            vectors = self._call_api([text], input_type)
+            vectors = self._run_with_retry(
+                lambda: self._call_api([text], input_type),
+                logger=logger,
+                operation_name="Cohere embedding",
+            )
             result = EmbedResult(dense_vector=self._normalize_vector(vectors[0]))
             # Estimate token usage
             estimated_tokens = self._estimate_tokens(text)

--- a/openviking/models/embedder/dashscope_embedders.py
+++ b/openviking/models/embedder/dashscope_embedders.py
@@ -89,6 +89,7 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
         self._openai_client = openai.OpenAI(
             api_key=self.api_key,
             base_url=f"{self.api_base}/compatible-mode/v1",
+            max_retries=0,
         )
         # Multimodal mode: httpx
         self._httpx_client = httpx.Client(
@@ -208,6 +209,7 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
             lambda: openai.AsyncOpenAI(
                 api_key=self.api_key,
                 base_url=f"{self.api_base}/compatible-mode/v1",
+                max_retries=0,
             )
         )
 

--- a/openviking/models/embedder/gemini_embedders.py
+++ b/openviking/models/embedder/gemini_embedders.py
@@ -8,13 +8,6 @@ from google import genai
 from google.genai import types
 from google.genai.errors import APIError, ClientError
 
-try:
-    from google.genai.types import HttpOptions, HttpRetryOptions
-
-    _HTTP_RETRY_AVAILABLE = True
-except ImportError:
-    _HTTP_RETRY_AVAILABLE = False
-
 from openviking.models.embedder.base import (
     DenseEmbedderBase,
     EmbedResult,
@@ -136,20 +129,7 @@ class GeminiDenseEmbedder(DenseEmbedderBase):
             )
         if dimension is not None and not (1 <= dimension <= 3072):
             raise ValueError(f"dimension must be between 1 and 3072, got {dimension}")
-        if _HTTP_RETRY_AVAILABLE:
-            self.client = genai.Client(
-                api_key=api_key,
-                http_options=HttpOptions(
-                    retry_options=HttpRetryOptions(
-                        attempts=max(self.max_retries + 1, 1),
-                        initial_delay=0.5,
-                        max_delay=8.0,
-                        exp_base=2.0,
-                    )
-                ),
-            )
-        else:
-            self.client = genai.Client(api_key=api_key)
+        self.client = genai.Client(api_key=api_key)
         self.task_type = task_type
         self.query_param = query_param
         self.document_param = document_param
@@ -216,14 +196,10 @@ class GeminiDenseEmbedder(DenseEmbedderBase):
             return EmbedResult(dense_vector=vector)
 
         try:
-            result = (
-                _call()
-                if _HTTP_RETRY_AVAILABLE
-                else self._run_with_retry(
-                    _call,
-                    logger=logger,
-                    operation_name="Gemini embedding",
-                )
+            result = self._run_with_retry(
+                _call,
+                logger=logger,
+                operation_name="Gemini embedding",
             )
             # Estimate token usage
             estimated_tokens = self._estimate_tokens(text)

--- a/openviking/models/embedder/jina_embedders.py
+++ b/openviking/models/embedder/jina_embedders.py
@@ -121,6 +121,7 @@ class JinaDenseEmbedder(DenseEmbedderBase):
         self.client = openai.OpenAI(
             api_key=self.api_key,
             base_url=self.api_base,
+            max_retries=0,
         )
         self._async_client_cache = LoopScopedAsyncClientCache()
 
@@ -163,6 +164,7 @@ class JinaDenseEmbedder(DenseEmbedderBase):
             lambda: openai.AsyncOpenAI(
                 api_key=self.api_key,
                 base_url=self.api_base,
+                max_retries=0,
             )
         )
 

--- a/openviking/models/embedder/litellm_embedders.py
+++ b/openviking/models/embedder/litellm_embedders.py
@@ -101,7 +101,7 @@ class LiteLLMDenseEmbedder(DenseEmbedderBase):
 
     def _build_kwargs(self, is_query: bool = False) -> Dict[str, Any]:
         """Build kwargs dict for litellm.embedding() call."""
-        kwargs: Dict[str, Any] = {"model": self.model_name}
+        kwargs: Dict[str, Any] = {"model": self.model_name, "max_retries": 0}
 
         if self.api_key:
             kwargs["api_key"] = self.api_key

--- a/openviking/models/embedder/minimax_embedders.py
+++ b/openviking/models/embedder/minimax_embedders.py
@@ -6,8 +6,6 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
 from openviking.models.embedder.base import DenseEmbedderBase, EmbedResult
 from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
@@ -78,8 +76,7 @@ class MinimaxDenseEmbedder(DenseEmbedderBase):
         if not self.api_key:
             raise ValueError("api_key is required for MiniMax embedder")
 
-        # Initialize session with retry logic
-        self.session = self._create_session()
+        self.session = requests.Session()
         self._async_client_cache = LoopScopedAsyncClientCache()
 
         # Auto-detect dimension if not provided
@@ -89,20 +86,6 @@ class MinimaxDenseEmbedder(DenseEmbedderBase):
             except Exception as e:
                 logger.warning(f"Failed to detect MiniMax dimension: {e}. Defaulting to 1536.")
                 self._dimension = 1536
-
-    def _create_session(self) -> requests.Session:
-        """Create a requests session with retry logic"""
-        session = requests.Session()
-        retry_strategy = Retry(
-            total=self.max_retries,
-            backoff_factor=0.5,
-            status_forcelist=[429, 500, 502, 503, 504],
-            allowed_methods=["POST"],
-        )
-        adapter = HTTPAdapter(max_retries=retry_strategy)
-        session.mount("https://", adapter)
-        session.mount("http://", adapter)
-        return session
 
     def _detect_dimension(self) -> int:
         """Detect dimension by making an actual API call"""
@@ -200,8 +183,16 @@ class MinimaxDenseEmbedder(DenseEmbedderBase):
 
     def embed(self, text: str, is_query: bool = False) -> EmbedResult:
         """Perform dense embedding on text"""
-        vectors = self._call_api([text], is_query=is_query)
-        result = EmbedResult(dense_vector=vectors[0])
+
+        def _call() -> EmbedResult:
+            vectors = self._call_api([text], is_query=is_query)
+            return EmbedResult(dense_vector=vectors[0])
+
+        result = self._run_with_retry(
+            _call,
+            logger=logger,
+            operation_name="MiniMax embedding",
+        )
         # Estimate token usage
         estimated_tokens = self._estimate_tokens(text)
         self.update_token_usage(

--- a/openviking/models/embedder/openai_embedders.py
+++ b/openviking/models/embedder/openai_embedders.py
@@ -135,7 +135,10 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
         self.extra_body = extra_body
         self._provider = provider.lower()
         self.provider = (configured_provider or provider).lower()
-        self._client_kwargs: Dict[str, Any] = {"api_key": self.api_key or "no-key"}
+        self._client_kwargs: Dict[str, Any] = {
+            "api_key": self.api_key or "no-key",
+            "max_retries": 0,
+        }
 
         # Allow missing api_key when api_base is set (e.g. local OpenAI-compatible servers)
         if not self.api_key and not self.api_base:

--- a/openviking/models/embedder/volcengine_embedders.py
+++ b/openviking/models/embedder/volcengine_embedders.py
@@ -171,7 +171,7 @@ class VolcengineDenseEmbedder(DenseEmbedderBase):
             raise ValueError("api_key is required")
 
         # Initialize Volcengine client
-        ark_kwargs = {"api_key": self.api_key}
+        ark_kwargs = {"api_key": self.api_key, "max_retries": 0}
         if self.api_base:
             ark_kwargs["base_url"] = self.api_base
         self.client = volcenginesdkarkruntime.Ark(**ark_kwargs)
@@ -374,7 +374,7 @@ class VolcengineSparseEmbedder(SparseEmbedderBase):
         if not self.api_key:
             raise ValueError("api_key is required")
 
-        ark_kwargs = {"api_key": self.api_key}
+        ark_kwargs = {"api_key": self.api_key, "max_retries": 0}
         if self.api_base:
             ark_kwargs["base_url"] = self.api_base
         self.client = volcenginesdkarkruntime.Ark(**ark_kwargs)
@@ -542,7 +542,7 @@ class VolcengineHybridEmbedder(HybridEmbedderBase):
         if not self.api_key:
             raise ValueError("api_key is required")
 
-        ark_kwargs = {"api_key": self.api_key}
+        ark_kwargs = {"api_key": self.api_key, "max_retries": 0}
         if self.api_base:
             ark_kwargs["base_url"] = self.api_base
         self.client = volcenginesdkarkruntime.Ark(**ark_kwargs)

--- a/openviking/models/embedder/voyage_embedders.py
+++ b/openviking/models/embedder/voyage_embedders.py
@@ -82,6 +82,7 @@ class VoyageDenseEmbedder(DenseEmbedderBase):
         self.client = openai.OpenAI(
             api_key=self.api_key,
             base_url=self.api_base,
+            max_retries=0,
         )
         self._async_client_cache = LoopScopedAsyncClientCache()
 
@@ -98,6 +99,7 @@ class VoyageDenseEmbedder(DenseEmbedderBase):
             lambda: openai.AsyncOpenAI(
                 api_key=self.api_key,
                 base_url=self.api_base,
+                max_retries=0,
             )
         )
 

--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -283,6 +283,7 @@ class LiteLLMVLMProvider(VLMBase):
             "messages": messages,
             "temperature": self.temperature,
             "timeout": self.timeout,
+            "max_retries": 0,
         }
         if self.max_tokens is not None:
             kwargs["max_tokens"] = self.max_tokens

--- a/openviking/models/vlm/backends/volcengine_vlm.py
+++ b/openviking/models/vlm/backends/volcengine_vlm.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from openviking.telemetry import tracer
+from openviking.utils.model_retry import is_retryable_api_error
 from openviking.utils.multimodal import redact_image_data_urls
 from openviking_cli.utils import get_logger
 
@@ -260,6 +261,8 @@ class VolcEngineVLM(OpenAIVLM):
             except Exception as e:
                 self.record_failed_call(duration_seconds=time.perf_counter() - t0, error=e)
                 last_error = e
+                if not is_retryable_api_error(e):
+                    raise
                 if attempt < self.max_retries:
                     await asyncio.sleep(2**attempt)
 

--- a/openviking/models/vlm/backends/volcengine_vlm.py
+++ b/openviking/models/vlm/backends/volcengine_vlm.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from openviking.telemetry import tracer
+from openviking.utils.model_retry import retry_async, retry_sync
 from openviking.utils.multimodal import redact_image_data_urls
 from openviking_cli.utils import get_logger
 
@@ -134,6 +135,58 @@ class VolcEngineVLM(OpenAIVLM):
             max_retries=0,
         )
 
+    def _create_completion(
+        self,
+        client,
+        kwargs: Dict[str, Any],
+        *,
+        has_tools: bool,
+    ) -> Union[str, VLMResponse]:
+        def _call() -> Union[str, VLMResponse]:
+            t0 = time.perf_counter()
+            try:
+                response = client.chat.completions.create(**kwargs)
+            except Exception as error:
+                self.record_failed_call(duration_seconds=time.perf_counter() - t0, error=error)
+                raise
+            elapsed = time.perf_counter() - t0
+            self._update_token_usage_from_response(response, duration_seconds=elapsed)
+            result = self._build_vlm_response(response, has_tools=has_tools)
+            return result if has_tools else self._clean_response(str(result))
+
+        return retry_sync(
+            _call,
+            max_retries=self.max_retries,
+            logger=logger,
+            operation_name="VolcEngine VLM completion",
+        )
+
+    async def _create_completion_async(
+        self,
+        client,
+        kwargs: Dict[str, Any],
+        *,
+        has_tools: bool,
+    ) -> Union[str, VLMResponse]:
+        async def _call() -> Union[str, VLMResponse]:
+            t0 = time.perf_counter()
+            try:
+                response = await client.chat.completions.create(**kwargs)
+            except Exception as error:
+                self.record_failed_call(duration_seconds=time.perf_counter() - t0, error=error)
+                raise
+            elapsed = time.perf_counter() - t0
+            self._update_token_usage_from_response(response, duration_seconds=elapsed)
+            result = self._build_vlm_response(response, has_tools=has_tools)
+            return result if has_tools else self._clean_response(str(result))
+
+        return await retry_async(
+            _call,
+            max_retries=self.max_retries,
+            logger=logger,
+            operation_name="VolcEngine VLM async completion",
+        )
+
     def supports_media(
         self,
         *,
@@ -191,19 +244,11 @@ class VolcEngineVLM(OpenAIVLM):
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
 
-        client = self.get_client()
-        t0 = time.perf_counter()
-        try:
-            response = client.chat.completions.create(**kwargs)
-        except Exception as error:
-            self.record_failed_call(duration_seconds=time.perf_counter() - t0, error=error)
-            raise
-        elapsed = time.perf_counter() - t0
-        self._update_token_usage_from_response(response, duration_seconds=elapsed)
-        result = self._build_vlm_response(response, has_tools=bool(tools))
-        if tools:
-            return result
-        return self._clean_response(str(result))
+        return self._create_completion(
+            self.get_client(),
+            kwargs,
+            has_tools=bool(tools),
+        )
 
     @tracer("volcengine.vlm.call", ignore_result=True, ignore_args=["messages"])
     async def get_completion_async(
@@ -240,23 +285,14 @@ class VolcEngineVLM(OpenAIVLM):
                 f"tools: {json.dumps([t['function']['name'] for t in tools], ensure_ascii=False)}"
             )
 
-        client = self.get_async_client()
-
-        t0 = time.perf_counter()
-        try:
-            response = await client.chat.completions.create(**kwargs)
-        except Exception as e:
-            self.record_failed_call(duration_seconds=time.perf_counter() - t0, error=e)
-            raise
-        elapsed = time.perf_counter() - t0
-        self._update_token_usage_from_response(response, duration_seconds=elapsed)
-        result = self._build_vlm_response(response, has_tools=bool(tools))
-        if tools:
-            return result
-        content = self._clean_response(str(result))
-        if content:
-            tracer.info(f"message.content={content}")
-        return content
+        result = await self._create_completion_async(
+            self.get_async_client(),
+            kwargs,
+            has_tools=bool(tools),
+        )
+        if not tools and result:
+            tracer.info(f"message.content={result}")
+        return result
 
     def _detect_image_format(self, data: bytes) -> str:
         """Detect image format from magic bytes.
@@ -406,19 +442,11 @@ class VolcEngineVLM(OpenAIVLM):
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
 
-        client = self.get_client()
-        t0 = time.perf_counter()
-        try:
-            response = client.chat.completions.create(**kwargs)
-        except Exception as error:
-            self.record_failed_call(duration_seconds=time.perf_counter() - t0, error=error)
-            raise
-        elapsed = time.perf_counter() - t0
-        self._update_token_usage_from_response(response, duration_seconds=elapsed)
-        result = self._build_vlm_response(response, has_tools=bool(tools))
-        if tools:
-            return result
-        return self._clean_response(str(result))
+        return self._create_completion(
+            self.get_client(),
+            kwargs,
+            has_tools=bool(tools),
+        )
 
     async def get_vision_completion_async(
         self,
@@ -454,16 +482,8 @@ class VolcEngineVLM(OpenAIVLM):
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
 
-        client = self.get_async_client()
-        t0 = time.perf_counter()
-        try:
-            response = await client.chat.completions.create(**kwargs)
-        except Exception as error:
-            self.record_failed_call(duration_seconds=time.perf_counter() - t0, error=error)
-            raise
-        elapsed = time.perf_counter() - t0
-        self._update_token_usage_from_response(response, duration_seconds=elapsed)
-        result = self._build_vlm_response(response, has_tools=bool(tools))
-        if tools:
-            return result
-        return self._clean_response(str(result))
+        return await self._create_completion_async(
+            self.get_async_client(),
+            kwargs,
+            has_tools=bool(tools),
+        )

--- a/openviking/models/vlm/backends/volcengine_vlm.py
+++ b/openviking/models/vlm/backends/volcengine_vlm.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0
 """VolcEngine VLM backend implementation."""
 
-import asyncio
 import base64
 import json
 import time
@@ -11,7 +10,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from openviking.telemetry import tracer
-from openviking.utils.model_retry import is_retryable_api_error
 from openviking.utils.multimodal import redact_image_data_urls
 from openviking_cli.utils import get_logger
 
@@ -244,32 +242,21 @@ class VolcEngineVLM(OpenAIVLM):
 
         client = self.get_async_client()
 
-        last_error = None
-        for attempt in range(self.max_retries + 1):
-            try:
-                t0 = time.perf_counter()
-                response = await client.chat.completions.create(**kwargs)
-                elapsed = time.perf_counter() - t0
-                self._update_token_usage_from_response(response, duration_seconds=elapsed)
-                result = self._build_vlm_response(response, has_tools=bool(tools))
-                if tools:
-                    return result
-                content = self._clean_response(str(result))
-                if content:
-                    tracer.info(f"message.content={content}")
-                return content
-            except Exception as e:
-                self.record_failed_call(duration_seconds=time.perf_counter() - t0, error=e)
-                last_error = e
-                if not is_retryable_api_error(e):
-                    raise
-                if attempt < self.max_retries:
-                    await asyncio.sleep(2**attempt)
-
-        if last_error:
-            raise last_error
-        else:
-            raise RuntimeError("Unknown error in async completion")
+        t0 = time.perf_counter()
+        try:
+            response = await client.chat.completions.create(**kwargs)
+        except Exception as e:
+            self.record_failed_call(duration_seconds=time.perf_counter() - t0, error=e)
+            raise
+        elapsed = time.perf_counter() - t0
+        self._update_token_usage_from_response(response, duration_seconds=elapsed)
+        result = self._build_vlm_response(response, has_tools=bool(tools))
+        if tools:
+            return result
+        content = self._clean_response(str(result))
+        if content:
+            tracer.info(f"message.content={content}")
+        return content
 
     def _detect_image_format(self, data: bytes) -> str:
         """Detect image format from magic bytes.

--- a/openviking/models/vlm/base.py
+++ b/openviking/models/vlm/base.py
@@ -411,8 +411,8 @@ def _annotate_vlm_error(exc: Exception, vlm_instance: "VLMBase") -> None:
 class FailoverVLM(VLMBase):
     """VLM wrapper that provides failover to a backup VLM instance.
 
-    When the primary VLM instance fails with permanent or quota errors,
-    this wrapper will automatically switch to using the backup VLM instance.
+    When the primary VLM instance has a credential error or exhausts retries for
+    a transient error, this wrapper switches to the backup VLM instance.
     After 10 minutes or 50 requests, it will attempt to failback to primary.
     """
 
@@ -762,9 +762,8 @@ class FailoverVLM(VLMBase):
 class MultiCredentialVLM(VLMBase):
     """VLM wrapper that provides failover across multiple ordered credentials.
 
-    When a credential fails with quota_exceeded or permanent errors, this wrapper
-    automatically advances to the next credential in the list. After failback thresholds
-    are met, it attempts to move back to a higher-priority credential.
+    Credential errors and exhausted transient failures advance to the next credential.
+    Request-level and unknown failures are returned without trying another credential.
 
     Credentials are tried in order (index 0 is highest priority).
     """

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -24,8 +24,8 @@ from openviking.server.config import ToolOutputExternalizationConfig
 from openviking.server.identity import RequestContext, Role
 from openviking.session.auto_commit_policy import AutoCommitPolicy
 from openviking.session.memory.constants import AGENT_EVOLUTION_MEMORY_TYPES
-from openviking.session.memory_policy import MemoryPolicy
 from openviking.session.memory.utils.language import resolve_output_language_from_conversation
+from openviking.session.memory_policy import MemoryPolicy
 from openviking.session.retention import (
     RETENTION_MODE_TURN_BUDGET,
     RetentionPlan,
@@ -48,7 +48,6 @@ from openviking.session.tool_result_synopsis import (
 from openviking.storage.abstract_overview import body_for_preview, render_abstract_overview
 from openviking.telemetry import get_current_telemetry, tracer
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
-from openviking.utils.model_retry import is_retryable_api_error, retry_async
 from openviking.utils.time_utils import get_current_timestamp
 from openviking.utils.token_estimation import estimate_text_tokens, truncate_text_to_token_budget
 from openviking_cli.exceptions import (
@@ -72,9 +71,6 @@ MemoryPolicyProvider = Callable[[], Awaitable[MemoryPolicyData]]
 logger = get_logger(__name__)
 
 _PHASE2_QUEUE_WAIT_TIMEOUT_SECONDS = 1800.0
-_MEMORY_EXTRACTION_MAX_RETRIES = 3
-_MEMORY_EXTRACTION_RETRY_BASE_DELAY_SECONDS = 1.0
-_MEMORY_EXTRACTION_RETRY_MAX_DELAY_SECONDS = 8.0
 _AGENT_TRAINING_REQUIRED_MEMORY_TYPES = frozenset({"experiences"})
 _SESSION_PHASE1_LOCK_TIMEOUT_SECONDS = 30.0
 _MEMORY_STEP_NAMES = ("long_term",)
@@ -2548,32 +2544,12 @@ class Session:
                                 },
                             )
 
-                    async def _run_retryable_phase2_step(
-                        operation_name: str,
-                        fn: Callable[[], Awaitable[Any]],
-                    ) -> Any:
-                        # Secondary safety net on top of the per-call retry that the
-                        # VLM/embedding layer already performs. Reuses the shared
-                        # transient-error classifier so permanent failures (auth,
-                        # quota, content-safety, 400, oversized input) fail fast
-                        # instead of being retried pointlessly.
-                        return await retry_async(
-                            fn,
-                            max_retries=_MEMORY_EXTRACTION_MAX_RETRIES,
-                            base_delay=_MEMORY_EXTRACTION_RETRY_BASE_DELAY_SECONDS,
-                            max_delay=_MEMORY_EXTRACTION_RETRY_MAX_DELAY_SECONDS,
-                            is_retryable=is_retryable_api_error,
-                            logger=logger,
-                            operation_name=operation_name,
-                        )
-
                     async def _run_recorded_memory_step(
-                        operation_name: str,
                         step: str,
                         step_messages: List[Message],
                         fn: Callable[[], Awaitable[Any]],
                     ) -> Any:
-                        result = await _run_retryable_phase2_step(operation_name, fn)
+                        result = await fn()
                         completed_memory_steps.setdefault(step, set()).update(
                             message.id for message in step_messages
                         )
@@ -2629,18 +2605,14 @@ class Session:
                         extraction_tasks: List[Any] = []
                         extraction_labels: List[str] = []
                         if working_memory_enabled:
-                            extraction_tasks.append(
-                                _run_retryable_phase2_step("archive_summary", _run_archive_summary)
-                            )
+                            extraction_tasks.append(_run_archive_summary())
                             extraction_labels.append("archive_summary")
 
                         if self._session_compressor and long_term_has_work:
 
                             async def _run_long_term_memory_extraction() -> Any:
-                                # strict_extract_errors=True lets transient failures
-                                # surface so _run_retryable_phase2_step can retry them
-                                # (and so a final failure is recorded as a skipped
-                                # archive instead of silently dropping the memory).
+                                # Surface extraction failures so the archive is marked
+                                # failed instead of silently dropping the memory.
                                 return await self._session_compressor.extract_long_term_memories(
                                     messages=long_term_messages,
                                     user=self.user,
@@ -2659,7 +2631,6 @@ class Session:
 
                             extraction_tasks.append(
                                 _run_recorded_memory_step(
-                                    "long_term_memory_extraction",
                                     "long_term",
                                     long_term_messages,
                                     _run_long_term_memory_extraction,
@@ -2671,10 +2642,10 @@ class Session:
                             *extraction_tasks,
                             return_exceptions=True,
                         )
-                        # The archive outcome is binary: if any Phase 2 step
-                        # still fails after retries, no .done marker is
-                        # published. Successful steps retain message IDs so the
-                        # same archive can resume without repeating them.
+                        # The archive outcome is binary: if any Phase 2 step fails,
+                        # no .done marker is published. Successful steps retain
+                        # message IDs so the same archive can resume without
+                        # repeating them.
                         extraction_error: Optional[BaseException] = None
                         for label, result in zip(extraction_labels, _results, strict=True):
                             if isinstance(result, Exception):
@@ -2726,12 +2697,7 @@ class Session:
                                 "Memory and session skill extraction skipped "
                                 "(disabled by config or memory_policy)"
                             )
-                        if working_memory_enabled:
-                            await _run_retryable_phase2_step(
-                                "archive_summary", _run_archive_summary
-                            )
-                        else:
-                            await _run_archive_summary()
+                        await _run_archive_summary()
 
                     # A recovered Phase 2 run may have already completed the
                     # long-term step before a sibling step failed. Reuse its

--- a/openviking/storage/collection_schemas.py
+++ b/openviking/storage/collection_schemas.py
@@ -7,11 +7,9 @@ Provides centralized schema definitions and factory functions for creating colle
 similar to how init_viking_fs encapsulates VikingFS initialization.
 """
 
-import asyncio
 import hashlib
 import json
 import threading
-import time
 from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
@@ -43,7 +41,6 @@ from openviking.utils.circuit_breaker import (
 from openviking.utils.model_retry import (
     ERROR_CLASS_AUTH,
     ERROR_CLASS_INPUT_TOO_LARGE,
-    ERROR_CLASS_PERMANENT,
 )
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import get_logger
@@ -461,28 +458,10 @@ class TextEmbeddingHandler(DequeueHandlerBase):
             reset_timeout=breaker_cfg.reset_timeout,
             max_reset_timeout=breaker_cfg.max_reset_timeout,
         )
-        self._breaker_open_last_log_at = 0.0
-        self._breaker_open_suppressed_count = 0
-        self._breaker_open_log_interval = 30.0
 
     def _initialize_embedder(self, config: "OpenVikingConfig"):
         """Initialize the embedder instance from config."""
         self._embedder = config.embedding.get_embedder()
-
-    def _log_breaker_open_reenqueue_summary(self) -> None:
-        """Log a throttled warning when embeddings are re-enqueued due to an open circuit breaker."""
-        now = time.monotonic()
-        if self._breaker_open_last_log_at == 0.0:
-            logger.warning("Embedding circuit breaker is open; re-enqueueing messages")
-            self._breaker_open_last_log_at = now
-            self._breaker_open_suppressed_count = 0
-            return
-
-        self._breaker_open_suppressed_count += 1
-        if now - self._breaker_open_last_log_at >= self._breaker_open_log_interval:
-            logger.warning("Embedding circuit breaker is open; re-enqueueing messages")
-            self._breaker_open_last_log_at = now
-            self._breaker_open_suppressed_count = 0
 
     @classmethod
     def _merge_request_stats(
@@ -586,11 +565,7 @@ class TextEmbeddingHandler(DequeueHandlerBase):
             inserted_data = embedding_msg.context_data
             account_id = inserted_data.get("account_id", "default")
             context_user = inserted_data.get("user") or {}
-            user_id = (
-                context_user.get("user_id")
-                or inserted_data.get("owner_user_id")
-                or "default"
-            )
+            user_id = context_user.get("user_id") or inserted_data.get("owner_user_id") or "default"
             user = UserIdentifier(account_id=account_id, user_id=user_id)
             ctx = RequestContext(user=user, role=Role.USER, bypass_acl=True)
             collector = resolve_telemetry(embedding_msg.telemetry_id)
@@ -613,33 +588,15 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                     report_success = True
                     return data
 
-                # Circuit breaker: if API is known-broken, re-enqueue and wait
                 try:
                     self._circuit_breaker.check()
-                    self._breaker_open_last_log_at = 0.0
-                    self._breaker_open_suppressed_count = 0
-                except CircuitBreakerOpen:
-                    self._log_breaker_open_reenqueue_summary()
-                    if self._vikingdb.has_queue_manager:
-                        wait = self._circuit_breaker.retry_after
-                        if wait > 0:
-                            await asyncio.sleep(wait)
-                        await self._vikingdb.enqueue_embedding_msg(embedding_msg)
-                        self._merge_request_stats(
-                            embedding_msg.telemetry_id,
-                            requeue_count=1,
-                        )
-                        get_request_wait_tracker().record_embedding_requeue(
-                            embedding_msg.telemetry_id
-                        )
-                        self.report_requeue()
-                        report_success = True
-                        return None
-                    # No queue manager — cannot re-enqueue, drop with error
+                except CircuitBreakerOpen as breaker_error:
                     error_msg = self._embedding_error_msg(
                         embedding_msg,
-                        "Circuit breaker open and no queue manager",
+                        str(breaker_error),
                     )
+                    logger.error(error_msg)
+                    self._merge_request_stats(embedding_msg.telemetry_id, error_count=1)
                     request_failed_message = error_msg
                     report_error_args = (error_msg, data)
                     return None
@@ -688,62 +645,12 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                         except Exception:
                             pass
 
-                        if error_class == ERROR_CLASS_INPUT_TOO_LARGE:
-                            logger.error(error_msg)
-                            self._merge_request_stats(embedding_msg.telemetry_id, error_count=1)
-                            request_failed_message = error_msg
-                            report_error_args = (error_msg, data)
-                            return None
-
-                        if error_class == ERROR_CLASS_PERMANENT:
-                            logger.critical(error_msg)
+                        logger.error(error_msg)
+                        if error_class not in (
+                            ERROR_CLASS_AUTH,
+                            ERROR_CLASS_INPUT_TOO_LARGE,
+                        ):
                             self._circuit_breaker.record_failure(embed_err)
-                            self._merge_request_stats(embedding_msg.telemetry_id, error_count=1)
-                            request_failed_message = error_msg
-                            report_error_args = (error_msg, data)
-                            return None
-
-                        if error_class == ERROR_CLASS_AUTH:
-                            # Bad/expired credential: retrying cannot succeed. Fail
-                            # terminally instead of re-enqueueing, which would cycle
-                            # forever and hold this resource's tree lock and its
-                            # add-resource --wait open. Don't trip the breaker: an open
-                            # breaker re-enqueues later messages and reintroduces the
-                            # same leak. See #2916.
-                            logger.error(error_msg)
-                            self._merge_request_stats(embedding_msg.telemetry_id, error_count=1)
-                            request_failed_message = error_msg
-                            report_error_args = (error_msg, data)
-                            return None
-
-                        # Transient or unknown — re-enqueue for retry
-                        logger.warning(error_msg)
-                        self._circuit_breaker.record_failure(embed_err)
-                        if self._vikingdb.has_queue_manager:
-                            try:
-                                await self._vikingdb.enqueue_embedding_msg(embedding_msg)
-                                self._merge_request_stats(
-                                    embedding_msg.telemetry_id,
-                                    requeue_count=1,
-                                )
-                                get_request_wait_tracker().record_embedding_requeue(
-                                    embedding_msg.telemetry_id
-                                )
-                                self.report_requeue()
-                                logger.info(
-                                    "Re-enqueued embedding message after transient error "
-                                    f"({self._embedding_msg_log_context(embedding_msg)})"
-                                )
-                                report_success = True
-                                return None
-                            except Exception as requeue_err:
-                                logger.error(
-                                    self._embedding_error_msg(
-                                        embedding_msg,
-                                        f"Failed to re-enqueue message: {requeue_err}",
-                                    )
-                                )
-
                         self._merge_request_stats(embedding_msg.telemetry_id, error_count=1)
                         request_failed_message = error_msg
                         report_error_args = (error_msg, data)

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -58,10 +58,8 @@ from openviking.telemetry.span_models import create_root_span_attributes
 from openviking.utils.circuit_breaker import (
     CircuitBreaker,
     CircuitBreakerOpen,
-    classify_api_error,
 )
 from openviking.utils.ingest_options import IngestOptions
-from openviking.utils.model_retry import ERROR_CLASS_INPUT_TOO_LARGE, ERROR_CLASS_PERMANENT
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import VikingURI
 from openviking_cli.utils.config import get_openviking_config
@@ -204,19 +202,8 @@ class SemanticProcessor(DequeueHandlerBase):
         return FILE_TYPE_OTHER
 
     async def _reenqueue_semantic_msg(self, msg: SemanticMsg) -> None:
-        """Re-enqueue a semantic message for later processing.
-
-        Throttles with a sleep when the circuit breaker is open to prevent
-        re-enqueue storms (messages cycling at 5/sec during OPEN window).
-        """
-        import asyncio
-
+        """Re-enqueue a semantic message whose lock is currently unavailable."""
         from openviking.storage.queuefs import get_queue_manager
-
-        # Throttle to prevent re-enqueue storm during OPEN window
-        wait = self._circuit_breaker.retry_after
-        if wait > 0:
-            await asyncio.sleep(wait)
 
         queue_manager = get_queue_manager()
         if queue_manager is not None:
@@ -226,7 +213,7 @@ class SemanticProcessor(DequeueHandlerBase):
         else:
             logger.warning(f"No queue manager available, cannot re-enqueue: {msg.uri}")
 
-    async def _requeue_semantic_msg_after_error(
+    async def _requeue_semantic_msg_after_lock_error(
         self,
         msg: SemanticMsg,
         data: Optional[Dict[str, Any]],
@@ -380,19 +367,7 @@ class SemanticProcessor(DequeueHandlerBase):
                         get_request_wait_tracker().mark_semantic_done(msg.telemetry_id, msg.id)
                     self.report_success()
                     return None
-            # Circuit breaker: if API is known-broken, re-enqueue and wait
-            try:
-                self._circuit_breaker.check()
-            except CircuitBreakerOpen:
-                logger.warning(
-                    f"Circuit breaker is open, re-enqueueing semantic message: {msg.uri}"
-                )
-                await self._reenqueue_semantic_msg(msg)
-                self._merge_request_stats(msg.telemetry_id, requeue_count=1)
-                get_request_wait_tracker().record_semantic_requeue(msg.telemetry_id)
-                self.report_requeue()
-                self.report_success()
-                return None
+            self._circuit_breaker.check()
             collector = resolve_telemetry(msg.telemetry_id)
             telemetry_ctx = bind_telemetry(collector) if collector is not None else nullcontext()
             with telemetry_ctx:
@@ -535,46 +510,26 @@ class SemanticProcessor(DequeueHandlerBase):
                     exc_info=True,
                 )
                 if msg is not None:
-                    await self._requeue_semantic_msg_after_error(msg, data, e)
+                    await self._requeue_semantic_msg_after_lock_error(msg, data, e)
                 else:
                     self.report_error(str(e), data)
                 return None
 
-            error_class = classify_api_error(e)
-            if error_class == ERROR_CLASS_INPUT_TOO_LARGE:
-                logger.error(
-                    f"Input too large processing semantic message, dropping: {e}",
-                    exc_info=True,
-                )
-                if msg is not None:
-                    self._merge_request_stats(msg.telemetry_id, error_count=1)
-                    get_request_wait_tracker().mark_semantic_failed(
-                        msg.telemetry_id, msg.id, str(e)
-                    )
-                self.report_error(str(e), data)
-            elif error_class == ERROR_CLASS_PERMANENT:
-                logger.critical(
-                    f"Permanent API error processing semantic message, dropping: {e}",
-                    exc_info=True,
-                )
+            logger.error(
+                "Failed to process semantic message; marking it failed: %s",
+                e,
+                exc_info=True,
+            )
+            if not isinstance(e, CircuitBreakerOpen):
                 self._circuit_breaker.record_failure(e)
-                if msg is not None:
-                    self._merge_request_stats(msg.telemetry_id, error_count=1)
-                    get_request_wait_tracker().mark_semantic_failed(
-                        msg.telemetry_id, msg.id, str(e)
-                    )
-                self.report_error(str(e), data)
-            else:
-                # Transient or unknown — re-enqueue for retry
-                logger.warning(
-                    f"Transient API error processing semantic message, re-enqueueing: {e}",
-                    exc_info=True,
+            if msg is not None:
+                self._merge_request_stats(msg.telemetry_id, error_count=1)
+                get_request_wait_tracker().mark_semantic_failed(
+                    msg.telemetry_id,
+                    msg.id,
+                    str(e),
                 )
-                self._circuit_breaker.record_failure(e)
-                if msg is not None:
-                    await self._requeue_semantic_msg_after_error(msg, data, e)
-                else:
-                    self.report_error(str(e), data)
+            self.report_error(str(e), data)
             return None
 
     async def on_cancelled(self, data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:

--- a/openviking/utils/circuit_breaker.py
+++ b/openviking/utils/circuit_breaker.py
@@ -33,10 +33,10 @@ class CircuitBreakerOpen(Exception):
 class CircuitBreaker:
     """Thread-safe circuit breaker for API call protection.
 
-    Trips after ``failure_threshold`` consecutive failures (or immediately for
-    permanent errors like 403/401). After ``reset_timeout`` seconds, allows one
-    probe request (HALF_OPEN). If the probe succeeds, the breaker closes; if it
-    fails, the breaker reopens.
+    Trips after ``failure_threshold`` consecutive failures, or immediately for
+    request, credential, and quota errors. After ``reset_timeout`` seconds,
+    allows one probe request (HALF_OPEN). If the probe succeeds, the breaker
+    closes; if it fails, the breaker reopens.
     """
 
     def __init__(

--- a/openviking/utils/model_retry.py
+++ b/openviking/utils/model_retry.py
@@ -191,6 +191,7 @@ def classify_api_error(error: Exception) -> str:
     """Classify an API error into one of the ERROR_CLASS_* categories.
 
     Order matters:
+    - structured HTTP status codes are checked before falling back to text matching.
     - ``content_safety`` is checked before ``permanent`` so a moderation
       rejection that happens to embed "400" in its message is not misclassified.
     - ``auth`` (401/403) is separated from ``permanent`` (400): auth errors are
@@ -216,6 +217,16 @@ def classify_api_error(error: Exception) -> str:
     for exc in (error, getattr(error, "__cause__", None)):
         if exc is not None and isinstance(exc, _PERMANENT_IO_ERRORS):
             return ERROR_CLASS_PERMANENT
+
+    error_code = extract_metric_error_code(error)
+    if error_code == "413":
+        return ERROR_CLASS_INPUT_TOO_LARGE
+    if error_code == "400":
+        return ERROR_CLASS_PERMANENT
+    if error_code in ("401", "403"):
+        return ERROR_CLASS_AUTH
+    if error_code in ("429", "500", "502", "503", "504"):
+        return ERROR_CLASS_TRANSIENT
 
     texts = [str(error)]
     if error.__cause__ is not None:

--- a/openviking/utils/model_retry.py
+++ b/openviking/utils/model_retry.py
@@ -6,7 +6,7 @@ import random
 import re
 import threading
 import time
-from typing import Awaitable, Callable, TypeVar
+from typing import AsyncIterator, Awaitable, Callable, Iterable, Iterator, TypeVar
 
 from openviking.utils.exceptions import AllCredentialsFailedError
 
@@ -42,6 +42,27 @@ def _normalize_metric_error_code(value: object) -> str | None:
     return code
 
 
+def _iter_structured_error_codes(error: BaseException) -> Iterator[str]:
+    for exc in _iter_exception_chain(error):
+        candidates = [getattr(exc, attr, None) for attr in ("status_code", "error_code", "code")]
+        response = getattr(exc, "response", None)
+        if response is not None:
+            candidates.append(getattr(response, "status_code", None))
+        body = getattr(exc, "body", None)
+        if isinstance(body, dict):
+            candidates.extend([body.get("status_code"), body.get("error_code"), body.get("code")])
+            nested = body.get("error")
+            if isinstance(nested, dict):
+                candidates.extend(
+                    [nested.get("status_code"), nested.get("error_code"), nested.get("code")]
+                )
+
+        for value in candidates:
+            normalized = _normalize_metric_error_code(value)
+            if normalized is not None:
+                yield normalized
+
+
 def extract_metric_error_code(error: BaseException) -> str:
     """Extract a low-cardinality provider error code for model-call metrics.
 
@@ -49,30 +70,16 @@ def extract_metric_error_code(error: BaseException) -> str:
     provider messages and request IDs are intentionally never used as metric labels.
     """
     error_chain = _iter_exception_chain(error)
-    for exc in error_chain:
-        for attr in ("status_code", "error_code", "code"):
-            normalized = _normalize_metric_error_code(getattr(exc, attr, None))
-            if normalized is not None:
-                return normalized
-
-        body = getattr(exc, "body", None)
-        if isinstance(body, dict):
-            candidates = [body.get("status_code"), body.get("error_code"), body.get("code")]
-            nested = body.get("error")
-            if isinstance(nested, dict):
-                candidates.extend(
-                    [nested.get("status_code"), nested.get("error_code"), nested.get("code")]
-                )
-            for value in candidates:
-                normalized = _normalize_metric_error_code(value)
-                if normalized is not None:
-                    return normalized
+    structured_code = next(_iter_structured_error_codes(error), None)
+    if structured_code is not None:
+        return structured_code
 
     if any(isinstance(exc, TimeoutError) for exc in error_chain):
         return "timeout"
     if any(isinstance(exc, ConnectionError) for exc in error_chain):
         return "connection_error"
     return "unknown"
+
 
 INPUT_TOO_LARGE_PATTERNS = (
     "413",
@@ -184,7 +191,24 @@ def _pattern_matches(text_lower: str, text_compact: str, pattern: str) -> bool:
         return bool(_get_numeric_pattern_re(pattern).search(text_lower)) or bool(
             _get_numeric_pattern_re(pattern).search(text_compact)
         )
-    return pattern in text_lower or pattern in text_compact
+    return pattern in text_lower or pattern.replace(" ", "") in text_compact
+
+
+def _classify_error_values(values: Iterable[str]) -> str:
+    texts = [(value.lower(), value.lower().replace(" ", "")) for value in values]
+    categories = (
+        (ERROR_CLASS_INPUT_TOO_LARGE, INPUT_TOO_LARGE_PATTERNS),
+        (ERROR_CLASS_CONTENT_SAFETY, CONTENT_SAFETY_PATTERNS),
+        (ERROR_CLASS_AUTH, AUTH_API_ERROR_PATTERNS),
+        (ERROR_CLASS_QUOTA_EXCEEDED, QUOTA_EXCEEDED_PATTERNS),
+        (ERROR_CLASS_PERMANENT, PERMANENT_API_ERROR_PATTERNS),
+        (ERROR_CLASS_TRANSIENT, TRANSIENT_API_ERROR_PATTERNS),
+    )
+    for error_class, patterns in categories:
+        for text_lower, text_compact in texts:
+            if any(_pattern_matches(text_lower, text_compact, pattern) for pattern in patterns):
+                return error_class
+    return ERROR_CLASS_UNKNOWN
 
 
 def classify_api_error(error: Exception) -> str:
@@ -214,70 +238,17 @@ def classify_api_error(error: Exception) -> str:
             return ERROR_CLASS_AUTH
         return ERROR_CLASS_UNKNOWN
 
-    for exc in (error, getattr(error, "__cause__", None)):
-        if exc is not None and isinstance(exc, _PERMANENT_IO_ERRORS):
-            return ERROR_CLASS_PERMANENT
-
-    error_code = extract_metric_error_code(error)
-    if error_code == "413":
-        return ERROR_CLASS_INPUT_TOO_LARGE
-    if error_code == "400":
+    error_chain = _iter_exception_chain(error)
+    if any(isinstance(exc, _PERMANENT_IO_ERRORS) for exc in error_chain):
         return ERROR_CLASS_PERMANENT
-    if error_code in ("401", "403"):
-        return ERROR_CLASS_AUTH
-    if error_code in ("429", "500", "502", "503", "504"):
+    if any(isinstance(exc, (TimeoutError, ConnectionError)) for exc in error_chain):
         return ERROR_CLASS_TRANSIENT
 
-    texts = [str(error)]
-    if error.__cause__ is not None:
-        texts.append(str(error.__cause__))
+    structured_class = _classify_error_values(_iter_structured_error_codes(error))
+    if structured_class != ERROR_CLASS_UNKNOWN:
+        return structured_class
 
-    for text in texts:
-        text_lower = text.lower()
-        text_compact = text_lower.replace(" ", "")
-        for pattern in INPUT_TOO_LARGE_PATTERNS:
-            if _pattern_matches(text_lower, text_compact, pattern):
-                return ERROR_CLASS_INPUT_TOO_LARGE
-
-    # Content safety before permanent so a moderation message containing "400"
-    # is not misclassified as a permanent parameter error.
-    for text in texts:
-        text_lower = text.lower()
-        text_compact = text_lower.replace(" ", "")
-        for pattern in CONTENT_SAFETY_PATTERNS:
-            if _pattern_matches(text_lower, text_compact, pattern):
-                return ERROR_CLASS_CONTENT_SAFETY
-
-    for text in texts:
-        text_lower = text.lower()
-        text_compact = text_lower.replace(" ", "")
-        for pattern in PERMANENT_API_ERROR_PATTERNS:
-            if _pattern_matches(text_lower, text_compact, pattern):
-                return ERROR_CLASS_PERMANENT
-
-    for text in texts:
-        text_lower = text.lower()
-        text_compact = text_lower.replace(" ", "")
-        for pattern in AUTH_API_ERROR_PATTERNS:
-            if _pattern_matches(text_lower, text_compact, pattern):
-                return ERROR_CLASS_AUTH
-
-    # Check quota_exceeded *before* transient so that "429 … AccountQuotaExceeded"
-    # is classified as quota_exceeded, not transient.
-    for text in texts:
-        text_lower = text.lower()
-        for pattern in QUOTA_EXCEEDED_PATTERNS:
-            if pattern in text_lower:
-                return ERROR_CLASS_QUOTA_EXCEEDED
-
-    for text in texts:
-        text_lower = text.lower()
-        text_compact = text_lower.replace(" ", "")
-        for pattern in TRANSIENT_API_ERROR_PATTERNS:
-            if _pattern_matches(text_lower, text_compact, pattern):
-                return ERROR_CLASS_TRANSIENT
-
-    return ERROR_CLASS_UNKNOWN
+    return _classify_error_values(str(exc) for exc in _iter_exception_chain(error))
 
 
 def is_retryable_api_error(error: Exception) -> bool:
@@ -350,9 +321,8 @@ def _structured_rate_limit_match(exc: BaseException) -> bool:
 def is_retryable_rate_limit_error(exc: BaseException) -> bool:
     """Return True for SDK/text-shaped LLM rate-limit errors.
 
-    This intentionally lives in a lightweight OpenViking utility module so both
-    VikingBot provider adapters and benchmark integrations can share the same
-    classifier without importing each other's heavier runtime dependencies.
+    This remains in a lightweight OpenViking utility module for benchmark
+    integrations that cannot import heavier runtime dependencies.
     """
     if _structured_rate_limit_match(exc):
         return True
@@ -467,11 +437,52 @@ async def retry_async(
             attempt += 1
 
 
+async def retry_async_iterator(
+    func: Callable[[], AsyncIterator[T]],
+    *,
+    max_retries: int,
+    base_delay: float = 0.5,
+    max_delay: float = 8.0,
+    jitter: bool = True,
+    is_retryable: Callable[[Exception], bool] = is_retryable_api_error,
+    logger=None,
+    operation_name: str = "operation",
+) -> AsyncIterator[T]:
+    """Retry an async stream only if it fails before emitting output."""
+    attempt = 0
+
+    while True:
+        emitted = False
+        try:
+            async for item in func():
+                emitted = True
+                yield item
+            return
+        except Exception as error:
+            if emitted or max_retries <= 0 or attempt >= max_retries or not is_retryable(error):
+                raise
+
+            delay = _compute_delay(
+                attempt,
+                base_delay=base_delay,
+                max_delay=max_delay,
+                jitter=jitter,
+            )
+            if logger:
+                logger.warning(
+                    f"{operation_name} failed before emitting output "
+                    f"(retry {attempt + 1}/{max_retries}): {error}; "
+                    f"retrying in {delay:.2f}s"
+                )
+            await asyncio.sleep(delay)
+            attempt += 1
+
+
 class PrimaryBackupSwitcher:
     """Thread-safe primary/backup switcher with automatic failback logic.
 
-    When an error of type ERROR_CLASS_PERMANENT or ERROR_CLASS_QUOTA_EXCEEDED occurs,
-    switches to backup immediately. Then, after either:
+    Credential errors and transient failures exhausted by the active provider
+    switch to backup. Then, after either:
     - 10 minutes have passed, OR
     - 200 requests have been made to backup
     it will attempt to failback to primary. If failback fails, it switches back
@@ -529,14 +540,14 @@ class PrimaryBackupSwitcher:
     def record_primary_failure(self, error: Exception) -> bool:
         """Record a primary failure. Returns True if should switch to backup.
 
-        Switches to backup immediately for ERROR_CLASS_PERMANENT,
-        ERROR_CLASS_AUTH or ERROR_CLASS_QUOTA_EXCEEDED.
+        Request-level and unknown errors fail fast. Credential-level errors and
+        exhausted transient failures switch to the backup.
         """
         error_class = classify_api_error(error)
         if error_class in (
-            ERROR_CLASS_PERMANENT,
             ERROR_CLASS_AUTH,
             ERROR_CLASS_QUOTA_EXCEEDED,
+            ERROR_CLASS_TRANSIENT,
         ):
             with self._lock:
                 if not self._using_backup:
@@ -564,8 +575,8 @@ class PrimaryBackupSwitcher:
 class OrderedCredentialSwitcher:
     """Thread-safe ordered N-credential switcher with hierarchical failback.
 
-    Supports ordered failover across multiple credentials. When a credential fails
-    with quota_exceeded or permanent error, it advances to the next credential.
+    Supports ordered failover across multiple credentials. Credential-level errors
+    and exhausted transient failures advance to the next credential.
     After failback thresholds are met, it attempts to move back to a higher-priority
     credential (one step at a time, not all the way back to index 0).
 
@@ -595,8 +606,9 @@ class OrderedCredentialSwitcher:
             - credential-level ``auth`` errors (401/403) advance to the next
               credential in multi-credential mode; the last (or single)
               credential fails fast.
-            - ``quota_exceeded`` (and ``transient`` once its retries are
-              exhausted) and ``unknown`` advance to the next credential.
+            - ``quota_exceeded`` and ``transient`` once its retries are
+              exhausted advance to the next credential.
+            - ``unknown`` fails fast because replay safety is not known.
         """
         if n < 1:
             raise ValueError("Number of credentials must be >= 1")
@@ -663,14 +675,14 @@ class OrderedCredentialSwitcher:
     def is_fail_fast(error_class: str) -> bool:
         """Whether an error is request-level and must not try other credentials.
 
-        Request-level errors (400 parameter error, input too large, content
-        safety) fail on every credential of the same model, so the caller should
-        re-raise immediately instead of cycling through credentials.
+        Request-level errors fail on every credential of the same model. Unknown
+        errors also fail fast because issuing the request again may duplicate work.
         """
         return error_class in (
             ERROR_CLASS_PERMANENT,
             ERROR_CLASS_INPUT_TOO_LARGE,
             ERROR_CLASS_CONTENT_SAFETY,
+            ERROR_CLASS_UNKNOWN,
         )
 
     def commit_success(self, idx: int) -> None:

--- a/tests/storage/test_collection_schemas.py
+++ b/tests/storage/test_collection_schemas.py
@@ -4,7 +4,6 @@
 import hashlib
 import inspect
 import json
-import logging
 from types import SimpleNamespace
 
 import pytest
@@ -298,9 +297,7 @@ async def test_embedding_handler_skip_all_work_when_manager_is_closing(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_embedding_handler_open_breaker_logs_summary_instead_of_per_item_warning(
-    monkeypatch, caplog
-):
+async def test_embedding_handler_open_breaker_fails_without_reenqueue(monkeypatch):
     from openviking.utils.circuit_breaker import CircuitBreakerOpen
 
     class _QueueingVikingDB:
@@ -333,27 +330,18 @@ async def test_embedding_handler_open_breaker_logs_summary_instead_of_per_item_w
         lambda: (_ for _ in ()).throw(CircuitBreakerOpen("open")),
     )
 
-    import openviking.storage.collection_schemas as collection_schemas
+    result = await handler.on_dequeue(_build_queue_payload())
 
-    collection_schemas.logger.addHandler(caplog.handler)
-    collection_schemas.logger.setLevel(logging.WARNING)
-    try:
-        with caplog.at_level(logging.WARNING):
-            await handler.on_dequeue(_build_queue_payload())
-            await handler.on_dequeue(_build_queue_payload())
-    finally:
-        collection_schemas.logger.removeHandler(caplog.handler)
-
-    warnings = [record.message for record in caplog.records if record.levelno == logging.WARNING]
-    assert warnings.count("Embedding circuit breaker is open; re-enqueueing messages") == 1
-    assert status == {"success": 2, "requeue": 2, "error": 0}
+    assert result is None
+    assert handler._vikingdb.enqueued == []
+    assert status == {"success": 0, "requeue": 0, "error": 1}
 
 
 @pytest.mark.asyncio
 async def test_embedding_auth_error_fails_terminally_without_reenqueue(monkeypatch):
     """A credential (401/403) failure must fail terminally, not re-enqueue: an
     infinite re-enqueue holds the resource's tree lock and add-resource --wait
-    open, and must not trip the circuit breaker (which re-enqueues too). #2916."""
+    open. Request-specific auth failures must not trip the shared breaker. #2916."""
 
     class _QueueingVikingDB:
         is_closing = False

--- a/tests/storage/test_memory_semantic_stall.py
+++ b/tests/storage/test_memory_semantic_stall.py
@@ -142,14 +142,8 @@ async def test_memory_ls_error_reports_error():
 
 
 @pytest.mark.asyncio
-async def test_memory_ls_transient_error_requeues():
-    """Transient errors during ls() re-enqueue the msg and increment requeue count.
-
-    A 500-class error wrapped by the processor's `raise RuntimeError(...) from e`
-    is classified as `transient`. The outer on_dequeue() path must call
-    _reenqueue_semantic_msg(), bump requeue_count, and fire both report_requeue()
-    and report_success() — not report_error().
-    """
+async def test_memory_ls_transient_error_fails_without_requeue():
+    """A handled processing failure is terminal; QueueFS should ACK it, not replay it."""
     processor = SemanticProcessor()
 
     fake_fs = MagicMock()
@@ -191,10 +185,10 @@ async def test_memory_ls_transient_error_requeues():
     ):
         await processor.on_dequeue(data)
 
-    assert requeue_called, "report_requeue() must fire for transient errors"
-    assert success_called, "report_success() must fire after successful re-enqueue"
-    assert not error_called, "report_error() must NOT fire for transient errors"
-    reenqueue_mock.assert_awaited_once()
+    assert error_called, "report_error() must fire for handled processing failures"
+    assert not requeue_called, "handled processing failures must not be re-enqueued"
+    assert not success_called, "failed processing must not be reported as successful"
+    reenqueue_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -210,9 +204,7 @@ async def test_memory_write_error_reports_error():
     fake_fs.ls = AsyncMock(return_value=[{"name": "file1.md", "isDir": False}])
     fake_fs.read_file = AsyncMock(return_value="some content")
     fake_fs.write_file = AsyncMock(side_effect=PermissionError("Permission denied"))
-    fake_fs._async_agfs.pathlock_acquire_exact_batch = AsyncMock(
-        return_value={"lease_ref": "test"}
-    )
+    fake_fs._async_agfs.pathlock_acquire_exact_batch = AsyncMock(return_value={"lease_ref": "test"})
     fake_fs._async_agfs.pathlock_release = AsyncMock()
     fake_fs._uri_to_path = MagicMock(
         side_effect=lambda uri, ctx=None: f"/local/acc1/{uri.removeprefix('viking://')}"

--- a/tests/unit/test_extra_headers_vlm.py
+++ b/tests/unit/test_extra_headers_vlm.py
@@ -342,14 +342,12 @@ class TestOpenAIVLMClientRetries:
         assert call_kwargs["max_retries"] == 0
 
     @patch("volcenginesdkarkruntime.AsyncArk")
-    def test_volcengine_async_client_does_not_retry_bad_request(
+    def test_volcengine_async_client_does_not_retry_provider_errors(
         self,
         mock_async_ark_class,
     ):
-        error = RuntimeError(
-            "InvalidParameter: Total tokens of multi-modal content and text exceed max message tokens"
-        )
-        error.status_code = 400
+        error = RuntimeError("RateLimitExceeded")
+        error.status_code = 429
         mock_client = MagicMock()
         mock_client.chat.completions.create = AsyncMock(side_effect=error)
         mock_async_ark_class.return_value = mock_client
@@ -363,7 +361,7 @@ class TestOpenAIVLMClientRetries:
             }
         )
 
-        with pytest.raises(RuntimeError, match="InvalidParameter"):
+        with pytest.raises(RuntimeError, match="RateLimitExceeded"):
             asyncio.run(vlm.get_completion_async("hello"))
 
         mock_async_ark_class.assert_called_once()

--- a/tests/unit/test_extra_headers_vlm.py
+++ b/tests/unit/test_extra_headers_vlm.py
@@ -342,12 +342,13 @@ class TestOpenAIVLMClientRetries:
         assert call_kwargs["max_retries"] == 0
 
     @patch("volcenginesdkarkruntime.AsyncArk")
-    def test_volcengine_async_client_does_not_retry_provider_errors(
+    def test_volcengine_async_client_does_not_retry_permanent_provider_errors(
         self,
         mock_async_ark_class,
     ):
-        error = RuntimeError("RateLimitExceeded")
-        error.status_code = 429
+        error = RuntimeError("InvalidParameter")
+        error.status_code = 400
+        error.code = "InvalidParameter"
         mock_client = MagicMock()
         mock_client.chat.completions.create = AsyncMock(side_effect=error)
         mock_async_ark_class.return_value = mock_client
@@ -361,7 +362,7 @@ class TestOpenAIVLMClientRetries:
             }
         )
 
-        with pytest.raises(RuntimeError, match="RateLimitExceeded"):
+        with pytest.raises(RuntimeError, match="InvalidParameter"):
             asyncio.run(vlm.get_completion_async("hello"))
 
         mock_async_ark_class.assert_called_once()
@@ -526,6 +527,7 @@ class TestVLMExtraRequestBody:
 
         # Ollama models also get a default num_ctx; the explicit think is kept.
         assert kwargs["extra_body"] == {"think": False, "num_ctx": 16384}
+        assert kwargs["max_retries"] == 0
 
     def test_ollama_defaults_num_ctx_and_think(self):
         """Ollama models get a larger context window and thinking disabled by default."""

--- a/tests/unit/test_extra_headers_vlm.py
+++ b/tests/unit/test_extra_headers_vlm.py
@@ -6,6 +6,8 @@ import asyncio
 import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from openviking.models.vlm.backends.litellm_vlm import (
     LiteLLMVLMProvider,
     detect_provider_by_model,
@@ -340,11 +342,17 @@ class TestOpenAIVLMClientRetries:
         assert call_kwargs["max_retries"] == 0
 
     @patch("volcenginesdkarkruntime.AsyncArk")
-    def test_volcengine_async_client_applies_timeout_and_disables_sdk_retries(
+    def test_volcengine_async_client_does_not_retry_bad_request(
         self,
         mock_async_ark_class,
     ):
-        mock_async_ark_class.return_value = MagicMock()
+        error = RuntimeError(
+            "InvalidParameter: Total tokens of multi-modal content and text exceed max message tokens"
+        )
+        error.status_code = 400
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(side_effect=error)
+        mock_async_ark_class.return_value = mock_client
 
         vlm = VolcEngineVLM(
             {
@@ -355,12 +363,14 @@ class TestOpenAIVLMClientRetries:
             }
         )
 
-        _ = vlm._build_async_client()
+        with pytest.raises(RuntimeError, match="InvalidParameter"):
+            asyncio.run(vlm.get_completion_async("hello"))
 
         mock_async_ark_class.assert_called_once()
         call_kwargs = mock_async_ark_class.call_args[1]
         assert call_kwargs["timeout"] == 12.0
         assert call_kwargs["max_retries"] == 0
+        mock_client.chat.completions.create.assert_awaited_once()
 
     @patch("openviking.models.vlm.backends.openai_vlm.openai.AzureOpenAI")
     def test_azure_sync_client_disables_sdk_retries(self, mock_azure_openai_class):

--- a/tests/unit/test_gemini_embedder.py
+++ b/tests/unit/test_gemini_embedder.py
@@ -302,15 +302,11 @@ class TestBuildConfig:
         assert "RETRIEVAL_DOCUMENT" in r
 
     @patch("openviking.models.embedder.gemini_embedders.genai.Client")
-    def test_client_constructed_with_retry_options(self, mock_client_class):
-        from openviking.models.embedder.gemini_embedders import (
-            _HTTP_RETRY_AVAILABLE,
-            GeminiDenseEmbedder,
-        )
+    def test_client_constructed_without_sdk_retry_options(self, mock_client_class):
+        from openviking.models.embedder.gemini_embedders import GeminiDenseEmbedder
 
         GeminiDenseEmbedder("gemini-embedding-2-preview", api_key="key")
         mock_client_class.assert_called_once()
         call_kwargs = mock_client_class.call_args[1]
         assert call_kwargs.get("api_key") == "key"
-        if _HTTP_RETRY_AVAILABLE:
-            assert "http_options" in call_kwargs
+        assert "http_options" not in call_kwargs

--- a/tests/unit/test_litellm_embedder.py
+++ b/tests/unit/test_litellm_embedder.py
@@ -42,6 +42,7 @@ class TestLiteLLMDenseEmbedder:
         call_kwargs = mock_litellm.embedding.call_args[1]
         assert call_kwargs["model"] == "openai/text-embedding-3-small"
         assert call_kwargs["api_key"] == "test-key"
+        assert call_kwargs["max_retries"] == 0
 
     @patch("openviking.models.embedder.litellm_embedders.litellm")
     async def test_embed_async_truncates_vector_to_configured_dimension(self, mock_litellm):

--- a/tests/unit/test_model_retry.py
+++ b/tests/unit/test_model_retry.py
@@ -130,7 +130,7 @@ def test_auth_takes_precedence_over_quota():
 
 def test_classify_400_is_permanent():
     """A 400 parameter error is request-level permanent (fail-fast)."""
-    error = RuntimeError("Error code: 400 - invalid parameter `model`")
+    error = _ProviderError(status_code=400, code="InvalidParameter")
     assert classify_api_error(error) == ERROR_CLASS_PERMANENT
 
 

--- a/tests/unit/test_model_retry.py
+++ b/tests/unit/test_model_retry.py
@@ -33,10 +33,13 @@ class _ProviderError(RuntimeError):
 
 
 def test_extract_metric_error_code_prefers_structured_provider_code():
-    assert extract_metric_error_code(_ProviderError(status_code=429, code="RateLimitExceeded")) == "429"
-    assert extract_metric_error_code(_ProviderError(body={"error": {"code": "InvalidParameter"}})) == (
-        "InvalidParameter"
+    assert (
+        extract_metric_error_code(_ProviderError(status_code=429, code="RateLimitExceeded"))
+        == "429"
     )
+    assert extract_metric_error_code(
+        _ProviderError(body={"error": {"code": "InvalidParameter"}})
+    ) == ("InvalidParameter")
 
 
 def test_extract_metric_error_code_uses_safe_fallbacks_only():
@@ -114,15 +117,22 @@ def test_classify_usage_quota():
 
 def test_quota_exceeded_takes_precedence_over_transient():
     """A 429 with AccountQuotaExceeded is quota_exceeded, not transient."""
-    error = RuntimeError(
-        '429 {"error":{"code":"AccountQuotaExceeded","message":"TooManyRequests"}}'
+    error = _ProviderError(
+        status_code=429,
+        body={"error": {"code": "AccountQuotaExceeded"}},
     )
     assert classify_api_error(error) == ERROR_CLASS_QUOTA_EXCEEDED
 
 
 def test_auth_takes_precedence_over_quota():
     """Auth errors (e.g. 403) take precedence over the quota substring."""
-    assert classify_api_error(RuntimeError("403 AccountQuotaExceeded")) == ERROR_CLASS_AUTH
+    error = _ProviderError(status_code=403, code="AccountQuotaExceeded")
+    assert classify_api_error(error) == ERROR_CLASS_AUTH
+
+
+def test_structured_auth_code_takes_precedence_over_generic_400():
+    error = _ProviderError(status_code=400, code="AccountOverdue")
+    assert classify_api_error(error) == ERROR_CLASS_AUTH
 
 
 # --- permanent vs auth split (400 vs 401/403) ---
@@ -161,6 +171,9 @@ def test_classify_content_filter_is_content_safety():
     assert classify_api_error(RuntimeError("content_filter triggered")) == (
         ERROR_CLASS_CONTENT_SAFETY
     )
+    assert classify_api_error(RuntimeError("SensitiveContentDetected")) == (
+        ERROR_CLASS_CONTENT_SAFETY
+    )
 
 
 def test_classify_content_policy_is_content_safety():
@@ -170,7 +183,7 @@ def test_classify_content_policy_is_content_safety():
 
 def test_content_safety_takes_precedence_over_400():
     """A moderation rejection containing '400' is content_safety, not permanent."""
-    error = RuntimeError("Error code: 400 - content_filter: sensitive content detected")
+    error = _ProviderError(status_code=400, code="ContentFilter")
     assert classify_api_error(error) == ERROR_CLASS_CONTENT_SAFETY
 
 

--- a/tests/unit/test_openai_embedder_http_pool.py
+++ b/tests/unit/test_openai_embedder_http_pool.py
@@ -107,6 +107,7 @@ async def test_openai_embedder_bounds_sync_and_async_connection_pools(provider: 
             assert pool._max_keepalive_connections == 3
             assert pool._keepalive_expiry == 5.0
             assert client._client.timeout == openai.DEFAULT_TIMEOUT
+            assert client.max_retries == 0
     finally:
         embedder.client.close()
         await async_client.close()

--- a/tests/unit/test_ordered_credential_switcher.py
+++ b/tests/unit/test_ordered_credential_switcher.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Unit tests for OrderedCredentialSwitcher"""
 
-
 import pytest
 
 from openviking.utils.model_retry import (
@@ -41,14 +40,14 @@ class TestOrderedCredentialSwitcher:
             OrderedCredentialSwitcher(n=-1)
 
     def test_is_fail_fast_classification(self):
-        """Request-level errors are fail-fast; credential/quota/transient are not."""
+        """Request-level and unknown errors fail fast."""
         assert OrderedCredentialSwitcher.is_fail_fast(ERROR_CLASS_PERMANENT) is True
         assert OrderedCredentialSwitcher.is_fail_fast(ERROR_CLASS_INPUT_TOO_LARGE) is True
         assert OrderedCredentialSwitcher.is_fail_fast(ERROR_CLASS_CONTENT_SAFETY) is True
         assert OrderedCredentialSwitcher.is_fail_fast(ERROR_CLASS_AUTH) is False
         assert OrderedCredentialSwitcher.is_fail_fast(ERROR_CLASS_QUOTA_EXCEEDED) is False
         assert OrderedCredentialSwitcher.is_fail_fast(ERROR_CLASS_TRANSIENT) is False
-        assert OrderedCredentialSwitcher.is_fail_fast(ERROR_CLASS_UNKNOWN) is False
+        assert OrderedCredentialSwitcher.is_fail_fast(ERROR_CLASS_UNKNOWN) is True
 
     def test_commit_success_different_index_fast_failover(self):
         """commit_success on a different index commits it as the new active one."""

--- a/tests/unit/test_vikingbot_vlm_adapter_retry.py
+++ b/tests/unit/test_vikingbot_vlm_adapter_retry.py
@@ -75,6 +75,7 @@ class _FakeStreamingVLM:
     provider = "volcengine"
     model = "test-model"
     thinking = False
+    max_retries = 1
 
     def __init__(self, completions: _FakeStreamingCompletions):
         self._client = SimpleNamespace(
@@ -94,19 +95,10 @@ class _CaptureLogger:
 
 
 @pytest.mark.asyncio
-async def test_chat_retries_rate_limit_until_success(monkeypatch):
-    sleep_delays: list[float] = []
-
-    async def _sleep(delay: float):
-        sleep_delays.append(delay)
-
-    monkeypatch.setattr(vlm_adapter, "rate_limit_retry_delay", lambda attempt: attempt)
-    monkeypatch.setattr(vlm_adapter.asyncio, "sleep", _sleep)
-
+async def test_chat_leaves_retry_to_vlm_layer():
     fake_vlm = _FakeVLM(
         [
             RuntimeError("Error code: 429 - ModelAccountTpmRateLimitExceeded"),
-            RuntimeError("TooManyRequests: rate limit"),
         ],
         result="done",
     )
@@ -114,19 +106,13 @@ async def test_chat_retries_rate_limit_until_success(monkeypatch):
 
     response = await adapter.chat(messages=[{"role": "user", "content": "hello"}])
 
-    assert response.content == "done"
-    assert response.finish_reason == "stop"
-    assert fake_vlm.calls == 3
-    assert sleep_delays == [1, 2]
+    assert response.finish_reason == "error"
+    assert "ModelAccountTpmRateLimitExceeded" in response.content
+    assert fake_vlm.calls == 1
 
 
 @pytest.mark.asyncio
-async def test_chat_does_not_retry_errors_without_rate_limit_markers(monkeypatch):
-    async def _sleep(_delay: float):
-        raise AssertionError("non-retryable errors must not sleep/retry")
-
-    monkeypatch.setattr(vlm_adapter.asyncio, "sleep", _sleep)
-
+async def test_chat_does_not_retry_errors_without_rate_limit_markers():
     fake_vlm = _FakeVLM([RuntimeError("AuthenticationError Unauthorized")])
     adapter = VLMProviderAdapter(fake_vlm, "test-model", langfuse_client=_DisabledLangfuse())
 
@@ -217,8 +203,7 @@ async def test_chat_stream_retries_rate_limit_until_success(monkeypatch):
     async def _sleep(delay: float):
         sleep_delays.append(delay)
 
-    monkeypatch.setattr(vlm_adapter, "rate_limit_retry_delay", lambda attempt: attempt)
-    monkeypatch.setattr(vlm_adapter.asyncio, "sleep", _sleep)
+    monkeypatch.setattr("openviking.utils.model_retry.asyncio.sleep", _sleep)
 
     chunk = SimpleNamespace(
         usage=None,
@@ -247,7 +232,7 @@ async def test_chat_stream_retries_rate_limit_until_success(monkeypatch):
     ]
 
     assert completions.calls == 2
-    assert sleep_delays == [1]
+    assert len(sleep_delays) == 1
     assert [event.type for event in events] == ["content_delta", "response"]
     assert events[0].content == "streamed"
     assert events[1].response.content == "streamed"

--- a/tests/unit/test_vlm_failover.py
+++ b/tests/unit/test_vlm_failover.py
@@ -430,8 +430,8 @@ class TestFailoverVLM:
         backup.get_completion.assert_not_called()
         assert failover.is_using_backup is False
 
-    def test_primary_fails_rate_limit_does_not_failover(self):
-        """Test that rate limit errors do not trigger failover to backup."""
+    def test_primary_fails_rate_limit_fails_over_after_provider_retries(self):
+        """A provider-exhausted rate limit error triggers credential failover."""
         primary = Mock()
         primary.model = "primary-model"
         primary.provider = "volcengine"
@@ -444,12 +444,12 @@ class TestFailoverVLM:
 
         failover = FailoverVLM(primary, backup)
 
-        with pytest.raises(Exception, match="rate limit exceeded"):
-            failover.get_completion(prompt="test")
+        result = failover.get_completion(prompt="test")
 
+        assert result == "backup response"
         primary.get_completion.assert_called_once()
-        backup.get_completion.assert_not_called()
-        assert failover.is_using_backup is False
+        backup.get_completion.assert_called_once()
+        assert failover.is_using_backup is True
 
     def test_primary_fails_quota_exceeded_fails_to_backup(self):
         """Test that AccountQuotaExceeded triggers immediate failover."""
@@ -476,8 +476,8 @@ class TestFailoverVLM:
         backup.get_completion.assert_called_once()
         assert failover.is_using_backup is True
 
-    def test_primary_fails_timeout_does_not_failover(self):
-        """Test that timeout errors do not trigger failover to backup."""
+    def test_primary_fails_timeout_fails_over_after_provider_retries(self):
+        """A provider-exhausted timeout triggers credential failover."""
         primary = Mock()
         primary.model = "primary-model"
         primary.provider = "volcengine"
@@ -490,13 +490,14 @@ class TestFailoverVLM:
 
         failover = FailoverVLM(primary, backup)
 
-        with pytest.raises(Exception, match="request timeout"):
-            failover.get_completion(prompt="test")
+        result = failover.get_completion(prompt="test")
 
-        assert failover.is_using_backup is False
+        assert result == "backup response"
+        backup.get_completion.assert_called_once()
+        assert failover.is_using_backup is True
 
-    def test_primary_fails_server_error_does_not_failover(self):
-        """Test that server errors do not trigger failover to backup."""
+    def test_primary_fails_server_error_fails_over_after_provider_retries(self):
+        """A provider-exhausted server error triggers credential failover."""
         primary = Mock()
         primary.model = "primary-model"
         primary.provider = "volcengine"
@@ -509,10 +510,11 @@ class TestFailoverVLM:
 
         failover = FailoverVLM(primary, backup)
 
-        with pytest.raises(Exception, match="server error 503"):
-            failover.get_completion(prompt="test")
+        result = failover.get_completion(prompt="test")
 
-        assert failover.is_using_backup is False
+        assert result == "backup response"
+        backup.get_completion.assert_called_once()
+        assert failover.is_using_backup is True
 
     def test_both_fail_raises_last_error(self):
         """Test that if both primary and backup fail, the last error is raised."""
@@ -695,8 +697,8 @@ class TestPrimaryBackupSwitcher:
         switcher.record_primary_success()
         assert switcher.is_using_backup is False
 
-    def test_switch_to_backup_on_permanent_error(self):
-        """Test permanent error triggers switch to backup."""
+    def test_switch_to_backup_on_auth_error(self):
+        """Test a credential-level auth error triggers switch to backup."""
         switcher = PrimaryBackupSwitcher()
         error = Exception("403 forbidden")
         switched = switcher.record_primary_failure(error)

--- a/tests/unit/test_volcengine_embedder_input.py
+++ b/tests/unit/test_volcengine_embedder_input.py
@@ -22,6 +22,10 @@ _MULTIMODAL_INPUT = [
 def test_sparse_embedder_downgrades_multimodal_input_to_text(_mock_ark):
     embedder = VolcengineSparseEmbedder(model_name="test", api_key="test-key")
 
+    _mock_ark.assert_called_once_with(
+        api_key="test-key",
+        max_retries=0,
+    )
     assert embedder.supports_multimodal is False
     assert embedder.prepare_embedding_input(_MULTIMODAL_INPUT) == "diagram of a heat exchanger"
 
@@ -35,8 +39,7 @@ def test_hybrid_embedder_downgrades_multimodal_input_to_text(_mock_ark):
 
 
 @patch("openviking.models.embedder.volcengine_embedders.volcenginesdkarkruntime.Ark")
-@patch("openviking.models.embedder.volcengine_embedders.time.perf_counter")
-def test_dense_embedder_passes_local_provider_duration_to_metrics(mock_perf_counter, mock_ark):
+def test_dense_embedder_passes_local_provider_duration_to_metrics(mock_ark):
     """Embedding call duration must come from this SDK request, not shared embedder state."""
     response = SimpleNamespace(
         usage=SimpleNamespace(prompt_tokens=3, total_tokens=3),
@@ -45,13 +48,17 @@ def test_dense_embedder_passes_local_provider_duration_to_metrics(mock_perf_coun
     client = MagicMock()
     client.embeddings.create.return_value = response
     mock_ark.return_value = client
-    mock_perf_counter.side_effect = [100.0, 100.25]
+    clock = MagicMock(side_effect=[100.0, 100.25])
 
     embedder = VolcengineDenseEmbedder(
         model_name="test", api_key="test-key", input_type="text", dimension=2
     )
     embedder.update_token_usage = MagicMock()
 
-    embedder.embed("hello")
+    with patch(
+        "openviking.models.embedder.volcengine_embedders.time",
+        SimpleNamespace(perf_counter=clock),
+    ):
+        embedder.embed("hello")
 
     assert embedder.update_token_usage.call_args.kwargs["duration_seconds"] == 0.25

--- a/tests/utils/test_circuit_breaker.py
+++ b/tests/utils/test_circuit_breaker.py
@@ -161,7 +161,7 @@ def test_thread_safety():
 
 def test_classify_filesystem_errors_as_permanent():
     from openviking.utils.circuit_breaker import classify_api_error
-    from openviking.utils.model_retry import ERROR_CLASS_PERMANENT, ERROR_CLASS_TRANSIENT, ERROR_CLASS_UNKNOWN
+    from openviking.utils.model_retry import ERROR_CLASS_PERMANENT
 
     assert classify_api_error(FileNotFoundError("/path/not/found")) == ERROR_CLASS_PERMANENT
     assert classify_api_error(PermissionError("Permission denied")) == ERROR_CLASS_PERMANENT
@@ -171,7 +171,7 @@ def test_classify_filesystem_errors_as_permanent():
 
 def test_classify_chained_filesystem_error_as_permanent():
     from openviking.utils.circuit_breaker import classify_api_error
-    from openviking.utils.model_retry import ERROR_CLASS_PERMANENT, ERROR_CLASS_TRANSIENT, ERROR_CLASS_UNKNOWN
+    from openviking.utils.model_retry import ERROR_CLASS_PERMANENT
 
     cause = FileNotFoundError("/missing")
     wrapper = RuntimeError("storage layer failed")
@@ -179,19 +179,19 @@ def test_classify_chained_filesystem_error_as_permanent():
     assert classify_api_error(wrapper) == ERROR_CLASS_PERMANENT
 
 
-def test_classify_permanent_errors():
+def test_classify_auth_errors():
     from openviking.utils.circuit_breaker import classify_api_error
-    from openviking.utils.model_retry import ERROR_CLASS_PERMANENT, ERROR_CLASS_TRANSIENT, ERROR_CLASS_UNKNOWN
+    from openviking.utils.model_retry import ERROR_CLASS_AUTH
 
-    assert classify_api_error(RuntimeError("403 Forbidden")) == ERROR_CLASS_PERMANENT
-    assert classify_api_error(RuntimeError("AccountOverdueError: 403")) == ERROR_CLASS_PERMANENT
-    assert classify_api_error(RuntimeError("401 Unauthorized")) == ERROR_CLASS_PERMANENT
-    assert classify_api_error(RuntimeError("Forbidden")) == ERROR_CLASS_PERMANENT
+    assert classify_api_error(RuntimeError("403 Forbidden")) == ERROR_CLASS_AUTH
+    assert classify_api_error(RuntimeError("AccountOverdueError: 403")) == ERROR_CLASS_AUTH
+    assert classify_api_error(RuntimeError("401 Unauthorized")) == ERROR_CLASS_AUTH
+    assert classify_api_error(RuntimeError("Forbidden")) == ERROR_CLASS_AUTH
 
 
 def test_classify_transient_errors():
     from openviking.utils.circuit_breaker import classify_api_error
-    from openviking.utils.model_retry import ERROR_CLASS_PERMANENT, ERROR_CLASS_TRANSIENT, ERROR_CLASS_UNKNOWN
+    from openviking.utils.model_retry import ERROR_CLASS_TRANSIENT
 
     assert classify_api_error(RuntimeError("429 TooManyRequests")) == ERROR_CLASS_TRANSIENT
     assert classify_api_error(RuntimeError("RateLimitError")) == ERROR_CLASS_TRANSIENT
@@ -204,7 +204,7 @@ def test_classify_transient_errors():
 
 def test_classify_unknown_errors():
     from openviking.utils.circuit_breaker import classify_api_error
-    from openviking.utils.model_retry import ERROR_CLASS_PERMANENT, ERROR_CLASS_TRANSIENT, ERROR_CLASS_UNKNOWN
+    from openviking.utils.model_retry import ERROR_CLASS_UNKNOWN
 
     assert classify_api_error(RuntimeError("something unexpected")) == ERROR_CLASS_UNKNOWN
     assert classify_api_error(ValueError("bad value")) == ERROR_CLASS_UNKNOWN
@@ -212,9 +212,9 @@ def test_classify_unknown_errors():
 
 def test_classify_chained_exception():
     from openviking.utils.circuit_breaker import classify_api_error
-    from openviking.utils.model_retry import ERROR_CLASS_PERMANENT, ERROR_CLASS_TRANSIENT, ERROR_CLASS_UNKNOWN
+    from openviking.utils.model_retry import ERROR_CLASS_AUTH
 
     cause = RuntimeError("403 Forbidden")
     wrapper = RuntimeError("API call failed")
     wrapper.__cause__ = cause
-    assert classify_api_error(wrapper) == ERROR_CLASS_PERMANENT
+    assert classify_api_error(wrapper) == ERROR_CLASS_AUTH


### PR DESCRIPTION
## Description

统一模型调用层的重试、凭证切换和队列失败边界，避免同一个模型请求在 SDK、Provider、业务层和队列层被重复执行。

### Before

- 部分 SDK 自带重试，Provider、VikingBot Adapter、Session Phase 2 和队列又各自重试或重新入队，实际调用次数无法由 `max_retries` 准确控制。
- 火山引擎 VLM 的文本、视觉、同步和异步路径行为不一致。
- 已经处理过的模型失败可能被 Semantic 或 Embedding 队列重新投放，重复执行整段任务。

### After

- SDK 内置重试统一关闭；每个 VLM/Embedding Provider 只通过共享重试器执行 `max_retries`。
- 错误分类先读取结构化 status/error code，无法识别时才匹配错误文本：
  - `429`、`500`、`502`、`503`、`504`、网络和超时错误：有限重试。
  - 超过上下文、普通 `400`、内容安全和未知错误：立即失败，不重试也不切凭证。
  - 鉴权和额度错误：当前凭证不重试；存在其他凭证时允许切换。
- 流式请求仅允许在首个输出产生前重试；已经输出后直接返回错误，避免重复内容。
- Session、VikingBot 普通调用及业务队列不再重复模型重试。Semantic/Embedding 的模型失败会记录为任务失败并 ACK；仅锁冲突、Session 前序 archive 尚未完成或进程在 ACK 前崩溃时保留队列回放语义。
- 删除被替代的 Session 重试包装、Adapter 无限重试、Embedding SDK 重试配置和未使用的旧退避 Helper。

### Example

超过模型上下文窗口、方舟返回 `400 InvalidParameter`，配置 `max_retries=3` 时：

- Before：可能在 SDK、模型调用方或队列层重复执行。
- After：模型接口只调用 1 次，任务记录失败，消息被 ACK，不会再次入队。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

无。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 统一模型错误分类、同步/异步/流式重试和凭证切换规则。
- 关闭 OpenAI、方舟、LiteLLM、Gemini 和 MiniMax 等 SDK 或 HTTP Adapter 的重复重试。
- 让火山引擎 VLM 的文本与视觉入口共用同一套 Provider 重试。
- 删除 Session、VikingBot Adapter、SemanticQueue 和 EmbeddingQueue 的重复模型重试或重新入队逻辑。
- 修改现有契约测试覆盖结构化错误码优先级、有限重试、流式首包边界、凭证切换和队列终态。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

执行：

- `ruff check` 与 `git diff --check`
- 聚焦模型、队列和 Provider 契约测试：`415 passed, 1 skipped`
- Session Commit 恢复与队列身份测试：`10 passed`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

本次不修改外部 API 或配置格式；`max_retries` 仍表示首次调用之后允许的最大重试次数。
