### PR TITLE
docs(config): add a self-hosted embedding example for OpenAI-compatible servers (#4646)

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -101,6 +101,34 @@ For `provider: "openai-codex"`, `vlm.api_key` is optional when Codex OAuth is al
 </details>
 
 <details>
+<summary><b>Self-hosted Embedding (OpenAI-compatible server)</b></summary>
+
+Any embedding server that exposes an OpenAI-compatible `/v1/embeddings` endpoint works through the `openai` provider — Ollama, llama.cpp's `llama-server`, vLLM, or Text Embeddings Inference (TEI). The example below targets Ollama serving `bge-m3`:
+
+```json
+{
+  "embedding": {
+    "dense": {
+      "api_base" : "http://127.0.0.1:11434/v1",
+      "api_key"  : "ollama",
+      "provider" : "openai",
+      "dimension": 1024,
+      "model"    : "bge-m3"
+    }
+  }
+}
+```
+
+Notes for local deployments (#4646):
+
+- `api_key` is required by the config schema but unused by local servers; any non-empty placeholder works.
+- `dimension` must match the model's actual output dimension (`bge-m3`: 1024, `nomic-embed-text`: 768, `mxbai-embed-large`: 1024). A mismatch fails vector index creation loudly.
+- Switching embedding models after ingestion changes vector semantics: re-run `ov reindex --mode vectors` (or `semantic_and_vectors`) so all existing content is re-embedded with the new model.
+- Retrieval quality with local models depends mostly on model size and language coverage; multilingual corpora generally do better with `bge-m3` or larger instruction-tuned models than with small English-only embedders.
+
+</details>
+
+<details>
 <summary><b>Volcengine Embedding + Codex VLM</b></summary>
 
 Use `openviking-server init` to complete the Codex login/import step, then run `openviking-server doctor`.

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -102,6 +102,34 @@ openviking-server doctor
 </details>
 
 <details>
+<summary><b>自托管 Embedding（OpenAI 兼容服务）</b></summary>
+
+任何暴露 OpenAI 兼容 `/v1/embeddings` 端点的 embedding 服务都可以通过 `openai` provider 接入 —— Ollama、llama.cpp 的 `llama-server`、vLLM 或 Text Embeddings Inference（TEI）。以下示例为 Ollama 部署 `bge-m3`：
+
+```json
+{
+  "embedding": {
+    "dense": {
+      "api_base" : "http://127.0.0.1:11434/v1",
+      "api_key"  : "ollama",
+      "provider" : "openai",
+      "dimension": 1024,
+      "model"    : "bge-m3"
+    }
+  }
+}
+```
+
+自部署注意事项（#4646）：
+
+- `api_key` 为配置必填项，本地服务不校验，填任意非空占位值即可。
+- `dimension` 必须与模型实际输出维度一致（`bge-m3`：1024，`nomic-embed-text`：768，`mxbai-embed-large`：1024），不匹配会在向量索引创建时报错。
+- 已有数据切换 embedding 模型后向量语义随之改变，需要执行 `ov reindex --mode vectors`（或 `semantic_and_vectors`）用新模型重新嵌入全部存量内容。
+- 本地模型的检索质量主要取决于模型规模与语言覆盖：多语言语料建议选用 `bge-m3` 或更大的指令微调模型，小型英文模型对中文/混合语料效果明显下降。
+
+</details>
+
+<details>
 <summary><b>火山引擎 Embedding + Codex VLM</b></summary>
 
 使用 `openviking-server init` 完成 Codex 登录/导入后，再执行 `openviking-server doctor`。


### PR DESCRIPTION
## Summary

Follow-up to #4646: the configuration guide shows Volcengine and OpenAI examples, but the "point OpenViking at a local embedding model" question keeps coming up and the answer — any OpenAI-compatible `/v1/embeddings` server via the `openai` provider — isn't discoverable from the existing examples.

Adds a third configuration example (mirrored into the Chinese guide) with:

- a concrete Ollama + `bge-m3` block (`api_base`/`provider`/`dimension`/`model`), noting llama.cpp `llama-server`, vLLM, and TEI work identically
- the placeholder-`api_key` note (required by the schema, unused by local servers)
- the dimension-matching rule with real model dimensions (`bge-m3` 1024, `nomic-embed-text` 768, `mxbai-embed-large` 1024)
- the reindex requirement after switching models (`ov reindex --mode vectors`), which is the step local-deployment users most often miss
- a one-line retrieval-quality pointer for multilingual corpora

Docs-only; no code paths touched.