### PR TITLE
fix(pi-extension): address #4692 review nits (watermark + drain budget)

### DIFF
--- a/examples/memory-plugin-shared/lib/batch-send.mjs
+++ b/examples/memory-plugin-shared/lib/batch-send.mjs
@@ -23,11 +23,12 @@ async function enqueueRemainder(sessionId, payloads, startIndex, result, retryab
   result.retryable = retryable;
   result.lastError = lastError ?? null;
 
-  if (!retryable) {
-    result.failed += Math.max(0, payloads.length - startIndex);
-    return result;
-  }
-
+  // Always enqueue the unsent suffix when the caller requested enqueue-on-failure
+  // semantics — including non-retryable statuses (400/403/…). Counting them as
+  // accepted-after-enqueue keeps the sync watermark moving; poison payloads are
+  // still dropped later by maxRetries/TTL. Skipping the enqueue here left
+  // accepted < payloads.length, so the next turn re-extracted already-sent
+  // messages and duplicated them on the server (#4692 review).
   const baseCreatedAt = Date.now();
   for (let i = startIndex; i < payloads.length; i++) {
     const queued = await enqueue("addMessage", sessionId, payloads[i], {
@@ -78,7 +79,8 @@ async function sendSerial(fetchJSON, sessionId, payloads, startIndex, opts, resu
  * @param {string} sessionId - OpenViking session id
  * @param {Array<object>} payloads - sanitized add-message request bodies
  * @param {object} opts
- * @param {boolean} opts.enqueueOnRetryable - enqueue unsent payloads after a retryable failure
+ * @param {boolean} opts.enqueueOnRetryable - enqueue unsent payloads after any send failure
+ *   (retryable or not); name kept for callers, semantics are enqueue-on-failure
  * @param {Function} opts.onSent - called with the number of messages durably sent after each success
  * @returns {Promise<{sent:number,queued:number,enqueueFailed:number,failed:number,retryable:boolean,usedBatch:boolean,lastError:any}>}
  */

--- a/examples/pi-coding-agent-extension/shared/batch-send.mjs
+++ b/examples/pi-coding-agent-extension/shared/batch-send.mjs
@@ -24,11 +24,12 @@ async function enqueueRemainder(sessionId, payloads, startIndex, result, retryab
   result.retryable = retryable;
   result.lastError = lastError ?? null;
 
-  if (!retryable) {
-    result.failed += Math.max(0, payloads.length - startIndex);
-    return result;
-  }
-
+  // Always enqueue the unsent suffix when the caller requested enqueue-on-failure
+  // semantics — including non-retryable statuses (400/403/…). Counting them as
+  // accepted-after-enqueue keeps the sync watermark moving; poison payloads are
+  // still dropped later by maxRetries/TTL. Skipping the enqueue here left
+  // accepted < payloads.length, so the next turn re-extracted already-sent
+  // messages and duplicated them on the server (#4692 review).
   const baseCreatedAt = Date.now();
   for (let i = startIndex; i < payloads.length; i++) {
     const queued = await enqueue("addMessage", sessionId, payloads[i], {
@@ -79,7 +80,8 @@ async function sendSerial(fetchJSON, sessionId, payloads, startIndex, opts, resu
  * @param {string} sessionId - OpenViking session id
  * @param {Array<object>} payloads - sanitized add-message request bodies
  * @param {object} opts
- * @param {boolean} opts.enqueueOnRetryable - enqueue unsent payloads after a retryable failure
+ * @param {boolean} opts.enqueueOnRetryable - enqueue unsent payloads after any send failure
+ *   (retryable or not); name kept for callers, semantics are enqueue-on-failure
  * @param {Function} opts.onSent - called with the number of messages durably sent after each success
  * @returns {Promise<{sent:number,queued:number,enqueueFailed:number,failed:number,retryable:boolean,usedBatch:boolean,lastError:any}>}
  */

--- a/examples/pi-coding-agent-extension/sync.ts
+++ b/examples/pi-coding-agent-extension/sync.ts
@@ -62,6 +62,9 @@ export class SyncManager {
 
   async flushForTakeover(): Promise<boolean> {
     if (!this.ovSessionId) return false;
+    // Drain is bounded (time / max batches). Remaining undelivered entries —
+    // including any still claimed as `.processing` — keep the barrier closed
+    // until a later turn finishes draining them.
     if (this.client.connected) await this.drainSessionBacklog();
     const pending = await listPending();
     return countUndeliveredForSession(pending, this.ovSessionId) === 0;
@@ -74,20 +77,44 @@ export class SyncManager {
    * large offline backlog block the takeover barrier for many turns (#4504).
    * Entries are claimed one batch at a time so a failed batch only costs a
    * retry for the entries it contained.
+   *
+   * Bounded per call via OPENVIKING_PENDING_DRAIN_BUDGET_MS (default 60s) and
+   * optional OPENVIKING_PENDING_DRAIN_MAX_BATCHES so a huge backlog cannot
+   * block turn_end for an unbounded wall time; remainder drains on later turns.
    */
   private async drainSessionBacklog(): Promise<void> {
     const sid = this.ovSessionId;
     if (!sid) return;
+    const budgetRaw = Number(process.env.OPENVIKING_PENDING_DRAIN_BUDGET_MS);
+    const timeBudgetMs = Number.isFinite(budgetRaw) && budgetRaw >= 0 ? budgetRaw : 60_000;
+    const maxRaw = Number(process.env.OPENVIKING_PENDING_DRAIN_MAX_BATCHES);
+    const maxBatches =
+      Number.isFinite(maxRaw) && maxRaw > 0 ? Math.floor(maxRaw) : Number.POSITIVE_INFINITY;
+    const started = Date.now();
+    let batches = 0;
+
     const backlog = (await listPending()).filter(
       ({ entry }) => entry?.type === "addMessage" && entry.sessionId === sid,
     );
     for (let start = 0; start < backlog.length; start += BATCH_LIMIT) {
+      if (batches >= maxBatches || Date.now() - started >= timeBudgetMs) {
+        this.logger.log("drain", {
+          session: sid,
+          stopped: batches >= maxBatches ? "max-batches" : "time-budget",
+          batches,
+          remaining: backlog.length - start,
+          elapsedMs: Date.now() - started,
+        });
+        return;
+      }
+
       const claimed: Array<{ filename: string; entry: any }> = [];
       for (const { filename, entry } of backlog.slice(start, start + BATCH_LIMIT)) {
         const name = await claimForReplay(filename);
         if (name) claimed.push({ filename: name, entry });
       }
       if (claimed.length === 0) continue;
+      batches += 1;
 
       let delivered = 0;
       await sendSessionMessages(

--- a/examples/pi-coding-agent-extension/tests/sync-barrier.test.mjs
+++ b/examples/pi-coding-agent-extension/tests/sync-barrier.test.mjs
@@ -270,3 +270,46 @@ test("failed batch keeps its entries queued with one retry and leaves the rest u
     assert.equal(retries.filter((r) => r === 0).length, 20);
   });
 });
+
+test("non-retryable batch failure still enqueues and advances the sync watermark", async () => {
+  await withPendingDir(async () => {
+    const { c, calls } = batchClient({ respond: () => ({ ok: false, status: 400, error: { message: "bad" } }) });
+    const sync = new SyncManager(c, config());
+    await sync.ensureSession("pi-session");
+
+    const result = await sync.syncBranch([
+      { type: "message", message: { role: "user", content: "Poison payload one for watermark enqueue test." } },
+      { type: "message", message: { role: "user", content: "Poison payload two for watermark enqueue test." } },
+    ]);
+
+    assert.equal(result.added, 2);
+    assert.equal(result.allDelivered, false);
+    assert.equal(sync.syncedCount, 2);
+    assert.equal(calls.length, 1);
+    assert.equal((await listPending()).length, 2);
+  });
+});
+
+test("drainSessionBacklog stops after maxBatches and leaves remainder for later turns", async () => {
+  await withPendingDir(async () => {
+    const previous = process.env.OPENVIKING_PENDING_DRAIN_MAX_BATCHES;
+    process.env.OPENVIKING_PENDING_DRAIN_MAX_BATCHES = "1";
+    try {
+      const { c, calls } = batchClient();
+      const sync = new SyncManager(c, config());
+      await sync.ensureSession("pi-session");
+      const t0 = Date.now();
+      for (let i = 0; i < 250; i++) {
+        await enqueue("addMessage", sync.sessionId, { role: "user", content: `m${i}` }, { createdAt: t0 + i });
+      }
+
+      assert.equal(await sync.flushForTakeover(), false);
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0].body.messages.length, 100);
+      assert.equal((await listPending()).length, 150);
+    } finally {
+      if (previous === undefined) delete process.env.OPENVIKING_PENDING_DRAIN_MAX_BATCHES;
+      else process.env.OPENVIKING_PENDING_DRAIN_MAX_BATCHES = previous;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Follow-up for #4692 review comments from @now-ing and @jiale-li-orion.

1. **Watermark / non-retryable mid-batch**: `enqueueRemainder` now queues the unsent suffix for *any* send failure (including 400/403), restoring accepted-after-enqueue so `syncedEntryCount` advances. Poison payloads still die via maxRetries/TTL.
2. **Bounded drain**: `drainSessionBacklog` stops after `OPENVIKING_PENDING_DRAIN_BUDGET_MS` (default 60s) or optional `OPENVIKING_PENDING_DRAIN_MAX_BATCHES`, leaving remainder for later turns.
3. **Tests**: non-retryable enqueue advances watermark; maxBatches=1 leaves remainder.

Happy for @ZaynJarvis to cherry-pick onto #4692 or merge this into the PR branch.

Co-authored-by context: continuing #4504 / #4616 collaboration.
