### PR TITLE
ci(pr): add a unit-test lane covering the tests/ tree

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -85,6 +85,43 @@ jobs:
           bash -n examples/codex-memory-plugin/setup-helper/install.sh
           bash -n examples/codex-memory-plugin/setup-helper/tos-install.sh
 
+  unit-tests:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install test dependencies
+        env:
+          # The unit-test tier below exercises pure-Python paths only; the
+          # native ragfs/ov/studio artifacts are not needed.
+          OV_SKIP_RAGFS_BUILD: '1'
+          OV_SKIP_OV_BUILD: '1'
+          OV_SKIP_STUDIO_BUILD: '1'
+        run: uv sync --frozen --extra test
+
+      - name: Run unit tests
+        run: |
+          # tests/test_session_task_tracking.py and tests/test_session_async_commit.py
+          # require the native task backend and are excluded from this tier.
+          UNIT_FILES=$(ls tests/test_*.py | grep -v -e test_session_task_tracking -e test_session_async_commit)
+          uv run pytest -q -o addopts='' -m "not integration and not cli_remote"             $UNIT_FILES             tests/ingest tests/metrics tests/models tests/observability             tests/resource tests/retrieve tests/telemetry tests/utils
+
+      # tests/cli must run in its own pytest process: its test modules do a bare
+      # ``from conftest import ...`` that resolves against whichever sibling
+      # tests/ subdirectory was collected first.
+      - name: Run unit tests (tests/cli)
+        run: |
+          uv run pytest -q -o addopts='' -m "not integration and not cli_remote" tests/cli
+
   check-deps:
     runs-on: ubuntu-24.04
     outputs:

--- a/tests/test_prompt_manager.py
+++ b/tests/test_prompt_manager.py
@@ -77,7 +77,7 @@ def test_profile_memory_template_includes_stable_identity_work_style_and_prefere
     )
 
     assert '"who the user is"' in text
-    assert "identity, work style, and preferences" in text
+    assert "relatively stable personal attributes" in text
     assert "profession, experience level, technical background" in text
     assert "communication style, work habits" in text
     assert "Do NOT include transient conversation content" in text
@@ -101,7 +101,7 @@ def test_preferences_memory_template_keeps_topic_specific_preferences():
     assert "specific topic" in text
     assert "code style, communication style, tools, workflow" in text
     assert "Store different topics as separate memory files" in text
-    assert "do not mix unrelated preferences" in text
+    assert "do NOT mix unrelated preferences" in text
 
 
 def test_prompt_manager_prefers_env_templates_dir_over_config(tmp_path, monkeypatch):

--- a/tests/utils/test_circuit_breaker.py
+++ b/tests/utils/test_circuit_breaker.py
@@ -181,12 +181,20 @@ def test_classify_chained_filesystem_error_as_permanent():
 
 def test_classify_permanent_errors():
     from openviking.utils.circuit_breaker import classify_api_error
-    from openviking.utils.model_retry import ERROR_CLASS_PERMANENT, ERROR_CLASS_TRANSIENT, ERROR_CLASS_UNKNOWN
+    from openviking.utils.model_retry import (
+        ERROR_CLASS_AUTH,
+        ERROR_CLASS_PERMANENT,
+        ERROR_CLASS_TRANSIENT,
+        ERROR_CLASS_UNKNOWN,
+    )
 
-    assert classify_api_error(RuntimeError("403 Forbidden")) == ERROR_CLASS_PERMANENT
-    assert classify_api_error(RuntimeError("AccountOverdueError: 403")) == ERROR_CLASS_PERMANENT
-    assert classify_api_error(RuntimeError("401 Unauthorized")) == ERROR_CLASS_PERMANENT
-    assert classify_api_error(RuntimeError("Forbidden")) == ERROR_CLASS_PERMANENT
+    # Since #2468, 401/403 are classified as auth (credential-level, may be
+    # resolved by switching credentials) rather than permanent.
+    assert classify_api_error(RuntimeError("403 Forbidden")) == ERROR_CLASS_AUTH
+    assert classify_api_error(RuntimeError("AccountOverdueError: 403")) == ERROR_CLASS_AUTH
+    assert classify_api_error(RuntimeError("401 Unauthorized")) == ERROR_CLASS_AUTH
+    assert classify_api_error(RuntimeError("Forbidden")) == ERROR_CLASS_AUTH
+    assert classify_api_error(RuntimeError("400 Bad Request")) == ERROR_CLASS_PERMANENT
 
 
 def test_classify_transient_errors():
@@ -212,9 +220,9 @@ def test_classify_unknown_errors():
 
 def test_classify_chained_exception():
     from openviking.utils.circuit_breaker import classify_api_error
-    from openviking.utils.model_retry import ERROR_CLASS_PERMANENT, ERROR_CLASS_TRANSIENT, ERROR_CLASS_UNKNOWN
+    from openviking.utils.model_retry import ERROR_CLASS_AUTH
 
     cause = RuntimeError("403 Forbidden")
     wrapper = RuntimeError("API call failed")
     wrapper.__cause__ = cause
-    assert classify_api_error(wrapper) == ERROR_CLASS_PERMANENT
+    assert classify_api_error(wrapper) == ERROR_CLASS_AUTH


### PR DESCRIPTION
> Supersedes #4674 (same branch and body; that one was closed because its title got polluted by an automation mishap on our side).

## Summary

The main `tests/` tree (637 test files covering `storage`, `session`, `service`, `ingest`, `metrics`, `parse`, `retrieve`, ...) currently has **zero CI coverage on PRs**:

- `pr.yml` runs the plugin-tests lane plus conditional `cuvs-tests` / `langchain-tests` lanes.
- `api_test.yml` runs the `tests/api_test/` black-box lane (real server + CLI) — which `pyproject.toml` keeps out of the default pytest run via `norecursedirs`.
- `_test_full.yml` ("13. _Test Suite (Full)") installs dependencies and builds extensions but **has no test step and no callers** — the full-suite lane was never wired up.

So for anything under `tests/` (except `api_test/`), the author's local machine is currently the *only* gate.

## Why this bites in practice

While maintaining PRs in this repo we hit this failure shape repeatedly:

- **#4375** — its lock-wait unit tests silently broke after the upstream internals they mocked were renamed; every CI check stayed green. Found only by a manual local re-run after a rebase.
- **#4371** — same family: `_FakeVikingFS` lacked a stub for `_ensure_access` added upstream; tests errored locally, green on CI.
- **`tests/utils/test_circuit_breaker.py`** — has been red **on main** since #2468 introduced the auth/permanent split: `classify_api_error("403 Forbidden")` returns `ERROR_CLASS_AUTH` while the assertions still expect `ERROR_CLASS_PERMANENT`. Nobody noticed because no lane runs `tests/utils`. Fixed in the first commit here.
- **`tests/test_prompt_manager.py`** — same drift for the profile/preferences template text (reworded upstream, assertions still pin the old phrasing). Fixed in the second commit.

A unit lane turns all four into red checks on the PR itself instead of relying on authors remembering to re-run locally after every rebase.

## What this adds

One `unit-tests` job to `pr.yml`:

- `ubuntu-24.04` + Python 3.10, `uv sync --frozen --extra test` with `OV_SKIP_RAGFS_BUILD=1` / `OV_SKIP_OV_BUILD=1` / `OV_SKIP_STUDIO_BUILD=1` — the tier below needs no native artifacts and no model configuration.
- Runs the directories that are green in a bare environment: top-level `tests/test_*.py` (minus `test_session_task_tracking.py` / `test_session_async_commit.py`, which need the native task backend) plus `ingest/ metrics/ models/ observability/ resource/ retrieve/ telemetry/ utils/`, and `tests/cli` in a **separate pytest process** — its modules do a bare `from conftest import ...` that resolves against whichever sibling `tests/` subdirectory is collected first, so it cannot share a run with e.g. `tests/metrics`.

## Local evidence (a8380147, Python 3.14)

- tier 1 (top-level + 8 dirs): **883 passed in 29s**
- `tests/cli`: **178 passed, 73 deselected** (`cli_remote` marker) in 11s
- with the two assertion fixes: 0 failed / 0 errors across 1061 tests

## Out of scope (follow-ups for maintainers to steer)

The remaining directories have environment-coupled failures that a bare runner cannot satisfy, roughly:

- `tests/server` (~709) + `tests/session` (~240): fixtures need the ragfs native binding and/or an `ov.conf` with model backends; some also collide when run in parallel (single-instance state).
- `tests/vectordb` / `tests/benchmark` / parts of `tests/unit`: cuVS extension (already has its own conditional lane via `_test_lite.yml`).
- `tests/parse` (~51): a mix of native-engine imports and encoding fixtures.

Tier 2 (server/session with ragfs built in CI, mock config) is doable but changes the runner setup; happy to prototype if there is interest.