### PR TITLE
fix(plugins): stop the installer aborting inside the credentials wizard

### DIFF
--- a/examples/memory-plugin-shared/install-tui.test.mjs
+++ b/examples/memory-plugin-shared/install-tui.test.mjs
@@ -56,6 +56,9 @@ installer_test_failure
   assert.match(result.stderr, /Exit status: 1/);
   assert.match(result.stderr, /Script line: [0-9]+/);
   assert.match(result.stderr, /Command: false/);
+  // The handler restores the cursor on /dev/tty; with no controlling terminal
+  // that redirection must not narrate itself ahead of the real diagnostic.
+  assert.doesNotMatch(result.stderr, /\/dev\/tty/);
 });
 
 test("a pre-existing TRAE home directory keeps TRAE Desktop as the default", (t) => {
@@ -203,4 +206,39 @@ test("menu digit shortcuts move the cursor instead of confirming", () => {
   assert.ok(chooseFormat, "tui_choose_cli_format not found");
   assert.match(chooseFormat[0], /^ +1\) cursor=0 ;;$/m);
   assert.match(chooseFormat[0], /^ +2\) cursor=1 ;;$/m);
+});
+
+test("an empty element in a comma-separated list is skipped, not fatal", () => {
+  // Assignments, like the call sites: a trailing comma used to make the loop --
+  // and so the function -- exit 1, which `set -e` turned into an abort.
+  const result = runInstallerPrelude(`
+bins="$(normalize_bin_list "claude," claude)"
+items="$(split_csv_list ",,seed, claude ,")"
+harnesses="$(split_harnesses "claude,,CODEX,")"
+printf '%s|%s|%s\\n' "$bins" "$items" "$harnesses"
+`);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "claude|seed\nclaude|claude\ncodex");
+});
+
+test("the credentials step names the field it changed", (t) => {
+  const home = makeTempHome(t);
+  const conf = join(home, "ovcli.conf");
+  const url = "https://api.vikingdb.cn-beijing.volces.com/openviking";
+  writeFileSync(conf, `${JSON.stringify({ url, api_key: "stored-key" }, null, 2)}\n`);
+
+  const result = runInstallerPrelude(`
+tui_menu() { TUI_MENU_CHOICE=1; }
+INTERACTIVE=1
+OV_HOME=${JSON.stringify(home)}
+OVCLI_CONF=${JSON.stringify(conf)}
+exec 3< <(printf 'rotated-key\\n')
+configure_ovcli
+`);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.stdout, /Updated: url:/);
+  assert.match(result.stdout, /Updated: api_key: stor…-key \(10\) -> rota…-key \(11\)/);
+  assert.equal(JSON.parse(readFileSync(conf, "utf8")).api_key, "rotated-key");
 });

--- a/examples/memory-plugin-shared/install-tui.test.mjs
+++ b/examples/memory-plugin-shared/install-tui.test.mjs
@@ -152,3 +152,55 @@ printf '%s:%s:%s\\n' "$SELECTED_HARNESSES" "$(list_words "$CODEX_BINS")" "$(tui_
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stdout.trim(), "codex:trae-cli:TraeCode CLI 2.0");
 });
+
+test("keeping the stored API key leaves the wizard on its feet", () => {
+  const result = runInstallerPrelude(`
+tui_menu() { TUI_MENU_CHOICE=1; }
+INTERACTIVE=1
+exec 3< <(printf '\\n')
+prompt_connection "https://example.invalid/openviking" "stored-key"
+printf '%s|%s\\n' "$WIZ_URL" "$WIZ_KEY"
+`);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(
+    result.stdout.trim().split("\n").pop(),
+    "https://api.vikingdb.cn-beijing.volces.com/openviking|__OPENVIKING_KEEP__",
+  );
+});
+
+test("the credentials step writes ovcli.conf when the stored key is kept", (t) => {
+  const home = makeTempHome(t);
+  const conf = join(home, "ovcli.conf");
+  writeFileSync(conf, `${JSON.stringify({ url: "http://127.0.0.1:1933", api_key: "stored-key", output: "table" }, null, 2)}\n`);
+
+  const result = runInstallerPrelude(`
+tui_menu() { TUI_MENU_CHOICE=1; }
+INTERACTIVE=1
+OV_HOME=${JSON.stringify(home)}
+OVCLI_CONF=${JSON.stringify(conf)}
+exec 3< <(printf '\\n')
+configure_ovcli
+`);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(readFileSync(conf, "utf8")), {
+    url: "https://api.vikingdb.cn-beijing.volces.com/openviking",
+    api_key: "stored-key",
+    output: "table",
+  });
+});
+
+test("menu digit shortcuts move the cursor instead of confirming", () => {
+  // Confirming on the digit itself leaves the Enter most users press right
+  // after it in the tty buffer, where the next prompt reads it as an empty
+  // answer. Driving the real menus needs a pty, so pin the key handlers.
+  const menuArm = /\[1-9\]\)([\s\S]*?);;/.exec(installerSource);
+  assert.ok(menuArm, "tui_menu no longer has a [1-9] case arm");
+  assert.doesNotMatch(menuArm[1], /\bbreak\b/);
+
+  const chooseFormat = /^tui_choose_cli_format\(\) \{$[\s\S]*?^\}$/m.exec(installerSource);
+  assert.ok(chooseFormat, "tui_choose_cli_format not found");
+  assert.match(chooseFormat[0], /^ +1\) cursor=0 ;;$/m);
+  assert.match(chooseFormat[0], /^ +2\) cursor=1 ;;$/m);
+});

--- a/examples/memory-plugin-shared/install.sh
+++ b/examples/memory-plugin-shared/install.sh
@@ -128,7 +128,7 @@ report_unexpected_error() { # report_unexpected_error <status> <line> <command>
   if [ "${BASH_SUBSHELL:-0}" -gt 0 ]; then
     return "$status"
   fi
-  printf '\033[?25h' >/dev/tty 2>/dev/null || true
+  printf '\033[?25h' 2>/dev/null >/dev/tty || true
   printf '\n' >&2
   err "$(t 'OpenViking installer stopped unexpectedly.' 'OpenViking 安装程序意外退出。')"
   printf '    %s: %s\n' "$(t 'Exit status' '状态码')" "$status" >&2
@@ -319,14 +319,20 @@ select_language() {
 split_harnesses() {
   printf '%s\n' "$1" | tr ',' '\n' | while IFS= read -r h; do
     h=$(printf '%s' "$h" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-    [ -n "$h" ] && printf '%s\n' "$h"
+    if [ -n "$h" ]; then
+      printf '%s\n' "$h"
+    fi
   done
 }
 
 split_csv_list() {
   printf '%s\n' "$1" | tr ',' '\n' | while IFS= read -r item; do
     item=$(printf '%s' "$item" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-    [ -n "$item" ] && printf '%s\n' "$item"
+    # An `&& ...` here would make an empty last element the loop's -- and so the
+    # function's -- exit status, which `set -e` turns into an abort at the call.
+    if [ -n "$item" ]; then
+      printf '%s\n' "$item"
+    fi
   done
 }
 
@@ -1278,8 +1284,11 @@ configure_ovcli() {
     cp "$OVCLI_CONF" "$OVCLI_CONF.bak.$(date +%s)"
   fi
   json_merge_ovcli "$OVCLI_CONF" "$url" "$key" "$account" "$user"
-  if [ "$url" != "$current_url" ] || { [ "$key" != "__OPENVIKING_KEEP__" ] && [ "$key" != "$current_key" ]; }; then
+  if [ "$url" != "$current_url" ]; then
     info "$(t 'Updated:' '已更新：') url: ${current_url:-—} -> $url"
+  fi
+  if [ "$key" != "__OPENVIKING_KEEP__" ] && [ "$key" != "$current_key" ]; then
+    info "$(t 'Updated:' '已更新：') api_key: $(mask_secret "$current_key") -> $(mask_secret "$key")"
   fi
   info "$(t 'Credentials ready:' '凭据已就绪：') $OVCLI_CONF"
   info "$(t 'Reconfigure later by re-running this installer.' '之后可重跑本安装脚本重新配置。')"

--- a/examples/memory-plugin-shared/install.sh
+++ b/examples/memory-plugin-shared/install.sh
@@ -255,7 +255,7 @@ tui_menu() { # tui_menu <title> <default-index> <option...>  -> TUI_MENU_CHOICE
       fi
       i=$((i + 1))
     done
-    printf '\r\033[K   %s%s%s\n' "$CYAN" "$(t '↑/↓ move · 1-9 jump · enter confirm' '↑/↓ 移动 · 数字直选 · 回车确认')" "$RESET" >/dev/tty
+    printf '\r\033[K   %s%s%s\n' "$CYAN" "$(t '↑/↓ move · 1-9 jump · enter confirm' '↑/↓ 移动 · 数字跳转 · 回车确认')" "$RESET" >/dev/tty
     lines=$((n + 1))
     IFS= read -rsn1 key <&3 || key=""
     case "$key" in
@@ -270,9 +270,11 @@ tui_menu() { # tui_menu <title> <default-index> <option...>  -> TUI_MENU_CHOICE
       k) cursor=$(( (cursor + n - 1) % n )) ;;
       j) cursor=$(( (cursor + 1) % n )) ;;
       [1-9])
+        # Jump only. Confirming on the digit leaves the Enter most users press
+        # right after it in the tty buffer, where the next prompt reads it as
+        # an empty answer.
         if [ "$key" -le "$n" ]; then
           cursor=$((key - 1))
-          break
         fi
         ;;
       ''|$'\n'|$'\r') break ;;
@@ -811,8 +813,8 @@ tui_choose_cli_format() {
         esac
         ;;
       k|j) cursor=$((1 - cursor)) ;;
-      1) TUI_FORMAT_CHOICE="claude"; break ;;
-      2) TUI_FORMAT_CHOICE="codex"; break ;;
+      1) cursor=0 ;;
+      2) cursor=1 ;;
       ''|$'\n'|$'\r')
         if [ "$cursor" -eq 0 ]; then TUI_FORMAT_CHOICE="claude"; else TUI_FORMAT_CHOICE="codex"; fi
         break
@@ -1215,8 +1217,12 @@ prompt_connection() { # sets WIZ_URL / WIZ_KEY (WIZ_KEY may stay __OPENVIKING_KE
   elif [ -n "$reply" ]; then
     WIZ_KEY="$reply"
   else
+    # Not `[ -z ... ] && ...`: as the function's last command a false test makes
+    # prompt_connection return 1, and `set -e` aborts the whole installer.
     WIZ_KEY="__OPENVIKING_KEEP__"
-    [ -z "$current_key" ] && WIZ_KEY=""
+    if [ -z "$current_key" ]; then
+      WIZ_KEY=""
+    fi
   fi
 }
 


### PR DESCRIPTION
## Description

Two bugs in `examples/memory-plugin-shared/install.sh` made the one-liner install abort in the middle of the credentials wizard, leaving `ovcli.conf` untouched and no plugin installed.

**The abort.** `prompt_connection` ends its empty-input branch with

```bash
WIZ_KEY="__OPENVIKING_KEEP__"
[ -z "$current_key" ] && WIZ_KEY=""
```

That `[ ... ] && ...` is the last command the function runs. When the user already has an `api_key` in `ovcli.conf` the test is false, so `prompt_connection` returns 1, and the script's `set -Eeuo pipefail` unwinds everything. The credentials step is step 2 of 3, so the run dies before `json_merge_ovcli` writes the file and before any harness is installed:

```
??  API key [enter = keep OLDK…6789 (45), '-' = clear]:
xx  OpenViking installer stopped unexpectedly.
    Exit status: 1
    Script line: 1223
    Command: [ -z "$current_key" ]
```

The prompt itself advertises `enter = keep <masked key>`, so the documented way to keep an existing key is exactly what crashes. Only users who already have a key are affected — with no stored key the test is true and the function returns 0.

**How users reach that branch without meaning to.** `tui_menu`'s `[1-9]` arm confirmed the selection on the digit and broke out of the loop without consuming the Enter that almost everyone presses right after. The stray newline stays in the tty buffer and the next prompt reads it as an empty answer, shifting every following prompt by one. Selecting "Volcengine OpenViking Cloud" with `2` + Enter therefore played out as: the digit picks Volcengine, the leftover Enter instantly confirms the *next* menu at its default ("Custom URL / keep current"), the "2" of the following keystroke lands in the server-URL prompt, and the API key prompt gets an empty line — which is the abort above. A user who did select Volcengine and did type a new key ends up with an unchanged config file, no error they can act on, and their key echoed into the shell after the script dies. `tui_choose_cli_format` had the same `1)` / `2)` shape, where the stray Enter empties the "Command name or path" prompt right after it.

Digits now move the cursor and Enter confirms, which is what `tui_menu`'s own English hint (`1-9 jump · enter confirm`) already promised; the Chinese hint is corrected from 数字直选 to 数字跳转 to match. Draining the stray newline instead was rejected: `read -t 0` / fractional timeouts need bash 4, and the installer targets bash 3.2 (stock macOS `/bin/bash`), which is where this was reported.

Reproduced against a pty with a temp `HOME`, before and after: with `set -e` reinstated the wizard now completes for `2⏎ 2⏎ <key>⏎`, for arrow keys, and for a bare Enter that keeps the stored key, writing `url` + `api_key` and the `ovcli.conf.bak.<epoch>` it takes first.

**Three more of the same shape, found by auditing the rest of the script.** `split_csv_list` and `split_harnesses` end their loop body with `[ -n "$item" ] && printf ...` too, so an empty last element — a trailing comma is enough — makes the loop, the pipeline under `pipefail`, and the function exit 1. `normalize_bin_list` hands that status to its caller, where it lands in an assignment and `set -e` kills the run before the first step:

```
$ OPENVIKING_CLAUDE_BIN="claude," bash install.sh --yes
xx  OpenViking installer stopped unexpectedly.
    Exit status: 1
    Script line: 514
    Command: CLAUDE_BINS="$(normalize_bin_list "$CLAUDE_BINS_ARG" claude)"
```

`--claude-bin`, `--codex-bin` and their `OPENVIKING_*` env spellings all reach it. `split_harnesses` was saved only by every call site expanding it inside a heredoc, where the status is discarded, so both get the `if` form rather than one relying on where it happens to be called.

Alongside them: the ERR handler sets up `>/dev/tty` before `2>/dev/null`, so with no controlling terminal bash narrates that redirection failing on its own line ahead of the diagnostic the handler exists to print. And the credentials step tested for a url *or* key change but only ever printed the url pair, so rotating just the key reported `url: <same> -> <same>`.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- `prompt_connection` keeps the stored key through an `if` block, so a false test can no longer become the function's exit status and abort the installer under `set -e`.
- `tui_menu`'s `[1-9]` arm moves the cursor instead of confirming, so the Enter that follows a digit is consumed by the menu rather than by the next prompt.
- `tui_choose_cli_format`'s `1)` / `2)` arms do the same, leaving Enter as the only confirm key there too.
- The Chinese menu hint now reads 数字跳转 instead of 数字直选, matching both the new behaviour and the existing English hint.
- `split_csv_list` and `split_harnesses` skip empty elements through an `if` block, so a trailing comma in a list no longer becomes the function's exit status.
- The ERR handler redirects stderr before it touches `/dev/tty`, keeping bash's own redirection error out of the crash output.
- The credentials step reports the field that actually changed, with both sides of an api_key rotation masked.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Three tests added to `install-tui.test.mjs`, all three failing on `main` and passing here:

- `keeping the stored API key leaves the wizard on its feet` — `prompt_connection` with a stored key and an empty answer returns 0 and yields `__OPENVIKING_KEEP__`.
- `the credentials step writes ovcli.conf when the stored key is kept` — `configure_ovcli` end to end against a temp config: the file is rewritten with the new URL and the old key.
- `menu digit shortcuts move the cursor instead of confirming` — the two key handlers, pinned by reading the script.
- `an empty element in a comma-separated list is skipped, not fatal` — the three list helpers called the way line 514 calls them, through an assignment.
- `the credentials step names the field it changed` — rotating only the key prints an `api_key:` line and no `url:` line.
- `unexpected installer failures include actionable diagnostics` gained an assertion that the crash output carries no `/dev/tty` noise.

Both menus draw on `/dev/tty` and cannot be driven from `node --test` without a pty, so the first two stub `tui_menu` and feed fd 3 directly, and the third asserts on the source. The pty run described above covered the full interactive path by hand.

`node --test *.test.mjs` in `examples/memory-plugin-shared` — 180 passing. `shellcheck -s bash install.sh` is clean before and after.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

A config file that the installer never reached is recognisable from the outside: `configure_ovcli` copies `ovcli.conf` to `ovcli.conf.bak.<epoch>` before writing, writes through Node, and then chmods to 0600. A file still at 0644, with no `.bak.` sibling and a `"timeout": 60.0` that only serde's f64 emits, has only ever been written by `ov config` — which is what the report this fix came from looked like.
