### PR TITLE
test(codex-plugin): accept both convergences of the Stop/SessionEnd marker race

### DIFF
--- a/examples/codex-memory-plugin/scripts/session-end.test.mjs
+++ b/examples/codex-memory-plugin/scripts/session-end.test.mjs
@@ -419,7 +419,21 @@ test("a concurrent Stop worker and session-end worker never double-send a turn",
     assert.equal(sentMessages(calls).length, 6, "each transcript turn must be sent exactly once");
     const state = await readState(stateDir, "s8");
     assert.equal(state.capturedTurnCount, 6);
-    assert.equal(state.ovSessionId, null);
+    // The two hooks race over the end marker. auto-capture clears markers
+    // older than its own start (resume semantics), so when the SessionEnd
+    // parent writes its marker just before the Stop hook starts — the exit
+    // race this test spawns — the marker is gone by the time the session-end
+    // worker takes the lock and it exits as superseded. The system then
+    // settles on the Stop worker's terminal state: the live session stays
+    // uncommitted for the SessionStart sweep's idle-TTL pass instead of being
+    // committed inline. Both convergences are correct as long as no turn is
+    // double-sent and no stale marker survives, so accept either one.
+    if (state.ovSessionId !== null) {
+      assert.equal(state.ovSessionId, "cx-s8",
+        "only the derived cx-s8 session may remain live");
+    }
+    assert.equal(await endedMarkerExists(stateDir, "s8"), false,
+      "a converged run must not leave a stale end marker");
   } finally {
     await rm(stateDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Problem

`session-end.test.mjs`'s "a concurrent Stop worker and session-end worker never double-send a turn" test is flaky on CI — it started failing on unrelated PRs as soon as they rebased onto main past #4429 (observed twice today: [plugin-tests on #3990](https://github.com/volcengine/OpenViking/actions/runs/33785519302/job/100749212154) and [plugin-tests on #4365](https://github.com/volcengine/OpenViking/actions/runs/33787006967/job/100754097084), both failing with `state.ovSessionId: 'cx-s8' !== null` while neither diff touches the codex plugin).

## Root cause

The test asserted a single terminal state (`ovSessionId === null`, i.e. the session-end worker committed inline), but the system legitimately converges two ways when both hooks fire on the same exit:

1. **session-end wins the marker** — the Stop hook starts before the marker is written, the session-end worker takes the lock, catches up, commits → `ovSessionId = null`.
2. **Stop wins the marker** — the SessionEnd parent writes its marker just before the Stop hook starts. `auto-capture` clears end markers older than its own start (resume semantics), so by the time the session-end worker takes the lock the marker is gone and it exits as `superseded`. The Stop worker's terminal state stands: turns are captured exactly once (`capturedTurnCount = 6`, six messages sent) but the live session stays uncommitted for the SessionStart sweep's idle-TTL pass instead of being committed inline.

Which hook wins depends on process spawn order, which is genuinely racy on slow CI runners — the assertion encoded an ordering assumption the design does not make.

## Fix

Assert the real invariants that both convergences satisfy:

- each transcript turn is sent exactly once (unchanged),
- the cursor is consistent (`capturedTurnCount = 6`, unchanged),
- if a session stays live it can only be the derived `cx-s8`,
- no stale end marker survives either convergence (cleared by `commitAndRelease` in one path, by `auto-capture`'s resume clear in the other).

No production code changes — this is a test-only fix. The Stop-wins path is by design the safe convergence: nothing is lost, the sweep commits within the idle TTL.

## Testing

- `node --test examples/codex-memory-plugin/scripts/session-end.test.mjs` — 14/14 pass.
- Race test looped 20× locally with zero failures.