### PR TITLE
fix(codex): revalidate stale lock generation before takeover

### DIFF
--- a/examples/codex-memory-plugin/scripts/session-state.mjs
+++ b/examples/codex-memory-plugin/scripts/session-state.mjs
@@ -253,9 +253,20 @@ const LOCK_POLL_MS = 100;
  * exactly one wins, and the losers re-read a lock that now carries the
  * winner's fresh stamp. The winner drops the claim as soon as it is stamped,
  * so later generations can take over in turn; a claim left behind by a taker
- * that died mid-takeover ages out like the lock itself.
+ * that died mid-takeover ages out like the lock itself. Winning the claim only
+ * grants the right to revalidate that observed generation, never to overwrite
+ * whatever owner happens to be present later.
  */
-async function claimStaleLock(dir, ownerFile, token, seen, staleMs) {
+function isReleaseRace(err) {
+  return err?.code === "ENOENT" || err?.code === "ENOTDIR";
+}
+
+function sameNode(left, right) {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+/** @internal Exported for deterministic race regression tests. */
+export async function claimStaleLock(dir, ownerFile, token, seen, staleMs, observed) {
   const key = createHash("sha256").update(seen ?? "\u0000unstamped").digest("hex").slice(0, 32);
   const claimDir = join(dir, `claim-${key}`);
   try {
@@ -267,14 +278,47 @@ async function claimStaleLock(dir, ownerFile, token, seen, staleMs) {
           await rmdir(claimDir).catch(() => {});
         }
       } catch {}
+      return false;
     }
-    return false;
+    if (isReleaseRace(err)) return false;
+    throw err;
   }
-  await writeFile(ownerFile, token);
-  const now = new Date();
-  await utimes(dir, now, now).catch(() => {});
-  await rmdir(claimDir).catch(() => {});
-  return true;
+  try {
+    let current = null;
+    try {
+      current = await readFile(ownerFile, "utf-8");
+    } catch (err) {
+      if (!isReleaseRace(err)) throw err;
+    }
+    if (current !== seen) return false;
+
+    let currentStamp;
+    try {
+      currentStamp = await stat(seen === null ? dir : ownerFile);
+    } catch (err) {
+      if (isReleaseRace(err)) return false;
+      throw err;
+    }
+    if (!sameNode(currentStamp, observed)) return false;
+    // Creating the claim changes an unstamped lock directory's mtime, so its
+    // pre-claim observation is the applicable age. A stamped lock's owner file
+    // is unaffected by mkdir and must still have the observed stale timestamp.
+    const applicableMtimeMs = seen === null ? observed.mtimeMs : currentStamp.mtimeMs;
+    if (seen !== null && currentStamp.mtimeMs !== observed.mtimeMs) return false;
+    if (Date.now() - applicableMtimeMs <= staleMs) return false;
+
+    try {
+      await writeFile(ownerFile, token, seen === null ? { flag: "wx" } : undefined);
+    } catch (err) {
+      if (isReleaseRace(err) || (seen === null && err?.code === "EEXIST")) return false;
+      throw err;
+    }
+    const now = new Date();
+    await utimes(dir, now, now).catch(() => {});
+    return true;
+  } finally {
+    await rmdir(claimDir).catch(() => {});
+  }
 }
 
 /**
@@ -317,14 +361,15 @@ export async function withSessionLock(codexSessionId, fn, { waitMs = 0, staleMs 
       try {
         seen = await readFile(ownerFile, "utf-8");
       } catch {}
-      let ageMs;
+      let observed;
       try {
-        ageMs = Date.now() - (await stat(seen === null ? dir : ownerFile)).mtimeMs;
+        observed = await stat(seen === null ? dir : ownerFile);
       } catch {
         continue; // holder released between mkdir and stat; retry immediately
       }
+      const ageMs = Date.now() - observed.mtimeMs;
       if (ageMs > staleMs) {
-        if (await claimStaleLock(dir, ownerFile, token, seen, staleMs)) {
+        if (await claimStaleLock(dir, ownerFile, token, seen, staleMs, observed)) {
           held = true;
           break;
         }

--- a/examples/codex-memory-plugin/scripts/session-state.test.mjs
+++ b/examples/codex-memory-plugin/scripts/session-state.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -7,7 +7,7 @@ import test from "node:test";
 const STATE_DIR = await mkdtemp(join(tmpdir(), "ov-session-state-"));
 process.env.OPENVIKING_CODEX_STATE_DIR = STATE_DIR;
 
-const { clearEnded, markEnded, readEndedAt, withSessionLock } = await import("./session-state.mjs");
+const { claimStaleLock, clearEnded, markEnded, readEndedAt, withSessionLock } = await import("./session-state.mjs");
 
 async function exists(path) {
   try { await stat(path); return true; } catch { return false; }
@@ -50,6 +50,81 @@ test("concurrent stale takeovers leave exactly one holder", async () => {
   assert.equal(maxInside, 1, "a stale takeover must never hand the lock to two takers");
   assert.equal(outcomes.filter((o) => o.value === true).length, 3);
   assert.equal(await exists(dir), false, "the last holder releases the lock");
+});
+
+test("a delayed stale claimant cannot overwrite the next owner generation", async () => {
+  const dir = join(STATE_DIR, "delayed-generation.lock");
+  const ownerFile = join(dir, "owner");
+  await mkdir(dir, { recursive: true });
+  await writeFile(ownerFile, "old-owner");
+  const old = new Date(Date.now() - 600_000);
+  await utimes(ownerFile, old, old);
+
+  // The delayed claimant took both of these observations before another
+  // claimant won, dropped the generation claim, and installed a live owner.
+  const seen = await readFile(ownerFile, "utf-8");
+  const observed = await stat(ownerFile);
+  await writeFile(ownerFile, "live-owner");
+
+  const claimed = await claimStaleLock(
+    dir,
+    ownerFile,
+    "delayed-owner",
+    seen,
+    300_000,
+    observed,
+  );
+
+  assert.equal(claimed, false);
+  assert.equal(await readFile(ownerFile, "utf-8"), "live-owner");
+  assert.deepEqual(await readdir(dir), ["owner"], "the losing claim is cleaned up");
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("a heartbeat that refreshed the observed owner prevents stale takeover", async () => {
+  const dir = join(STATE_DIR, "refreshed-generation.lock");
+  const ownerFile = join(dir, "owner");
+  await mkdir(dir, { recursive: true });
+  await writeFile(ownerFile, "same-owner");
+  const old = new Date(Date.now() - 600_000);
+  await utimes(ownerFile, old, old);
+  const observed = await stat(ownerFile);
+
+  const now = new Date();
+  await utimes(ownerFile, now, now);
+  const claimed = await claimStaleLock(
+    dir,
+    ownerFile,
+    "stale-claimant",
+    "same-owner",
+    300_000,
+    observed,
+  );
+
+  assert.equal(claimed, false);
+  assert.equal(await readFile(ownerFile, "utf-8"), "same-owner");
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("a release race after claiming returns false instead of throwing", async () => {
+  const dir = join(STATE_DIR, "released-during-claim.lock");
+  await mkdir(dir, { recursive: true });
+  const old = new Date(Date.now() - 600_000);
+  await utimes(dir, old, old);
+  const observed = await stat(dir);
+
+  const claimed = await claimStaleLock(
+    dir,
+    join(dir, "released", "owner"),
+    "new-owner",
+    null,
+    300_000,
+    observed,
+  );
+
+  assert.equal(claimed, false);
+  assert.deepEqual(await readdir(dir), [], "the failed claim is cleaned up");
+  await rm(dir, { recursive: true, force: true });
 });
 
 test("a claim left behind by a dead taker does not wedge the lock", async () => {

--- a/examples/codex-memory-plugin/scripts/session-state.test.mjs
+++ b/examples/codex-memory-plugin/scripts/session-state.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, readdir, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rename, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -77,6 +77,36 @@ test("a delayed stale claimant cannot overwrite the next owner generation", asyn
 
   assert.equal(claimed, false);
   assert.equal(await readFile(ownerFile, "utf-8"), "live-owner");
+  assert.deepEqual(await readdir(dir), ["owner"], "the losing claim is cleaned up");
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("a replaced owner inode prevents takeover with the same token and mtime", async () => {
+  const dir = join(STATE_DIR, "replaced-inode.lock");
+  const ownerFile = join(dir, "owner");
+  const replacement = join(dir, "replacement");
+  await mkdir(dir, { recursive: true });
+  const seen = "same-owner";
+  const old = new Date(Math.floor(Date.now() / 1000) * 1000 - 600_000);
+  await writeFile(ownerFile, seen);
+  await utimes(ownerFile, old, old);
+  const observed = await stat(ownerFile);
+
+  // Allocate the replacement while the old inode still exists to avoid reuse.
+  await writeFile(replacement, seen);
+  await utimes(replacement, old, old);
+  await rename(replacement, ownerFile);
+  const current = await stat(ownerFile);
+  assert.equal(current.dev, observed.dev);
+  assert.notEqual(current.ino, observed.ino);
+  assert.equal(current.mtimeMs, observed.mtimeMs);
+
+  const claimed = await claimStaleLock(
+    dir, ownerFile, "delayed-owner", seen, 300_000, observed,
+  );
+
+  assert.equal(claimed, false);
+  assert.equal(await readFile(ownerFile, "utf-8"), seen);
   assert.deepEqual(await readdir(dir), ["owner"], "the losing claim is cleaned up");
   await rm(dir, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Description

Follow up on #4591 by treating a generation claim as permission to revalidate the stale lock, rather than permission to overwrite whichever owner is present by then.

A claimant can observe a stale owner, pause, and resume after another claimant has already won, stamped the lock, and removed the shared claim directory. Without revalidation, the delayed claimant recreates that claim directory and overwrites the live owner's token, so both enter the critical section. A lock release during takeover can also surface as an unhandled filesystem error.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Follow-up to #4591 and its unresolved [generation-race review finding](https://github.com/volcengine/OpenViking/pull/4591#discussion_r3913358607).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Re-read the owner token while holding the per-generation claim and reject a changed generation.
- Revalidate the observed inode, timestamp, and staleness before stamping; use exclusive creation for an unstamped owner.
- Treat lock-release races as a lost claim and always clean up the claim directory.
- Add deterministic regressions for a delayed claimant, a refreshed heartbeat, and a disappearing owner target.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands:

```text
node --check session-state.mjs
node --check session-state.test.mjs
node --test session-state.test.mjs
# 9 passed; repeated 50 times with Node 25
```

The delayed-generation regression fails on the current implementation because `claimStaleLock` returns `true` and replaces the live owner.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The broader memory-plugin suite exercised 541 tests locally. All 9 tests in the changed lock suite passed; unrelated local failures were confined to existing compressor and installer environment paths. The current upstream plugin suite is green on GitHub.
