### PR TITLE
fix(openclaw): strip dev dependencies from release artifacts

### DIFF
--- a/.github/workflows/clawhub-dev-release.yml
+++ b/.github/workflows/clawhub-dev-release.yml
@@ -314,9 +314,13 @@ jobs:
           set -euo pipefail
           npm version --no-git-tag-version --allow-same-version "$VERSION"
           npm ci
+          npm run prepack
+          # OpenClaw installs the extracted artifact as a project root. Even with
+          # --omit=dev, npm resolves devDependencies and can hit Arborist peer bugs.
+          npm pkg delete devDependencies
           pack_dir="$RUNNER_TEMP/openviking-pack"
           mkdir -p "$pack_dir"
-          npm pack --pack-destination "$pack_dir"
+          npm pack --ignore-scripts --pack-destination "$pack_dir"
           tarball="$(find "$pack_dir" -maxdepth 1 -name '*.tgz' -print -quit)"
           if [ -z "$tarball" ]; then
             echo "::error title=Pack failed::npm pack did not produce a tgz file."
@@ -364,10 +368,13 @@ jobs:
           set -euo pipefail
           npm version --no-git-tag-version --allow-same-version "$VERSION"
           npm ci
+          npm run prepack
+          # Keep the legacy ClawHub zip runtime-only for the same install path.
+          npm pkg delete devDependencies
           pack_dir="$RUNNER_TEMP/openviking-clawhub-pack"
           package_dir="$RUNNER_TEMP/openviking-clawhub-package"
           mkdir -p "$pack_dir" "$package_dir"
-          npm pack --pack-destination "$pack_dir"
+          npm pack --ignore-scripts --pack-destination "$pack_dir"
           tarball="$(find "$pack_dir" -maxdepth 1 -name '*.tgz' -print -quit)"
           if [ -z "$tarball" ]; then
             echo "::error title=Pack failed::npm pack did not produce a tgz file for ClawHub."

--- a/examples/openclaw-plugin/docs/openviking-install-package-contract.md
+++ b/examples/openclaw-plugin/docs/openviking-install-package-contract.md
@@ -38,7 +38,9 @@ The `setupEntry` must point at compiled JavaScript, not source TypeScript.
 
 ## Runtime Dependencies
 
-Runtime dependencies must include everything the compiled plugin imports at runtime. Development-only test/build packages belong in `devDependencies`.
+Runtime dependencies must include everything the compiled plugin imports at runtime. Development-only test/build packages belong in `devDependencies` in the source manifest.
+
+Published npm and ClawHub artifacts must remove the `devDependencies` field after `npm ci` and before `npm pack`. OpenClaw installs the extracted artifact as a project root, and `npm install --omit=dev` still resolves the root development dependency graph. Shipping that graph can therefore trigger npm Arborist peer-resolution failures even though none of those packages are needed at runtime.
 
 The package currently keeps an `axios` override to avoid installing vulnerable or incompatible transitive versions through OpenClaw packaging.
 
@@ -78,7 +80,8 @@ The package contract test should verify:
 - `openclaw.extensions` and `openclaw.setupEntry` point to `dist/*.js`,
 - package `files` include runtime assets and docs,
 - install manifest required files exist,
-- runtime dependencies and overrides are present.
+- runtime dependencies and overrides are present,
+- both release packaging paths strip `devDependencies` before `npm pack`.
 
 ## Out Of Scope
 

--- a/examples/openclaw-plugin/tests/ut/package-install-contract.test.ts
+++ b/examples/openclaw-plugin/tests/ut/package-install-contract.test.ts
@@ -87,6 +87,32 @@ describe("OpenClaw plugin package and install contract", () => {
     ]));
   });
 
+  it("strips dev dependencies before packing npm and ClawHub release artifacts", () => {
+    const workflow = readFileSync(
+      join(repoRoot, ".github/workflows/clawhub-dev-release.yml"),
+      "utf8",
+    );
+
+    for (const stepName of [
+      "Pack OpenViking plugin",
+      "Prepare ClawHub legacy package folder",
+    ]) {
+      const stepStart = workflow.indexOf(`      - name: ${stepName}`);
+      expect(stepStart, `${stepName} should exist`).toBeGreaterThanOrEqual(0);
+      const nextStep = workflow.indexOf("\n      - name:", stepStart + 1);
+      const step = workflow.slice(stepStart, nextStep < 0 ? undefined : nextStep);
+      const buildIndex = step.indexOf("npm run prepack");
+      const stripIndex = step.indexOf("npm pkg delete devDependencies");
+      const packIndex = step.indexOf("npm pack --ignore-scripts --pack-destination");
+
+      expect(buildIndex, `${stepName} should build before sanitizing`).toBeGreaterThanOrEqual(0);
+      expect(stripIndex, `${stepName} should strip devDependencies`).toBeGreaterThan(buildIndex);
+      expect(packIndex, `${stepName} should pack without rerunning scripts`).toBeGreaterThan(
+        stripIndex,
+      );
+    }
+  });
+
   it("ships and registers the canonical Experience skill", () => {
     const pluginManifest = readJson("openclaw.plugin.json");
     const installManifest = readJson("install-manifest.json");


### PR DESCRIPTION
## Description

Published OpenViking plugin artifacts currently retain the source manifest's `devDependencies`. OpenClaw extracts the artifact and runs `npm install --omit=dev` with that directory as the project root, but npm still resolves the omitted development dependency graph. On distro npm 9.2.0, the Vitest/Vite optional-peer graph can crash Arborist in `loadPeerSet` with `Cannot read properties of null (reading 'edgesOut')`.

Build while development dependencies are still present, then remove `devDependencies` before producing both npm and legacy ClawHub artifacts. Source checkouts keep their development tooling unchanged.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

- Upstream npm failure: https://github.com/npm/cli/issues/9787

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Run the existing `prepack` build before sanitizing release manifests.
- Delete `devDependencies` before both npm and ClawHub packaging, then use `npm pack --ignore-scripts` to avoid rebuilding after sanitization.
- Add a package-contract regression test and document the runtime-only artifact requirement.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands and checks:

```text
cd examples/openclaw-plugin && ./node_modules/.bin/vitest run tests/ut/package-install-contract.test.ts  # 7 passed
cd examples/openclaw-plugin && ./node_modules/.bin/tsc -p tsconfig.json                                  # passed
PyYAML parse of .github/workflows/clawhub-dev-release.yml                                                # passed
sanitized npm-pack manifest smoke check                                                                  # no devDependencies; runtime deps preserved
git diff --check                                                                                          # passed
```

The full plugin suite currently reports 761 passing tests and 4 existing failures in `architecture-boundaries.test.ts`; those assertions concern `client.ts`/`commands/setup.ts`, which this PR does not modify.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Previously published versions are immutable. The fix takes effect when the next plugin version is published to npm and ClawHub.
