### PR TITLE
perf(ragfs): 无 redirects 时跳过 redirect 元数据读取

### DIFF
--- a/crates/ragfs/src/core/multibackend_wrapper.rs
+++ b/crates/ragfs/src/core/multibackend_wrapper.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use futures::stream::{self, StreamExt};
 use regex::Regex;
 use serde_json::Value;
 use tokio::sync::{Mutex, Notify};
@@ -21,11 +22,10 @@ use tokio::sync::{Mutex, Notify};
 use super::context::{FsContext, FS_CTX};
 use super::encryption_wrapper::EncryptionWrappedFS;
 use super::errors::{Error, Result};
-use super::filesystem::{normalize_prefix_path, relative_match_file, FileSystem};
+use super::filesystem::{normalize_prefix_path, relative_depth, relative_match_file, FileSystem};
 use super::types::{
-    BackendRole, BackendSyncState, FileInfo, GlobEntry, GlobPage, GrepResult,
-    OperationItemConfig, RedirectEntry, RedirectPolicy, SyncLogEntry, SyncOp, SyncType, TreeEntry,
-    WriteFlag,
+    BackendRole, BackendSyncState, FileInfo, GlobEntry, GlobPage, GrepResult, OperationItemConfig,
+    RedirectEntry, RedirectPolicy, SyncLogEntry, SyncOp, SyncType, TreeEntry, WriteFlag,
 };
 use crate::core::glob::{
     compare_rel_paths, decode_offset_token, encode_offset_token, PreparedGlob,
@@ -53,6 +53,8 @@ const DEFAULT_MAX_RETRIES_PER_ROUND: usize = 3;
 const DEFAULT_QUARANTINE_AFTER_FAILURES: u32 = 9;
 /// Default wait timeout when shutting down background tasks.
 const DEFAULT_SHUTDOWN_WAIT: Duration = Duration::from_secs(5);
+/// Maximum concurrent metadata reads when merging redirect entries into tree output.
+const DEFAULT_TREE_REDIRECT_META_CONCURRENCY: usize = 32;
 
 #[derive(Debug)]
 struct SyncFanoutTaskResult {
@@ -717,6 +719,10 @@ impl Inner {
         path: &str,
         ctx: &FsContext,
     ) -> Result<Option<Vec<String>>> {
+        if self.redirects.is_empty() {
+            return Ok(None);
+        }
+
         let dir = parent_dir(path);
         let name = file_name(path);
         let redirect_meta = self.meta_store.get_redirect_meta(&dir, ctx).await?;
@@ -1391,6 +1397,10 @@ impl FileSystem for MultiWriteWrappedFS {
         // Filter multi-write internal names.
         entries.retain(|e| !MULTIWRITE_INTERNAL_NAMES.contains(&e.name.as_str()));
 
+        if inner.redirects.is_empty() {
+            return Ok(entries);
+        }
+
         // Merge redirect entries so users can see redirected files in listings.
         let ctx =
             current_required_ctx().or_else(|_| inner.meta_store.ctx_resolver().resolve(path))?;
@@ -1546,6 +1556,10 @@ impl FileSystem for MultiWriteWrappedFS {
             !MULTIWRITE_INTERNAL_NAMES.contains(&file_name)
         });
         result.count = result.matches.len();
+
+        if inner.redirects.is_empty() {
+            return Ok(result);
+        }
 
         // For redirect files, also grep in target backends.
         let ctx = current_required_ctx()
@@ -1737,25 +1751,60 @@ impl FileSystem for MultiWriteWrappedFS {
             !MULTIWRITE_INTERNAL_NAMES.contains(&name)
         });
 
+        if self.inner.redirects.is_empty() {
+            return Ok(entries);
+        }
+
+        if node_limit.is_some_and(|limit| entries.len() >= limit) {
+            return Ok(entries);
+        }
+
         let ctx = current_required_ctx()
             .or_else(|_| self.inner.meta_store.ctx_resolver().resolve(&base))?;
         let mut seen_paths: HashSet<String> = entries.iter().map(|e| e.path.clone()).collect();
-        let mut dir_paths = vec![base.clone()];
+        let mut dir_paths = Vec::new();
+        let mut queued_dirs: HashSet<String> = HashSet::new();
+        if !matches!(level_limit, Some(0)) {
+            queued_dirs.insert(base.clone());
+            dir_paths.push(base.clone());
+        }
         for entry in &entries {
             if entry.info.is_dir {
                 let dir = normalize_prefix_path(&entry.path);
-                if !dir_paths.iter().any(|p| p == &dir) {
+                let may_emit_redirect_children = match level_limit {
+                    Some(limit) => {
+                        let rel = relative_match_file(&base, &dir);
+                        relative_depth(&rel) < limit
+                    }
+                    None => true,
+                };
+                if may_emit_redirect_children && queued_dirs.insert(dir.clone()) {
                     dir_paths.push(dir);
                 }
             }
         }
 
-        for dir in dir_paths {
-            let redirect_meta = match self.inner.meta_store.get_redirect_meta(&dir, &ctx).await {
-                Ok(meta) => meta,
-                Err(_) => continue,
+        let inner = Arc::clone(&self.inner);
+        let mut redirect_results = stream::iter(dir_paths)
+            .map(|dir| {
+                let inner = Arc::clone(&inner);
+                let ctx = ctx.clone();
+                async move {
+                    let redirect_meta = inner.meta_store.get_redirect_meta(&dir, &ctx).await.ok();
+                    (dir, redirect_meta)
+                }
+            })
+            .buffered(DEFAULT_TREE_REDIRECT_META_CONCURRENCY);
+
+        'redirect_dirs: while let Some((dir, redirect_meta)) = redirect_results.next().await {
+            let Some(redirect_meta) = redirect_meta else {
+                continue;
             };
             for (name, redirect_entry) in redirect_meta.entries {
+                if node_limit.is_some_and(|limit| entries.len() >= limit) {
+                    break 'redirect_dirs;
+                }
+
                 let virtual_path = if dir == "/" {
                     format!("/{}", name)
                 } else {
@@ -1773,6 +1822,9 @@ impl FileSystem for MultiWriteWrappedFS {
                         .trim_start_matches('/')
                         .to_string()
                 };
+                if level_limit.is_some_and(|limit| relative_depth(&rel_path) > limit) {
+                    continue;
+                }
                 let mut extra = HashMap::new();
                 extra.insert("redirect".to_string(), Value::Bool(true));
                 entries.push(TreeEntry {

--- a/crates/ragfs/src/core/multibackend_wrapper/routing.rs
+++ b/crates/ragfs/src/core/multibackend_wrapper/routing.rs
@@ -80,6 +80,11 @@ impl Inner {
             return Some(self.primary().backend.clone());
         }
 
+        if self.redirects.is_empty() {
+            self.record_read_route(ReadRouteSource::Miss);
+            return None;
+        }
+
         let dir = parent_dir(&normalized);
         let name = file_name(&normalized).to_string();
         let ctx = current_required_ctx()

--- a/crates/ragfs/src/core/multibackend_wrapper/tests.rs
+++ b/crates/ragfs/src/core/multibackend_wrapper/tests.rs
@@ -91,6 +91,93 @@ async fn test_read_dir_redirect_entries_use_target_stat() {
         })
         .await
         .unwrap();
+
+    let no_redirect_fs = test_multiwrite_fs(Vec::new());
+    let no_redirect_ctx = test_ctx();
+
+    FS_CTX
+        .scope(no_redirect_ctx.clone(), async {
+            no_redirect_fs
+                .ensure_parent_dirs("/local/acct/docs/real.txt", 0o755)
+                .await?;
+            no_redirect_fs
+                .write(
+                    "/local/acct/docs/real.txt",
+                    b"real body",
+                    0,
+                    WriteFlag::Create,
+                )
+                .await?;
+            no_redirect_fs
+                .inner
+                .meta_store
+                .update_dir_meta(
+                    "/local/acct/docs",
+                    &no_redirect_ctx,
+                    |redirect, _sync_log| {
+                        redirect.entries.insert(
+                            "ghost.pdf".to_string(),
+                            RedirectEntry {
+                                targets: vec!["backup1".to_string()],
+                            },
+                        );
+                        Ok(())
+                    },
+                )
+                .await?;
+            let backup = no_redirect_fs
+                .inner
+                .backup_by_name("backup1")
+                .expect("backup exists")
+                .backend
+                .clone();
+            backup
+                .ensure_parent_dirs("/local/acct/docs/ghost.pdf", 0o755)
+                .await?;
+            backup
+                .write(
+                    "/local/acct/docs/ghost.pdf",
+                    b"GHOST_MARKER\n",
+                    0,
+                    WriteFlag::Create,
+                )
+                .await?;
+
+            let entries = no_redirect_fs.read_dir("/local/acct/docs").await?;
+            let names: Vec<&str> = entries.iter().map(|entry| entry.name.as_str()).collect();
+            assert_eq!(names, vec!["real.txt"]);
+
+            let tree = no_redirect_fs
+                .tree_directory("/local/acct", false, None, Some(3))
+                .await?;
+            let paths: Vec<&str> = tree.iter().map(|entry| entry.path.as_str()).collect();
+            assert!(!paths.contains(&"/local/acct/docs/ghost.pdf"));
+
+            let grep = no_redirect_fs
+                .grep(
+                    "/local/acct/docs",
+                    "GHOST_MARKER",
+                    false,
+                    false,
+                    None,
+                    None,
+                    Some(1),
+                )
+                .await?;
+            assert_eq!(grep.count, 0);
+
+            let err = no_redirect_fs
+                .rename("/local/acct/docs/ghost.pdf", "/local/acct/docs/renamed.pdf")
+                .await
+                .expect_err("stale redirect metadata is ignored when redirects are disabled");
+            assert!(matches!(err, Error::NotFound(_)));
+            assert!(backup.exists("/local/acct/docs/ghost.pdf").await);
+            assert!(!backup.exists("/local/acct/docs/renamed.pdf").await);
+
+            Ok::<(), Error>(())
+        })
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -112,6 +199,36 @@ async fn test_recursive_grep_finds_nested_redirected_files() {
                 WriteFlag::Create,
             )
             .await?;
+
+            let shallow = fs
+                .tree_directory("/local/acct/resources", false, None, Some(1))
+                .await?;
+            let shallow_paths: Vec<&str> =
+                shallow.iter().map(|entry| entry.path.as_str()).collect();
+            assert_eq!(shallow_paths, vec!["/local/acct/resources/doc-1"]);
+
+            let root_only = fs
+                .tree_directory("/local/acct/resources", false, None, Some(0))
+                .await?;
+            assert!(root_only.is_empty());
+
+            let deep = fs
+                .tree_directory("/local/acct/resources", false, None, Some(2))
+                .await?;
+            let deep_paths: Vec<&str> = deep.iter().map(|entry| entry.path.as_str()).collect();
+            assert_eq!(
+                deep_paths,
+                vec![
+                    "/local/acct/resources/doc-1",
+                    "/local/acct/resources/doc-1/page.md",
+                ]
+            );
+
+            let capped = fs
+                .tree_directory("/local/acct/resources", false, Some(1), Some(2))
+                .await?;
+            let capped_paths: Vec<&str> = capped.iter().map(|entry| entry.path.as_str()).collect();
+            assert_eq!(capped_paths, vec!["/local/acct/resources/doc-1"]);
 
             let result = fs
                 .grep(

--- a/crates/ragfs/src/multibackend/meta.rs
+++ b/crates/ragfs/src/multibackend/meta.rs
@@ -345,16 +345,12 @@ impl MetaStateStore {
 
     /// Read redirect metadata for a directory (public, used by read_dir to merge redirect entries).
     pub async fn get_redirect_meta(&self, dir: &str, ctx: &FsContext) -> Result<RedirectMeta> {
-        self.read_dir_meta_pair(dir, ctx)
-            .await
-            .map(|(redirect, _)| redirect)
+        self.read_redirect_meta(dir, ctx).await
     }
 
     /// Read sync log metadata for a directory (public, used by retry_loop).
     pub async fn get_sync_log_meta(&self, dir: &str, ctx: &FsContext) -> Result<SyncLogMeta> {
-        self.read_dir_meta_pair(dir, ctx)
-            .await
-            .map(|(_, sync_log)| sync_log)
+        self.read_sync_log_meta(dir, ctx).await
     }
 
     /// Get a reference to the context resolver.


### PR DESCRIPTION
## Description

这个 PR 修复 multi-write filesystem 在没有配置 `redirects` 时，读路径仍然读取 redirect / sync-log 元数据的问题。

`redirects=[]` 表示当前实例没有启用 redirect 语义，普通读接口不应该每次读 `.redirect.json`；`.sync_log.json` 只属于同步 / retry 路径，也不应该被普通 redirect 读路径顺带读取。

### 复核结论（2026-09-04 更新）

这次补充复核后，结论调整为：

- PR 的有效收益在 **writer / multi-write 路径** 上可以稳定看到。
- enterprise 的 data-server 只读接口会路由到 `*-readonly` reader；当前 reader 配置是 single-backend（`backups=0`），不经过这个 PR 修改的 multi-write wrapper，所以 data-server 端到端读压测不能作为本 PR 收益证明。
- `redirects` 没有开启；两个 STG A/B 实例 writer/reader 均为 `redirects=0`。

### 本地 release 对比

```text
优化前：094b76f24bbb（PR merge commit 的 parent）
优化后：e273459c6478（PR #4683 merge commit）
Build：本地 macOS release build
配置：encrypted multi-write，local primary + local backup，redirects=0，300 files
样本：sequential 每组 30 次；concurrent 为 8 并发、总 80 次
```

| 场景 | 优化前 p50 | 优化前 p95 | 优化后 p50 | 优化后 p95 |
| --- | ---: | ---: | ---: | ---: |
| fs/tree node_limit=1 | 0.85ms | 0.90ms | 0.49ms | 0.62ms |
| fs/tree node_limit=10 | 0.85ms | 0.91ms | 0.49ms | 0.51ms |
| fs/tree node_limit=300 | 0.88ms | 0.91ms | 0.52ms | 0.56ms |
| 并发 fs/tree，c=8，total=80 | 2.58ms | 3.10ms | 1.94ms | 2.41ms |

说明：早先 Description 里的 “macOS dev build” 结果会放大旧路径成本，不应按云上 release 口径解读；这里改为 release build 结果。

### STG writer / multi-write 路径对比

```text
环境：STG 两组 A/B enterprise collection
访问路径：直接进入 writer pod，访问 localhost:1933
配置：local primary + async backup，redirects=0，多目录数据集（300 child dirs）
样本：sequential 每组 10 次
```

| 场景 | 优化前 p50 | 优化前 p95 | 优化后 p50 | 优化后 p95 |
| --- | ---: | ---: | ---: | ---: |
| fs/tree node_limit=1 | 35.04ms | 41.33ms | 25.37ms | 31.36ms |
| fs/tree node_limit=10 | 227.10ms | 250.27ms | 143.87ms | 158.40ms |
| fs/tree node_limit=300 | 1820.98ms | 1851.82ms | 1196.19ms | 1291.97ms |

同一数据集上，直接调用 raw RAGFS `tree_directory`，三轮中位数：

| 场景 | 优化前 p50 | 优化前 p95 | 优化后 p50 | 优化后 p95 |
| --- | ---: | ---: | ---: | ---: |
| raw tree node_limit=1 | 16.88ms | 18.96ms | 11.67ms | 14.08ms |
| raw tree node_limit=10 | 60.15ms | 64.45ms | 43.02ms | 55.35ms |
| raw tree node_limit=300 | 1597.01ms | 1730.14ms | 1030.98ms | 1119.79ms |

### STG data-server 端到端观察

enterprise 库的只读接口会走 reader：

```text
/api/v1/fs/tree 属于只读白名单
enterprise collection: data-server -> <ResourceID>-readonly reader service
reader storage config: local single-backend，backups=0，redirects=0
```

所以 data-server 端到端读压测基本看不到这个 PR 的收益，这是符合预期的路径差异，不代表 writer / multi-write 优化没有生效。

用同一个多目录数据集验证：

| 路径 | 场景 | 优化前 p50 | 优化前 p95 | 优化后 p50 | 优化后 p95 |
| --- | --- | ---: | ---: | ---: | ---: |
| data-server -> reader | fs/tree node_limit=300 | 1324.71ms | 1452.45ms | 1336.97ms | 1467.76ms |
| reader localhost | fs/tree node_limit=300 | 1291.22ms | 1371.37ms | 1248.87ms | 1324.21ms |

这两组结果说明：data-server 读接口测到的是 reader/single-backend 路径，不是本 PR 修改的 writer/multi-write 路径。

### 行为变化

修改前，`tree`、`read_dir`、`grep` 和单文件读路由即使在 `redirects=[]` 的实例上，也可能进入 redirect 元数据读取逻辑。并且旧的 `get_redirect_meta()` 会通过 `read_dir_meta_pair()` 同时读取 `.redirect.json` 和 `.sync_log.json`，导致普通 `tree` / `read_dir` 请求也会付出 sync-log 元数据读取成本。

修改后，只有实例实际配置了 redirect 后端时，读路径才读取 `.redirect.json`；sync-log 元数据只由同步 / retry 路径读取。

示例：

```text
配置：primary + 1 backup，encrypted multi-write，redirects=[]
请求：tree("/local/acct/resources", node_limit=300, level_limit=2)

修改前：primary tree + redirect meta lookup；get_redirect_meta 还会读 sync-log meta。
修改后：只返回 primary tree；因为没有启用 redirect 语义，所以跳过 redirect meta。
```

## Human Involvement

- [x] 有人类参与实现或 review 过程
- [ ] 此 PR 完全由 AI agents 生成，过程中无人类参与

## Related Issue

N/A

## Type of Change

- [x] Bug fix，不破坏兼容性的修复
- [ ] New feature，不破坏兼容性的新功能
- [ ] Breaking change，可能导致现有行为不兼容的变更
- [ ] Documentation update
- [ ] Refactoring，无行为变化的重构
- [x] Performance improvement
- [x] Test update

## Changes Made

- `redirects` 为空时，multi-write 的 `read_dir`、`tree_directory`、`grep` 和读路由直接走正常 primary / backup 读语义，不再读取 redirect 元数据。
- 拆开 `get_redirect_meta()` 和 `get_sync_log_meta()`，避免 redirect 读路径顺带读取 `.sync_log.json`。
- 保留 redirect 已启用时的行为，包括 redirected tree entry 合并、`node_limit` 和 `level_limit` 语义。

## Testing

- [x] 已修改现有测试覆盖本次修复
- [x] 新增/现有单测在本地通过
- [x] 已在以下平台验证：
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

命令：

```text
cargo test --quiet --manifest-path OpenViking/Cargo.toml -p ragfs multibackend_wrapper
cargo test --quiet --manifest-path OpenViking/Cargo.toml -p ragfs
git -C OpenViking diff --check HEAD~1..HEAD
python3 test_scripts/ragfs_tree_pressure_compare/bench.py --label before_release --ragfs-path /private/tmp/ov-pr4683-before/crates/ragfs --release
python3 test_scripts/ragfs_tree_pressure_compare/bench.py --label after_release --ragfs-path /private/tmp/ov-pr4683-after/crates/ragfs --release
python3 test_scripts/pr4683_kernel_ragfs_raw_compare.py --base-root <many-dir-base-uri> --head-root <many-dir-head-uri> --rounds 3
python3 test_scripts/pr4683_kernel_local_tree_dirs.py --component writer --iterations 10 --warmup 2
python3 test_scripts/pr4683_kernel_local_tree_dirs.py --component reader --iterations 10 --warmup 2
python3 test_scripts/stg_tree_dirs_ab_bench.py --dirs 300 --iterations 30 --warmup 5
```

结果：

```text
multibackend_wrapper: 18 passed
ragfs: 435 passed；integration group: 1 passed, 1 ignored
diff --check: passed
STG writer/multi-write A/B: completed，errors=0
STG data-server reader-path observation: completed，errors=0
```

说明：`cargo test` 仍会输出仓库已有 warning，主要是 git 模块缺少 doc、`lock/provider.rs` 里一个未使用变量；测试通过，本次改动没有引入新的测试失败。

## Checklist

- [x] 代码符合项目风格
- [x] 已完成自查
- [ ] 已为难懂逻辑添加注释
- [ ] 已更新相关文档
- [x] 本次改动没有引入新的 warning
- [ ] 依赖变更已合并并发布

## Screenshots (if applicable)

N/A

## Additional Notes

STG A/B collection 已创建并完成 writer/multi-write、reader/single-backend、data-server 端到端对比；有效收益以 writer/multi-write 结果为准。
