### PR TITLE
feat(metrics): expose per-queue enqueue-to-dequeue wait as a histogram (#4578)

### DIFF
--- a/docs/en/concepts/12-metrics.md
+++ b/docs/en/concepts/12-metrics.md
@@ -228,6 +228,7 @@ Notes:
 | `openviking_queue_errors_total` | Counter | `queue` | total error count per queue |
 | `openviking_queue_pending` | Gauge | `queue` | pending queue items |
 | `openviking_queue_in_progress` | Gauge | `queue` | in-progress queue items |
+| `openviking_queue_wait_seconds` | Histogram | `queue` | enqueue-to-dequeue wait per message; long upper buckets filling indicates interactive work starving behind bulk backlog (#4578) |
 | `openviking_lock_active` | Gauge | none | current active locks |
 | `openviking_lock_waiting` | Gauge | none | locks currently waiting |
 | `openviking_lock_stale` | Gauge | none | potentially stale locks |

--- a/openviking/metrics/collectors/__init__.py
+++ b/openviking/metrics/collectors/__init__.py
@@ -24,6 +24,7 @@ from .model_usage import ModelUsageCollector
 from .observer_health import ObserverHealthCollector
 from .observer_state import ObserverStateCollector
 from .queue import QueueCollector
+from .queue_wait import QueueWaitCollector
 from .rerank import RerankCollector
 from .retrieval import RetrievalCollector
 from .retrieval_backend_probe import RetrievalBackendProbeCollector
@@ -47,6 +48,7 @@ __all__ = [
     "EncryptionCollector",
     "FeedbackCollector",
     "QueueCollector",
+    "QueueWaitCollector",
     "RerankCollector",
     "LockCollector",
     "VikingDBCollector",

--- a/openviking/metrics/collectors/queue_wait.py
+++ b/openviking/metrics/collectors/queue_wait.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co. Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Queue wait-duration collector.
+
+Events are emitted by ``NamedQueue._report_queue_wait`` at dequeue time with the
+wall-clock duration the message spent between enqueue and dequeue. Long waits are
+the measurable symptom of bulk ingestion starving interactive queues (#4578);
+the existing ``QueueCollector`` already exports per-queue depth gauges — this
+collector adds the latency dimension.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from openviking.metrics.core.base import MetricCollector
+
+from .base import EventMetricCollector
+
+# Queue waits span from milliseconds (healthy) to hours (starved), so use a
+# log-ish ladder rather than the request-latency default buckets.
+QUEUE_WAIT_BUCKETS: tuple[float, ...] = (0.1, 0.5, 1, 5, 15, 60, 300, 1800, 7200)
+
+
+@dataclass
+class QueueWaitCollector(EventMetricCollector):
+    """Translate ``queue.wait`` events into a per-queue wait-duration histogram."""
+
+    DOMAIN: ClassVar[str] = "queue"
+    # rule: <METRICS_NAMESPACE>_<DOMAIN>_wait_seconds
+    # e.g.: openviking_queue_wait_seconds
+    WAIT_SECONDS: ClassVar[str] = MetricCollector.metric_name(
+        DOMAIN, "wait", unit="seconds"
+    )
+
+    SUPPORTED_EVENTS: ClassVar[frozenset[str]] = frozenset({"queue.wait"})
+
+    def collect(self, registry=None) -> None:
+        """No-op: queue-wait metrics are event-driven."""
+        return None
+
+    def receive_hook(self, event_name: str, payload: dict, registry) -> None:
+        """Record one dequeue wait observation for the emitting queue."""
+        if event_name != "queue.wait":
+            return
+        if "queue" not in payload or "wait_seconds" not in payload:
+            return
+        try:
+            wait_seconds = float(payload["wait_seconds"])
+        except (TypeError, ValueError):
+            return
+        if wait_seconds < 0:
+            return
+        registry.observe_histogram(
+            self.WAIT_SECONDS,
+            wait_seconds,
+            labels={"queue": str(payload["queue"])},
+            label_names=("queue",),
+            buckets=QUEUE_WAIT_BUCKETS,
+        )

--- a/openviking/metrics/global_api.py
+++ b/openviking/metrics/global_api.py
@@ -44,6 +44,7 @@ from .collectors.cache import CacheCollector
 from .collectors.embedding import EmbeddingCollector
 from .collectors.encryption import EncryptionCollector
 from .collectors.http import HTTPCollector
+from .collectors.queue_wait import QueueWaitCollector
 from .collectors.rerank import RerankCollector
 from .collectors.resource import ResourceIngestionCollector
 from .collectors.retrieval import RetrievalCollector
@@ -304,6 +305,7 @@ def _build_event_router(registry: MetricRegistry) -> EventCollectorRouter:
     retrieval_collector = RetrievalCollector()
     encryption_collector = EncryptionCollector()
     telemetry_bridge_collector = TelemetryBridgeCollector()
+    queue_wait_collector = QueueWaitCollector()
 
     def _receiver(collector, event_name: str):
         """
@@ -346,6 +348,7 @@ def _build_event_router(registry: MetricRegistry) -> EventCollectorRouter:
         ("encryption.key_cache_miss", encryption_collector),
         ("encryption.key_version_usage", encryption_collector),
         ("telemetry.summary", telemetry_bridge_collector),
+        ("queue.wait", queue_wait_collector),
     ):
         router.register(event_name, _receiver(collector, event_name))
     return router

--- a/openviking/storage/queuefs/named_queue.py
+++ b/openviking/storage/queuefs/named_queue.py
@@ -4,6 +4,7 @@ import abc
 import asyncio
 import json
 import threading
+import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -250,6 +251,11 @@ class NamedQueue:
                 f"Task {task_metadata.task_id} is cancelling; rejected work for {self.name}"
             )
 
+        if isinstance(data, dict):
+            # Queue-wait observability (#4578): stamp the enqueue wall time so the
+            # dequeue side can report how long the message sat behind backlog.
+            # Popped before handlers run, so consumers never see this field.
+            data["_ov_enqueued_at"] = time.time()
         try:
             if isinstance(data, dict):
                 data = json.dumps(data)
@@ -345,12 +351,40 @@ class NamedQueue:
             logger.debug(f"[NamedQueue] Dequeue raw failed for {self.name}: {e}")
             return None
 
+    def _report_queue_wait(self, data: Dict[str, Any]) -> None:
+        """Pop the enqueue timestamp and publish the queue-wait duration (best-effort).
+
+        Long waits are the visible symptom of bulk ingestion starving interactive
+        queues (#4578); a per-queue histogram makes starvation measurable before it
+        becomes a multi-day incident.
+        """
+        if not isinstance(data, dict):
+            return
+        enqueued_at = data.pop("_ov_enqueued_at", None)
+        if enqueued_at is None:
+            return
+        try:
+            wait_seconds = max(0.0, time.time() - float(enqueued_at))
+        except (TypeError, ValueError):
+            return
+        try:
+            from openviking.observability.events import try_publish_event
+
+            try_publish_event(
+                "queue.wait",
+                {"queue": self.name, "wait_seconds": wait_seconds},
+            )
+        except Exception:  # noqa: BLE001 - observability must never break dequeue
+            logger.debug("[NamedQueue] Failed to publish queue.wait event", exc_info=True)
+
     async def process_dequeued(self, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Invoke the dequeue handler on already-fetched raw data.
 
         NOTE: caller must call _on_dequeue_start() before invoking this method
         so that in_progress is incremented atomically with the dequeue.
         """
+        self._report_queue_wait(data)
+
         if self._dequeue_handler is None:
             return data
 

--- a/tests/metrics/test_queue_wait_collector.py
+++ b/tests/metrics/test_queue_wait_collector.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co. Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for the ``queue.wait`` event → histogram mapping (#4578)."""
+
+from openviking.metrics.collectors.queue_wait import QueueWaitCollector
+from openviking.metrics.core.registry import MetricRegistry
+from openviking.metrics.exporters.prometheus import PrometheusExporter
+
+
+def _render(events):
+    registry = MetricRegistry()
+    collector = QueueWaitCollector()
+    for name, payload in events:
+        collector.receive_hook(name, payload, registry)
+    return PrometheusExporter(registry=registry).render()
+
+
+def test_queue_wait_event_renders_histogram():
+    text = _render([("queue.wait", {"queue": "Semantic", "wait_seconds": 42.0})])
+    assert "openviking_queue_wait_seconds_bucket" in text
+    assert 'queue="Semantic"' in text
+    assert 'le="60.0"' in text  # 42s observation lands in the 60s bucket
+
+
+def test_queue_wait_ignores_missing_fields_and_bad_values():
+    text = _render(
+        [
+            ("queue.wait", {"queue": "Semantic"}),  # missing wait_seconds
+            ("queue.wait", {"wait_seconds": 1.0}),  # missing queue
+            ("queue.wait", {"queue": "E", "wait_seconds": "soon"}),  # non-numeric
+            ("queue.wait", {"queue": "E", "wait_seconds": -5.0}),  # negative
+            ("http.request", {}),  # unsupported event name
+        ]
+    )
+    assert "openviking_queue_wait_seconds_bucket" not in text
+
+
+def test_queue_wait_per_queue_labels():
+    text = _render(
+        [
+            ("queue.wait", {"queue": "Semantic", "wait_seconds": 1.0}),
+            ("queue.wait", {"queue": "SessionCommit", "wait_seconds": 7200.0}),
+        ]
+    )
+    assert 'queue="Semantic"' in text
+    assert 'queue="SessionCommit"' in text
+    assert 'le="7200.0"' in text

--- a/tests/storage/test_named_queue_wait_stamp.py
+++ b/tests/storage/test_named_queue_wait_stamp.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co. Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for the queue-wait stamp lifecycle in NamedQueue (#4578).
+
+The enqueue side stamps ``_ov_enqueued_at`` onto dict payloads; the dequeue funnel
+(``_report_queue_wait``) pops it and publishes one ``queue.wait`` event, so handlers
+never observe the private field.
+"""
+
+import time
+from types import SimpleNamespace
+
+from openviking.storage.queuefs.named_queue import NamedQueue
+
+
+def _bare_queue(name: str = "Semantic") -> NamedQueue:
+    q = NamedQueue.__new__(NamedQueue)
+    q.name = name
+    q.path = f"/queues/{name}"
+    return q
+
+
+class _CapturingBus:
+    def __init__(self) -> None:
+        self.events = []
+
+    def publish(self, event) -> None:
+        self.events.append((event.name, dict(event.payload)))
+
+
+def test_report_queue_wait_pops_stamp_and_emits(monkeypatch):
+    q = _bare_queue("Semantic")
+    import openviking.observability.events as events_mod
+
+    captured = []
+
+    def fake_publish(event_name, payload=None):
+        captured.append((event_name, dict(payload or {})))
+
+    import openviking.observability.events as events_mod
+
+    monkeypatch.setattr(events_mod, "try_publish_event", fake_publish)
+
+    enqueued_at = time.time() - 30.0
+    data = {"id": "m1", "_ov_enqueued_at": enqueued_at}
+    q._report_queue_wait(data)
+
+    assert "_ov_enqueued_at" not in data, "stamp must be popped before handlers run"
+    assert captured == [
+        ("queue.wait", {"queue": "Semantic", "wait_seconds": captured[0][1]["wait_seconds"]})
+    ] if captured else False, "one queue.wait event must be published"
+    assert len(captured) == 1
+    assert captured[0][0] == "queue.wait"
+    assert captured[0][1]["queue"] == "Semantic"
+    assert 25.0 <= captured[0][1]["wait_seconds"] <= 35.0
+
+
+def test_report_queue_wait_noop_without_stamp():
+    q = _bare_queue("Semantic")
+    data = {"id": "m2"}
+    q._report_queue_wait(data)  # must not raise
+    assert data == {"id": "m2"}
+
+
+def test_report_queue_wait_tolerates_bad_stamp():
+    q = _bare_queue("Semantic")
+    q._report_queue_wait({"id": "m3", "_ov_enqueued_at": "not-a-number"})
+    # bad stamp is popped and silently dropped (observability must not break dequeue)
+    assert True
+
+
+def test_enqueue_stamps_dict_payload(monkeypatch):
+    q = _bare_queue("Embedding")
+    captured = {}
+
+    async def fake_ensure():
+        return None
+
+    async def fake_write(path, content):
+        captured["content"] = content
+        return "msg-1"
+
+    q._ensure_initialized = fake_ensure
+    q._enqueue_hook = None
+    q._task_work_index = None
+    q._async_agfs = SimpleNamespace(write=fake_write)
+
+    import asyncio
+
+    msg_id = asyncio.run(q.enqueue({"payload": 1}))
+    assert msg_id == "msg-1"
+    import json
+
+    sent = json.loads(captured["content"].decode("utf-8"))
+    assert "_ov_enqueued_at" in sent, "dict payloads must carry the enqueue stamp"
+    assert abs(sent["_ov_enqueued_at"] - time.time()) < 5.0


### PR DESCRIPTION
## Summary

First observability slice for #4578, as proposed in the issue discussion: bulk ingestion can starve interactive `session_commit` extraction behind FIFO backlogs for hours to days, and the only queue signal exported today is the instantaneous `openviking_queue_pending` depth gauge — nothing measures how long messages actually **wait** between enqueue and dequeue.

This adds that measurement:

- `NamedQueue.enqueue` stamps dict payloads with a private `_ov_enqueued_at` wall time; the dequeue funnel (`process_dequeued`, the single path both the serial and concurrent workers use) pops it and publishes one best-effort `queue.wait` event. Handlers never observe the field, and observability failures cannot break dequeue (guarded, `try_publish_event` is already best-effort).
- New `QueueWaitCollector` (event-driven, same pattern as `HTTPCollector`) maps `queue.wait` to `openviking_queue_wait_seconds{queue}` with a log-ish bucket ladder `0.1 … 7200s` — covering both healthy sub-second queues and the multi-hour starvation the issue describes.
- The event is wired on the default in-process router in `global_api`, so the Prometheus surface picks it up with no config change.

With this, an operator watching `openviking_queue_wait_seconds` during a bulk ingestion sees the starvation start as the `le="300"` / `le="1800"` buckets filling, instead of discovering it as "session_commit produced 0 memories for 19 hours".

No scheduling behavior is changed in this PR — priority classes / queue isolation remain open per the issue discussion.

## Testing

- `tests/metrics/test_queue_wait_collector.py`: 3 passed (histogram render with bucket placement, defensive rejection of missing/malformed/negative payloads and unknown events, per-queue labels)
- `tests/storage/test_named_queue_wait_stamp.py`: 4 passed (stamp popped before handlers + event payload sanity, no-stamp and bad-stamp no-ops, enqueue stamps dict payloads end-to-end with a fake AGFS)
- adjacent metrics suites re-run: 35 passed (remaining errors are the known conftest-fixture ones, identical on pristine main)