### PR TITLE
feat(memory-plugin): add an opt-in {git_port} peer source variable

### DIFF
--- a/docs/en/agent-integrations/16-capability-reference.md
+++ b/docs/en/agent-integrations/16-capability-reference.md
@@ -218,6 +218,7 @@ Family A resolves credentials in the following order (refer to individual profil
 | Variable | Value | Empty when |
 |---|---|---|
 | `{git_remote}` | The normalized `origin` URL as `github.com-org-repo`. Host and path are lowercased and `.git` plus any userinfo is dropped, so the ssh and https spellings of one repo agree and an embedded token can never reach the peer id. | Not a git repository, or `origin` is unset |
+| `{git_port}` | The remote's non-default port (`8443` in `https://forge.corp:8443/group/repo`), for an opt-in chain such as `["{git_remote}-{git_port}", "{git_remote}"]` | The remote carries no port or only its scheme's default |
 | `{git_root}` | The repository root path, under the legacy sanitation above | Outside a git repository. A marker file inside a repository still leaves this the repository's own root, so marking a subdirectory does not split the default peer |
 | `{cwd}` | The working directory, under the legacy sanitation above | Never — and it is in no default chain, so a bare path becomes a peer only when you ask for one |
 | `{dir}` | The workspace root's directory name: the repository root, or the directory holding `.openviking/config.json` | The directory is not a workspace |

--- a/docs/en/configuration/02-client.md
+++ b/docs/en/configuration/02-client.md
@@ -227,6 +227,7 @@ The other ways to set it, highest precedence first:
 | Variable | Value | Empty when |
 |---|---|---|
 | `{git_remote}` | Normalized `origin`, as `github.com-org-repo` | Outside a git repository, or the repository has no `origin` |
+| `{git_port}` | The remote's port when it is not the scheme's default (`8443` in `https://forge.corp:8443/group/repo`) | The remote carries no port — the scp spelling never does — or only its scheme's default |
 | `{git_root}` | Repository root path, with every non-alphanumeric character replaced by `-` | Outside a git repository. A `.openviking/config.json` inside a repository still leaves this the repository's own root, so marking a subdirectory does not split the default peer |
 | `{cwd}` | Working directory, with every non-alphanumeric character replaced by `-` | Never — and it is in no default chain, so a bare path becomes a peer only when you ask for one |
 | `{dir}` | The workspace root's directory name: the repository root, or the directory holding `.openviking/config.json` | The directory is not a workspace |
@@ -245,6 +246,7 @@ In `/Users/x/Dev/OpenViking/examples/codex-memory-plugin` with `origin` `git@git
 | One subproject of a monorepo needing its own memory | Put a `config.json` in the subdirectory with `peer.source: "{git_remote}-{dir}"`. A marker file alone keeps the repository's peer, because `{git_remote}` resolves first |
 | A throwaway task directory (a dated folder an app creates, an unpacked archive) | Nothing. Its memories go to your user-level space |
 | Each agent keeping its own memory of one repository | `peer.source: "{git_remote}-{harness}"`. Not the default — one shared project memory across agents is usually what you want, so this one is opt-in |
+| Two forges on one host and path (`:8443` vs `:9443`) | `peer.source: ["{git_remote}-{git_port}", "{git_remote}"]`. Not the default — ports are folded away so the ssh and https spellings of one repository agree, which self-hosted forges make common; this chain is for when one host really does serve two forges |
 | Several directories sharing one memory | Write the same `peer.id` in each |
 | Not wanting per-project separation at all | `peer.source: "none"` (the same as `OPENVIKING_WORKSPACE_PEER=0`) |
 

--- a/docs/zh/agent-integrations/16-capability-reference.md
+++ b/docs/zh/agent-integrations/16-capability-reference.md
@@ -220,6 +220,7 @@ per-harness 章节（档案卡）只写差异；所有共享事实均在本章�
 | 变量 | 取值 | 何时为空 |
 |---|---|---|
 | `{git_remote}` | 归一化后的 `origin`，形如 `github.com-org-repo`；host 与 path 转小写，`.git` 后缀与 userinfo 一并丢弃，因此同一仓库的 ssh / https 两种写法结果一致，且 URL 里内嵌的 token 不可能进入 peer id | 非 git 仓库，或未配 `origin` |
+| `{git_port}` | remote 的非默认端口（`https://forge.corp:8443/group/repo` 中的 `8443`），供自选链如 `["{git_remote}-{git_port}", "{git_remote}"]` 使用 | remote 不带端口，或只是协议默认端口 |
 | `{git_root}` | 仓库根路径，按上述旧 sanitation 处理 | 不在 git 仓库中。仓库内某个子目录放了标记文件时，它仍然是仓库自己的根，因此标记子目录不会拆散默认 peer |
 | `{cwd}` | 当前工作目录，按上述旧 sanitation 处理 | 从不为空——它也不在任何默认链里，裸路径只有在你明确要求时才会成为 peer |
 | `{dir}` | 工作区根目录的目录名：仓库根，或放着 `.openviking/config.json` 的那个目录 | 该目录不是工作区 |

--- a/docs/zh/configuration/02-client.md
+++ b/docs/zh/configuration/02-client.md
@@ -227,6 +227,7 @@ peer 是用户空间下的一段路径前缀——`viking://user/<you>/peers/<pe
 | 变量 | 取值 | 何时为空 |
 |---|---|---|
 | `{git_remote}` | 归一化后的 `origin`，形如 `github.com-org-repo` | 不在 git 仓库中，或仓库没有 `origin` |
+| `{git_port}` | remote 的端口，仅当它不是协议默认端口时才有值（如 `https://forge.corp:8443/group/repo` 的 `8443`） | remote 不带端口——scp 写法永远不带——或只是协议默认端口 |
 | `{git_root}` | 仓库根路径，所有非字母数字字符替换成 `-` | 不在 git 仓库中。仓库内某个子目录放了 `.openviking/config.json` 时，它仍然是仓库自己的根，因此标记子目录不会拆散默认 peer |
 | `{cwd}` | 工作目录，所有非字母数字字符替换成 `-` | 从不为空——它也不在任何默认链里，裸路径只有在你明确要求时才会成为 peer |
 | `{dir}` | 工作区根目录的目录名：仓库根，或放着 `.openviking/config.json` 的那个目录 | 该目录不是工作区 |
@@ -245,6 +246,7 @@ peer 是用户空间下的一段路径前缀——`viking://user/<you>/peers/<pe
 | monorepo 里某个子项目要单独记忆 | 在子目录放 `config.json`，写 `peer.source: "{git_remote}-{dir}"`。只放标记文件仍会沿用仓库 peer，因为 `{git_remote}` 先解析成功 |
 | 一次性任务目录（应用按日期新建的目录、临时解包目录） | 什么都不用做，记忆进入用户级空间 |
 | 同一仓库下各个 agent 想各存各的 | `peer.source: "{git_remote}-{harness}"`。默认不这么分——跨 agent 共享一份项目记忆通常才是想要的，所以这一档得自己写 |
+| 同一台主机、同一路径跑着两个 forge（`:8443` 与 `:9443`） | `peer.source: ["{git_remote}-{git_port}", "{git_remote}"]`。默认不这么分——端口会被折叠，好让同一仓库的 ssh 与 https 写法归为同一个 peer（自建 forge 常是这种形态）；这条链留给一台主机上确实跑着两个 forge 的场景 |
 | 几个目录共享一份记忆 | 各处写同一个 `peer.id` |
 | 不想按项目区分 | `peer.source: "none"`（等同于 `OPENVIKING_WORKSPACE_PEER=0`） |
 

--- a/examples/claude-code-memory-plugin/scripts/shared/workspace-identity.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/workspace-identity.mjs
@@ -30,6 +30,14 @@ const IDENTITY_CACHE_TTL_MS = 60_000;
 // hash suffix and for anything that later prefixes a peer id.
 const MAX_PEER_ID_LENGTH = 100;
 
+// The scheme default ports, stripped from the authority as identity-free:
+// folding them away is what makes the `ssh://` and `https://` spellings of one
+// repository agree, which the `git` preset depends on. `new URL` already drops
+// them for its special schemes, so the table carries the non-special ones git
+// remotes use — and it is also the judge of which explicit port `{git_port}`
+// surfaces: any port that is not the scheme's default.
+const DEFAULT_REMOTE_PORTS = { ssh: "22", http: "80", https: "443", git: "9418", rsync: "873" };
+
 export function stateDir(env = process.env) {
   const explicit = String(env.OPENVIKING_STATE_DIR || "").trim();
   if (explicit) return explicit;
@@ -77,43 +85,62 @@ export function sanitizePeerId(value) {
 }
 
 /**
+ * Parse a remote URL into its parts, or null when it names no shared identity.
+ *
+ * `port` is the explicit port as written. The scp spelling has no port syntax
+ * in git — a leading `8443/` there is a literal path — so it yields none, and
+ * `new URL` has already dropped the default port of its special schemes
+ * (`https://…:443` arrives as no port). The port never reaches the normalized
+ * remote; it exists for `{git_port}`.
+ */
+function parseGitRemote(url) {
+  const raw = String(url || "").trim();
+  if (!raw) return null;
+
+  // `C:\src\repo` and `C:/src/repo` are one machine's directory, not a shared
+  // identity — and the scp pattern would happily read the drive as a host.
+  if (/^[A-Za-z]:[\\/]/.test(raw)) return null;
+
+  const scp = /^(?:[^@/\\]+@)?([^:/\\]+):(?!\/)(.+)$/.exec(raw);
+  if (scp && !/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(raw)) {
+    return { scheme: "ssh", host: scp[1], path: scp[2], port: "" };
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  // A local clone has no stable shared identity — fall through to the path
+  // rules instead of minting one from `file://` or a bare directory.
+  if (parsed.protocol === "file:" || !parsed.hostname) return null;
+  return {
+    scheme: parsed.protocol.slice(0, -1),
+    host: parsed.hostname,
+    path: parsed.pathname,
+    port: parsed.port,
+  };
+}
+
+/**
  * Normalize a remote URL to `host/path`, lowercased.
  *
  * Both spellings of the same repo converge, and userinfo is dropped — so a
  * remote with an embedded token cannot leak it into a peer id. The cost of
  * case folding is that two repos differing only in case share one namespace on
- * the rare case-sensitive forge.
+ * the rare case-sensitive forge. Ports are folded away too, default or not:
+ * that is what keeps one repository one peer when its ssh and https remotes
+ * sit on different ports, which is the common self-hosted shape (#4565).
  */
 export function normalizeGitRemote(url) {
-  const raw = String(url || "").trim();
-  if (!raw) return "";
+  return normalizeParsedRemote(parseGitRemote(url));
+}
 
-  // `C:\src\repo` and `C:/src/repo` are one machine's directory, not a shared
-  // identity — and the scp pattern would happily read the drive as a host.
-  if (/^[A-Za-z]:[\\/]/.test(raw)) return "";
-
-  let host = "";
-  let path = "";
-  const scp = /^(?:[^@/\\]+@)?([^:/\\]+):(?!\/)(.+)$/.exec(raw);
-  if (scp && !/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(raw)) {
-    host = scp[1];
-    path = scp[2];
-  } else {
-    let parsed;
-    try {
-      parsed = new URL(raw);
-    } catch {
-      return "";
-    }
-    // A local clone has no stable shared identity — fall through to the path
-    // rules instead of minting one from `file://` or a bare directory.
-    if (parsed.protocol === "file:" || !parsed.hostname) return "";
-    host = parsed.hostname;
-    path = parsed.pathname;
-  }
-
-  host = host.toLowerCase().replace(/^\[|\]$/g, "");
-  path = path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "").toLowerCase();
+function normalizeParsedRemote(parts) {
+  if (!parts) return "";
+  const host = parts.host.toLowerCase().replace(/^\[|\]$/g, "");
+  const path = parts.path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "").toLowerCase();
   if (!host || !path) return "";
   return `${host}/${path}`;
 }
@@ -275,6 +302,12 @@ function readCache(path, now) {
     if (typeof cached?.ts !== "number" || cached.ts > now || now - cached.ts > IDENTITY_CACHE_TTL_MS) return null;
     const identity = cached.identity;
     if (identity && typeof identity === "object" && identity.vars && typeof identity.vars === "object") {
+      // A key set from an older build — before `git_port` existed — makes
+      // `renderPeerTemplate` treat the variable as empty rather than unknown,
+      // so a template naming it would silently fall through to the port-less
+      // one for the rest of the TTL. Treat the mismatch as a miss; the walk
+      // is cheap and the entry rewrites in the new shape.
+      if (!Object.hasOwn(identity.vars, "git_port")) return null;
       return identity;
     }
   } catch { /* a cold or corrupt cache just costs one walk */ }
@@ -308,8 +341,16 @@ export function resolveWorkspaceIdentity({ cwd = "", env = process.env, cache = 
   const { root, rootKind, git, gitRoot } = findWorkspaceRoot(key, env);
   // Only the normalized form is kept. The raw URL may carry a token, and this
   // file outlives the process — writing it here would undo the care
-  // `normalizeGitRemote` takes to drop userinfo.
-  const remote = git ? normalizeGitRemote(readGitRemoteUrl(git.commonDir)) : "";
+  // `parseGitRemote` takes to drop userinfo.
+  const remoteParts = git ? parseGitRemote(readGitRemoteUrl(git.commonDir)) : null;
+  const remote = normalizeParsedRemote(remoteParts);
+  // The port a forge is actually served on, empty for the scheme default and
+  // for the scp spelling. No preset names the variable, so the default peer
+  // keeps folding ports away; opting in is what separates two forges that
+  // share a host and path.
+  const gitPort = remoteParts?.port && remoteParts.port !== (DEFAULT_REMOTE_PORTS[remoteParts.scheme] || "")
+    ? remoteParts.port
+    : "";
   const identity = {
     cwd: key,
     root,
@@ -327,6 +368,7 @@ export function resolveWorkspaceIdentity({ cwd = "", env = process.env, cache = 
       git_root: git ? legacySanitize(gitRoot) : "",
       cwd: legacySanitize(key),
       dir: root ? sanitizePeerId(root.split(/[/\\]/).filter(Boolean).pop() || "") : "",
+      git_port: gitPort,
     },
   };
   if (cache) writeCache(path, identity, now);

--- a/examples/codex-memory-plugin/scripts/shared/workspace-identity.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/workspace-identity.mjs
@@ -30,6 +30,14 @@ const IDENTITY_CACHE_TTL_MS = 60_000;
 // hash suffix and for anything that later prefixes a peer id.
 const MAX_PEER_ID_LENGTH = 100;
 
+// The scheme default ports, stripped from the authority as identity-free:
+// folding them away is what makes the `ssh://` and `https://` spellings of one
+// repository agree, which the `git` preset depends on. `new URL` already drops
+// them for its special schemes, so the table carries the non-special ones git
+// remotes use — and it is also the judge of which explicit port `{git_port}`
+// surfaces: any port that is not the scheme's default.
+const DEFAULT_REMOTE_PORTS = { ssh: "22", http: "80", https: "443", git: "9418", rsync: "873" };
+
 export function stateDir(env = process.env) {
   const explicit = String(env.OPENVIKING_STATE_DIR || "").trim();
   if (explicit) return explicit;
@@ -77,43 +85,62 @@ export function sanitizePeerId(value) {
 }
 
 /**
+ * Parse a remote URL into its parts, or null when it names no shared identity.
+ *
+ * `port` is the explicit port as written. The scp spelling has no port syntax
+ * in git — a leading `8443/` there is a literal path — so it yields none, and
+ * `new URL` has already dropped the default port of its special schemes
+ * (`https://…:443` arrives as no port). The port never reaches the normalized
+ * remote; it exists for `{git_port}`.
+ */
+function parseGitRemote(url) {
+  const raw = String(url || "").trim();
+  if (!raw) return null;
+
+  // `C:\src\repo` and `C:/src/repo` are one machine's directory, not a shared
+  // identity — and the scp pattern would happily read the drive as a host.
+  if (/^[A-Za-z]:[\\/]/.test(raw)) return null;
+
+  const scp = /^(?:[^@/\\]+@)?([^:/\\]+):(?!\/)(.+)$/.exec(raw);
+  if (scp && !/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(raw)) {
+    return { scheme: "ssh", host: scp[1], path: scp[2], port: "" };
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  // A local clone has no stable shared identity — fall through to the path
+  // rules instead of minting one from `file://` or a bare directory.
+  if (parsed.protocol === "file:" || !parsed.hostname) return null;
+  return {
+    scheme: parsed.protocol.slice(0, -1),
+    host: parsed.hostname,
+    path: parsed.pathname,
+    port: parsed.port,
+  };
+}
+
+/**
  * Normalize a remote URL to `host/path`, lowercased.
  *
  * Both spellings of the same repo converge, and userinfo is dropped — so a
  * remote with an embedded token cannot leak it into a peer id. The cost of
  * case folding is that two repos differing only in case share one namespace on
- * the rare case-sensitive forge.
+ * the rare case-sensitive forge. Ports are folded away too, default or not:
+ * that is what keeps one repository one peer when its ssh and https remotes
+ * sit on different ports, which is the common self-hosted shape (#4565).
  */
 export function normalizeGitRemote(url) {
-  const raw = String(url || "").trim();
-  if (!raw) return "";
+  return normalizeParsedRemote(parseGitRemote(url));
+}
 
-  // `C:\src\repo` and `C:/src/repo` are one machine's directory, not a shared
-  // identity — and the scp pattern would happily read the drive as a host.
-  if (/^[A-Za-z]:[\\/]/.test(raw)) return "";
-
-  let host = "";
-  let path = "";
-  const scp = /^(?:[^@/\\]+@)?([^:/\\]+):(?!\/)(.+)$/.exec(raw);
-  if (scp && !/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(raw)) {
-    host = scp[1];
-    path = scp[2];
-  } else {
-    let parsed;
-    try {
-      parsed = new URL(raw);
-    } catch {
-      return "";
-    }
-    // A local clone has no stable shared identity — fall through to the path
-    // rules instead of minting one from `file://` or a bare directory.
-    if (parsed.protocol === "file:" || !parsed.hostname) return "";
-    host = parsed.hostname;
-    path = parsed.pathname;
-  }
-
-  host = host.toLowerCase().replace(/^\[|\]$/g, "");
-  path = path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "").toLowerCase();
+function normalizeParsedRemote(parts) {
+  if (!parts) return "";
+  const host = parts.host.toLowerCase().replace(/^\[|\]$/g, "");
+  const path = parts.path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "").toLowerCase();
   if (!host || !path) return "";
   return `${host}/${path}`;
 }
@@ -275,6 +302,12 @@ function readCache(path, now) {
     if (typeof cached?.ts !== "number" || cached.ts > now || now - cached.ts > IDENTITY_CACHE_TTL_MS) return null;
     const identity = cached.identity;
     if (identity && typeof identity === "object" && identity.vars && typeof identity.vars === "object") {
+      // A key set from an older build — before `git_port` existed — makes
+      // `renderPeerTemplate` treat the variable as empty rather than unknown,
+      // so a template naming it would silently fall through to the port-less
+      // one for the rest of the TTL. Treat the mismatch as a miss; the walk
+      // is cheap and the entry rewrites in the new shape.
+      if (!Object.hasOwn(identity.vars, "git_port")) return null;
       return identity;
     }
   } catch { /* a cold or corrupt cache just costs one walk */ }
@@ -308,8 +341,16 @@ export function resolveWorkspaceIdentity({ cwd = "", env = process.env, cache = 
   const { root, rootKind, git, gitRoot } = findWorkspaceRoot(key, env);
   // Only the normalized form is kept. The raw URL may carry a token, and this
   // file outlives the process — writing it here would undo the care
-  // `normalizeGitRemote` takes to drop userinfo.
-  const remote = git ? normalizeGitRemote(readGitRemoteUrl(git.commonDir)) : "";
+  // `parseGitRemote` takes to drop userinfo.
+  const remoteParts = git ? parseGitRemote(readGitRemoteUrl(git.commonDir)) : null;
+  const remote = normalizeParsedRemote(remoteParts);
+  // The port a forge is actually served on, empty for the scheme default and
+  // for the scp spelling. No preset names the variable, so the default peer
+  // keeps folding ports away; opting in is what separates two forges that
+  // share a host and path.
+  const gitPort = remoteParts?.port && remoteParts.port !== (DEFAULT_REMOTE_PORTS[remoteParts.scheme] || "")
+    ? remoteParts.port
+    : "";
   const identity = {
     cwd: key,
     root,
@@ -327,6 +368,7 @@ export function resolveWorkspaceIdentity({ cwd = "", env = process.env, cache = 
       git_root: git ? legacySanitize(gitRoot) : "",
       cwd: legacySanitize(key),
       dir: root ? sanitizePeerId(root.split(/[/\\]/).filter(Boolean).pop() || "") : "",
+      git_port: gitPort,
     },
   };
   if (cache) writeCache(path, identity, now);

--- a/examples/dsh-memory-plugin/shared/workspace-identity.mjs
+++ b/examples/dsh-memory-plugin/shared/workspace-identity.mjs
@@ -30,6 +30,14 @@ const IDENTITY_CACHE_TTL_MS = 60_000;
 // hash suffix and for anything that later prefixes a peer id.
 const MAX_PEER_ID_LENGTH = 100;
 
+// The scheme default ports, stripped from the authority as identity-free:
+// folding them away is what makes the `ssh://` and `https://` spellings of one
+// repository agree, which the `git` preset depends on. `new URL` already drops
+// them for its special schemes, so the table carries the non-special ones git
+// remotes use — and it is also the judge of which explicit port `{git_port}`
+// surfaces: any port that is not the scheme's default.
+const DEFAULT_REMOTE_PORTS = { ssh: "22", http: "80", https: "443", git: "9418", rsync: "873" };
+
 export function stateDir(env = process.env) {
   const explicit = String(env.OPENVIKING_STATE_DIR || "").trim();
   if (explicit) return explicit;
@@ -77,43 +85,62 @@ export function sanitizePeerId(value) {
 }
 
 /**
+ * Parse a remote URL into its parts, or null when it names no shared identity.
+ *
+ * `port` is the explicit port as written. The scp spelling has no port syntax
+ * in git — a leading `8443/` there is a literal path — so it yields none, and
+ * `new URL` has already dropped the default port of its special schemes
+ * (`https://…:443` arrives as no port). The port never reaches the normalized
+ * remote; it exists for `{git_port}`.
+ */
+function parseGitRemote(url) {
+  const raw = String(url || "").trim();
+  if (!raw) return null;
+
+  // `C:\src\repo` and `C:/src/repo` are one machine's directory, not a shared
+  // identity — and the scp pattern would happily read the drive as a host.
+  if (/^[A-Za-z]:[\\/]/.test(raw)) return null;
+
+  const scp = /^(?:[^@/\\]+@)?([^:/\\]+):(?!\/)(.+)$/.exec(raw);
+  if (scp && !/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(raw)) {
+    return { scheme: "ssh", host: scp[1], path: scp[2], port: "" };
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  // A local clone has no stable shared identity — fall through to the path
+  // rules instead of minting one from `file://` or a bare directory.
+  if (parsed.protocol === "file:" || !parsed.hostname) return null;
+  return {
+    scheme: parsed.protocol.slice(0, -1),
+    host: parsed.hostname,
+    path: parsed.pathname,
+    port: parsed.port,
+  };
+}
+
+/**
  * Normalize a remote URL to `host/path`, lowercased.
  *
  * Both spellings of the same repo converge, and userinfo is dropped — so a
  * remote with an embedded token cannot leak it into a peer id. The cost of
  * case folding is that two repos differing only in case share one namespace on
- * the rare case-sensitive forge.
+ * the rare case-sensitive forge. Ports are folded away too, default or not:
+ * that is what keeps one repository one peer when its ssh and https remotes
+ * sit on different ports, which is the common self-hosted shape (#4565).
  */
 export function normalizeGitRemote(url) {
-  const raw = String(url || "").trim();
-  if (!raw) return "";
+  return normalizeParsedRemote(parseGitRemote(url));
+}
 
-  // `C:\src\repo` and `C:/src/repo` are one machine's directory, not a shared
-  // identity — and the scp pattern would happily read the drive as a host.
-  if (/^[A-Za-z]:[\\/]/.test(raw)) return "";
-
-  let host = "";
-  let path = "";
-  const scp = /^(?:[^@/\\]+@)?([^:/\\]+):(?!\/)(.+)$/.exec(raw);
-  if (scp && !/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(raw)) {
-    host = scp[1];
-    path = scp[2];
-  } else {
-    let parsed;
-    try {
-      parsed = new URL(raw);
-    } catch {
-      return "";
-    }
-    // A local clone has no stable shared identity — fall through to the path
-    // rules instead of minting one from `file://` or a bare directory.
-    if (parsed.protocol === "file:" || !parsed.hostname) return "";
-    host = parsed.hostname;
-    path = parsed.pathname;
-  }
-
-  host = host.toLowerCase().replace(/^\[|\]$/g, "");
-  path = path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "").toLowerCase();
+function normalizeParsedRemote(parts) {
+  if (!parts) return "";
+  const host = parts.host.toLowerCase().replace(/^\[|\]$/g, "");
+  const path = parts.path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "").toLowerCase();
   if (!host || !path) return "";
   return `${host}/${path}`;
 }
@@ -275,6 +302,12 @@ function readCache(path, now) {
     if (typeof cached?.ts !== "number" || cached.ts > now || now - cached.ts > IDENTITY_CACHE_TTL_MS) return null;
     const identity = cached.identity;
     if (identity && typeof identity === "object" && identity.vars && typeof identity.vars === "object") {
+      // A key set from an older build — before `git_port` existed — makes
+      // `renderPeerTemplate` treat the variable as empty rather than unknown,
+      // so a template naming it would silently fall through to the port-less
+      // one for the rest of the TTL. Treat the mismatch as a miss; the walk
+      // is cheap and the entry rewrites in the new shape.
+      if (!Object.hasOwn(identity.vars, "git_port")) return null;
       return identity;
     }
   } catch { /* a cold or corrupt cache just costs one walk */ }
@@ -308,8 +341,16 @@ export function resolveWorkspaceIdentity({ cwd = "", env = process.env, cache = 
   const { root, rootKind, git, gitRoot } = findWorkspaceRoot(key, env);
   // Only the normalized form is kept. The raw URL may carry a token, and this
   // file outlives the process — writing it here would undo the care
-  // `normalizeGitRemote` takes to drop userinfo.
-  const remote = git ? normalizeGitRemote(readGitRemoteUrl(git.commonDir)) : "";
+  // `parseGitRemote` takes to drop userinfo.
+  const remoteParts = git ? parseGitRemote(readGitRemoteUrl(git.commonDir)) : null;
+  const remote = normalizeParsedRemote(remoteParts);
+  // The port a forge is actually served on, empty for the scheme default and
+  // for the scp spelling. No preset names the variable, so the default peer
+  // keeps folding ports away; opting in is what separates two forges that
+  // share a host and path.
+  const gitPort = remoteParts?.port && remoteParts.port !== (DEFAULT_REMOTE_PORTS[remoteParts.scheme] || "")
+    ? remoteParts.port
+    : "";
   const identity = {
     cwd: key,
     root,
@@ -327,6 +368,7 @@ export function resolveWorkspaceIdentity({ cwd = "", env = process.env, cache = 
       git_root: git ? legacySanitize(gitRoot) : "",
       cwd: legacySanitize(key),
       dir: root ? sanitizePeerId(root.split(/[/\\]/).filter(Boolean).pop() || "") : "",
+      git_port: gitPort,
     },
   };
   if (cache) writeCache(path, identity, now);

--- a/examples/memory-plugin-shared/lib/workspace-identity.mjs
+++ b/examples/memory-plugin-shared/lib/workspace-identity.mjs
@@ -29,6 +29,14 @@ const IDENTITY_CACHE_TTL_MS = 60_000;
 // hash suffix and for anything that later prefixes a peer id.
 const MAX_PEER_ID_LENGTH = 100;
 
+// The scheme default ports, stripped from the authority as identity-free:
+// folding them away is what makes the `ssh://` and `https://` spellings of one
+// repository agree, which the `git` preset depends on. `new URL` already drops
+// them for its special schemes, so the table carries the non-special ones git
+// remotes use — and it is also the judge of which explicit port `{git_port}`
+// surfaces: any port that is not the scheme's default.
+const DEFAULT_REMOTE_PORTS = { ssh: "22", http: "80", https: "443", git: "9418", rsync: "873" };
+
 export function stateDir(env = process.env) {
   const explicit = String(env.OPENVIKING_STATE_DIR || "").trim();
   if (explicit) return explicit;
@@ -76,43 +84,62 @@ export function sanitizePeerId(value) {
 }
 
 /**
+ * Parse a remote URL into its parts, or null when it names no shared identity.
+ *
+ * `port` is the explicit port as written. The scp spelling has no port syntax
+ * in git — a leading `8443/` there is a literal path — so it yields none, and
+ * `new URL` has already dropped the default port of its special schemes
+ * (`https://…:443` arrives as no port). The port never reaches the normalized
+ * remote; it exists for `{git_port}`.
+ */
+function parseGitRemote(url) {
+  const raw = String(url || "").trim();
+  if (!raw) return null;
+
+  // `C:\src\repo` and `C:/src/repo` are one machine's directory, not a shared
+  // identity — and the scp pattern would happily read the drive as a host.
+  if (/^[A-Za-z]:[\\/]/.test(raw)) return null;
+
+  const scp = /^(?:[^@/\\]+@)?([^:/\\]+):(?!\/)(.+)$/.exec(raw);
+  if (scp && !/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(raw)) {
+    return { scheme: "ssh", host: scp[1], path: scp[2], port: "" };
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  // A local clone has no stable shared identity — fall through to the path
+  // rules instead of minting one from `file://` or a bare directory.
+  if (parsed.protocol === "file:" || !parsed.hostname) return null;
+  return {
+    scheme: parsed.protocol.slice(0, -1),
+    host: parsed.hostname,
+    path: parsed.pathname,
+    port: parsed.port,
+  };
+}
+
+/**
  * Normalize a remote URL to `host/path`, lowercased.
  *
  * Both spellings of the same repo converge, and userinfo is dropped — so a
  * remote with an embedded token cannot leak it into a peer id. The cost of
  * case folding is that two repos differing only in case share one namespace on
- * the rare case-sensitive forge.
+ * the rare case-sensitive forge. Ports are folded away too, default or not:
+ * that is what keeps one repository one peer when its ssh and https remotes
+ * sit on different ports, which is the common self-hosted shape (#4565).
  */
 export function normalizeGitRemote(url) {
-  const raw = String(url || "").trim();
-  if (!raw) return "";
+  return normalizeParsedRemote(parseGitRemote(url));
+}
 
-  // `C:\src\repo` and `C:/src/repo` are one machine's directory, not a shared
-  // identity — and the scp pattern would happily read the drive as a host.
-  if (/^[A-Za-z]:[\\/]/.test(raw)) return "";
-
-  let host = "";
-  let path = "";
-  const scp = /^(?:[^@/\\]+@)?([^:/\\]+):(?!\/)(.+)$/.exec(raw);
-  if (scp && !/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(raw)) {
-    host = scp[1];
-    path = scp[2];
-  } else {
-    let parsed;
-    try {
-      parsed = new URL(raw);
-    } catch {
-      return "";
-    }
-    // A local clone has no stable shared identity — fall through to the path
-    // rules instead of minting one from `file://` or a bare directory.
-    if (parsed.protocol === "file:" || !parsed.hostname) return "";
-    host = parsed.hostname;
-    path = parsed.pathname;
-  }
-
-  host = host.toLowerCase().replace(/^\[|\]$/g, "");
-  path = path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "").toLowerCase();
+function normalizeParsedRemote(parts) {
+  if (!parts) return "";
+  const host = parts.host.toLowerCase().replace(/^\[|\]$/g, "");
+  const path = parts.path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "").toLowerCase();
   if (!host || !path) return "";
   return `${host}/${path}`;
 }
@@ -274,6 +301,12 @@ function readCache(path, now) {
     if (typeof cached?.ts !== "number" || cached.ts > now || now - cached.ts > IDENTITY_CACHE_TTL_MS) return null;
     const identity = cached.identity;
     if (identity && typeof identity === "object" && identity.vars && typeof identity.vars === "object") {
+      // A key set from an older build — before `git_port` existed — makes
+      // `renderPeerTemplate` treat the variable as empty rather than unknown,
+      // so a template naming it would silently fall through to the port-less
+      // one for the rest of the TTL. Treat the mismatch as a miss; the walk
+      // is cheap and the entry rewrites in the new shape.
+      if (!Object.hasOwn(identity.vars, "git_port")) return null;
       return identity;
     }
   } catch { /* a cold or corrupt cache just costs one walk */ }
@@ -307,8 +340,16 @@ export function resolveWorkspaceIdentity({ cwd = "", env = process.env, cache = 
   const { root, rootKind, git, gitRoot } = findWorkspaceRoot(key, env);
   // Only the normalized form is kept. The raw URL may carry a token, and this
   // file outlives the process — writing it here would undo the care
-  // `normalizeGitRemote` takes to drop userinfo.
-  const remote = git ? normalizeGitRemote(readGitRemoteUrl(git.commonDir)) : "";
+  // `parseGitRemote` takes to drop userinfo.
+  const remoteParts = git ? parseGitRemote(readGitRemoteUrl(git.commonDir)) : null;
+  const remote = normalizeParsedRemote(remoteParts);
+  // The port a forge is actually served on, empty for the scheme default and
+  // for the scp spelling. No preset names the variable, so the default peer
+  // keeps folding ports away; opting in is what separates two forges that
+  // share a host and path.
+  const gitPort = remoteParts?.port && remoteParts.port !== (DEFAULT_REMOTE_PORTS[remoteParts.scheme] || "")
+    ? remoteParts.port
+    : "";
   const identity = {
     cwd: key,
     root,
@@ -326,6 +367,7 @@ export function resolveWorkspaceIdentity({ cwd = "", env = process.env, cache = 
       git_root: git ? legacySanitize(gitRoot) : "",
       cwd: legacySanitize(key),
       dir: root ? sanitizePeerId(root.split(/[/\\]/).filter(Boolean).pop() || "") : "",
+      git_port: gitPort,
     },
   };
   if (cache) writeCache(path, identity, now);

--- a/examples/memory-plugin-shared/workspace-identity.test.mjs
+++ b/examples/memory-plugin-shared/workspace-identity.test.mjs
@@ -61,6 +61,24 @@ test("normalizeGitRemote refuses identities that are only local", () => {
   }
 });
 
+test("normalizeGitRemote keeps folding ports away, default or not", () => {
+  // Deliberate, and the RFC's own worked example: a self-hosted forge serves
+  // ssh and https on different ports (GitLab alt-ssh 2222, https 443), and
+  // those are two spellings of one repository — folding the port is what keeps
+  // them one peer. The opt-in `{git_port}` template variable is where a port
+  // shows up, so no default chain changes here.
+  const expected = "gitlab.corp/group/repo";
+  for (const url of [
+    "https://gitlab.corp/group/repo.git",
+    "https://gitlab.corp:443/group/repo.git",
+    "ssh://git@gitlab.corp:2222/group/repo.git",
+    "http://gitlab.corp:80/group/repo.git",
+    "git://gitlab.corp:9418/group/repo.git",
+  ]) {
+    assert.equal(normalizeGitRemote(url), expected, `failed on ${url}`);
+  }
+});
+
 test("sanitizePeerId produces a server-valid id and dodges the reserved names", () => {
   assert.equal(sanitizePeerId("github.com/volcengine/openviking"), "github.com-volcengine-openviking");
   assert.match(sanitizePeerId("github.com/volcengine/openviking"), /^[a-zA-Z0-9_.@-]+$/);
@@ -245,7 +263,7 @@ test("identity exposes every template variable, git and non-git alike", async ()
   assert.equal(identity.vars.dir, sanitizePeerId(root.split("/").pop()));
   // `harness` belongs to the caller, not here: this result is cached on disk
   // under a cwd-only key, which two harnesses in one directory would share.
-  assert.deepEqual(Object.keys(identity.vars).sort(), ["cwd", "dir", "git_remote", "git_root"]);
+  assert.deepEqual(Object.keys(identity.vars).sort(), ["cwd", "dir", "git_port", "git_remote", "git_root"]);
 
   const plain = await tempRoot("plain");
   const outside = resolveWorkspaceIdentity({ cwd: plain, env, cache: false });
@@ -254,6 +272,30 @@ test("identity exposes every template variable, git and non-git alike", async ()
   assert.equal(outside.vars.git_root, "");
   assert.equal(outside.vars.dir, "", "a directory that is no workspace names nothing");
   assert.equal(outside.vars.cwd, legacySanitize(plain));
+  assert.equal(outside.vars.git_port, "");
+});
+
+test("git_port surfaces only a port that is not the scheme's default", async () => {
+  const root = await tempRoot("port");
+  await makeRepo(root, { remote: "https://forge.corp:8443/group/repo.git" });
+  const env = { HOME: "/nonexistent-home", OPENVIKING_STATE_DIR: join(root, ".state") };
+  assert.equal(resolveWorkspaceIdentity({ cwd: root, env, cache: false }).vars.git_port, "8443");
+
+  for (const [remote, note] of [
+    ["https://forge.corp/group/repo.git", "no port at all"],
+    ["https://forge.corp:443/group/repo.git", "the special scheme's own default"],
+    ["ssh://git@forge.corp:22/group/repo.git", "a non-special scheme's default"],
+    ["git://forge.corp:9418/group/repo.git", "the git scheme's default"],
+    ["rsync://forge.corp:873/group/repo.git", "the rsync scheme's default"],
+    ["git@forge.corp:group/repo.git", "the scp spelling has no port syntax"],
+  ]) {
+    await writeFile(join(root, ".git", "config"), `[remote "origin"]\n\turl = ${remote}\n`);
+    assert.equal(
+      resolveWorkspaceIdentity({ cwd: root, env, cache: false }).vars.git_port,
+      "",
+      `${remote}: ${note}`,
+    );
+  }
 });
 
 test("a repo with no origin leaves git_remote empty but still names the root", async () => {
@@ -362,6 +404,29 @@ test("a cache holding the wrong shape is re-derived instead of returned", async 
 
   const identity = resolveWorkspaceIdentity({ cwd: root, env, now: 1000 });
   assert.equal(identity.vars.git_remote, "github.com-o-r");
+});
+
+test("a cache entry from before git_port existed is re-derived, not served", async () => {
+  const root = await tempRoot("oldcache");
+  await makeRepo(root, { remote: "https://forge.corp:8443/group/repo.git" });
+  const state = join(root, ".state");
+  const env = { HOME: "/nonexistent-home", OPENVIKING_STATE_DIR: state };
+
+  const identity = resolveWorkspaceIdentity({ cwd: root, env, now: 1000 });
+  assert.equal(identity.vars.git_port, "8443");
+  // Rewrite the entry the way a pre-git_port build wrote it: a valid identity
+  // whose vars key set simply predates the variable. Serving it would render
+  // `{git_port}` as empty — and to `renderPeerTemplate` an empty variable
+  // falls through exactly like an absent one, so the port-less template would
+  // win for the rest of the TTL without anyone seeing why.
+  for (const name of await readdir(state)) {
+    const cached = JSON.parse(await readFile(join(state, name), "utf-8"));
+    delete cached.identity.vars.git_port;
+    await writeFile(join(state, name), JSON.stringify(cached));
+  }
+
+  const rederived = resolveWorkspaceIdentity({ cwd: root, env, now: 1000 });
+  assert.equal(rederived.vars.git_port, "8443", "a stale key set is a miss, not a value");
 });
 
 test("findWorkspaceRoot returns nothing rather than throwing on a dead cwd", () => {

--- a/examples/memory-plugin-shared/workspace-peer.test.mjs
+++ b/examples/memory-plugin-shared/workspace-peer.test.mjs
@@ -162,6 +162,32 @@ test("{harness} splits one repository per agent, for whoever asks for it", async
   assert.equal(chain.origin, "{git_remote}");
 });
 
+test("{git_port} separates same-host forges, for whoever opts in", async () => {
+  // The default keeps folding ports away — one repository stays one peer when
+  // its ssh and https remotes sit on different ports, which is the common
+  // self-hosted shape. This chain is for the rarer one: two forges on a single
+  // host serving the same path, distinguishable only by port.
+  const chain = ["{git_remote}-{git_port}", "{git_remote}"];
+
+  const forge8443 = await repo({ remote: "https://forge.corp:8443/group/repo.git" });
+  assert.equal(resolve(forge8443.root, forge8443.env, { peerSource: chain }).peerId, "forge.corp-group-repo-8443");
+  assert.equal(resolve(forge8443.root, forge8443.env).peerId, "forge.corp-group-repo",
+    "and the default chain still drops the port");
+
+  const forge9443 = await repo({ remote: "https://forge.corp:9443/group/repo.git" });
+  assert.equal(resolve(forge9443.root, forge9443.env, { peerSource: chain }).peerId, "forge.corp-group-repo-9443",
+    "the two forges stay distinct namespaces under the opt-in chain");
+
+  // Everything else falls through to the port-less template: the scp spelling
+  // (no port syntax), an absent port, and any scheme's default port.
+  for (const remote of ["git@forge.corp:group/repo.git", "https://forge.corp/group/repo.git", "ssh://git@forge.corp:22/group/repo.git"]) {
+    const r = await repo({ remote });
+    const resolved = resolve(r.root, r.env, { peerSource: chain });
+    assert.equal(resolved.peerId, "forge.corp-group-repo", `${remote} falls through`);
+    assert.equal(resolved.origin, "{git_remote}");
+  }
+});
+
 test("a template naming only empty variables resolves to no peer at all", async () => {
   const plain = await repo({ git: false });
   const unresolved = resolve(plain.root, plain.env, { peerSource: ["{git_remote}"] });

--- a/examples/opencode-plugin/lib/shared/workspace-identity.mjs
+++ b/examples/opencode-plugin/lib/shared/workspace-identity.mjs
@@ -30,6 +30,14 @@ const IDENTITY_CACHE_TTL_MS = 60_000;
 // hash suffix and for anything that later prefixes a peer id.
 const MAX_PEER_ID_LENGTH = 100;
 
+// The scheme default ports, stripped from the authority as identity-free:
+// folding them away is what makes the `ssh://` and `https://` spellings of one
+// repository agree, which the `git` preset depends on. `new URL` already drops
+// them for its special schemes, so the table carries the non-special ones git
+// remotes use — and it is also the judge of which explicit port `{git_port}`
+// surfaces: any port that is not the scheme's default.
+const DEFAULT_REMOTE_PORTS = { ssh: "22", http: "80", https: "443", git: "9418", rsync: "873" };
+
 export function stateDir(env = process.env) {
   const explicit = String(env.OPENVIKING_STATE_DIR || "").trim();
   if (explicit) return explicit;
@@ -77,43 +85,62 @@ export function sanitizePeerId(value) {
 }
 
 /**
+ * Parse a remote URL into its parts, or null when it names no shared identity.
+ *
+ * `port` is the explicit port as written. The scp spelling has no port syntax
+ * in git — a leading `8443/` there is a literal path — so it yields none, and
+ * `new URL` has already dropped the default port of its special schemes
+ * (`https://…:443` arrives as no port). The port never reaches the normalized
+ * remote; it exists for `{git_port}`.
+ */
+function parseGitRemote(url) {
+  const raw = String(url || "").trim();
+  if (!raw) return null;
+
+  // `C:\src\repo` and `C:/src/repo` are one machine's directory, not a shared
+  // identity — and the scp pattern would happily read the drive as a host.
+  if (/^[A-Za-z]:[\\/]/.test(raw)) return null;
+
+  const scp = /^(?:[^@/\\]+@)?([^:/\\]+):(?!\/)(.+)$/.exec(raw);
+  if (scp && !/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(raw)) {
+    return { scheme: "ssh", host: scp[1], path: scp[2], port: "" };
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  // A local clone has no stable shared identity — fall through to the path
+  // rules instead of minting one from `file://` or a bare directory.
+  if (parsed.protocol === "file:" || !parsed.hostname) return null;
+  return {
+    scheme: parsed.protocol.slice(0, -1),
+    host: parsed.hostname,
+    path: parsed.pathname,
+    port: parsed.port,
+  };
+}
+
+/**
  * Normalize a remote URL to `host/path`, lowercased.
  *
  * Both spellings of the same repo converge, and userinfo is dropped — so a
  * remote with an embedded token cannot leak it into a peer id. The cost of
  * case folding is that two repos differing only in case share one namespace on
- * the rare case-sensitive forge.
+ * the rare case-sensitive forge. Ports are folded away too, default or not:
+ * that is what keeps one repository one peer when its ssh and https remotes
+ * sit on different ports, which is the common self-hosted shape (#4565).
  */
 export function normalizeGitRemote(url) {
-  const raw = String(url || "").trim();
-  if (!raw) return "";
+  return normalizeParsedRemote(parseGitRemote(url));
+}
 
-  // `C:\src\repo` and `C:/src/repo` are one machine's directory, not a shared
-  // identity — and the scp pattern would happily read the drive as a host.
-  if (/^[A-Za-z]:[\\/]/.test(raw)) return "";
-
-  let host = "";
-  let path = "";
-  const scp = /^(?:[^@/\\]+@)?([^:/\\]+):(?!\/)(.+)$/.exec(raw);
-  if (scp && !/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(raw)) {
-    host = scp[1];
-    path = scp[2];
-  } else {
-    let parsed;
-    try {
-      parsed = new URL(raw);
-    } catch {
-      return "";
-    }
-    // A local clone has no stable shared identity — fall through to the path
-    // rules instead of minting one from `file://` or a bare directory.
-    if (parsed.protocol === "file:" || !parsed.hostname) return "";
-    host = parsed.hostname;
-    path = parsed.pathname;
-  }
-
-  host = host.toLowerCase().replace(/^\[|\]$/g, "");
-  path = path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "").toLowerCase();
+function normalizeParsedRemote(parts) {
+  if (!parts) return "";
+  const host = parts.host.toLowerCase().replace(/^\[|\]$/g, "");
+  const path = parts.path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "").toLowerCase();
   if (!host || !path) return "";
   return `${host}/${path}`;
 }
@@ -275,6 +302,12 @@ function readCache(path, now) {
     if (typeof cached?.ts !== "number" || cached.ts > now || now - cached.ts > IDENTITY_CACHE_TTL_MS) return null;
     const identity = cached.identity;
     if (identity && typeof identity === "object" && identity.vars && typeof identity.vars === "object") {
+      // A key set from an older build — before `git_port` existed — makes
+      // `renderPeerTemplate` treat the variable as empty rather than unknown,
+      // so a template naming it would silently fall through to the port-less
+      // one for the rest of the TTL. Treat the mismatch as a miss; the walk
+      // is cheap and the entry rewrites in the new shape.
+      if (!Object.hasOwn(identity.vars, "git_port")) return null;
       return identity;
     }
   } catch { /* a cold or corrupt cache just costs one walk */ }
@@ -308,8 +341,16 @@ export function resolveWorkspaceIdentity({ cwd = "", env = process.env, cache = 
   const { root, rootKind, git, gitRoot } = findWorkspaceRoot(key, env);
   // Only the normalized form is kept. The raw URL may carry a token, and this
   // file outlives the process — writing it here would undo the care
-  // `normalizeGitRemote` takes to drop userinfo.
-  const remote = git ? normalizeGitRemote(readGitRemoteUrl(git.commonDir)) : "";
+  // `parseGitRemote` takes to drop userinfo.
+  const remoteParts = git ? parseGitRemote(readGitRemoteUrl(git.commonDir)) : null;
+  const remote = normalizeParsedRemote(remoteParts);
+  // The port a forge is actually served on, empty for the scheme default and
+  // for the scp spelling. No preset names the variable, so the default peer
+  // keeps folding ports away; opting in is what separates two forges that
+  // share a host and path.
+  const gitPort = remoteParts?.port && remoteParts.port !== (DEFAULT_REMOTE_PORTS[remoteParts.scheme] || "")
+    ? remoteParts.port
+    : "";
   const identity = {
     cwd: key,
     root,
@@ -327,6 +368,7 @@ export function resolveWorkspaceIdentity({ cwd = "", env = process.env, cache = 
       git_root: git ? legacySanitize(gitRoot) : "",
       cwd: legacySanitize(key),
       dir: root ? sanitizePeerId(root.split(/[/\\]/).filter(Boolean).pop() || "") : "",
+      git_port: gitPort,
     },
   };
   if (cache) writeCache(path, identity, now);

--- a/examples/pi-coding-agent-extension/shared/workspace-identity.mjs
+++ b/examples/pi-coding-agent-extension/shared/workspace-identity.mjs
@@ -30,6 +30,14 @@ const IDENTITY_CACHE_TTL_MS = 60_000;
 // hash suffix and for anything that later prefixes a peer id.
 const MAX_PEER_ID_LENGTH = 100;
 
+// The scheme default ports, stripped from the authority as identity-free:
+// folding them away is what makes the `ssh://` and `https://` spellings of one
+// repository agree, which the `git` preset depends on. `new URL` already drops
+// them for its special schemes, so the table carries the non-special ones git
+// remotes use — and it is also the judge of which explicit port `{git_port}`
+// surfaces: any port that is not the scheme's default.
+const DEFAULT_REMOTE_PORTS = { ssh: "22", http: "80", https: "443", git: "9418", rsync: "873" };
+
 export function stateDir(env = process.env) {
   const explicit = String(env.OPENVIKING_STATE_DIR || "").trim();
   if (explicit) return explicit;
@@ -77,43 +85,62 @@ export function sanitizePeerId(value) {
 }
 
 /**
+ * Parse a remote URL into its parts, or null when it names no shared identity.
+ *
+ * `port` is the explicit port as written. The scp spelling has no port syntax
+ * in git — a leading `8443/` there is a literal path — so it yields none, and
+ * `new URL` has already dropped the default port of its special schemes
+ * (`https://…:443` arrives as no port). The port never reaches the normalized
+ * remote; it exists for `{git_port}`.
+ */
+function parseGitRemote(url) {
+  const raw = String(url || "").trim();
+  if (!raw) return null;
+
+  // `C:\src\repo` and `C:/src/repo` are one machine's directory, not a shared
+  // identity — and the scp pattern would happily read the drive as a host.
+  if (/^[A-Za-z]:[\\/]/.test(raw)) return null;
+
+  const scp = /^(?:[^@/\\]+@)?([^:/\\]+):(?!\/)(.+)$/.exec(raw);
+  if (scp && !/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(raw)) {
+    return { scheme: "ssh", host: scp[1], path: scp[2], port: "" };
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  // A local clone has no stable shared identity — fall through to the path
+  // rules instead of minting one from `file://` or a bare directory.
+  if (parsed.protocol === "file:" || !parsed.hostname) return null;
+  return {
+    scheme: parsed.protocol.slice(0, -1),
+    host: parsed.hostname,
+    path: parsed.pathname,
+    port: parsed.port,
+  };
+}
+
+/**
  * Normalize a remote URL to `host/path`, lowercased.
  *
  * Both spellings of the same repo converge, and userinfo is dropped — so a
  * remote with an embedded token cannot leak it into a peer id. The cost of
  * case folding is that two repos differing only in case share one namespace on
- * the rare case-sensitive forge.
+ * the rare case-sensitive forge. Ports are folded away too, default or not:
+ * that is what keeps one repository one peer when its ssh and https remotes
+ * sit on different ports, which is the common self-hosted shape (#4565).
  */
 export function normalizeGitRemote(url) {
-  const raw = String(url || "").trim();
-  if (!raw) return "";
+  return normalizeParsedRemote(parseGitRemote(url));
+}
 
-  // `C:\src\repo` and `C:/src/repo` are one machine's directory, not a shared
-  // identity — and the scp pattern would happily read the drive as a host.
-  if (/^[A-Za-z]:[\\/]/.test(raw)) return "";
-
-  let host = "";
-  let path = "";
-  const scp = /^(?:[^@/\\]+@)?([^:/\\]+):(?!\/)(.+)$/.exec(raw);
-  if (scp && !/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(raw)) {
-    host = scp[1];
-    path = scp[2];
-  } else {
-    let parsed;
-    try {
-      parsed = new URL(raw);
-    } catch {
-      return "";
-    }
-    // A local clone has no stable shared identity — fall through to the path
-    // rules instead of minting one from `file://` or a bare directory.
-    if (parsed.protocol === "file:" || !parsed.hostname) return "";
-    host = parsed.hostname;
-    path = parsed.pathname;
-  }
-
-  host = host.toLowerCase().replace(/^\[|\]$/g, "");
-  path = path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "").toLowerCase();
+function normalizeParsedRemote(parts) {
+  if (!parts) return "";
+  const host = parts.host.toLowerCase().replace(/^\[|\]$/g, "");
+  const path = parts.path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "").toLowerCase();
   if (!host || !path) return "";
   return `${host}/${path}`;
 }
@@ -275,6 +302,12 @@ function readCache(path, now) {
     if (typeof cached?.ts !== "number" || cached.ts > now || now - cached.ts > IDENTITY_CACHE_TTL_MS) return null;
     const identity = cached.identity;
     if (identity && typeof identity === "object" && identity.vars && typeof identity.vars === "object") {
+      // A key set from an older build — before `git_port` existed — makes
+      // `renderPeerTemplate` treat the variable as empty rather than unknown,
+      // so a template naming it would silently fall through to the port-less
+      // one for the rest of the TTL. Treat the mismatch as a miss; the walk
+      // is cheap and the entry rewrites in the new shape.
+      if (!Object.hasOwn(identity.vars, "git_port")) return null;
       return identity;
     }
   } catch { /* a cold or corrupt cache just costs one walk */ }
@@ -308,8 +341,16 @@ export function resolveWorkspaceIdentity({ cwd = "", env = process.env, cache = 
   const { root, rootKind, git, gitRoot } = findWorkspaceRoot(key, env);
   // Only the normalized form is kept. The raw URL may carry a token, and this
   // file outlives the process — writing it here would undo the care
-  // `normalizeGitRemote` takes to drop userinfo.
-  const remote = git ? normalizeGitRemote(readGitRemoteUrl(git.commonDir)) : "";
+  // `parseGitRemote` takes to drop userinfo.
+  const remoteParts = git ? parseGitRemote(readGitRemoteUrl(git.commonDir)) : null;
+  const remote = normalizeParsedRemote(remoteParts);
+  // The port a forge is actually served on, empty for the scheme default and
+  // for the scp spelling. No preset names the variable, so the default peer
+  // keeps folding ports away; opting in is what separates two forges that
+  // share a host and path.
+  const gitPort = remoteParts?.port && remoteParts.port !== (DEFAULT_REMOTE_PORTS[remoteParts.scheme] || "")
+    ? remoteParts.port
+    : "";
   const identity = {
     cwd: key,
     root,
@@ -327,6 +368,7 @@ export function resolveWorkspaceIdentity({ cwd = "", env = process.env, cache = 
       git_root: git ? legacySanitize(gitRoot) : "",
       cwd: legacySanitize(key),
       dir: root ? sanitizePeerId(root.split(/[/\\]/).filter(Boolean).pop() || "") : "",
+      git_port: gitPort,
     },
   };
   if (cache) writeCache(path, identity, now);

--- a/examples/zcode-memory-plugin/scripts/shared/workspace-identity.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/workspace-identity.mjs
@@ -30,6 +30,14 @@ const IDENTITY_CACHE_TTL_MS = 60_000;
 // hash suffix and for anything that later prefixes a peer id.
 const MAX_PEER_ID_LENGTH = 100;
 
+// The scheme default ports, stripped from the authority as identity-free:
+// folding them away is what makes the `ssh://` and `https://` spellings of one
+// repository agree, which the `git` preset depends on. `new URL` already drops
+// them for its special schemes, so the table carries the non-special ones git
+// remotes use — and it is also the judge of which explicit port `{git_port}`
+// surfaces: any port that is not the scheme's default.
+const DEFAULT_REMOTE_PORTS = { ssh: "22", http: "80", https: "443", git: "9418", rsync: "873" };
+
 export function stateDir(env = process.env) {
   const explicit = String(env.OPENVIKING_STATE_DIR || "").trim();
   if (explicit) return explicit;
@@ -77,43 +85,62 @@ export function sanitizePeerId(value) {
 }
 
 /**
+ * Parse a remote URL into its parts, or null when it names no shared identity.
+ *
+ * `port` is the explicit port as written. The scp spelling has no port syntax
+ * in git — a leading `8443/` there is a literal path — so it yields none, and
+ * `new URL` has already dropped the default port of its special schemes
+ * (`https://…:443` arrives as no port). The port never reaches the normalized
+ * remote; it exists for `{git_port}`.
+ */
+function parseGitRemote(url) {
+  const raw = String(url || "").trim();
+  if (!raw) return null;
+
+  // `C:\src\repo` and `C:/src/repo` are one machine's directory, not a shared
+  // identity — and the scp pattern would happily read the drive as a host.
+  if (/^[A-Za-z]:[\\/]/.test(raw)) return null;
+
+  const scp = /^(?:[^@/\\]+@)?([^:/\\]+):(?!\/)(.+)$/.exec(raw);
+  if (scp && !/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(raw)) {
+    return { scheme: "ssh", host: scp[1], path: scp[2], port: "" };
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  // A local clone has no stable shared identity — fall through to the path
+  // rules instead of minting one from `file://` or a bare directory.
+  if (parsed.protocol === "file:" || !parsed.hostname) return null;
+  return {
+    scheme: parsed.protocol.slice(0, -1),
+    host: parsed.hostname,
+    path: parsed.pathname,
+    port: parsed.port,
+  };
+}
+
+/**
  * Normalize a remote URL to `host/path`, lowercased.
  *
  * Both spellings of the same repo converge, and userinfo is dropped — so a
  * remote with an embedded token cannot leak it into a peer id. The cost of
  * case folding is that two repos differing only in case share one namespace on
- * the rare case-sensitive forge.
+ * the rare case-sensitive forge. Ports are folded away too, default or not:
+ * that is what keeps one repository one peer when its ssh and https remotes
+ * sit on different ports, which is the common self-hosted shape (#4565).
  */
 export function normalizeGitRemote(url) {
-  const raw = String(url || "").trim();
-  if (!raw) return "";
+  return normalizeParsedRemote(parseGitRemote(url));
+}
 
-  // `C:\src\repo` and `C:/src/repo` are one machine's directory, not a shared
-  // identity — and the scp pattern would happily read the drive as a host.
-  if (/^[A-Za-z]:[\\/]/.test(raw)) return "";
-
-  let host = "";
-  let path = "";
-  const scp = /^(?:[^@/\\]+@)?([^:/\\]+):(?!\/)(.+)$/.exec(raw);
-  if (scp && !/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(raw)) {
-    host = scp[1];
-    path = scp[2];
-  } else {
-    let parsed;
-    try {
-      parsed = new URL(raw);
-    } catch {
-      return "";
-    }
-    // A local clone has no stable shared identity — fall through to the path
-    // rules instead of minting one from `file://` or a bare directory.
-    if (parsed.protocol === "file:" || !parsed.hostname) return "";
-    host = parsed.hostname;
-    path = parsed.pathname;
-  }
-
-  host = host.toLowerCase().replace(/^\[|\]$/g, "");
-  path = path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "").toLowerCase();
+function normalizeParsedRemote(parts) {
+  if (!parts) return "";
+  const host = parts.host.toLowerCase().replace(/^\[|\]$/g, "");
+  const path = parts.path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "").toLowerCase();
   if (!host || !path) return "";
   return `${host}/${path}`;
 }
@@ -275,6 +302,12 @@ function readCache(path, now) {
     if (typeof cached?.ts !== "number" || cached.ts > now || now - cached.ts > IDENTITY_CACHE_TTL_MS) return null;
     const identity = cached.identity;
     if (identity && typeof identity === "object" && identity.vars && typeof identity.vars === "object") {
+      // A key set from an older build — before `git_port` existed — makes
+      // `renderPeerTemplate` treat the variable as empty rather than unknown,
+      // so a template naming it would silently fall through to the port-less
+      // one for the rest of the TTL. Treat the mismatch as a miss; the walk
+      // is cheap and the entry rewrites in the new shape.
+      if (!Object.hasOwn(identity.vars, "git_port")) return null;
       return identity;
     }
   } catch { /* a cold or corrupt cache just costs one walk */ }
@@ -308,8 +341,16 @@ export function resolveWorkspaceIdentity({ cwd = "", env = process.env, cache = 
   const { root, rootKind, git, gitRoot } = findWorkspaceRoot(key, env);
   // Only the normalized form is kept. The raw URL may carry a token, and this
   // file outlives the process — writing it here would undo the care
-  // `normalizeGitRemote` takes to drop userinfo.
-  const remote = git ? normalizeGitRemote(readGitRemoteUrl(git.commonDir)) : "";
+  // `parseGitRemote` takes to drop userinfo.
+  const remoteParts = git ? parseGitRemote(readGitRemoteUrl(git.commonDir)) : null;
+  const remote = normalizeParsedRemote(remoteParts);
+  // The port a forge is actually served on, empty for the scheme default and
+  // for the scp spelling. No preset names the variable, so the default peer
+  // keeps folding ports away; opting in is what separates two forges that
+  // share a host and path.
+  const gitPort = remoteParts?.port && remoteParts.port !== (DEFAULT_REMOTE_PORTS[remoteParts.scheme] || "")
+    ? remoteParts.port
+    : "";
   const identity = {
     cwd: key,
     root,
@@ -327,6 +368,7 @@ export function resolveWorkspaceIdentity({ cwd = "", env = process.env, cache = 
       git_root: git ? legacySanitize(gitRoot) : "",
       cwd: legacySanitize(key),
       dir: root ? sanitizePeerId(root.split(/[/\\]/).filter(Boolean).pop() || "") : "",
+      git_port: gitPort,
     },
   };
   if (cache) writeCache(path, identity, now);


### PR DESCRIPTION
Follow-up to #4595 (and the cleanup of #3540): `normalizeGitRemote` derives the host from `URL.hostname`, which drops **every** explicit port. Two distinct forges on the same host and path — `https://gitlab.corp:8443/group/repo` vs `https://gitlab.corp:9443/group/repo` — therefore normalize to the same string and silently share one peer namespace.

Issue #3516 asks to remove *default* ports and requires that distinct repositories do not collide; the review on #3540 flagged stripping all ports as blocking for exactly this reason. This restores that requirement on top of the landed implementation.

## What changes

- Only the scheme's default port is identity-free: `ssh 22, http 80, https 443, git 9418, rsync 873`. Any other explicit port is kept in the normalized remote (`gitlab.corp:8443/group/repo`).
- `new URL` already strips default ports for special schemes (`https://h:443/x` arrives with `port === ""`); the table mainly serves non-special schemes (`ssh://`, `git://`, `rsync://`).
- The scp-like spelling is untouched: it has no port syntax in git, and a leading `8443/` there is a literal path segment.

## Tests

- The existing userinfo regression keeps its token-dropping assertion and now expects the `:8443` its URL always carried.
- New test: all spellings of one non-default-port remote agree (`ssh://`, `https://`, `http://`, with userinfo), a different non-default port stays distinct, explicit default ports still fold.
- Generated copies re-synced via `sync.mjs`; `workspace-identity` 27, `workspace-peer` 15, `sync` 4, pi `config` 10 all green locally.
