### PR TITLE
fix(codex-memory-plugin): quote ${PLUGIN_ROOT} in hook commands

### DIFF
--- a/examples/codex-memory-plugin/hooks/hooks.json
+++ b/examples/codex-memory-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${PLUGIN_ROOT}/scripts/session-start-commit.mjs",
+            "command": "node \"${PLUGIN_ROOT}/scripts/session-start-commit.mjs\"",
             "timeout": 70
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${PLUGIN_ROOT}/scripts/auto-recall.mjs",
+            "command": "node \"${PLUGIN_ROOT}/scripts/auto-recall.mjs\"",
             "timeout": 130
           }
         ]
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${PLUGIN_ROOT}/scripts/auto-capture.mjs",
+            "command": "node \"${PLUGIN_ROOT}/scripts/auto-capture.mjs\"",
             "timeout": 30
           }
         ]
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${PLUGIN_ROOT}/scripts/session-end.mjs",
+            "command": "node \"${PLUGIN_ROOT}/scripts/session-end.mjs\"",
             "timeout": 3
           }
         ]
@@ -54,7 +54,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${PLUGIN_ROOT}/scripts/pre-compact-capture.mjs",
+            "command": "node \"${PLUGIN_ROOT}/scripts/pre-compact-capture.mjs\"",
             "timeout": 60
           }
         ]


### PR DESCRIPTION
## Summary

Fixes #4623

On macOS, when the plugin is installed under a path containing spaces (e.g. Orca-managed
`/Users/<user>/Library/Application Support/orca/...`), every hook in
`examples/codex-memory-plugin/hooks/hooks.json` fails with exit code 1: the unquoted
`${PLUGIN_ROOT}` expansion is word-split by the shell, so Node receives a truncated path
(`/Users/<user>/Library/Application`).

## Changes

Quote the script path in all five hook commands:

- `SessionStart`: `node "${PLUGIN_ROOT}/scripts/session-start-commit.mjs"`
- `UserPromptSubmit`: `node "${PLUGIN_ROOT}/scripts/auto-recall.mjs"`
- `Stop`: `node "${PLUGIN_ROOT}/scripts/auto-capture.mjs"`
- `SessionEnd`: `node "${PLUGIN_ROOT}/scripts/session-end.mjs"`
- `PreCompact`: `node "${PLUGIN_ROOT}/scripts/pre-compact-capture.mjs"`

Modern Codex injects and inline-substitutes `${PLUGIN_ROOT}` (per the plugin README), so the
token remains intact and quoting only guards the expansion against word splitting.

## Verification

- `hooks.json` still parses as valid JSON and every command keeps the native `${PLUGIN_ROOT}` token.
- `node scripts/marketplace.test.mjs` in `examples/codex-memory-plugin`: all tests pass (fail 0).
- The reporter of #4623 verified the quoted form works in their real environment.