### PR TITLE
fix(codex): quote plugin hook script paths

### DIFF
--- a/examples/codex-memory-plugin/hooks/hooks.json
+++ b/examples/codex-memory-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${PLUGIN_ROOT}/scripts/session-start-commit.mjs",
+            "command": "node \"${PLUGIN_ROOT}/scripts/session-start-commit.mjs\"",
             "timeout": 70
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${PLUGIN_ROOT}/scripts/auto-recall.mjs",
+            "command": "node \"${PLUGIN_ROOT}/scripts/auto-recall.mjs\"",
             "timeout": 130
           }
         ]
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${PLUGIN_ROOT}/scripts/auto-capture.mjs",
+            "command": "node \"${PLUGIN_ROOT}/scripts/auto-capture.mjs\"",
             "timeout": 30
           }
         ]
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${PLUGIN_ROOT}/scripts/session-end.mjs",
+            "command": "node \"${PLUGIN_ROOT}/scripts/session-end.mjs\"",
             "timeout": 3
           }
         ]
@@ -54,7 +54,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${PLUGIN_ROOT}/scripts/pre-compact-capture.mjs",
+            "command": "node \"${PLUGIN_ROOT}/scripts/pre-compact-capture.mjs\"",
             "timeout": 60
           }
         ]

--- a/examples/codex-memory-plugin/scripts/marketplace.test.mjs
+++ b/examples/codex-memory-plugin/scripts/marketplace.test.mjs
@@ -158,7 +158,11 @@ test("hooks.json uses Codex's native ${PLUGIN_ROOT}, not the legacy placeholder"
     .map((h) => h.command || "");
   assert.ok(commands.length >= 5, "expected at least 5 hook commands (SessionStart/UserPromptSubmit/Stop/SessionEnd/PreCompact)");
   for (const cmd of commands) {
-    assert.ok(cmd.includes("${PLUGIN_ROOT}/scripts/"), `hook command must be rooted at \${PLUGIN_ROOT}: ${cmd}`);
+    assert.match(
+      cmd,
+      /^node "\$\{PLUGIN_ROOT\}\/scripts\/[^"\n]+\.mjs"$/,
+      `hook command must quote the \${PLUGIN_ROOT} script path: ${cmd}`,
+    );
   }
 });
 


### PR DESCRIPTION
## Description

When the Codex plugin is installed under a path containing spaces, the unquoted `${PLUGIN_ROOT}` expansion in each hook command is split by the shell. Quoting the complete script path keeps the expansion as one argument and prevents the affected hooks from exiting with code 1.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4623

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Quoted the `${PLUGIN_ROOT}/scripts/*.mjs` path in all five Codex hook commands.
- Strengthened the existing marketplace regression test to require the quoted command shape.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

- `node --test examples/codex-memory-plugin/scripts/marketplace.test.mjs` passed locally: 16 tests passed.
- `hooks.json` parsed successfully, and an explicit validation confirmed all five hook commands use the quoted `${PLUGIN_ROOT}` form.
- The reported Codex/Orca runtime was not available locally; the failure mode was validated from the live configuration and the documented shell word-splitting behavior.
