### PR TITLE
feat(usage-audit): count MCP find/search tool calls in retrieval dashboard

### DIFF
--- a/examples/codex-memory-plugin/scripts/marketplace.test.mjs
+++ b/examples/codex-memory-plugin/scripts/marketplace.test.mjs
@@ -196,7 +196,7 @@ test("Codex MCP entrypoint forwards only native OpenViking tools", () => {
 test("canonical MCP tool list matches server registrations", () => {
   const source = readFileSync(mcpEndpointPath, "utf-8");
   const registered = [
-    ...source.matchAll(/@mcp\.tool\(([^)]*)\)\s*\nasync def ([a-z_]+)\(/g),
+    ...source.matchAll(/@mcp\.tool\(([^)]*)\)\s*\n(?:@[^\n]+\n\s*)*async def ([a-z_]+)\(/g),
   ].map((match) => match[1].match(/(?:^|,\s*)name="([a-z_]+)"/)?.[1] || match[2]);
   assert.deepEqual(registered, REAL_MCP_TOOLS);
 });

--- a/openviking/observability/usage_audit/README.md
+++ b/openviking/observability/usage_audit/README.md
@@ -111,14 +111,23 @@ store backend，而不是让多个实例各写各的本地 SQLite。
 
 ### 今日检索
 
-来自 HTTP 请求完成事件 `http.request`：
+REST 请求来自 HTTP 请求完成事件 `http.request`：
 
 | API route | operation |
 | --- | --- |
 | `POST /api/v1/search/find` | `find` |
 | `POST /api/v1/search/search` | `search` |
 
-`2xx` 和 `3xx` 记为 `success`，`4xx/5xx` 记为 `error`。Dashboard 今日检索只展示成功请求数。
+MCP 工具调用（`POST /mcp` 无 per-tool 路由）来自 `mcp.tool` 事件，MCP `find`/`search`
+工具与 REST 端点计入同一组计数器。
+
+| MCP tool | operation |
+| --- | --- |
+| `find` | `find` |
+| `search` | `search` |
+
+REST `2xx` 和 `3xx` 记为 `success`，`4xx/5xx` 记为 `error`；MCP 工具调用成功记为
+`success`，参数校验或后端失败记为 `error`。Dashboard 今日检索只展示成功请求数。
 
 ### 上下文提交热力图
 

--- a/openviking/observability/usage_audit/projection.py
+++ b/openviking/observability/usage_audit/projection.py
@@ -148,6 +148,14 @@ def project_events(
                 touched_audit_accounts=touched_audit_accounts,
             )
 
+        if event.event_name == "mcp.tool":
+            _project_mcp_tool(
+                event,
+                event_date=event_date,
+                hour=event_hour,
+                retrieval_rows=retrieval_rows,
+            )
+
     return UsageAuditProjection(
         token_rows=dict(token_rows),
         retrieval_rows=dict(retrieval_rows),
@@ -289,6 +297,38 @@ def _project_http_request(
 def should_skip_audit_route(route: str) -> bool:
     """Return whether an HTTP route should be omitted from product audit."""
     return route in AUDIT_EXCLUDED_ROUTES or route.startswith("/api/v1/console/")
+
+
+MCP_RETRIEVAL_OPERATIONS = frozenset({"find", "search"})
+
+
+def _project_mcp_tool(
+    event: ObservabilityEvent,
+    *,
+    event_date: str,
+    hour: int,
+    retrieval_rows: defaultdict[tuple, tuple[int, int]],
+) -> None:
+    """Count MCP retrieval tool calls into the same dashboard buckets as REST search.
+
+    MCP tool traffic reaches the server as ``POST /mcp`` with no per-tool route,
+    so the route-based projection in ``_project_http_request`` cannot see it.
+    The MCP endpoint emits one ``mcp.tool`` event per find/search call carrying
+    the tool name and outcome, and this projection feeds the same
+    ``retrieval_rows`` shape the REST endpoints produce.
+    """
+    operation = str(event.payload.get("tool") or "")
+    if operation not in MCP_RETRIEVAL_OPERATIONS:
+        return
+    account = normalize_identity(
+        event.payload.get("account_id") or event.account_id,
+        unknown=True,
+    )
+    row_user = normalize_identity(event.payload.get("user_id") or event.user_id) or ""
+    status = "error" if event.payload.get("status") == "error" else "success"
+    key = (account, row_user, event_date, hour, operation, status)
+    prev_count, prev_results = retrieval_rows[key]
+    retrieval_rows[key] = (prev_count + 1, prev_results)
 
 
 def retrieval_operation_for_http(method: str, route: str) -> str | None:

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import base64
 import contextvars
+import functools
 import os
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
@@ -100,6 +101,53 @@ def _get_ctx() -> RequestContext:
     if ctx is None:
         raise UnauthenticatedError("MCP request identity not set")
     return ctx
+
+
+def _emit_mcp_tool_usage(tool_name: str, *, ok: bool) -> None:
+    """Emit a best-effort ``mcp.tool`` usage event for Studio dashboard counters.
+
+    MCP tool traffic arrives as ``POST /mcp``, so route-based usage projections
+    cannot tell which tool ran. The usage-audit pipeline consumes these events
+    to count MCP find/search calls alongside the REST search endpoints.
+    """
+    try:
+        from openviking.observability.events import try_publish_event
+
+        payload: Dict[str, Any] = {
+            "tool": tool_name,
+            "status": "success" if ok else "error",
+        }
+        ctx = _mcp_ctx.get()
+        if ctx is not None:
+            payload["account_id"] = ctx.account_id
+            payload["user_id"] = ctx.user.user_id
+        try_publish_event("mcp.tool", payload)
+    except Exception:
+        pass
+
+
+def _count_retrieval_usage(tool_name: str):
+    """Wrap an MCP retrieval tool so every completed call emits a usage event.
+
+    Argument-validation and backend failures count as ``error`` outcomes, which
+    matches the REST projection where non-2xx search calls land in the error
+    bucket rather than being dropped.
+    """
+
+    def decorator(fn):
+        @functools.wraps(fn)
+        async def wrapper(*args, **kwargs):
+            ok = False
+            try:
+                result = await fn(*args, **kwargs)
+                ok = True
+                return result
+            finally:
+                _emit_mcp_tool_usage(tool_name, ok=ok)
+
+        return wrapper
+
+    return decorator
 
 
 def _resolve_mcp_workspace_uri(uri: str, ctx: RequestContext) -> str:
@@ -246,6 +294,7 @@ def _resolve_context_type_filter(
 
 
 @mcp.tool()
+@_count_retrieval_usage("find")
 async def find(
     query: str,
     target_uri: str = "",
@@ -273,6 +322,7 @@ async def find(
 
 
 @mcp.tool()
+@_count_retrieval_usage("search")
 async def search(
     query: str,
     target_uri: str = "",

--- a/tests/observability/test_usage_audit_mcp_projection.py
+++ b/tests/observability/test_usage_audit_mcp_projection.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Projection of ``mcp.tool`` events into dashboard retrieval counters."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from openviking.observability.events import ObservabilityEvent
+from openviking.observability.usage_audit.projection import project_events
+
+TS = datetime(2026, 5, 12, 1, 2, 3, tzinfo=timezone.utc)
+
+
+def _mcp_event(
+    tool: str,
+    *,
+    status: str = "success",
+    account_id: str | None = "acct-1",
+    user_id: str | None = "user-1",
+) -> ObservabilityEvent:
+    payload: dict = {"tool": tool, "status": status}
+    if account_id is not None:
+        payload["account_id"] = account_id
+    if user_id is not None:
+        payload["user_id"] = user_id
+    return ObservabilityEvent(
+        event_name="mcp.tool",
+        payload=payload,
+        timestamp=TS,
+        account_id=account_id,
+        user_id=user_id,
+    )
+
+
+def test_mcp_find_and_search_count_as_retrievals():
+    rows = project_events(
+        [
+            _mcp_event("find"),
+            _mcp_event("search"),
+            _mcp_event("find"),
+        ]
+    ).retrieval_rows
+    assert rows[("acct-1", "user-1", "2026-05-12", 1, "find", "success")] == (2, 0)
+    assert rows[("acct-1", "user-1", "2026-05-12", 1, "search", "success")] == (1, 0)
+
+
+def test_mcp_tool_error_buckets_separately():
+    rows = project_events(
+        [
+            _mcp_event("find"),
+            _mcp_event("find", status="error"),
+        ]
+    ).retrieval_rows
+    assert rows[("acct-1", "user-1", "2026-05-12", 1, "find", "success")] == (1, 0)
+    assert rows[("acct-1", "user-1", "2026-05-12", 1, "find", "error")] == (1, 0)
+
+
+def test_non_retrieval_mcp_tools_are_ignored():
+    for tool in ("read", "multi_read", "list", "write", "glob", "add_resource"):
+        rows = project_events([_mcp_event(tool)]).retrieval_rows
+        assert rows == {}
+
+
+def test_identity_falls_back_to_event_envelope():
+    event = ObservabilityEvent(
+        event_name="mcp.tool",
+        payload={"tool": "search", "status": "success"},
+        timestamp=TS,
+        account_id="acct-2",
+        user_id="user-2",
+    )
+    rows = project_events([event]).retrieval_rows
+    assert rows[("acct-2", "user-2", "2026-05-12", 1, "search", "success")] == (1, 0)
+
+
+def test_missing_identity_normalizes_to_unknown():
+    event = ObservabilityEvent(
+        event_name="mcp.tool",
+        payload={"tool": "search", "status": "success"},
+        timestamp=TS,
+    )
+    rows = project_events([event]).retrieval_rows
+    assert rows[("__unknown__", "", "2026-05-12", 1, "search", "success")] == (1, 0)
+
+
+def test_mcp_events_do_not_touch_audit_rows():
+    projection = project_events([_mcp_event("find")])
+    assert projection.audit_rows == []
+    assert projection.touched_audit_accounts == set()
+
+
+def test_missing_status_defaults_to_success():
+    event = ObservabilityEvent(
+        event_name="mcp.tool",
+        payload={"tool": "find"},
+        timestamp=TS,
+        account_id="acct-1",
+        user_id="user-1",
+    )
+    rows = project_events([event]).retrieval_rows
+    assert rows[("acct-1", "user-1", "2026-05-12", 1, "find", "success")] == (1, 0)

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -1852,3 +1852,97 @@ async def test_tree_include_abstract_still_renders(service):
 
     result = await tree(uri="viking://resources/test_tree_abs", include_abstract=True)
     assert "\nnote.md (11 B)" in result
+
+
+# ---------------------------------------------------------------------------
+# retrieval usage events (mcp.tool)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def published_usage_events(monkeypatch):
+    """Capture mcp.tool usage events emitted during a test."""
+    events: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        "openviking.observability.events.try_publish_event",
+        lambda name, payload: events.append((name, dict(payload))),
+    )
+    return events
+
+
+@pytest.mark.asyncio
+async def test_find_tool_emits_retrieval_usage_event(service, monkeypatch, published_usage_events):
+    async def fake_find(**kwargs):
+        return SimpleNamespace(memories=[], resources=[], skills=[])
+
+    monkeypatch.setattr(service.search, "find", fake_find)
+
+    result = await mcp_endpoint.find(query="fast lookup")
+
+    assert result == "No matching context found."
+    assert published_usage_events == [
+        (
+            "mcp.tool",
+            {
+                "tool": "find",
+                "status": "success",
+                "account_id": "default",
+                "user_id": "test_user",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_find_tool_error_counts_as_error(service, monkeypatch, published_usage_events):
+    async def fake_find(**kwargs):
+        raise InvalidArgumentError("bad query")
+
+    monkeypatch.setattr(service.search, "find", fake_find)
+
+    with pytest.raises(InvalidArgumentError):
+        await mcp_endpoint.find(query="q")
+
+    assert published_usage_events[-1][0] == "mcp.tool"
+    assert published_usage_events[-1][1]["tool"] == "find"
+    assert published_usage_events[-1][1]["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_search_tool_emits_retrieval_usage_event(service, monkeypatch, published_usage_events):
+    async def fake_search(**kwargs):
+        return SimpleNamespace(memories=[], resources=[], skills=[])
+
+    monkeypatch.setattr(service.search, "search", fake_search)
+
+    await mcp_endpoint.search(query="deep lookup")
+
+    assert published_usage_events[-1][0] == "mcp.tool"
+    assert published_usage_events[-1][1]["tool"] == "search"
+    assert published_usage_events[-1][1]["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_search_tool_validation_failure_counts_as_error(
+    service, monkeypatch, published_usage_events
+):
+    # mode="context" + read_content=True is rejected before any backend call.
+    with pytest.raises(InvalidArgumentError):
+        await mcp_endpoint.search(query="q", mode="context", read_content=True)
+
+    assert published_usage_events[-1][0] == "mcp.tool"
+    assert published_usage_events[-1][1]["tool"] == "search"
+    assert published_usage_events[-1][1]["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_read_tool_does_not_emit_retrieval_usage_event(
+    service, monkeypatch, published_usage_events
+):
+    async def fake_read(*args, **kwargs):
+        return "content"
+
+    monkeypatch.setattr(service.fs, "read", fake_read)
+    await mcp_endpoint.read(uris="viking://user/test_user/a.md")
+
+    assert published_usage_events == []


### PR DESCRIPTION
Fixes #4688

## Problem

MCP tool traffic reaches the server as `POST /mcp` with no per-tool route, so `retrieval_operation_for_http` in `observability/usage_audit/projection.py` never matches it. Studio's "今日检索 / today_retrievals" stays at 0 for MCP-first deployments (Claude Code, Codex, Cursor, ...) even though retrievals succeed — exactly the gap reported in #4688.

## Approach

Rather than unwrapping JSON-RPC bodies in the HTTP middleware (one POST /mcp may not be one tool call, and body re-parsing in middleware conflicts with FastMCP's body handling), the MCP endpoint now emits one semantic event per tool call, mirroring how `llm.call` / `rerank.call` / `resource.stage` already flow through the shared observability event bus:

- **`openviking/server/mcp_endpoint.py`** — `find` / `search` are wrapped with `_count_retrieval_usage(...)`, a decorator that emits a best-effort `mcp.tool` event in a `finally` block with `{tool, status, account_id, user_id}` (identity from the request context var). Argument-validation failures and backend errors count as `error`, matching the REST projection where non-2xx search calls land in the error bucket instead of being dropped.
- **`openviking/observability/usage_audit/projection.py`** — `_project_mcp_tool` consumes `mcp.tool` events and feeds `find`/`search` into the same `retrieval_rows` shape the REST endpoints produce (same key tuple, same success/error bucketing). Other MCP tools (`read`, `list`, ...) are ignored, so the dashboard scope is unchanged. Identity falls back to the event envelope and normalizes to `__unknown__` when absent, consistent with `_project_http_request`.
- **README** — documents the MCP counting path alongside the REST table.

No double counting: the `POST /mcp` `http.request` event never produced retrieval rows (route mismatch), and `mcp.tool` never produces audit rows.

## Verification

- 7 new projection unit tests (`tests/observability/test_usage_audit_mcp_projection.py`): find/search counting, error bucketing, non-retrieval tools ignored, envelope fallback identity, `__unknown__` normalization, audit rows untouched, missing-status default — all pass.
- 5 new MCP endpoint tests (`tests/server/test_mcp_endpoint.py`): find/search emit on success, backend error and validation error count as `error`, non-retrieval tool emits nothing. Note: the whole `tests/server/test_mcp_endpoint.py` file requires the ragfs native binding in the local environment, so these follow the file's existing local-verification status.
- End-to-end check through the real event bus (local script): decorated `find`/`search` called with a fake service — 3 events captured (2 success + 1 error), identity propagated, `project_events` produced the expected rows.
- FastMCP tool schemas unchanged after decoration: `find` 7 params / `search` 22 params / `required=['query']`, identical to `upstream/main`.
- `tests/observability/` suite: 37 passed (7 new + 30 existing).

## Notes for reviewers

- The reporter's alternative (document that MCP traffic is excluded) would have been simpler, but MCP is the primary integration path per the docs, so counting it aligns the dashboard with the "run-health observability" goal stated in the issue.
- `mcp.tool` events are also available to the metrics router if Prometheus-side MCP counters are wanted later; no collector consumes them yet, which is intentionally out of scope here.
