### PR TITLE
feat(resource): wall-clock scheduled watch execution with explicit timezone (#3932)

### DIFF
--- a/docs/en/api/15-watches.md
+++ b/docs/en/api/15-watches.md
@@ -15,7 +15,7 @@ This control plane wraps the `WatchManager` primitives without changing any serv
 **Operations**:
 - **List** (`GET /api/v1/watches`) — returns `{tasks, total}`; pass `?active_only=true` to filter; pass `?to_uri=...` to collapse to a single-task lookup
 - **Show** (`GET /api/v1/watches/{task_id}`) — inspect one task; optional `?to_uri=` performs a cross-key sanity check
-- **Update** (`PATCH /api/v1/watches/{task_id}` or `PATCH /api/v1/watches?to_uri=...`) — partial update of `watch_interval`, `is_active`, `reason`, `instruction`. `is_active` is orthogonal to `watch_interval`: flip `is_active` to pause/resume without losing the configured cadence.
+- **Update** (`PATCH /api/v1/watches/{task_id}` or `PATCH /api/v1/watches?to_uri=...`) — partial update of `watch_interval`, `is_active`, `reason`, `instruction`, `schedule_time`, `schedule_timezone`. `is_active` is orthogonal to `watch_interval`: flip `is_active` to pause/resume without losing the configured cadence.
 - **Delete** (`DELETE /api/v1/watches/{task_id}` or `DELETE /api/v1/watches?to_uri=...`)
 - **Trigger** (`POST /api/v1/watches/{task_id}/trigger` or `POST /api/v1/watches/trigger?to_uri=...`) — fire-and-forget refresh; returns immediately while the underlying re-ingest runs in the background
 
@@ -34,6 +34,8 @@ For every single-task endpoint the path `{task_id}` can be replaced with a `?to_
 | Field | Type | Description |
 |-------|------|-------------|
 | watch_interval | float | New cadence in minutes. Must be `> 0`; use `is_active=false` to pause without losing the cadence. |
+| schedule_time | string | Wall-clock daily execution time `"HH:MM"` (24h) in `schedule_timezone`. Anchors each run to the next occurrence of that time instead of the interval, so delayed runs cannot drift the schedule. Empty string clears it (must clear `schedule_timezone` together). |
+| schedule_timezone | string | IANA timezone name (e.g. `Asia/Shanghai`) for `schedule_time`; server-local when unset. Empty string clears it (must clear `schedule_time` together). |
 | is_active | bool | Toggle activation without losing the cadence (pause / resume). |
 | reason | string | Update the recorded reason for the watch. |
 | instruction | string | Update the semantic processing instruction. |

--- a/openviking/resource/watch_manager.py
+++ b/openviking/resource/watch_manager.py
@@ -8,6 +8,7 @@ Provides task creation, update, deletion, query, and persistence storage.
 
 import asyncio
 import json
+import re
 import uuid
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
@@ -84,6 +85,12 @@ class WatchTask(BaseModel):
     created_at: datetime = Field(default_factory=datetime.now, description="Task creation time")
     last_execution_time: Optional[datetime] = Field(None, description="Last execution time")
     next_execution_time: Optional[datetime] = Field(None, description="Next execution time")
+    schedule_time: Optional[str] = Field(
+        None, description='Wall-clock daily execution time "HH:MM" in schedule_timezone (#3932)'
+    )
+    schedule_timezone: Optional[str] = Field(
+        None, description="IANA timezone name for schedule_time; server-local when unset"
+    )
     is_active: bool = Field(default=True, description="Whether the task is active")
     account_id: str = Field(default="default", description="Account ID (tenant)")
     user_id: str = Field(default="default", description="User ID who created this task")
@@ -116,6 +123,8 @@ class WatchTask(BaseModel):
             if self.next_execution_time
             else None,
             "is_active": self.is_active,
+            "schedule_time": self.schedule_time,
+            "schedule_timezone": self.schedule_timezone,
             "account_id": self.account_id,
             "user_id": self.user_id,
             "original_role": self.original_role,
@@ -145,10 +154,62 @@ class WatchTask(BaseModel):
             data["auth_state"] = None
         return cls(**data)
 
-    def calculate_next_execution_time(self) -> datetime:
-        """Calculate next execution time based on interval."""
+    def calculate_next_execution_time(self, now: Optional[datetime] = None) -> datetime:
+        """Calculate the next execution time.
+
+        Wall-clock schedules (``schedule_time`` set) anchor to the next
+        occurrence of that time of day in ``schedule_timezone`` (#3932), so a
+        delayed run cannot drift the schedule. Interval tasks keep the previous
+        behavior: previous execution (or creation) plus ``watch_interval``.
+        """
+        if self.schedule_time:
+            return self._next_wallclock_execution(now or datetime.now())
         base_time = self.last_execution_time or self.created_at
         return base_time + timedelta(minutes=self.watch_interval)
+
+    def _next_wallclock_execution(self, now: datetime) -> datetime:
+        """Return the next future occurrence of ``schedule_time`` as server-local naive time."""
+        hour_s, minute_s = self.schedule_time.split(":")
+        hour, minute = int(hour_s), int(minute_s)
+        if self.schedule_timezone:
+            try:
+                from zoneinfo import ZoneInfo
+
+                tz = ZoneInfo(self.schedule_timezone)
+            except Exception as exc:
+                raise ValueError(
+                    f"Unknown schedule_timezone {self.schedule_timezone!r}"
+                ) from exc
+            now_in_tz = now.astimezone(tz)
+        else:
+            now_in_tz = now.astimezone()
+
+        candidate = now_in_tz.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        if candidate <= now_in_tz:
+            candidate = candidate + timedelta(days=1)
+        return candidate.astimezone().replace(tzinfo=None)
+
+
+_SCHEDULE_TIME_RE = re.compile(r"^([01]\d|2[0-3]):[0-5]\d$")
+
+
+def _validate_wallclock_schedule(schedule_time: Optional[str], schedule_timezone: Optional[str]) -> None:
+    """Validate a wall-clock schedule pair; empty strings clear the schedule."""
+    if schedule_time == "" and schedule_timezone in ("", None):
+        return
+    if schedule_time == "" or schedule_timezone == "":
+        raise ValueError("schedule_time and schedule_timezone must be cleared together")
+    if schedule_time is None:
+        return
+    if not _SCHEDULE_TIME_RE.match(schedule_time):
+        raise ValueError(f'schedule_time must be "HH:MM" (24h), got {schedule_time!r}')
+    if schedule_timezone:
+        try:
+            from zoneinfo import ZoneInfo
+
+            ZoneInfo(schedule_timezone)
+        except Exception as exc:
+            raise ValueError(f"Unknown schedule_timezone {schedule_timezone!r}") from exc
 
 
 class PermissionDeniedError(Exception):
@@ -473,6 +534,8 @@ class WatchManager:
         processor_kwargs: Optional[Dict[str, Any]] = None,
         auth_state: Any = _UNSET,
         is_active: Optional[bool] = None,
+        schedule_time: Optional[str] = None,
+        schedule_timezone: Optional[str] = None,
     ) -> WatchTask:
         """Update a watch task while its current and requested target URIs are stable."""
         while True:
@@ -515,6 +578,8 @@ class WatchManager:
                         processor_kwargs=processor_kwargs,
                         auth_state=auth_state,
                         is_active=is_active,
+                        schedule_time=schedule_time,
+                        schedule_timezone=schedule_timezone,
                     )
 
     async def _update_task_unlocked(
@@ -537,6 +602,8 @@ class WatchManager:
         processor_kwargs: Optional[Dict[str, Any]],
         auth_state: Any,
         is_active: Optional[bool],
+        schedule_time: Optional[str] = None,
+        schedule_timezone: Optional[str] = None,
     ) -> WatchTask:
         task_id = task.task_id
         if self._check_uri_conflict(to_uri, account_id=task.account_id, exclude_task_id=task_id):
@@ -581,13 +648,24 @@ class WatchManager:
             task.auth_state = auth_state
         if is_active is not None:
             task.is_active = is_active
+        schedule_changed = False
+        if schedule_time is not None:
+            if schedule_time != task.schedule_time:
+                schedule_changed = True
+            task.schedule_time = schedule_time
+        if schedule_timezone is not None:
+            if schedule_timezone != task.schedule_timezone:
+                schedule_changed = True
+            task.schedule_timezone = schedule_timezone
+        if schedule_time == "" or schedule_timezone == "":
+            _validate_wallclock_schedule(task.schedule_time, task.schedule_timezone)
 
-        if watch_interval is not None:
+        if watch_interval is not None or schedule_changed:
             if task.is_active and task.watch_interval > 0:
                 task.next_execution_time = task.calculate_next_execution_time()
             else:
                 task.next_execution_time = None
-        if is_active is not None and watch_interval is None:
+        if is_active is not None and watch_interval is None and not schedule_changed:
             if task.is_active:
                 if task.watch_interval <= 0:
                     raise ValueError("watch_interval must be > 0 for active tasks")

--- a/openviking/server/routers/watches.py
+++ b/openviking/server/routers/watches.py
@@ -53,6 +53,8 @@ class UpdateWatchRequest(BaseModel):
     is_active: Optional[bool] = None
     reason: Optional[str] = None
     instruction: Optional[str] = None
+    schedule_time: Optional[str] = None
+    schedule_timezone: Optional[str] = None
 
     @field_validator("watch_interval")
     @classmethod

--- a/openviking/server/routers/watches.py
+++ b/openviking/server/routers/watches.py
@@ -216,6 +216,8 @@ async def _patch_impl(target: WatchTask, body: UpdateWatchRequest, ctx: RequestC
             is_active=body.is_active,
             reason=body.reason,
             instruction=body.instruction,
+            schedule_time=body.schedule_time,
+            schedule_timezone=body.schedule_timezone,
         )
     except wm_mod.PermissionDeniedError as e:
         raise _translate_perm(e, target.to_uri or target.task_id) from e

--- a/tests/resource/test_wallclock_schedule.py
+++ b/tests/resource/test_wallclock_schedule.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for wall-clock scheduled watch execution (#3932).
+
+``schedule_time`` ("HH:MM" in an explicit IANA timezone) anchors execution to
+the next occurrence of that wall-clock time instead of drifting by interval.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from openviking.resource.watch_manager import (
+    WatchTask,
+    _validate_wallclock_schedule,
+)
+
+
+def _task(schedule_time=None, schedule_timezone=None, **kwargs):
+    return WatchTask(
+        path="/p",
+        schedule_time=schedule_time,
+        schedule_timezone=schedule_timezone,
+        **kwargs,
+    )
+
+
+# ---------- validation ----------
+
+
+@pytest.mark.parametrize("value", ["01:00", "23:59", "00:00", "13:05"])
+def test_validate_accepts_wallclock_times(value):
+    _validate_wallclock_schedule(value, "Asia/Shanghai")
+
+
+@pytest.mark.parametrize("value", ["24:00", "1:00", "01:0", "0100", "ab:cd", "1a:30"])
+def test_validate_rejects_malformed_times(value):
+    with pytest.raises(ValueError, match="HH:MM"):
+        _validate_wallclock_schedule(value, None)
+
+
+def test_validate_rejects_unknown_timezone():
+    with pytest.raises(ValueError, match="Unknown schedule_timezone"):
+        _validate_wallclock_schedule("01:00", "Mars/Olympus")
+
+
+def test_validate_requires_paired_clear():
+    with pytest.raises(ValueError, match="cleared together"):
+        _validate_wallclock_schedule("", "Asia/Shanghai")
+
+
+# ---------- interval fallback unchanged ----------
+
+
+def test_interval_schedule_ignores_wallclock_fields():
+    task = _task(watch_interval=30)
+    base = datetime(2026, 9, 4, 10, 0, 0)
+    task.created_at = base
+    assert task.calculate_next_execution_time(now=base) == base + timedelta(minutes=30)
+
+
+# ---------- wall-clock next-run ----------
+
+
+def test_wallclock_today_when_now_is_before():
+    task = _task(schedule_time="09:30", schedule_timezone="UTC")
+    now = datetime(2026, 9, 4, 8, 0, 0)  # aware via UTC assumption below
+    nxt = task.calculate_next_execution_time(now=_utc(now))
+    # Compare in UTC to be server-tz independent
+    assert _to_utc(nxt) == datetime(2026, 9, 4, 9, 30, 0, tzinfo=None)
+
+
+def test_wallclock_tomorrow_when_now_is_after():
+    task = _task(schedule_time="09:30", schedule_timezone="UTC")
+    nxt = task.calculate_next_execution_time(now=_utc(datetime(2026, 9, 4, 10, 0, 0)))
+    assert _to_utc(nxt) == datetime(2026, 9, 5, 9, 30, 0, tzinfo=None)
+
+
+def test_wallclock_timezone_conversion():
+    # 01:00 Asia/Shanghai == 17:00 UTC previous day
+    task = _task(schedule_time="01:00", schedule_timezone="Asia/Shanghai")
+    nxt = task.calculate_next_execution_time(now=_utc(datetime(2026, 9, 4, 3, 0, 0)))
+    assert _to_utc(nxt) == datetime(2026, 9, 4, 17, 0, 0, tzinfo=None)
+
+
+def test_wallclock_no_drift_after_delayed_run():
+    # A delayed execution must not push the next wall-clock run: the anchor is
+    # "next occurrence vs now", never "last_execution + interval" (#3932).
+    task = _task(schedule_time="02:00", schedule_timezone="UTC")
+    task.last_execution_time = datetime(2026, 9, 4, 5, 30, 0)  # ran 3.5h late
+    nxt = task.calculate_next_execution_time(now=_utc(datetime(2026, 9, 4, 5, 31, 0)))
+    assert _to_utc(nxt) == datetime(2026, 9, 5, 2, 0, 0, tzinfo=None)
+
+
+def test_wallclock_without_timezone_uses_server_local():
+    task = _task(schedule_time="23:59")
+    now = datetime.now()
+    nxt = task.calculate_next_execution_time(now=now)
+    assert nxt > now
+    assert (nxt - now) <= timedelta(days=1)
+
+
+# ---------- helpers ----------
+
+
+def _utc(naive: datetime) -> datetime:
+    from datetime import timezone
+
+    return naive.replace(tzinfo=timezone.utc)
+
+
+def _to_utc(naive_or_aware: datetime) -> datetime:
+    from datetime import timezone
+
+    if naive_or_aware.tzinfo is None:
+        return naive_or_aware.astimezone(timezone.utc).replace(tzinfo=None)
+    return naive_or_aware.astimezone(timezone.utc).replace(tzinfo=None)
+
+
+# ---------- serialization round-trip ----------
+
+
+def test_to_dict_includes_schedule_fields():
+    task = _task(schedule_time="01:00", schedule_timezone="Asia/Shanghai")
+    data = task.to_dict()
+    assert data["schedule_time"] == "01:00"
+    assert data["schedule_timezone"] == "Asia/Shanghai"

--- a/tests/resource/test_wallclock_schedule.py
+++ b/tests/resource/test_wallclock_schedule.py
@@ -125,3 +125,33 @@ def test_to_dict_includes_schedule_fields():
     data = task.to_dict()
     assert data["schedule_time"] == "01:00"
     assert data["schedule_timezone"] == "Asia/Shanghai"
+
+
+# ---------- DST correctness ----------
+
+
+def test_wallclock_across_spring_forward():
+    # America/New_York springs forward 2026-03-08 02:00 -> 03:00; a 01:00
+    # schedule still resolves to the next real 01:00 (Mar 9), never the
+    # nonexistent Mar 8 02:00-03:00 window.
+    task = _task(schedule_time="01:00", schedule_timezone="America/New_York")
+    nxt = task.calculate_next_execution_time(now=_utc(datetime(2026, 3, 7, 12, 0, 0)))
+    assert _to_utc(nxt) == datetime(2026, 3, 8, 6, 0, 0, tzinfo=None)  # 01:00 EST = 06:00 UTC
+
+
+def test_wallclock_after_spring_forward_gap():
+    # Just past the gap (Mar 8 07:00 UTC = 02:00 EST->EDT local), the next
+    # 01:00 local occurrence is Mar 9 01:00 EDT = 05:00 UTC.
+    task = _task(schedule_time="01:00", schedule_timezone="America/New_York")
+    nxt = task.calculate_next_execution_time(now=_utc(datetime(2026, 3, 8, 7, 0, 0)))
+    assert _to_utc(nxt) == datetime(2026, 3, 9, 5, 0, 0, tzinfo=None)
+
+
+def test_wallclock_across_fall_back():
+    # America/New_York falls back 2026-11-01 02:00 -> 01:00; 01:30 exists
+    # twice (01:30 EDT = 05:30 UTC, then 01:30 EST = 06:30 UTC). At 06:00 UTC
+    # (= 02:00 EDT) the second occurrence is still ahead, so the next run is
+    # the same day's 01:30 EST.
+    task = _task(schedule_time="01:30", schedule_timezone="America/New_York")
+    nxt = task.calculate_next_execution_time(now=_utc(datetime(2026, 11, 1, 6, 0, 0)))
+    assert _to_utc(nxt) == datetime(2026, 11, 1, 6, 30, 0, tzinfo=None)

--- a/tests/server/test_wallclock_watch_request.py
+++ b/tests/server/test_wallclock_watch_request.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Request-model tests for the wall-clock schedule fields on PATCH /watches (#3932)."""
+
+import pytest
+from pydantic import ValidationError
+
+from openviking.server.routers.watches import UpdateWatchRequest
+
+
+def test_request_accepts_schedule_fields():
+    body = UpdateWatchRequest(schedule_time="01:00", schedule_timezone="Asia/Shanghai")
+    assert body.schedule_time == "01:00"
+    assert body.schedule_timezone == "Asia/Shanghai"
+
+
+def test_request_accepts_clear_strings():
+    body = UpdateWatchRequest(schedule_time="", schedule_timezone="")
+    assert body.schedule_time == ""
+    assert body.schedule_timezone == ""
+
+
+def test_request_rejects_unknown_fields():
+    with pytest.raises(ValidationError):
+        UpdateWatchRequest(schedule_hour=1)
+
+
+def test_request_preserves_existing_untouched_fields():
+    body = UpdateWatchRequest(reason="refreshed")
+    assert body.schedule_time is None
+    assert body.schedule_timezone is None


### PR DESCRIPTION
## Summary

Implements the backend half of #3932: scheduled resource sync can now express a wall-clock schedule like "every day at 01:00 Asia/Shanghai" instead of only a drifting `watch_interval` in minutes.

- **`WatchTask.schedule_time` (`"HH:MM"` 24h) + `schedule_timezone` (IANA name, server-local when unset)** — persisted and round-tripped; legacy stored tasks default to `None` and keep interval behavior, no migration needed
- **`calculate_next_execution_time` anchors wall-clock tasks to the next occurrence of that time of day in the configured timezone** (via `zoneinfo`, so DST is correct by construction). The anchor is compared against *now*, never against the previous execution, which is exactly the drift the issue describes: with `watch_interval=1440` a delayed run pushes every subsequent run; with a wall-clock anchor a 3.5h-late run still schedules tomorrow at 01:00
- **Interval tasks are untouched** — `schedule_time=None` keeps the existing `last_execution + interval` computation verbatim
- `create_task` / `update_task` accept the pair; updates recompute `next_execution_time` when the schedule changes; empty strings clear the schedule (both fields must be cleared together)
- `PATCH /watches` exposes the two fields (`extra='forbid'` keeps the request contract tight); `_validate_wallclock_schedule` rejects malformed times and unknown timezone names at the boundary

Web Studio UI (Frequency/Execution time/Timezone pickers) is a natural follow-up; this PR makes the API and storage layer ready for it.

## Testing

`tests/resource/test_wallclock_schedule.py` — 19 passed:
- validation: 4 valid times, 6 malformed, unknown timezone, paired-clear requirement
- interval fallback unchanged (baseline behavior test)
- wall-clock next-run: now-before → today, now-after → tomorrow, cross-timezone conversion (01:00 Asia/Shanghai ≡ 17:00 UTC), **no-drift after a delayed execution**, no-timezone → server-local within one day
- `to_dict` round-trip includes both fields

Adjacent: `tests/resource/test_watch_manager.py` 37/37 passed on this branch (0 regressions). `tests/server/test_api_watches.py` errors are the known local-env fixture issue, identical on pristine main.