### PR TITLE
feat(dsh-memory-plugin): optional attribution tags for session commits

### DIFF
--- a/examples/dsh-memory-plugin/attribution-tags.test.mjs
+++ b/examples/dsh-memory-plugin/attribution-tags.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveConfig } from "./config.mjs";
+
+test("attribution tags default to empty (feature off)", () => {
+  const config = resolveConfig({}, {
+    OPENVIKING_URL: "http://127.0.0.1:19464/",
+  }, "/workspace/project");
+
+  assert.equal(config.attributionTags, "");
+});
+
+test("attribution tags opt in via environment", () => {
+  const config = resolveConfig({}, {
+    OPENVIKING_URL: "http://127.0.0.1:19464/",
+    OPENVIKING_ATTRIBUTION_TAGS: "agent=dsh",
+  }, "/workspace/project");
+
+  assert.equal(config.attributionTags, "agent=dsh");
+});

--- a/examples/dsh-memory-plugin/client.mjs
+++ b/examples/dsh-memory-plugin/client.mjs
@@ -114,11 +114,15 @@ export class OpenVikingClient {
   }
 
   async commitSession(sessionId, actorPeerId, options = {}) {
+    const body = { keep_recent_count: this.config.commitKeepRecentCount };
+    if (this.config.attributionTags) {
+      body.extraction_metadata = { event: { tags: String(this.config.attributionTags).split(",").map((t) => t.trim()).filter(Boolean) } };
+    }
     return this.fetchJSON(
       `/api/v1/sessions/${encodeURIComponent(sessionId)}/commit`,
       {
         method: "POST",
-        body: JSON.stringify({ keep_recent_count: this.config.commitKeepRecentCount }),
+        body: JSON.stringify(body),
       },
       { timeoutMs: options.timeoutMs ?? 30000, actorPeerId },
     );

--- a/examples/dsh-memory-plugin/config.mjs
+++ b/examples/dsh-memory-plugin/config.mjs
@@ -41,6 +41,7 @@ const DEFAULT_CONFIG = Object.freeze({
   skipSubagentSessions: false,
   requestTimeoutMs: 10000,
   mcpToolCallTimeoutMs: 60000,
+  attributionTags: "",
 });
 
 export function resolveConfig(input = {}, env = process.env, cwd = process.cwd()) {
@@ -77,6 +78,9 @@ export function resolveConfig(input = {}, env = process.env, cwd = process.cwd()
   if (env.OPENVIKING_RECALL_LIMIT) {
     config.recallLimit = env.OPENVIKING_RECALL_LIMIT;
     config.recallLimitConfigured = true;
+  }
+  if (env.OPENVIKING_ATTRIBUTION_TAGS !== undefined) {
+    config.attributionTags = String(env.OPENVIKING_ATTRIBUTION_TAGS);
   }
 
   config.endpoint = String(config.endpoint || DEFAULT_CONFIG.endpoint).replace(/\/+$/, "");

--- a/examples/dsh-memory-plugin/runtime.mjs
+++ b/examples/dsh-memory-plugin/runtime.mjs
@@ -196,11 +196,17 @@ export class OpenVikingRuntime {
         error: response.ok ? undefined : response.error?.message || response.error?.code,
       });
       if (isRetryableFailure(response)) {
-        await this.enqueueFinalCommit(state, {
+        await this.enqueueFinalCommit(state, this.commitExtras(state, {
           keep_recent_count: state.config.commitKeepRecentCount,
-        });
+        }));
       }
     });
+  }
+
+  commitExtras(state, base) {
+    const tags = state.config?.attributionTags;
+    if (!tags) return base;
+    return { ...base, extraction_metadata: { event: { tags: String(tags).split(",").map((t) => t.trim()).filter(Boolean) } } };
   }
 
   dispose(session) {
@@ -210,9 +216,9 @@ export class OpenVikingRuntime {
     state.disposing = (async () => {
       this.enqueueWrite(state, async () => {
         if (!state.config.syncTurns) return;
-        const commitPayload = {
+        const commitPayload = this.commitExtras(state, {
           keep_recent_count: state.config.commitKeepRecentCount,
-        };
+        });
         if (state.hasPendingWrites) {
           await this.enqueueFinalCommit(state, commitPayload);
           return;


### PR DESCRIPTION
## Problem

Deployments that run several agent harnesses against one OpenViking server cannot tell which harness produced a given memory after extraction: session commits from different agents are indistinguishable in the store, and there is no filterable attribution on extracted memories.

## Solution

Add an opt-in `attributionTags` setting to the dsh memory-plugin example (env `OPENVIKING_ATTRIBUTION_TAGS`). When set, every session commit carries `extraction_metadata.event.tags` — the same field `commit_session` already accepts server-side — for example `agent=dsh`.

- Tags are strict `k=v` strings (lowercase, exactly one `=`), matching `normalize_search_tag`, and become filterable through the `tags` parameter on `/api/v1/search/find`.
- Default is empty: zero behavior change for existing deployments.
- Queued (pending-queue) commit payloads carry the tags too, so retries after a restart keep attribution.
- Agent-hook based harnesses (which share this example family) can mirror the same body shape to keep attribution uniform across harnesses.

## Changes

- `config.mjs`: new `attributionTags` setting + `OPENVIKING_ATTRIBUTION_TAGS` env override (default empty).
- `client.mjs`: `commitSession` attaches `extraction_metadata.event.tags` when configured.
- `runtime.mjs`: `commitExtras` passthrough so queued fallback commits keep the tags.
- `attribution-tags.test.mjs`: default-off and env opt-in coverage.
