### PR TITLE
fix(pi-extension): tolerate hosts without buildContextEntries() (#4652)

### DIFF
--- a/examples/pi-coding-agent-extension/index.ts
+++ b/examples/pi-coding-agent-extension/index.ts
@@ -19,6 +19,7 @@ import { RecallLedger } from "./shared/recall-ledger.mjs";
 import { SyncManager } from "./sync.js";
 import { buildProfileBlock } from "./shared/profile-inject.mjs";
 import { guardVikingUriToolCall } from "./lib/uri-guard-adapter.mjs";
+import { collectUserEntryIds } from "./lib/context-entries.mjs";
 import { registerTools } from "./tools.js";
 import { createTakeoverManager } from "./takeover.js";
 
@@ -184,10 +185,11 @@ export default async function (pi: ExtensionAPI) {
     // The context hook omits persisted entry ids, but its user messages are a
     // deep copy of the active SessionManager context. Associate those objects
     // with stable ids before takeover may filter the array; retained messages
-    // keep object identity through that transform.
-    const userEntryIds = ctx.sessionManager.buildContextEntries()
-      .filter((entry: any) => entry?.type === "message" && entry.message?.role === "user")
-      .map((entry: any) => entry.id as string);
+    // keep object identity through that transform. Hosts without
+    // buildContextEntries() (e.g. OMP 18.1.5) expose the same persisted
+    // entries via getBranch(); with neither API we skip stable-id mapping
+    // rather than throwing (#4652).
+    const userEntryIds = collectUserEntryIds(ctx.sessionManager);
     const messageIds = new WeakMap<object, string>();
     let userIndex = 0;
     for (const message of event.messages as any[]) {

--- a/examples/pi-coding-agent-extension/lib/context-entries.mjs
+++ b/examples/pi-coding-agent-extension/lib/context-entries.mjs
@@ -1,0 +1,23 @@
+// Collect stable entry ids for user messages from the host SessionManager.
+//
+// Hosts differ in how they expose the persisted context: pi exposes
+// buildContextEntries(), while OMP (18.1.5+) exposes the equivalent entries
+// through getBranch(). When neither API exists, return an empty list so the
+// context hook skips stable-id mapping instead of throwing (#4652).
+export function collectUserEntryIds(sessionManager) {
+  const sm = sessionManager;
+  let entries;
+  if (sm && typeof sm.buildContextEntries === "function") {
+    entries = sm.buildContextEntries();
+  } else if (sm && typeof sm.getBranch === "function") {
+    entries = sm.getBranch();
+  } else {
+    entries = [];
+  }
+  if (!Array.isArray(entries)) return [];
+  // Positional placeholders (undefined) keep user-message index alignment
+  // intact when an entry carries no usable id.
+  return entries
+    .filter((entry) => entry?.type === "message" && entry.message?.role === "user")
+    .map((entry) => (typeof entry?.id === "string" ? entry.id : undefined));
+}

--- a/examples/pi-coding-agent-extension/tests/context-entries.test.mjs
+++ b/examples/pi-coding-agent-extension/tests/context-entries.test.mjs
@@ -1,0 +1,56 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { collectUserEntryIds } from "../lib/context-entries.mjs"
+
+const ENTRIES = [
+  { type: "message", id: "e1", message: { role: "user", content: "hi" } },
+  { type: "message", id: "e2", message: { role: "assistant", content: "hello" } },
+  { type: "message", id: "e3", message: { role: "user", content: "again" } },
+]
+
+test("prefers buildContextEntries when the host exposes it", () => {
+  const calls = []
+  const sm = {
+    buildContextEntries: () => { calls.push("bce"); return ENTRIES },
+    getBranch: () => { calls.push("gb"); return ENTRIES },
+  }
+  assert.deepEqual(collectUserEntryIds(sm), ["e1", "e3"])
+  assert.deepEqual(calls, ["bce"])
+})
+
+test("falls back to getBranch when buildContextEntries is missing (OMP 18.1.5)", () => {
+  const sm = { getBranch: () => ENTRIES }
+  assert.deepEqual(collectUserEntryIds(sm), ["e1", "e3"])
+})
+
+test("returns [] when neither API exists instead of throwing", () => {
+  assert.deepEqual(collectUserEntryIds({}), [])
+  assert.deepEqual(collectUserEntryIds(null), [])
+  assert.deepEqual(collectUserEntryIds(undefined), [])
+})
+
+test("returns [] when the host returns a non-array", () => {
+  assert.deepEqual(collectUserEntryIds({ buildContextEntries: () => null }), [])
+  assert.deepEqual(collectUserEntryIds({ getBranch: () => ({}) }), [])
+})
+
+test("keeps positional placeholders for id-less user entries", () => {
+  const entries = [
+    { type: "message", id: "e1", message: { role: "user" } },
+    { type: "message", message: { role: "user" } }, // no id: must stay aligned as undefined
+    { type: "message", id: 42, message: { role: "user" } }, // non-string id: same
+  ]
+  const sm = { buildContextEntries: () => entries }
+  assert.deepEqual(collectUserEntryIds(sm), ["e1", undefined, undefined])
+})
+
+test("ignores non-message entries and non-user roles", () => {
+  const entries = [
+    { type: "tool_call", id: "t1", message: { role: "user" } },
+    { type: "message", id: "e1", message: { role: "user" } },
+    { type: "message", id: "e2" },
+    null,
+    "garbage",
+  ]
+  assert.deepEqual(collectUserEntryIds({ getBranch: () => entries }), ["e1"])
+})


### PR DESCRIPTION
## Summary

Fixes #4652.

The Pi extension's `context` hook called `ctx.sessionManager.buildContextEntries()` unguarded. Hosts that expose the equivalent persisted entries through `getBranch()` instead (OMP 18.1.5 is Pi-compatible but has no `buildContextEntries`) throw from inside the hook, which prevents OpenViking from completing context transformation at all.

- Extract the user-entry-id collection into `lib/context-entries.mjs` with a three-tier fallback: `buildContextEntries()` when present → `getBranch()` as the OMP equivalent → empty list when neither API exists. With no host API, recall injection simply skips stable-id mapping instead of throwing; recall and takeover continue.
- `getBranch()` entries are already consumed elsewhere in this extension (`turn_end` → `syncBranch` → `entryPayload`) with the same `{type: "message", message: {role}}` shape, so the user-message filter works unchanged on the fallback path.
- Id-less user entries map to `undefined` placeholders, preserving the positional alignment between host entries and `event.messages` (a `filter` would silently shift indices).

## Testing

- New `tests/context-entries.test.mjs` (6 cases): prefers `buildContextEntries` when present; falls back to `getBranch` (OMP 18.1.5 shape); returns `[]` for hosts exposing neither API (object / null / undefined); tolerates non-array returns; keeps positional placeholders for id-less user entries; ignores non-message entries and non-user roles.
- Full extension suite: 64/64 green across all 8 test files (run per-file with `node --test`, matching the CI plugin-tests glob `examples/pi-coding-agent-extension/tests/*.test.mjs`).
