### PR TITLE
fix(build): reject ASan-linked RAGFS wheels

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -140,7 +140,7 @@ jobs:
         # Retry apt-get update
         for i in 1 2 3 4 5; do apt-get update && break || sleep 5; done
         apt-get install -y \
-          git ca-certificates cmake build-essential clang tzdata curl \
+          git ca-certificates cmake build-essential binutils clang tzdata curl \
           libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
           libffi-dev liblzma-dev libgdbm-dev libnss3-dev libncurses5-dev \
           libncursesw5-dev tk-dev uuid-dev libexpat1-dev
@@ -294,6 +294,9 @@ jobs:
         rm dist/*.whl
         mv dist_fixed/*.whl dist/
         rmdir dist_fixed
+
+    - name: Verify RAGFS wheel has no ASan runtime (Linux)
+      run: uv run python -m build_support.ragfs_wheel dist/*.whl
 
     - name: Smoke test built wheel (Linux)
       shell: bash

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,7 @@ include pyproject.toml
 include setup.py
 include Cargo.toml
 include Cargo.lock
+graft build_support
 graft crates/ragfs
 graft crates/ragfs-python
 recursive-include openviking *.yaml

--- a/build_support/ragfs_wheel.py
+++ b/build_support/ragfs_wheel.py
@@ -1,0 +1,156 @@
+"""Validation helpers for the native RAGFS extension in Linux wheels."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Sequence
+
+
+class WheelValidationError(RuntimeError):
+    """Raised when a built RAGFS wheel contains an unsafe native dependency."""
+
+
+def _is_ragfs_extension(member_name: str) -> bool:
+    basename = Path(member_name).name
+    return basename == "ragfs_python.pyd" or (
+        basename.startswith("ragfs_python.abi3.") and basename.endswith(".so")
+    )
+
+
+def _packaged_asan_members(member_names: Sequence[str]) -> list[str]:
+    return [
+        name
+        for name in member_names
+        if Path(name).name.lower().startswith("libasan")
+    ]
+
+
+def _resolve_readelf(readelf_binary: str | None) -> str:
+    resolved = readelf_binary or shutil.which("readelf")
+    if not resolved:
+        raise WheelValidationError(
+            "cannot validate the RAGFS wheel: `readelf` was not found; "
+            "install binutils before building Linux wheels"
+        )
+    return resolved
+
+
+def _readelf_dynamic_section(readelf_binary: str, native_path: Path) -> str:
+    try:
+        result = subprocess.run(
+            [readelf_binary, "-d", str(native_path)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as exc:
+        raise WheelValidationError(
+            f"cannot execute `{readelf_binary}` while validating {native_path.name}: {exc}"
+        ) from exc
+
+    output = "\n".join(part for part in (result.stdout, result.stderr) if part)
+    if result.returncode != 0:
+        raise WheelValidationError(
+            f"readelf failed for {native_path.name} with exit code {result.returncode}:\n{output}"
+        )
+    return output
+
+
+def validate_linux_ragfs_wheel(
+    wheel_path: str | Path,
+    *,
+    readelf_binary: str | None = None,
+) -> None:
+    """Reject a Linux RAGFS wheel that links or bundles the ASan runtime.
+
+    The RAGFS extension is loaded by Python with ``dlopen``. A native ASan
+    dependency is therefore unsafe in a normal release process: the runtime
+    is not guaranteed to be first in the initial library list. This check is
+    intentionally performed against the wheel archive before it is installed.
+    """
+
+    wheel_path = Path(wheel_path)
+    if not wheel_path.is_file():
+        raise WheelValidationError(f"RAGFS wheel does not exist: {wheel_path}")
+
+    try:
+        archive = zipfile.ZipFile(wheel_path)
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise WheelValidationError(f"cannot read RAGFS wheel {wheel_path}: {exc}") from exc
+
+    with archive:
+        member_names = archive.namelist()
+        packaged_asan = _packaged_asan_members(member_names)
+        if packaged_asan:
+            names = ", ".join(packaged_asan)
+            raise WheelValidationError(
+                f"{wheel_path} packages an ASan runtime ({names}); release wheels must not "
+                "contain libasan"
+            )
+
+        native_members = [name for name in member_names if _is_ragfs_extension(name)]
+        if not native_members:
+            raise WheelValidationError(
+                f"{wheel_path} contains no ragfs_python stable-ABI extension"
+            )
+
+        readelf = _resolve_readelf(readelf_binary)
+        with tempfile.TemporaryDirectory(prefix="openviking-ragfs-wheel-") as temp_dir:
+            temp_root = Path(temp_dir)
+            for index, member_name in enumerate(native_members):
+                native_path = temp_root / f"ragfs_python-{index}.so"
+                native_path.write_bytes(archive.read(member_name))
+                dynamic_section = _readelf_dynamic_section(readelf, native_path)
+                asan_lines = [
+                    line for line in dynamic_section.splitlines() if "asan" in line.lower()
+                ]
+                if asan_lines:
+                    details = "\n".join(asan_lines)
+                    raise WheelValidationError(
+                        f"{wheel_path} links the ASan runtime from {member_name}; "
+                        "release wheels must not reference libasan:\n"
+                        f"{details}"
+                    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Reject Linux RAGFS wheels that link or package libasan."
+    )
+    parser.add_argument(
+        "wheels",
+        nargs="+",
+        type=Path,
+        help="one or more wheel archives to validate",
+    )
+    parser.add_argument(
+        "--readelf",
+        dest="readelf_binary",
+        help="readelf executable to use (defaults to readelf from PATH)",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        for wheel_path in args.wheels:
+            validate_linux_ragfs_wheel(
+                wheel_path,
+                readelf_binary=args.readelf_binary,
+            )
+            print(f"[OK] {wheel_path}: no libasan dependency or bundled runtime")
+    except WheelValidationError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/en/guides/14-ragfs-cache.md
+++ b/docs/en/guides/14-ragfs-cache.md
@@ -153,6 +153,21 @@ OpenViking uses `cache.params.library` to load the dynamic library. All remainin
 }
 ```
 
+### Linux wheel validation
+
+The Linux wheel build validates the bundled `ragfs_python` extension before
+the wheel is published. It runs `readelf -d` and fails if the extension
+references ASan or if any `libasan*` file is packaged. Run the same guard
+locally from the repository root with:
+
+```bash
+python -m build_support.ragfs_wheel dist/openviking-*.whl
+```
+
+This check must fail for a deliberately ASan-enabled native build and pass
+for a clean release build; a passing check alone does not prove that the
+guard is effective.
+
 ## Architecture
 
 RAGFS splits caching into two layers:

--- a/docs/zh/guides/14-ragfs-cache.md
+++ b/docs/zh/guides/14-ragfs-cache.md
@@ -153,6 +153,19 @@ DynamicProvider 配置：
 }
 ```
 
+### Linux wheel 校验
+
+Linux wheel 构建会在发布前校验其中携带的 `ragfs_python` 扩展：执行
+`readelf -d`，如果扩展引用 ASan，或 wheel 中包含任何 `libasan*` 文件，构建都会失败。
+在仓库根目录可以用下面的命令执行同一个 guard：
+
+```bash
+python -m build_support.ragfs_wheel dist/openviking-*.whl
+```
+
+对于刻意启用 ASan 的 native 构建，该检查必须失败；对于干净的 release
+构建必须通过。只有通过检查本身，不能证明 guard 一定能拦截错误构建。
+
 ## 整体架构
 
 RAGFS 将缓存拆成两层：

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,9 @@ get_host_engine_build_config = importlib.import_module(
 resolve_openviking_version = importlib.import_module(
     "build_support.versioning"
 ).resolve_openviking_version
+validate_linux_ragfs_wheel = importlib.import_module(
+    "build_support.ragfs_wheel"
+).validate_linux_ragfs_wheel
 
 CMAKE_PATH = shutil.which("cmake") or "cmake"
 C_COMPILER_PATH = os.environ.get("CC") or shutil.which("gcc") or "gcc"
@@ -332,6 +335,9 @@ class OpenVikingBuildExt(build_ext):
                         raise RuntimeError(message)
                     print(f"[Warning] {message}")
                     return
+
+                if require_ragfs_artifact and sys.platform.startswith("linux"):
+                    validate_linux_ragfs_wheel(whl_files[0])
 
                 ragfs_lib_dir.mkdir(parents=True, exist_ok=True)
                 for stale_artifact in ragfs_lib_dir.glob("ragfs_python*.so"):

--- a/tests/misc/test_ragfs_wheel_validation.py
+++ b/tests/misc/test_ragfs_wheel_validation.py
@@ -1,0 +1,70 @@
+import stat
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from build_support.ragfs_wheel import WheelValidationError, validate_linux_ragfs_wheel
+
+
+def _make_wheel(path: Path, members: dict[str, bytes]) -> Path:
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, contents in members.items():
+            archive.writestr(name, contents)
+    return path
+
+
+def _make_readelf(tmp_path: Path, output: str, return_code: int = 0) -> Path:
+    readelf = tmp_path / "readelf"
+    escaped_output = output.replace("\\", "\\\\").replace('"', '\\"')
+    readelf.write_text(
+        f'#!/bin/sh\nprintf "%s\\n" "{escaped_output}"\nexit {return_code}\n',
+        encoding="utf-8",
+    )
+    readelf.chmod(readelf.stat().st_mode | stat.S_IXUSR)
+    return readelf
+
+
+def _native_member() -> dict[str, bytes]:
+    return {"ragfs_python/ragfs_python.abi3.so": b"not an ELF file"}
+
+
+def test_clean_linux_ragfs_wheel_passes(tmp_path: Path):
+    wheel = _make_wheel(tmp_path / "clean.whl", _native_member())
+    readelf = _make_readelf(
+        tmp_path,
+        "Dynamic section at offset 0x0 contains 1 entry:\n"
+        " 0x0000000000000001 (NEEDED) Shared library: [libc.so.6]",
+    )
+
+    validate_linux_ragfs_wheel(wheel, readelf_binary=str(readelf))
+
+
+def test_asan_dependency_is_rejected(tmp_path: Path):
+    wheel = _make_wheel(tmp_path / "asan.whl", _native_member())
+    readelf = _make_readelf(
+        tmp_path,
+        " 0x0000000000000001 (NEEDED) Shared library: [libasan.so.8]",
+    )
+
+    with pytest.raises(WheelValidationError, match="links the ASan runtime"):
+        validate_linux_ragfs_wheel(wheel, readelf_binary=str(readelf))
+
+
+def test_bundled_asan_runtime_is_rejected_before_readelf(tmp_path: Path):
+    members = {
+        **_native_member(),
+        "ragfs_python.libs/libasan.so.8": b"asan runtime",
+    }
+    wheel = _make_wheel(tmp_path / "bundled-asan.whl", members)
+
+    with pytest.raises(WheelValidationError, match="packages an ASan runtime"):
+        validate_linux_ragfs_wheel(wheel, readelf_binary="does-not-exist")
+
+
+def test_readelf_failure_is_rejected(tmp_path: Path):
+    wheel = _make_wheel(tmp_path / "invalid.whl", _native_member())
+    readelf = _make_readelf(tmp_path, "not an ELF file", return_code=1)
+
+    with pytest.raises(WheelValidationError, match="readelf failed"):
+        validate_linux_ragfs_wheel(wheel, readelf_binary=str(readelf))


### PR DESCRIPTION
## Description

The current `main` branch no longer contains the workspace-excluded Mooncake adapter or `docker/mooncake-test`, so item 2 of #4468 is already covered by the RAGFS cache-runtime refactor. This PR addresses the remaining wheel-validation gap: native `ragfs_python` extensions are checked before packaging, and the final repaired Linux wheel is checked again.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Related to #4468

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Added `build_support.ragfs_wheel`, which rejects `DT_NEEDED`/dynamic-section ASan references and packaged `libasan*` files.
- Wired the guard into Linux wheel builds in `setup.py` and into the final repaired-wheel CI path.
- Added `binutils` to the Linux distribution build dependencies.
- Added clean, ASan-linked, bundled-ASan, and `readelf` failure coverage.
- Documented the guard in both English and Chinese cache guides.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

- Item 2 requires no new patch in the current tree: the Mooncake adapter and smoke-test files were removed by the cache-runtime refactor, and the manifest-isolation tests confirm that the legacy crate is absent.
- Focused validation passed: `PYTHONPATH=. pytest --noconftest -q tests/misc/test_ragfs_wheel_validation.py tests/misc/test_ragfs_python_manifest_isolation.py -o addopts=''` (8 passed); Ruff, Python compilation, workflow YAML parsing, and `cargo check -p ragfs-python` also passed.
- The actual Linux wheel build was not run locally because the development host is macOS; the Linux CI job now installs `binutils` and runs the guard after `auditwheel repair`.
- A broader selected packaging check still reports three unrelated repository assertions in `tests/misc/test_root_docker_image_packaging.py` and `tests/misc/test_abi3_packaging_config.py`.
