### PR TITLE
feat(storage): record which children changed so aggregation rebuilds only dirty inputs (#4577)

### DIFF
--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -488,6 +488,7 @@ class FSService:
             overview_sample_limit=getattr(semantic_config, "overview_sample_limit", 32),
             refresh_ratio=getattr(semantic_config, "freshness_refresh_ratio", 0.10),
             force_refresh=force_refresh,
+            changed_child_uris=[deleted_uri],
         )
         if decision.action is not FreshnessAction.REFRESH_NOW:
             return decision.action

--- a/openviking/storage/abstract_overview.py
+++ b/openviking/storage/abstract_overview.py
@@ -89,6 +89,13 @@ def _bounded_string(value: Any, *, field: str, limit: int) -> str:
     return normalized
 
 
+# Upper bound for remembering *which* children changed. Beyond this the set is
+# dropped and an overflow flag forces aggregations back to full sampled rebuilds
+# (#4577): a pending counter alone cannot tell the executor which sampled inputs
+# are actually dirty, so every aggregation rebuilds the whole sample set.
+PENDING_CHILD_URIS_LIMIT = 128
+
+
 def _normalize_metadata(metadata: Mapping[str, Any]) -> Dict[str, Any]:
     """Validate known fields and silently discard fields outside the schema.
 
@@ -165,6 +172,23 @@ def _normalize_metadata(metadata: Mapping[str, Any]) -> Dict[str, Any]:
                     "must be a non-negative integer"
                 )
             counters["missing_summary_entries"] = value
+        if "pending_child_uris" in freshness:
+            value = freshness["pending_child_uris"]
+            if not isinstance(value, list) or len(value) > PENDING_CHILD_URIS_LIMIT or not all(
+                isinstance(item, str) and item for item in value
+            ):
+                raise AbstractOverviewFormatError(
+                    "abstract overview freshness.pending_child_uris must be a "
+                    f"bounded list of non-empty strings (max {PENDING_CHILD_URIS_LIMIT})"
+                )
+            counters["pending_child_uris"] = list(value)
+        if "pending_child_uris_overflow" in freshness:
+            value = freshness["pending_child_uris_overflow"]
+            if not isinstance(value, bool):
+                raise AbstractOverviewFormatError(
+                    "abstract overview freshness.pending_child_uris_overflow must be a boolean"
+                )
+            counters["pending_child_uris_overflow"] = value
         if counters["sampled_entries"] + counters["unsampled_entries"] != counters["total_entries"]:
             raise AbstractOverviewFormatError(
                 "abstract overview freshness sampled + unsampled must equal total"
@@ -541,6 +565,34 @@ async def _raw_if_exists(viking_fs: Any, uri: str, ctx: Optional[RequestContext]
         raise
 
 
+def _merge_pending_child_uris(
+    freshness: Mapping[str, Any],
+    changed_child_uris: Optional[Sequence[str]],
+) -> Dict[str, Any]:
+    """Merge changed-child URIs into a bounded pending set under one update.
+
+    Returns only the freshness keys to update. When the accumulated set would
+    exceed ``PENDING_CHILD_URIS_LIMIT`` the set is cleared and an overflow flag
+    is stored so aggregation falls back to the conservative full-sample rebuild.
+    """
+    overflow = bool(freshness.get("pending_child_uris_overflow"))
+    existing = freshness.get("pending_child_uris")
+    merged: set = {str(uri) for uri in existing} if isinstance(existing, list) else set()
+    if changed_child_uris:
+        merged.update(str(uri) for uri in changed_child_uris)
+    if not merged:
+        updates: Dict[str, Any] = {}
+        if overflow:
+            # already overflowed: keep the empty collection + sticky flag so
+            # aggregation stays on the conservative full-sample rebuild.
+            updates["pending_child_uris"] = []
+            updates["pending_child_uris_overflow"] = True
+        return updates
+    if overflow or len(merged) > PENDING_CHILD_URIS_LIMIT:
+        return {"pending_child_uris": [], "pending_child_uris_overflow": True}
+    return {"pending_child_uris": sorted(merged)}
+
+
 async def plan_abstract_overview_refresh(
     *,
     viking_fs: Any,
@@ -552,6 +604,7 @@ async def plan_abstract_overview_refresh(
     overview_sample_limit: int = 32,
     refresh_ratio: float = 0.10,
     lock_timeout_secs: float = 0.0,
+    changed_child_uris: Optional[Sequence[str]] = None,
 ) -> FreshnessDecision:
     """Atomically record direct-child changes and choose refresh scheduling.
 
@@ -642,6 +695,9 @@ async def plan_abstract_overview_refresh(
             metadata = dict(document.metadata)
             updated_freshness = dict(freshness)
             updated_freshness["pending_child_changes"] = decision.pending_after
+            updated_freshness.update(
+                _merge_pending_child_uris(updated_freshness, changed_child_uris)
+            )
             metadata["freshness"] = updated_freshness
             rendered = render_abstract_overview(level, dir_uri, document.body, metadata)
             raw = await _raw_if_exists(viking_fs, uri, ctx)
@@ -678,6 +734,53 @@ async def read_abstract_overview_pending_snapshot(
             if document is not None and not document.legacy and isinstance(freshness, Mapping):
                 pending_values.append(int(freshness["pending_child_changes"]))
         return max(pending_values, default=0)
+    finally:
+        if owns_lease:
+            await viking_fs._async_agfs.pathlock_release(snapshot_lease)
+
+
+async def read_abstract_overview_pending_child_uris(
+    *,
+    viking_fs: Any,
+    dir_uri: str,
+    ctx: Optional[RequestContext],
+    lock: Optional[Dict[str, Any]] = None,
+) -> tuple[set, bool]:
+    """Read the bounded set of changed-child URIs captured by freshness accounting.
+
+    Returns ``(uris, overflow)``. An empty set with ``overflow=False`` means the
+    accounting never recorded URIs (legacy sidecars) — callers must fall back to
+    the conservative full-sample rebuild (#4577).
+    """
+    uris = [
+        f"{dir_uri.rstrip('/')}/.overview.md",
+        f"{dir_uri.rstrip('/')}/.abstract.md",
+    ]
+    owns_lease = lock is None
+    snapshot_lease = lock
+    if owns_lease:
+        lock_paths = [viking_fs._uri_to_path(uri, ctx=ctx) for uri in uris]
+        snapshot_lease = await viking_fs._async_agfs.pathlock_acquire_exact_batch(lock_paths)
+    try:
+        merged: set = set()
+        overflow = False
+        saw_collection = False
+        for uri in uris:
+            document = await _read_existing_document(viking_fs, uri, ctx)
+            freshness = document.metadata.get("freshness") if document else None
+            if document is None or document.legacy or not isinstance(freshness, Mapping):
+                continue
+            if "pending_child_uris" in freshness:
+                saw_collection = True
+                value = freshness.get("pending_child_uris")
+                if isinstance(value, list):
+                    merged.update(str(item) for item in value)
+            if freshness.get("pending_child_uris_overflow"):
+                overflow = True
+                saw_collection = True
+        if not saw_collection:
+            return set(), False  # legacy sidecar: no collection recorded
+        return merged, overflow
     finally:
         if owns_lease:
             await viking_fs._async_agfs.pathlock_release(snapshot_lease)

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -588,6 +588,9 @@ class ContentWriteCoordinator:
             overview_sample_limit=getattr(semantic_config, "overview_sample_limit", 32),
             refresh_ratio=getattr(semantic_config, "freshness_refresh_ratio", 0.10),
             force_refresh=force_refresh,
+            changed_child_uris=[
+                uri for values in changes.values() for uri in values
+            ],
         )
         aggregate_directory = decision.action is FreshnessAction.REFRESH_NOW
         has_live_files = any(changes.get(kind) for kind in ("added", "modified"))

--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -19,6 +19,7 @@ from openviking.storage.abstract_overview import (
     body_for_preview,
     deterministic_sample,
     freshness_metadata,
+    read_abstract_overview_pending_child_uris,
     read_abstract_overview_pending_snapshot,
     write_abstract_overview,
 )
@@ -53,6 +54,11 @@ class DirNode:
     pending_snapshot: int = 0
     sampled_children_dirs: Optional[Set[str]] = None
     sampled_file_paths: Optional[Set[str]] = None
+    # Bounded changed-child URI set from freshness accounting (#4577). When
+    # present and not overflowing, aggregation only rebuilds sampled inputs that
+    # are actually dirty instead of the whole sample set.
+    pending_child_uris: Optional[Set[str]] = None
+    pending_child_uris_overflow: bool = False
     total_entries: Optional[int] = None
     missing_summary_entries: Optional[int] = None
     transfer_inputs_ready: bool = True
@@ -413,6 +419,19 @@ class SemanticDagExecutor:
                 if self._aggregate_directory
                 else 0
             )
+            pending_child_uris: Optional[Set[str]] = None
+            pending_child_uris_overflow = False
+            if self._aggregate_directory:
+                pending_child_uris, pending_child_uris_overflow = (
+                    await read_abstract_overview_pending_child_uris(
+                        viking_fs=self._viking_fs,
+                        dir_uri=dir_uri,
+                        ctx=self._ctx,
+                        lock=self._lock,
+                    )
+                )
+                if not pending_child_uris and not pending_child_uris_overflow:
+                    pending_child_uris = None  # legacy sidecar: no collection recorded
             file_index = {path: idx for idx, path in enumerate(file_paths)}
             child_index = {path: idx for idx, path in enumerate(children_dirs)}
             # Recursive/initial work still maintains every file. Incremental
@@ -446,6 +465,8 @@ class SemanticDagExecutor:
                 children_abstracts=[None] * len(children_dirs),
                 pending=pending,
                 pending_snapshot=pending_snapshot,
+                pending_child_uris=pending_child_uris,
+                pending_child_uris_overflow=pending_child_uris_overflow,
                 sampled_children_dirs=sampled_children_dirs,
                 sampled_file_paths=sampled_file_paths,
                 dispatched=True,
@@ -548,6 +569,16 @@ class SemanticDagExecutor:
             ctx=self._ctx,
             lock=self._lock,
         )
+        pending_child_uris, pending_child_uris_overflow = (
+            await read_abstract_overview_pending_child_uris(
+                viking_fs=self._viking_fs,
+                dir_uri=dir_uri,
+                ctx=self._ctx,
+                lock=self._lock,
+            )
+        )
+        if not pending_child_uris and not pending_child_uris_overflow:
+            pending_child_uris = None  # legacy sidecar: no collection recorded
         return DirNode(
             uri=dir_uri,
             children_dirs=selected_dirs,
@@ -558,6 +589,8 @@ class SemanticDagExecutor:
             children_abstracts=[loaded[("directory", uri)] for uri in selected_dirs],
             pending=0,
             pending_snapshot=pending_snapshot,
+                pending_child_uris=pending_child_uris,
+                pending_child_uris_overflow=pending_child_uris_overflow,
             total_entries=len(candidates),
             missing_summary_entries=missing_count,
             transfer_inputs_ready=not candidates or bool(selected),
@@ -770,13 +803,33 @@ class SemanticDagExecutor:
                 content_changed = await self._check_file_content_changed(file_path)
                 self._file_change_status[file_path] = content_changed
                 node = self._nodes.get(parent_uri)
-                regenerate_sampled_summary = bool(
-                    self._aggregate_directory
-                    and node is not None
-                    and node.pending_snapshot > 0
-                    and node.sampled_file_paths is not None
-                    and file_path in node.sampled_file_paths
+                node_has_pending_uris = (
+                    node is not None
+                    and node.pending_child_uris is not None
+                    and not node.pending_child_uris_overflow
                 )
+                if node_has_pending_uris:
+                    # Freshness accounting recorded *which* children changed
+                    # (#4577): only dirty sampled inputs must be rebuilt; the
+                    # rest of the sample set can trust their existing L1.
+                    regenerate_sampled_summary = bool(
+                        self._aggregate_directory
+                        and node is not None
+                        and node.pending_snapshot > 0
+                        and node.pending_child_uris is not None
+                        and file_path in node.pending_child_uris
+                    )
+                else:
+                    # Legacy sidecar (no URI collection) or overflow: pending
+                    # freshness records a count only, so rebuild every sampled
+                    # input once aggregation triggers.
+                    regenerate_sampled_summary = bool(
+                        self._aggregate_directory
+                        and node is not None
+                        and node.pending_snapshot > 0
+                        and node.sampled_file_paths is not None
+                        and file_path in node.sampled_file_paths
+                    )
 
                 if not content_changed and not regenerate_sampled_summary:
                     summary_dict = await self._read_existing_summary(file_path)

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -273,6 +273,7 @@ class SemanticProcessor(DequeueHandlerBase):
                 changed_entries=1,
                 ctx=parent_ctx,
                 l0_body_changed=l0_body_changed,
+                changed_child_uris=[uri.rstrip("/")],
                 # This helper handles automatic upward propagation only. Manual
                 # refresh/ingest bypasses the threshold for its requested root,
                 # not for every ancestor reached afterwards.

--- a/tests/storage/test_pending_child_uris.py
+++ b/tests/storage/test_pending_child_uris.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for bounded pending-child-URI accounting (#4577).
+
+A pending *counter* alone cannot tell the DAG executor which sampled inputs are
+dirty, so every triggered aggregation rebuilds the whole sample set. The URI
+collection added here records *which* children changed (bounded, with an
+overflow fallback), letting aggregation rebuild only dirty inputs.
+"""
+
+import asyncio
+
+import pytest
+
+from openviking.core.context import ContextLevel
+from openviking.storage.abstract_overview import (
+    PENDING_CHILD_URIS_LIMIT,
+    _merge_pending_child_uris,
+    freshness_metadata,
+    parse_abstract_overview,
+    plan_abstract_overview_refresh,
+    read_abstract_overview_pending_child_uris,
+    render_abstract_overview,
+)
+
+
+class _FakeFS:
+    def __init__(self, files):
+        self.files = dict(files)
+        self._async_agfs = self
+        self._lock = asyncio.Lock()
+
+    async def read_file(self, uri, ctx=None):
+        if uri not in self.files:
+            raise KeyError(uri)
+        return self.files[uri]
+
+    async def write_file(self, uri, content, ctx=None, lease_ref=None):
+        self.files[uri] = content
+
+    def _uri_to_path(self, uri, ctx=None):
+        return uri
+
+    async def pathlock_acquire_exact_batch(self, paths, timeout_secs=0.0):
+        await self._lock.acquire()
+        return {"paths": paths}
+
+    async def pathlock_release(self, lease):
+        self._lock.release()
+        return None
+
+
+def _files(dir_uri, *, total=161, pending=3, extra_freshness=None):
+    freshness = freshness_metadata(total, min(total, 32), pending)
+    if extra_freshness:
+        freshness = {**freshness, **extra_freshness}
+    metadata = {"freshness": freshness}
+    return {
+        f"{dir_uri}/.overview.md": render_abstract_overview(
+            ContextLevel.OVERVIEW, dir_uri, "overview", metadata
+        ),
+        f"{dir_uri}/.abstract.md": render_abstract_overview(
+            ContextLevel.ABSTRACT, dir_uri, "abstract", metadata
+        ),
+    }
+
+
+def _freshness_of(fs, uri):
+    document = parse_abstract_overview(fs.files[f"{uri}/.overview.md"])
+    return document.metadata["freshness"]
+
+
+# ---------- _merge_pending_child_uris (pure) ----------
+
+
+def test_merge_records_and_dedupes_uris():
+    first = _merge_pending_child_uris({}, ["viking://r/a", "viking://r/b"])
+    assert first == {"pending_child_uris": ["viking://r/a", "viking://r/b"]}
+    second = _merge_pending_child_uris(first, ["viking://r/b", "viking://r/c"])
+    assert second["pending_child_uris"] == ["viking://r/a", "viking://r/b", "viking://r/c"]
+    assert "pending_child_uris_overflow" not in second
+
+
+def test_merge_without_uris_touches_nothing():
+    assert _merge_pending_child_uris({}, None) == {}
+
+
+def test_merge_overflow_drops_set_and_flags():
+    many = [f"viking://r/f{i}" for i in range(PENDING_CHILD_URIS_LIMIT + 1)]
+    result = _merge_pending_child_uris({}, many)
+    assert result["pending_child_uris"] == []
+    assert result["pending_child_uris_overflow"] is True
+
+
+def test_merge_overflow_sticks_until_cleared():
+    overflowed = {"pending_child_uris": [], "pending_child_uris_overflow": True}
+    # further merges stay in overflow (conservative full rebuild)
+    result = _merge_pending_child_uris(overflowed, ["viking://r/x"])
+    assert result["pending_child_uris_overflow"] is True
+
+
+# ---------- plan side-effect on sidecar metadata ----------
+
+
+@pytest.mark.asyncio
+async def test_plan_persists_uris_into_sidecars():
+    fs = _FakeFS(_files("viking://r"))
+    await plan_abstract_overview_refresh(
+        viking_fs=fs,
+        dir_uri="viking://r",
+        changed_entries=1,
+        ctx=None,
+        changed_child_uris=["viking://r/a.md"],
+    )
+    freshness = _freshness_of(fs, "viking://r")
+    assert freshness["pending_child_uris"] == ["viking://r/a.md"]
+
+
+@pytest.mark.asyncio
+async def test_plan_without_uris_keeps_legacy_counter_only():
+    fs = _FakeFS(_files("viking://r"))
+    await plan_abstract_overview_refresh(
+        viking_fs=fs, dir_uri="viking://r", changed_entries=1, ctx=None
+    )
+    freshness = _freshness_of(fs, "viking://r")
+    assert "pending_child_uris" not in freshness
+
+
+# ---------- read side: three states ----------
+
+
+@pytest.mark.asyncio
+async def test_read_returns_collection_when_recorded():
+    fs = _FakeFS(
+        _files("viking://r", extra_freshness={"pending_child_uris": ["viking://r/a.md"]})
+    )
+    uris, overflow = await read_abstract_overview_pending_child_uris(
+        viking_fs=fs, dir_uri="viking://r", ctx=None
+    )
+    assert uris == {"viking://r/a.md"}
+    assert overflow is False
+
+
+@pytest.mark.asyncio
+async def test_read_legacy_sidecar_reports_empty_not_overflow():
+    fs = _FakeFS(_files("viking://r"))
+    uris, overflow = await read_abstract_overview_pending_child_uris(
+        viking_fs=fs, dir_uri="viking://r", ctx=None
+    )
+    assert uris == set()
+    assert overflow is False  # empty+False = legacy, executor falls back
+
+
+@pytest.mark.asyncio
+async def test_read_overflow_flags_full_rebuild():
+    fs = _FakeFS(
+        _files(
+            "viking://r",
+            extra_freshness={"pending_child_uris": [], "pending_child_uris_overflow": True},
+        )
+    )
+    uris, overflow = await read_abstract_overview_pending_child_uris(
+        viking_fs=fs, dir_uri="viking://r", ctx=None
+    )
+    assert uris == set()
+    assert overflow is True
+
+
+@pytest.mark.asyncio
+async def test_write_after_aggregation_returns_to_legacy_state():
+    # A fresh write builds metadata via freshness_metadata(), which has no URI
+    # collection — after aggregation the sidecar is intentionally "legacy"
+    # (empty + no overflow), so the next aggregation without new URIs falls
+    # back to the conservative behavior.
+    freshness = freshness_metadata(total_entries=10, sampled_entries=10, pending=0)
+    assert "pending_child_uris" not in freshness
+    assert "pending_child_uris_overflow" not in freshness

--- a/tests/storage/test_semantic_dag_incremental.py
+++ b/tests/storage/test_semantic_dag_incremental.py
@@ -627,3 +627,120 @@ async def test_content_copy_propagates_vector_summary_read_failure(monkeypatch):
 
 if __name__ == "__main__":
     pytest.main([__file__])
+
+
+@pytest.mark.asyncio
+async def test_pending_child_uris_rebuild_only_dirty_sampled_files(monkeypatch):
+    """With a recorded changed-child URI set, aggregation rebuilds only dirty sampled inputs (#4577).
+
+    The legacy test above (no URI collection) rebuilds every sampled file once
+    pending triggers; here freshness also recorded *which* child changed, so
+    untouched sampled files trust their existing L1 summaries.
+    """
+    root_uri = "viking://resources/narrow"
+    file_names = [f"file-{idx:03}.txt" for idx in range(40)]
+    file_paths = [f"{root_uri}/{name}" for name in file_names]
+    sampled_paths = deterministic_sample(file_paths, 4)
+    changed_path = f"{root_uri}/file-020.txt"
+    old_overview = "FILES:\n" + "\n".join(f"- {name}: old-summary" for name in file_names)
+    metadata = {
+        "freshness": {
+            **freshness_metadata(40, 4, pending=1),
+            "pending_child_uris": [changed_path],
+        }
+    }
+    fake_fs = _FakeVikingFS(
+        tree={
+            root_uri: [{"name": name, "isDir": False} for name in file_names],
+        },
+        file_contents={
+            **dict.fromkeys(file_paths, "content"),
+            f"{root_uri}/.overview.md": render_abstract_overview(
+                ContextLevel.OVERVIEW, root_uri, old_overview, metadata
+            ),
+            f"{root_uri}/.abstract.md": render_abstract_overview(
+                ContextLevel.ABSTRACT, root_uri, "old abstract", metadata
+            ),
+        },
+    )
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_dag.get_openviking_config",
+        lambda: SimpleNamespace(semantic=SimpleNamespace(overview_sample_limit=4)),
+    )
+
+    processor = _FakeProcessor(fake_fs)
+    ctx = RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER)
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=2,
+        ctx=ctx,
+        incremental_update=True,
+        target_uri=root_uri,
+        recursive=False,
+        changes={"modified": [changed_path]},
+    )
+
+    await executor.run(root_uri)
+
+    # Only the dirty file is re-summarized; other sampled files keep their L1.
+    assert processor.summarized_files == [changed_path]
+    assert processor.vectorized_files == [changed_path]
+    overview = parse_abstract_overview(fake_fs._file_contents[f"{root_uri}/.overview.md"])
+    assert overview.metadata["freshness"]["pending_child_changes"] == 0
+
+
+@pytest.mark.asyncio
+async def test_pending_child_uris_overflow_falls_back_to_full_sample_rebuild(monkeypatch):
+    """An overflowed URI collection must fall back to the conservative rebuild."""
+    root_uri = "viking://resources/overflow"
+    file_names = [f"file-{idx:03}.txt" for idx in range(40)]
+    file_paths = [f"{root_uri}/{name}" for name in file_names]
+    sampled_paths = deterministic_sample(file_paths, 4)
+    changed_path = f"{root_uri}/file-020.txt"
+    old_overview = "FILES:\n" + "\n".join(f"- {name}: old-summary" for name in file_names)
+    metadata = {
+        "freshness": {
+            **freshness_metadata(40, 4, pending=4),
+            "pending_child_uris": [],
+            "pending_child_uris_overflow": True,
+        }
+    }
+    fake_fs = _FakeVikingFS(
+        tree={
+            root_uri: [{"name": name, "isDir": False} for name in file_names],
+        },
+        file_contents={
+            **dict.fromkeys(file_paths, "content"),
+            f"{root_uri}/.overview.md": render_abstract_overview(
+                ContextLevel.OVERVIEW, root_uri, old_overview, metadata
+            ),
+            f"{root_uri}/.abstract.md": render_abstract_overview(
+                ContextLevel.ABSTRACT, root_uri, "old abstract", metadata
+            ),
+        },
+    )
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_dag.get_openviking_config",
+        lambda: SimpleNamespace(semantic=SimpleNamespace(overview_sample_limit=4)),
+    )
+
+    processor = _FakeProcessor(fake_fs)
+    ctx = RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER)
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=2,
+        ctx=ctx,
+        incremental_update=True,
+        target_uri=root_uri,
+        recursive=False,
+        changes={"modified": [changed_path]},
+    )
+
+    await executor.run(root_uri)
+
+    # Overflow: conservative full-sample rebuild, same as the legacy behavior.
+    assert set(processor.summarized_files) == set(sampled_paths) | {changed_path}


### PR DESCRIPTION
## Summary

Fixes the O(store) rebuild blast radius reported in #4577, at the exact layer where the amplification happens.

**Root cause** (visible in existing code comments): freshness accounting recorded a pending **counter** only — not *which* children changed. So once the counter crossed the aggregation threshold, the DAG executor had no way to distinguish dirty sampled inputs from clean ones and rebuilt the **entire sample set** (`semantic_dag.py`: *"Pending freshness only records a count, not the changed child URIs. Once that debt triggers aggregation, rebuild every sampled input instead of trusting the old L1 body."*). For the issue's store (17.9k files, topology change touching ~2%), that turned a ~74-directory change into a 3,484-node, multi-day full rebuild.

**This PR makes the accounting remember which children changed**, bounded and backward-compatible:

- `plan_abstract_overview_refresh` accepts `changed_child_uris` and maintains a bounded `pending_child_uris` set (limit 128) inside the freshness sidecars, plus a sticky `pending_child_uris_overflow` flag when the bound is exceeded. All three producers pass the real URIs: fs_service delete/copy refresh, content_write change batches, and the semantic processor's upward propagation.
- `SemanticDagExecutor` narrows `regenerate_sampled_summary`: when the pending collection exists and has not overflowed, only sampled files **actually in the set** are rebuilt — the rest of the sample set trusts its existing L1 summary. This is where the 46× amplification dies.
- **Backward compatibility by construction**: a fresh post-aggregation write produces metadata without the collection, and legacy sidecars never had it — both read as "no collection", and the executor falls back to today's conservative full-sample rebuild. Overflow behaves the same way. No migration needed.
- Freshness metadata schema validation accepts the two new fields with the same strictness as existing counters (bounded list of non-empty strings / boolean), keeping the "unknown fields are discarded, known fields are strict" contract.

Not addressed here (separate concerns per the issue discussion): queue priority isolation for the remaining bulk work (#4578) and executor-side subtree skipping for non-aggregation rebuilds.

## Testing

- `tests/storage/test_pending_child_uris.py`: 10 passed — merge/dedupe/overflow-stickiness of the bounded set, sidecar persistence via `plan_abstract_overview_refresh`, the three read states (collection / legacy / overflow), and post-write return-to-legacy
- adjacent suites: 25 passed across `test_abstract_overview_freshness.py`, `test_freshness_policy.py`, `test_semantic_dag_media_overview.py`, `test_semantic_processor_overview_batching.py`; 38 passed across the full dag/overview/freshness/abstract test set — the only 2 failures (`test_semantic_dag_skip_files`) reproduce identically on pristine upstream/main (local config env issue), verified via baseline diff