### PR TITLE
fix(bot): reject non-bare filenames in send:// URIs (path traversal)

### DIFF
--- a/bot/tests/test_send_uri_traversal.py
+++ b/bot/tests/test_send_uri_traversal.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""send:// URIs must resolve to bare filenames inside the images directory.
+
+The URI text is authored by the model at runtime; without a filename
+allowlist a crafted remainder (``../../secrets``) reads arbitrary server
+files and channel image delivery would exfiltrate them.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from vikingbot.channels.base import BaseChannel
+
+
+class _Channel(BaseChannel):
+    """Minimal concrete channel exposing _parse_data_uri."""
+
+    async def send(self, msg):  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    async def receive(self):  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    async def start(self):  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    async def stop(self):  # pragma: no cover - abstract
+        raise NotImplementedError
+
+
+def _channel(tmp_path: Path) -> _Channel:
+    ch = _Channel.__new__(_Channel)
+    return ch
+
+
+@pytest.fixture
+def images_dir(tmp_path: Path, monkeypatch) -> Path:
+    images = tmp_path / "data" / "images"
+    images.mkdir(parents=True)
+    (images / "cat.png").write_bytes(b"PNG-fake-bytes")
+
+    import vikingbot.channels.base as base_mod
+
+    monkeypatch.setattr(
+        base_mod, "get_data_path", lambda: (tmp_path / "data")
+    )
+    return images
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "send://../secrets.txt",
+        "send://../../etc/passwd",
+        "send://..%2f..%2fx.png",
+        "send:///etc/passwd",
+        "send://sub/dir/cat.png",
+        "send://.hidden",
+        "send://",
+        "send://.",
+        "send://..",
+    ],
+)
+async def test_send_uri_rejects_non_bare_filenames(images_dir, uri):
+    with pytest.raises(ValueError, match="bare filename"):
+        await _channel(images_dir)._parse_data_uri(uri)
+
+
+@pytest.mark.asyncio
+async def test_send_uri_accepts_bare_filename(images_dir):
+    is_content, data = await _channel(images_dir)._parse_data_uri("send://cat.png")
+    assert is_content is False
+    assert data == b"PNG-fake-bytes"
+
+
+@pytest.mark.asyncio
+async def test_send_uri_missing_file_raises_not_traversal(images_dir):
+    # A bare-but-absent filename is a normal missing file, not a rejection.
+    with pytest.raises(FileNotFoundError):
+        await _channel(images_dir)._parse_data_uri("send://nope.png")

--- a/bot/vikingbot/channels/base.py
+++ b/bot/vikingbot/channels/base.py
@@ -1,5 +1,10 @@
 """Base channel interface for chat platforms."""
 
+import re as _re
+
+# Bare image filenames only: no path separators, no "..", bounded length.
+_SEND_FILENAME_RE = _re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,200}")
+
 import base64
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -231,7 +236,16 @@ class BaseChannel(ABC):
 
                 return False, content
         elif data_uri.startswith("send://"):
-            path_obj = get_data_path() / "images" / data_uri.split("send://", 1)[1]
+            filename = data_uri.split("send://", 1)[1]
+            # send:// URIs come from model-authored outbound content and must
+            # never escape the images directory: a crafted remainder such as
+            # "../../secrets.txt" would otherwise read an arbitrary server file
+            # and (via channel image delivery) exfiltrate it.
+            if not _SEND_FILENAME_RE.fullmatch(filename):
+                raise ValueError(
+                    f"send:// URI must be a bare filename, got {filename!r}"
+                )
+            path_obj = get_data_path() / "images" / filename
             return False, path_obj.read_bytes()
         else:
             # Try to resolve as local file path


### PR DESCRIPTION
## Summary

Security fix found while reviewing #4660: the `send://` branch of `BaseChannel._parse_data_uri` (`bot/vikingbot/channels/base.py`) joined the URI remainder onto `get_data_path() / "images"` with no validation:

```python
path_obj = get_data_path() / "images" / data_uri.split("send://", 1)[1]
return False, path_obj.read_bytes()
```

so a crafted URI like `send://../../secrets.txt` (or any path with separators) read an **arbitrary server file** as "image bytes". The URI text comes from model-authored outbound content at runtime — the same untrusted surface being fenced on the extraction/overview paths (#4292, #4641, #4664) — so a prompt-injected response could make the bot read a sensitive local file and attach it to a chat message. Feishu already had this exposure; #4660 extends image delivery to Discord/Slack/Telegram, which triples the exfiltration surface.

**Fix**: the `send://` remainder must now be a bare filename matching `[A-Za-z0-9][A-Za-z0-9._-]{0,200}`; anything containing path separators, leading dots, or percent-escapes raises `ValueError` **before** any file is opened. The regular expression check also bounds length. Bare-but-missing filenames still surface as `FileNotFoundError` (unchanged semantics).

## Testing

`bot/tests/test_send_uri_traversal.py` — 11 passed:
- 9 rejection cases: `../secrets.txt`, `../../etc/passwd`, `..%2f` escape, absolute path injection, `sub/dir/cat.png`, `.hidden`, empty, `.`, `..`
- bare filename accepted and read correctly
- missing bare filename still raises `FileNotFoundError` (not a traversal rejection)

Adjacent channel suites (`test_channel_delivery_metadata.py`, `test_channel_sender_name.py`) 17/17 green.

Found during the security pass in #4660's review; independent of that PR's channel work.