### PR TITLE
fix(models): classify SiliconFlow code 20015 embedding 400s as input-too-large

### DIFF
--- a/openviking/utils/model_retry.py
+++ b/openviking/utils/model_retry.py
@@ -89,6 +89,13 @@ INPUT_TOO_LARGE_PATTERNS = (
     "exceeds the max input length",
     "is too large to process",
     "expected maxlength",
+    # SiliconFlow reports an oversized embedding input as a generic 400 whose
+    # payload carries code 20015 ("The parameter is invalid") with no size
+    # keyword in the message. Match the structured code field (both the dict
+    # repr and the JSON string form) so the message is skipped instead of
+    # arming the circuit breaker for the whole queue (#4676).
+    "code': 20015",
+    'code": 20015',
 )
 
 PERMANENT_API_ERROR_PATTERNS = ("400",)

--- a/tests/unit/test_model_retry.py
+++ b/tests/unit/test_model_retry.py
@@ -219,10 +219,37 @@ def test_quota_exceeded_case_insensitive():
             "'input (8525 tokens) is too large to process. increase the physical batch size "
             "(current batch size: 2048)', 'type': 'server_error'}}"
         ),
+        # SiliconFlow generic 400 with structured code 20015, dict-repr form (#4676)
+        (
+            "Error code: 400 - {'code': 20015, 'message': "
+            "'The parameter is invalid. Please check again.', 'data': None}"
+        ),
+        # JSON string form
+        'Error code: 400 - {"code": 20015, "message": "The parameter is invalid."}',
     ],
 )
 def test_classify_input_too_large_errors(message):
     assert classify_api_error(RuntimeError(message)) == ERROR_CLASS_INPUT_TOO_LARGE
+
+
+def test_other_siliconflow_400_codes_stay_permanent():
+    """Only code 20015 is reclassified; other SiliconFlow parameter errors
+    (e.g. a bad model name) must remain permanent request-level failures."""
+    error = RuntimeError(
+        "Error code: 400 - {'code': 20012, 'message': 'Model not exists', 'data': None}"
+    )
+    assert classify_api_error(error) == ERROR_CLASS_PERMANENT
+
+
+def test_20015_inside_request_id_is_not_input_too_large():
+    """A rate-limit error whose request ID happens to contain 20015 must not
+    be misclassified as INPUT_TOO_LARGE."""
+    error = RuntimeError(
+        "Error code: 429 - {'error': {'code': 'TooManyRequests', "
+        "'message': 'RPM limit exceeded', "
+        "'request_id': '0217801248873024200158fe53d7c9130f34413480585e683685bc95'}}"
+    )
+    assert classify_api_error(error) == ERROR_CLASS_TRANSIENT
 
 
 def test_retry_sync_does_not_retry_input_too_large():


### PR DESCRIPTION
## Problem

Follow-up to #931. On OpenAI-compatible providers that report an input-length violation as a **generic 400 with a structured code** (SiliconFlow: `code 20015`, "The parameter is invalid"), a single oversized document kills the entire `add_resource` indexing task:

1. The message contains none of the `INPUT_TOO_LARGE_PATTERNS` keywords, so `classify_api_error()` falls through to `PERMANENT_API_ERROR_PATTERNS = ("400",)` → `ERROR_CLASS_PERMANENT`.
2. The embedding handler in `collection_schemas.py` arms the circuit breaker on the permanent branch (`_circuit_breaker.record_failure(...)`), and the open breaker then drops / re-enqueues every semantic message until the whole indexing task fails.

Reported in #4676 with a verbatim repro (78 KB SQL file, `Pro/BAAI/bge-m3` via SiliconFlow, OpenViking 0.4.17).

## Fix

Add the structured code field to `INPUT_TOO_LARGE_PATTERNS` in both forms an error string can carry it:

```python
"code': 20015",   # dict-repr form from the OpenAI SDK message
'code": 20015',   # JSON string form
```

Classification order already checks `input_too_large` before `permanent`, and the `ERROR_CLASS_INPUT_TOO_LARGE` branch in the embedding handler already does the right thing (log + skip that single message, breaker untouched) — so the fix is a two-line pattern addition, no behavior redesign.

## Boundary

The patterns are deliberately anchored to the `code` field rather than the bare `20015` / "parameter is invalid" text, so the reclassification stays narrow:

- `test_other_siliconflow_400_codes_stay_permanent` — a 400 with code `20012` ("Model not exists") still classifies as permanent.
- `test_20015_inside_request_id_is_not_input_too_large` — a 429 whose request ID happens to contain `20015` stays transient.

Known trade-off: a *non-oversized* SiliconFlow 20015 (a genuinely malformed parameter OpenViking constructed itself) would now take the skip path instead of failing the task. For embedding requests — where OpenViking controls the parameter surface and oversized input is the dominant 20015 cause — degrading to a logged per-message skip is strictly better than killing the whole queue; the error is still logged with the resource URI.

## Relation to #4661

Orthogonal by construction: #4661 refactors the classification loop (`_classify_error_values`, structured-status-first) without touching the pattern tables, and this PR only extends a pattern table. Either merge order works; the only textual overlap is the tail of the same tuple.

## Open questions (from the reporter, intentionally out of scope here)

- **Conservative default truncation for unlisted models** (`resolve_embedding_max_input_tokens()` returning `None`) — a behavior change worth its own discussion: a too-low default would silently truncate requests that the provider would have accepted.
- **Request-level embedding failures should perhaps never arm the queue-wide breaker** — a design change in `collection_schemas.py` that also covers error shapes we cannot enumerate today.

## Testing

`tests/unit/test_model_retry.py`: **35 passed** locally (2 new parametrized forms + 2 boundary tests). CI covers this file in the unit-test lane.

Fixes #4676
