### PR TITLE
docs(bot): add Parallel Search MCP setup example

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -441,6 +441,30 @@ Configure third-party MCP Servers under `bot.tools.mcp_servers`:
 
 Supported transports are `stdio`, `sse`, and `streamableHttp`. Tool names use the form `mcp_<server>_<tool>`. A failed MCP connection does not block other Agent capabilities.
 
+#### Parallel Search example
+
+[Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) provides public web search and page extraction without a Parallel account or API key. To enable it, merge this example into your `ov.conf`, keeping your existing settings and MCP servers:
+
+```json
+{
+  "bot": {
+    "tools": {
+      "mcp_servers": {
+        "parallel": {
+          "type": "streamableHttp",
+          "url": "https://search.parallel.ai/mcp",
+          "enabled_tools": ["web_search", "web_fetch"]
+        }
+      }
+    }
+  }
+}
+```
+
+Restart VikingBot to make `mcp_parallel_web_search` and `mcp_parallel_web_fetch` available alongside the built-in web tools. The agent can choose these tools during a conversation. Queries, requested URLs, and any supplied objectives or context are sent to Parallel. Free access is rate limited.
+
+To disable the connection, remove the `parallel` entry and restart VikingBot. This example does not change the built-in search backend or its fallback order.
+
 ## Sandbox
 
 | Backend | Description |

--- a/bot/README_CN.md
+++ b/bot/README_CN.md
@@ -438,6 +438,30 @@ Agent 实际使用的活动目录还取决于 `bot.sandbox.mode`：
 
 支持 `stdio`、`sse` 和 `streamableHttp`。工具注册名为 `mcp_<server>_<tool>`；单个 MCP 连接失败不会阻断其他 Agent 能力。
 
+#### Parallel Search 示例
+
+[Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) 提供公开网页搜索和内容提取，无需 Parallel 账号或 API Key。要启用它，请将以下示例合并到 `ov.conf`，保留现有设置和 MCP Server：
+
+```json
+{
+  "bot": {
+    "tools": {
+      "mcp_servers": {
+        "parallel": {
+          "type": "streamableHttp",
+          "url": "https://search.parallel.ai/mcp",
+          "enabled_tools": ["web_search", "web_fetch"]
+        }
+      }
+    }
+  }
+}
+```
+
+重启 VikingBot 后，`mcp_parallel_web_search` 和 `mcp_parallel_web_fetch` 将与内置网页工具一起可用。Agent 可以在对话中自行选择调用这些工具。查询、请求的 URL，以及提供的目标或上下文会发送给 Parallel。免费访问有速率限制。
+
+要禁用该连接，请删除 `parallel` 配置项并重启 VikingBot。此示例不会更改内置搜索后端及其回退顺序。
+
 ## 沙箱
 
 | 后端 | 说明 |


### PR DESCRIPTION
## Description

This adds a working Parallel Search MCP example to VikingBot's English and Chinese setup guides. It gives users web search and page extraction without a Parallel account or API key.

VikingBot already [enables web search automatically](https://github.com/volcengine/OpenViking/blob/2251aa136a0dcbdef7e79af2a61e9b3748a9eec6/bot/vikingbot/agent/tools/factory.py#L84-L93). Its [selection order is Tavily, Exa, Brave, then DDGS](https://github.com/volcengine/OpenViking/blob/2251aa136a0dcbdef7e79af2a61e9b3748a9eec6/bot/vikingbot/agent/tools/websearch/registry.py#L72-L95): Tavily gets first pick when its key is configured; with no provider keys, it falls back to DDGS. These are built-in search adapters, rather than MCP presets, so those are the providers I'm comparing here.

The biggest quality gaps in [Artificial Analysis's Search API leaderboard](https://artificialanalysis.ai/agents/search-api#details), using its August 31, 2026 data, are:

- **Against Tavily basic:** Parallel advanced scores **77% vs. 59% on BrowseComp**, an 18 percentage point lead. VikingBot's Tavily adapter uses `search_depth="basic"`.
- **Against Brave web:** Parallel advanced scores **81 vs. 62 on DeepSearchQA F1**, a 19-point lead on the 0–100 scale. VikingBot uses Brave's web-search endpoint, not its LLM-context product.
- **Against Exa auto:** the gap is smaller. Parallel advanced scores **77% vs. 74% on BrowseComp** and **75 vs. 74 on the overall Search Index**.

On the overall index, Parallel advanced also scores **75 vs. Tavily basic's 66 and Brave web's 65**. To see the Tavily and Brave web rows, enable them in the leaderboard's provider filter. DDGS isn't listed, so there isn't a published score comparison for the no-key default.

If getting better answers is the priority, I'd consider evaluating Parallel as the default, starting with Tavily, which currently gets first pick. These results are a reason to try that on VikingBot's own tasks. They aren't a guarantee: [Artificial Analysis evaluates specific Search API configurations in its own harness](https://artificialanalysis.ai/methodology/search-api), not this free MCP endpoint, and a benchmark lead doesn't mean better results on every task.

This PR adds the setup example through the existing `bot.tools.mcp_servers` loader. It leaves provider selection and dependencies alone. The guide explains that the agent can choose enabled tools, what data goes to Parallel, the free-access limits, and how to disable the connection.

I work at Parallel, which operates this service.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

None. This documents existing configuration behavior without changing its semantics.

## Type of Change

- [x] Documentation update

## Changes Made

- Add the same anonymous connection example to `bot/README.md` and `bot/README_CN.md`.
- Restrict discovery to `web_search` and `web_fetch`, and document their VikingBot tool names.
- Explain configuration merging, activation, data transfer, limits, and removal.

## Testing

- `git diff --check` passed.
- A disposable Python check parsed the exact JSON from both README files, confirmed they match, and loaded it through `vikingbot.config.loader.load_config`.
- With credentials absent, the same check exercised `connect_mcp_servers` and `MCPToolWrapper.execute`: both tools registered, search and fetch returned nonempty results with URLs and no MCP `isError`, and connection cleanup completed.
- Checked on macOS with Python 3.12, MCP SDK 1.29.1, HTTPX 0.28.1, and Pydantic 2.13.5. Command: `env -i HOME=/private/tmp/openviking-parallel-evidence PATH=/usr/bin:/bin /private/tmp/openviking-parallel-env/bin/python /private/tmp/openviking-parallel-evidence/check.py`.

The check imported the unchanged loader, client, registry, and wrappers while bypassing the unrelated eager `vikingbot.agent` and `vikingbot.agent.tools` package initializers. It did not run the full agent loop. Dependencies were prebuilt; no repository build or full test suite was run. The optional Langfuse integration remained disabled.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation

## Additional Notes

This changes two Markdown files only. No new regression test was added for the static example. The repository's PR workflow ignores Markdown, and its documentation build is scoped to `docs/`.
