### PR TITLE
test(cli): create a real file for the non-recursive cp test (#4662)

### DIFF
--- a/tests/cli/test_cli_filesystem.py
+++ b/tests/cli/test_cli_filesystem.py
@@ -7,7 +7,7 @@ import tempfile
 import uuid
 
 import pytest
-from conftest import ov, ov_add_resource, ov_cp, ov_mkdir, ov_mv, ov_rm
+from conftest import ov, ov_add_resource, ov_cp, ov_mkdir, ov_mv, ov_rm, ov_write
 
 pytestmark = pytest.mark.cli_remote
 
@@ -143,11 +143,12 @@ class TestFsCp:
         source = f"{test_dir_uri}/cp_source_{suffix}.txt"
         json_target = f"{test_dir_uri}/cp_json_{suffix}.txt"
         human_target = f"{test_dir_uri}/cp_human_{suffix}.txt"
-        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False, mode="w") as f:
-            f.write("copy me")
-            temp_path = f.name
         try:
-            assert ov_add_resource(temp_path, source)["exit_code"] == 0
+            # `add-resource --to` creates a resource root directory even when
+            # the target URI ends in ".txt", so a non-recursive `ov cp` on it
+            # correctly fails with FAILED_PRECONDITION (#4662). Create a true
+            # file instead so this test keeps covering the file-copy path.
+            assert ov_write(source, "copy me", "--mode", "create")["exit_code"] == 0
             json_result = ov_cp(source, json_target)
             assert json_result["exit_code"] == 0, json_result["stderr"]
             assert json_result["json"] and json_result["json"].get("ok") is True
@@ -156,7 +157,6 @@ class TestFsCp:
             assert human_result["exit_code"] == 0, human_result["stderr"]
             assert "Copied:" in human_result["stdout"]
         finally:
-            os.unlink(temp_path)
             ov_rm(source)
             ov_rm(json_target)
             ov_rm(human_target)


### PR DESCRIPTION
## Problem

`06. API & CLI Integration Tests` has been failing on main since #4185 landed (`f6d9dec6`), identically on Ubuntu and macOS:

```text
tests/cli/test_cli_filesystem.py::TestFsCp::test_cp_file_json_and_human_output
FAILED_PRECONDITION: Cannot copy directory without --recursive: .../cp_source_*.txt
```

As diagnosed in #4662: the test staged its source via `ov_add_resource(temp_path, source)`, but `add-resource --to` creates a **resource root directory** even when the target URI ends in `.txt`. The server-side `stat` then correctly reports `isDir=true` and the non-recursive `ov cp` fails by design — the test data was wrong, not the copy implementation.

## Fix

Create a real file instead, exactly as suggested in #4662:

```python
assert ov_write(source, "copy me", "--mode", "create")["exit_code"] == 0
```

- `ov_write` (tests/cli/conftest.py) already passes `--wait --timeout`, so the file exists before `cp` runs.
- Deliberately **no `-r`** — otherwise the test would degrade into a directory copy and still not cover the file-copy path.
- Dropped the now-unneeded local temp file (`--content` carries the payload directly).

## Verification

- `pytest tests/cli/test_cli_filesystem.py --collect-only` → 13 tests collected, target test intact.
- `--mode create` confirmed as a server-side write mode (`openviking/storage/content_write.py`), same call shape as the existing `tests/cli/test_cli_snapshot.py` usage.
- Local end-to-end run needs the Rust `ov` binary plus a live model backend, so the integration pass is left to the API & CLI job, which demonstrably executes these tests on PR CI (the same job surfaces real fs_cp failures on other PRs).

Fixes #4662
