### PR TITLE
fix(openclaw): restore package build after peer role rename

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -95,6 +95,18 @@ jobs:
           bash -n examples/codex-memory-plugin/setup-helper/install.sh
           bash -n examples/codex-memory-plugin/setup-helper/tos-install.sh
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: examples/openclaw-plugin/package-lock.json
+
+      - name: Verify OpenClaw plugin package
+        working-directory: examples/openclaw-plugin
+        run: |
+          npm ci
+          npm pack --dry-run
+
   check-deps:
     runs-on: ubuntu-24.04
     outputs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -95,18 +95,6 @@ jobs:
           bash -n examples/codex-memory-plugin/setup-helper/install.sh
           bash -n examples/codex-memory-plugin/setup-helper/tos-install.sh
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: examples/openclaw-plugin/package-lock.json
-
-      - name: Verify OpenClaw plugin package
-        working-directory: examples/openclaw-plugin
-        run: |
-          npm ci
-          npm pack --dry-run
-
   check-deps:
     runs-on: ubuntu-24.04
     outputs:

--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -1,5 +1,5 @@
 import type { OpenVikingClient } from "./client.js";
-import type { MemoryOpenVikingConfig } from "./config.js";
+import type { ParsedMemoryOpenVikingConfig } from "./config.js";
 import type { RuntimeQueryConfigStore } from "./query-config.js";
 import {
   AUTO_RECALL_SOURCE_MARKER,
@@ -248,7 +248,7 @@ export function createMemoryOpenVikingContextEngine(params: {
   id: string;
   name: string;
   version?: string;
-  cfg: Required<MemoryOpenVikingConfig>;
+  cfg: ParsedMemoryOpenVikingConfig;
   logger: Logger;
   getClient: () => Promise<OpenVikingClient>;
   /** Extra args help match hook-populated routing when OpenClaw provides sessionKey / OV session id. */


### PR DESCRIPTION
## Why

- #4546 合并后，发布在 `npm pack` 的 TypeScript build 阶段失败，npm 和 ClawHub 均未开始发布。
- 输入配置兼容旧值 `person`，但 context engine 错用输入类型，重新放宽了已经规范化为 `none | assistant | sender` 的 runtime config。
- context engine 改为消费 `ParsedMemoryOpenVikingConfig`；不改变运行时行为。

## Tested

- 基线 `./node_modules/.bin/tsc -p tsconfig.build.json --pretty false`（exit 2，复现 TS2322）
- 修复后 `./node_modules/.bin/tsc -p tsconfig.build.json --pretty false`
- `./node_modules/.bin/tsc -p tsconfig.json --pretty false`
- `./node_modules/.bin/vitest run tests/ut/config.test.ts tests/ut/plugin-modules.test.ts tests/ut/package-install-contract.test.ts --reporter=dot --pool=threads --maxWorkers=1 --no-file-parallelism`
- `./node_modules/.bin/vitest run tests/ut/context-engine-afterTurn.test.ts tests/ut/context-engine-assemble.test.ts tests/ut/context-engine-compact.test.ts --reporter=dot --pool=threads --maxWorkers=1 --no-file-parallelism`（合计 6 files / 154 tests passed）
- `git diff --check`
- Not run: 本机带 lifecycle script 的 `npm pack --dry-run` 被宿主 SIGKILL（exit 137）；发布 workflow 将是完整 npm lifecycle 的最终验证。
