### PR TITLE
fix: watch task path conflict error

### DIFF
--- a/docs/en/about/02-changelog.md
+++ b/docs/en/about/02-changelog.md
@@ -5,6 +5,16 @@ This changelog is automatically generated from [GitHub Releases](https://github.
 
 ## Unreleased
 
+- **Watch API migration (breaking change)**: Re-importing with `watch_interval > 0`
+  no longer updates or reactivates an existing Watch. Native Watches retain exclusive
+  ownership while paused, and incompatible target reuse returns `409 Conflict`.
+  Replace scripts that re-import to update a Watch with `PATCH /api/v1/watches/{task_id}`
+  (use `is_active: true` to resume), or delete the old Watch before creating its replacement.
+  Connector Watches may share targets; repeating the same source and target creates a new
+  independent Watch, so retries are not idempotent. Use task IDs to manage shared targets;
+  URI lookups with multiple accessible Watches return 409. One-off Connector imports
+  (`watch_interval <= 0`) leave existing Watches untouched; pause or delete them through
+  the watches API. See [resource task management](../api/02-resources.md#task-management-operations).
 - **Session policy compatibility**: String `"false"` memory-policy switches now disable
   extraction correctly. Existing boolean-like values remain temporarily compatible and
   emit deprecation warnings; use JSON booleans for new configurations.

--- a/docs/en/api/02-resources.md
+++ b/docs/en/api/02-resources.md
@@ -118,6 +118,12 @@ Resource incremental updates are implemented via the **Watch Task** mechanism:
 - `WatchManager` handles task persistence
 - Supports multi-tenant permission control (ROOT/ADMIN/USER permission levels)
 
+#### Target Ownership
+
+- Within an account, a native Watch exclusively owns its resolved target, even while paused. A new native Watch requires an unoccupied target; a Connector Watch cannot share with a native Watch.
+- Multiple Connector Watches may share a target. Repeating the same source and target creates another independent Watch; imports do not update or reactivate an existing Watch. The same source imported into different targets also gets separate Watches.
+- Connector Watches are created before the initial import and held by the scheduler until that import records its result.
+
 #### Task Scheduling & Execution
 - `WatchScheduler` checks for expired tasks every 60 seconds
 - Default concurrency control prevents duplicate execution
@@ -125,10 +131,10 @@ Resource incremental updates are implemented via the **Watch Task** mechanism:
 - Updates task's last execution time and next execution time
 
 #### Task Management Operations
-- **Create**: Creates new task or reactivates disabled task when `watch_interval > 0`
-- **Update**: Re-sets parameters for the same target URI
-- **Cancel**: Disables task when `watch_interval <= 0` for the same target URI
-- **Query**: Queries task status by task ID or target URI
+- **Create**: `watch_interval > 0` creates a new task subject to the target ownership rules above; incompatible occupancy returns `409 Conflict`.
+- **Update or resume**: Use `PATCH /api/v1/watches/{task_id}` to change parameters or set `is_active: true`. Re-importing does not update or reactivate a task.
+- **Pause or delete**: Use `PATCH /api/v1/watches/{task_id}` with `is_active: false` to pause, or `DELETE /api/v1/watches/{task_id}` to release the target. A native import with an explicit `to` and `watch_interval <= 0` pauses the single accessible Watch on that target; multiple accessible Watches produce `409 Conflict`. A one-off Connector import leaves existing Watches untouched.
+- **Query**: Use the task ID, or the target URI when it identifies a single accessible Watch. URI lookup returns `409 Conflict` for multiple accessible Watches; use `task_id` to query, update, or delete an individual task.
 
 ## API Reference
 
@@ -178,7 +184,7 @@ This endpoint is the core entry point for resource management, supporting adding
 | directly_upload_media | bool | No | True | Whether to directly upload media files |
 | preserve_structure | bool | No | None | Whether to preserve directory structure |
 | args | object | No | `{}` | Parser-specific import options forwarded to the source parser/accessor. Native HTTPS Git imports and watches accept HTTP Basic credentials over TLS as `args.auth_config={"username":"oauth2","token":"..."}`; `username` defaults to `oauth2`. Git `branch` or `commit` remains at the top level of `args`. To import a private TOS object through its HTTP(S) URL, pass exactly one non-empty string: `args.tos_signature` (sent as `X-Tos-Signature`) or `args.tos_access` (sent as `X-Tos-Access`). TOS credentials are used only for the current HEAD/GET fetch, which is staged as a snapshot; they are not persisted to resource metadata or queue jobs. `args.parse_mode` accepts `default` (existing splitting behavior) or `no_split` (parse and convert each source document to one Markdown body). E.g. `args.site=true/false` forces/opts out of whole-site (sitemap/RSS) ingestion, `args.max_pages` etc. override the `webfeed` config; the recursive web crawler accepts `args.depth`, `args.max_pages`, `args.include_paths`, `args.exclude_paths`, `args.allow_external_links`, `args.skip_download_links`; Feishu user-token imports pass `args.feishu_access_token`. Core `add_resource` fields such as `path`, `to`, `watch_interval`, `include`, and `exclude` are not allowed inside `args` |
-| watch_interval | float | No | 0 | Scheduled update interval (minutes). >0 creates a task for a re-readable URL/sitemap/RSS source; uploaded `temp_file_id` content is a static snapshot and must be re-added when it changes. <=0 cancels a task; explicit `to` wins, otherwise binds to the imported `root_uri` |
+| watch_interval | float | No | 0 | Scheduled update interval (minutes). >0 creates a new Watch for a re-readable source, subject to target ownership rules; uploaded `temp_file_id` snapshots cannot be watched. <=0 creates no Watch: native imports with explicit `to` pause a single accessible task (409 if ambiguous), while Connector imports leave Watches untouched. Explicit `to` wins, otherwise the Watch binds to the imported `root_uri`. |
 | is_active | bool | No | True | Initial Watch scheduling state. `false` requires `watch_interval > 0` and either `to` or `parent`. `parent` is supported for native Feishu URL imports; Connector imports still require an exact `to`. The initial import still runs once and the Watch remains paused afterward |
 | processing_mode | string | No | `semantic_and_vectors` | Post-ingest processing mode. `semantic_and_vectors` is the normal flow: generate semantic artifacts (`.abstract.md`, `.overview.md`) and vectors. `vectors_only` skips semantic understanding/VLM summarization and only vectorizes current resource files |
 | telemetry | TelemetryRequest | No | False | Whether to return telemetry data |
@@ -482,8 +488,9 @@ ov add-resource https://github.com/example/repo.git --to viking://resources/guid
 # Enable scheduled updates and bind to the URI created by this import
 ov add-resource https://github.com/example/repo.git --watch-interval 60
 
-# Cancel scheduled updates
-ov add-resource https://github.com/example/repo.git --to viking://resources/guide.md --watch-interval 0
+# Pause a Watch through PATCH /api/v1/watches/{task_id} with {"is_active": false}.
+# For a native import, --watch-interval 0 also pauses a single accessible target Watch.
+# One-off Connector imports leave existing Watches untouched.
 
 # Add a Feishu document with a one-time user access token
 ov add-resource https://example.feishu.cn/docx/doc_token --args feishu_access_token:u-...

--- a/docs/zh/about/02-changelog.md
+++ b/docs/zh/about/02-changelog.md
@@ -5,6 +5,14 @@ OpenViking 的所有重要变更都将记录在此文件中。
 
 ## 未发布
 
+- **Watch API 迁移（不兼容变更）**：使用 `watch_interval > 0` 重新导入不再更新或恢复已有 Watch。
+  原生 Watch 暂停后仍独占目标，不兼容的目标复用返回 `409 Conflict`。
+  依赖重新导入来更新 Watch 的脚本应改用 `PATCH /api/v1/watches/{task_id}`
+  （恢复时设置 `is_active: true`），或先删除旧 Watch 再创建替代任务。
+  Connector Watch 可共享目标，但重复导入相同来源和目标会创建新的独立 Watch，重试并不幂等。
+  共享目标应通过任务 ID 管理；按 URI 查询多个可访问的 Watch 时返回 409。
+  一次性 Connector 导入（`watch_interval <= 0`）不影响已有 Watch，暂停或删除请使用 watches API。
+  详见[资源任务管理](../api/02-resources.md#任务管理操作)。
 - **Session policy 兼容性**：字符串 `"false"` 现在会正确关闭对应的记忆抽取开关。
   现有 boolean-like 值暂时保持兼容并产生弃用警告；新配置应使用 JSON 布尔值。
 - **工作区 peer 派生规则**：coding agent 插件不再按工作目录派生工作区 peer，改为按 git 派生。新的默认值 `peer.source: "git"` 取仓库归一化后的 `origin` URL（`github.com-volcengine-openviking`），其次回退到仓库根路径，因此同一个仓库的每个 clone、worktree 和子目录共用同一个 peer，而 fork 仍是独立的 peer。不在 git 仓库中的目录现在完全不发送 peer，在那里记下的内容进入用户级空间，而不是为每个目录新建一个命名空间。要让这样的目录拥有独立记忆，在其中创建 `.openviking/config.json`，写入 `{"version": 1, "peer": {"id": "my-project"}}`。无需任何迁移：此前按工作目录派生的 id 随时可以在本地重新算出，而默认的 `peer_scope: "all"` 召回本来就会扫描所有 peer，因此写在旧 id 下的记忆照常召回（`peer_scope: "actor"` 时，Claude Code、Codex、OpenCode 和 DSH 插件会额外查询该 id）。设置 `peer.source: "cwd"`（或 `OPENVIKING_PEER_SOURCE=cwd`）即可保持旧行为。

--- a/docs/zh/api/02-resources.md
+++ b/docs/zh/api/02-resources.md
@@ -111,6 +111,12 @@ URL/文件  Parser  TreeBuilder  AGFS    Summarizer/Vector
 - `WatchManager` 负责任务持久化存储
 - 支持多租户权限控制（ROOT/ADMIN/USER 权限分级）
 
+#### 目标占用规则
+
+- 同一账户内，原生 Watch 独占解析后的目标，暂停后仍然占用。新建原生 Watch 要求目标未被占用，Connector Watch 也不能与原生 Watch 共享目标。
+- 多个 Connector Watch 可以共享目标。重复导入相同来源和目标会创建新的独立 Watch，不会更新或恢复已有任务；同一来源导入不同目标也会创建独立 Watch。
+- Connector Watch 在首次导入前创建，调度器会等待首次导入记录结果后再执行定时任务。
+
 #### 任务调度执行
 - `WatchScheduler` 每 60 秒检查到期任务
 - 默认并发控制，避免重复执行
@@ -118,10 +124,10 @@ URL/文件  Parser  TreeBuilder  AGFS    Summarizer/Vector
 - 更新任务的最后执行时间和下次执行时间
 
 #### 任务管理操作
-- **创建**：`watch_interval > 0` 时创建新任务或重新激活已停用任务
-- **更新**：对同一目标 URI 重新设置参数
-- **取消**：对同一目标 URI 设置 `watch_interval <= 0` 时停用任务
-- **查询**：通过任务 ID 或目标 URI 查询任务状态
+- **创建**：`watch_interval > 0` 时按上述目标占用规则创建新任务；不兼容的占用返回 `409 Conflict`。
+- **更新或恢复**：通过 `PATCH /api/v1/watches/{task_id}` 修改参数或设置 `is_active: true`；重新导入不会更新或恢复已有任务。
+- **暂停或删除**：通过 `PATCH /api/v1/watches/{task_id}` 设置 `is_active: false` 暂停任务，或通过 `DELETE /api/v1/watches/{task_id}` 删除任务以释放目标。原生导入显式指定 `to` 且 `watch_interval <= 0` 时，会暂停该目标上唯一可访问的 Watch；存在多个可访问的 Watch 时返回 `409 Conflict`。一次性 Connector 导入不影响已有 Watch。
+- **查询**：通过任务 ID 查询；目标 URI 仅在对应唯一可访问的 Watch 时可用于定位。存在多个可访问的 Watch 时，按 URI 查询返回 `409 Conflict`，需通过 `task_id` 查询、更新或删除指定任务。
 
 ## API 参考
 
@@ -171,7 +177,7 @@ URL/文件  Parser  TreeBuilder  AGFS    Summarizer/Vector
 | directly_upload_media | bool | 否 | True | 是否直接上传媒体文件 |
 | preserve_structure | bool | 否 | None | 是否保留目录结构 |
 | args | object | 否 | `{}` | 传给特定 parser/accessor 的导入参数。原生 HTTPS Git 导入和 Watch 可通过 `args.auth_config={"username":"oauth2","token":"..."}` 在 TLS 上传递 HTTP Basic 凭据；`username` 默认为 `oauth2`。Git 的 `branch` 或 `commit` 仍放在 `args` 顶层。通过 HTTP(S) URL 导入私有 TOS 对象时，二选一传入非空字符串：`args.tos_signature`（映射为 `X-Tos-Signature`）或 `args.tos_access`（映射为 `X-Tos-Access`）。TOS 凭证只用于当前 HEAD/GET 抓取；资源会先保存为快照，凭证不会写入资源元数据或队列任务。`args.parse_mode` 支持 `default`（保持现有拆分行为）和 `no_split`（正常解析并将每个源文档正文保存为一个 Markdown 文件）。例如 `args.site=true/false` 强制/禁用整站（sitemap/RSS）导入，`args.max_pages` 等可覆盖 `webfeed` 配置；递归网页爬虫支持 `args.depth`、`args.max_pages`、`args.include_paths`、`args.exclude_paths`、`args.allow_external_links`、`args.skip_download_links`；飞书用户 token 导入传 `args.feishu_access_token`。`path`、`to`、`watch_interval`、`include`、`exclude` 等 `add_resource` 核心字段不能放入 `args` |
-| watch_interval | float | 否 | 0 | 定时更新间隔（分钟）。>0 为 URL/sitemap/RSS 等可重新读取的来源创建任务；通过 `temp_file_id` 上传的内容是一次性快照，变化后需重新添加。≤0 取消任务；显式 `to` 优先，否则绑定本次导入的 `root_uri` |
+| watch_interval | float | 否 | 0 | 定时更新间隔（分钟）。>0 按目标占用规则为可重新读取的来源创建新 Watch；通过 `temp_file_id` 上传的一次性快照不能创建 Watch。≤0 不创建 Watch：原生导入显式指定 `to` 时暂停唯一可访问的任务（存在歧义时返回 409），Connector 导入不影响已有 Watch。显式 `to` 优先，否则绑定本次导入的 `root_uri`。 |
 | is_active | bool | 否 | True | Watch 初始调度状态。设为 `false` 时要求 `watch_interval > 0`，并在 `to`、`parent` 中二选一。`parent` 仅支持原生飞书 URL 导入；Connector 仍要求精确的 `to`。首次导入仍执行一次，随后保持暂停 |
 | processing_mode | string | 否 | `semantic_and_vectors` | 入库后的处理模式。`semantic_and_vectors` 是默认流程：生成语义产物（`.abstract.md`、`.overview.md`）并生成向量。`vectors_only` 跳过语义理解/VLM 总结，只对当前资源文件生成向量 |
 | tags | string[] | 否 | None | 导入时写入向量检索记录的显式检索标签，格式必须是 `k=v`，例如 `["team=search", "env=test"]`。搜索接口可用同名 `tags` 参数过滤召回 |
@@ -488,8 +494,9 @@ ov add-resource https://github.com/example/repo.git --to viking://resources/my_r
 # 开启定时更新并自动绑定本次导入生成的 URI
 ov add-resource https://github.com/example/repo.git --watch-interval 60
 
-# 取消定时更新
-ov add-resource https://github.com/example/repo.git --to viking://resources/my_repo --watch-interval 0
+# 通过 PATCH /api/v1/watches/{task_id} 提交 {"is_active": false} 暂停 Watch。
+# 原生导入也可通过 --watch-interval 0 暂停目标上唯一可访问的 Watch。
+# 一次性 Connector 导入不会影响已有 Watch。
 
 # 使用一次性用户 access token 添加飞书文档
 ov add-resource https://example.feishu.cn/docx/doc_token --args feishu_access_token:u-...

--- a/openviking/resource/watch_manager.py
+++ b/openviking/resource/watch_manager.py
@@ -196,7 +196,10 @@ class WatchManager:
             viking_fs: VikingFS instance for persistence storage
         """
         self._tasks: Dict[str, WatchTask] = {}
-        self._uri_to_task: Dict[tuple[str, str], str] = {}
+        # (account_id, to_uri) -> task ids. A native watch owns its target alone
+        # (a refresh replaces the whole root); Connector watches write
+        # ``to/<relative_path>`` and may share one target.
+        self._uri_to_task: Dict[tuple[str, str], set[str]] = {}
         self._lock = asyncio.Lock()
         self._uri_mutation_coordinator = uri_mutation_coordinator or UriMutationCoordinator()
         self._viking_fs = viking_fs
@@ -274,8 +277,7 @@ class WatchManager:
                             task.next_execution_time = task.calculate_next_execution_time()
                             normalized = True
                     self._tasks[task.task_id] = task
-                    if task.to_uri:
-                        self._uri_to_task[(task.account_id, task.to_uri)] = task.task_id
+                    self._index_add(task.account_id, task.to_uri, task.task_id)
                 except Exception as e:
                     logger.warning(
                         f"[WatchManager] Failed to load task {task_data.get('task_id')}: {e}"
@@ -376,32 +378,70 @@ class WatchManager:
 
         return task.user_id == user_id
 
+    # ── Target index helpers ─────────────────────────────────────────────
+
+    def _index_get(self, account_id: str, to_uri: Optional[str]) -> set[str]:
+        if not to_uri:
+            return set()
+        return set(self._uri_to_task.get((account_id, to_uri), ()))
+
+    def _index_add(self, account_id: str, to_uri: Optional[str], task_id: str) -> None:
+        if to_uri:
+            self._uri_to_task.setdefault((account_id, to_uri), set()).add(task_id)
+
+    def _index_remove(self, account_id: str, to_uri: Optional[str], task_id: str) -> None:
+        if not to_uri:
+            return
+        ids = self._uri_to_task.get((account_id, to_uri))
+        if ids is None:
+            return
+        ids.discard(task_id)
+        if not ids:
+            del self._uri_to_task[(account_id, to_uri)]
+
+    @staticmethod
+    def _is_connector_auth_state(auth_state: Optional[Dict[str, Any]]) -> bool:
+        from openviking.connector.delegate import ConnectorDelegate
+
+        return ConnectorDelegate.is_watch_auth_state(auth_state)
+
+    def _all_connector_tasks(self, task_ids: set[str]) -> bool:
+        return all(
+            self._is_connector_auth_state(self._tasks[task_id].auth_state)
+            for task_id in task_ids
+            if task_id in self._tasks
+        )
+
+    def _blocking_task_ids(
+        self,
+        to_uri: Optional[str],
+        account_id: str,
+        auth_state: Optional[Dict[str, Any]],
+        exclude_task_ids: Optional[set[str]] = None,
+    ) -> set[str]:
+        """Task ids that keep a watch with *auth_state* off *to_uri*.
+
+        Connector watches (identified by their auth_state provider) may share a
+        target with other Connector watches; anything involving a native watch
+        is exclusive.
+        """
+        others = self._index_get(account_id, to_uri) - (exclude_task_ids or set())
+        if not others:
+            return set()
+        if self._is_connector_auth_state(auth_state) and self._all_connector_tasks(others):
+            return set()
+        return others
+
     def _check_uri_conflict(
         self,
         to_uri: Optional[str],
         account_id: str = "default",
         exclude_task_id: Optional[str] = None,
+        auth_state: Optional[Dict[str, Any]] = None,
     ) -> bool:
-        """Check if target URI conflicts with existing tasks.
-
-        Args:
-            to_uri: Target URI to check
-            exclude_task_id: Task ID to exclude from conflict check (for updates)
-
-        Returns:
-            True if there's a conflict, False otherwise
-        """
-        if not to_uri:
-            return False
-
-        existing_task_id = self._uri_to_task.get((account_id, to_uri))
-        if not existing_task_id:
-            return False
-
-        if exclude_task_id and existing_task_id == exclude_task_id:
-            return False
-
-        return True
+        """Return True when a watch with *auth_state* may not target *to_uri*."""
+        exclude = {exclude_task_id} if exclude_task_id else None
+        return bool(self._blocking_task_ids(to_uri, account_id, auth_state, exclude))
 
     async def create_task(
         self,
@@ -432,9 +472,13 @@ class WatchManager:
 
         async with self._uri_mutation_coordinator.access(account_id, [to_uri]):
             async with self._lock:
-                if self._check_uri_conflict(to_uri, account_id=account_id):
+                blocking = self._blocking_task_ids(to_uri, account_id, auth_state)
+                if blocking:
+                    # The target URI is the watch identity; only Connector watches
+                    # may share one, and never with a native watch.
                     raise ConflictError(
-                        f"Target URI '{to_uri}' is already used by another task",
+                        f"Target URI '{to_uri}' is already being monitored by task "
+                        f"{', '.join(sorted(blocking))}. Delete or update that watch first.",
                         resource=to_uri,
                     )
 
@@ -464,8 +508,7 @@ class WatchManager:
                 )
 
                 self._tasks[task.task_id] = task
-                if to_uri:
-                    self._uri_to_task[(account_id, to_uri)] = task.task_id
+                self._index_add(account_id, to_uri, task.task_id)
 
                 await self._save_tasks()
 
@@ -564,7 +607,12 @@ class WatchManager:
         is_active: Optional[bool],
     ) -> WatchTask:
         task_id = task.task_id
-        if self._check_uri_conflict(to_uri, account_id=task.account_id, exclude_task_id=task_id):
+        if self._check_uri_conflict(
+            to_uri,
+            account_id=task.account_id,
+            exclude_task_id=task_id,
+            auth_state=task.auth_state if auth_state is _UNSET else auth_state,
+        ):
             raise ConflictError(
                 f"Target URI '{to_uri}' is already used by another task",
                 resource=to_uri,
@@ -627,9 +675,8 @@ class WatchManager:
 
         if to_uri is not None:
             if old_to_uri and old_to_uri != to_uri:
-                self._uri_to_task.pop((task.account_id, old_to_uri), None)
-            if to_uri:
-                self._uri_to_task[(task.account_id, to_uri)] = task_id
+                self._index_remove(task.account_id, old_to_uri, task_id)
+            self._index_add(task.account_id, to_uri, task_id)
 
         await self._save_tasks()
         logger.info(f"[WatchManager] Updated task {task_id} by user {account_id}/{user_id}")
@@ -708,16 +755,16 @@ class WatchManager:
                 plan[task_id] = _rewrite_uri_prefix(task.to_uri or "", old_prefix, new_prefix)
 
         moving_task_ids = set(plan)
+        landing: Dict[str, set[str]] = {}
         for task_id, target_uri in plan.items():
-            existing_task_id = self._uri_to_task.get((account_id, target_uri))
-            if existing_task_id and existing_task_id not in moving_task_ids:
+            landing.setdefault(target_uri, set()).add(task_id)
+        for target_uri, movers in landing.items():
+            # Whoever ends up on the target (stayers plus movers) must be able to
+            # share it: more than one occupant is only fine when all are Connector.
+            occupants = (self._index_get(account_id, target_uri) - moving_task_ids) | movers
+            if len(occupants) > 1 and not self._all_connector_tasks(occupants):
                 raise ConflictError(
                     f"Target URI '{target_uri}' is already used by another task",
-                    resource=target_uri,
-                )
-            if existing_task_id in moving_task_ids and existing_task_id != task_id:
-                raise ConflictError(
-                    f"Target URI '{target_uri}' is already used by another moved task",
                     resource=target_uri,
                 )
         return plan
@@ -749,13 +796,12 @@ class WatchManager:
                 for task_id, task in self._tasks.items()
                 if task_id in plan
             }
-            original_uri_to_task = dict(self._uri_to_task)
+            original_uri_to_task = {key: set(ids) for key, ids in self._uri_to_task.items()}
 
             try:
                 for task_id in plan:
                     task = self._tasks[task_id]
-                    if task.to_uri:
-                        self._uri_to_task.pop((account_id, task.to_uri), None)
+                    self._index_remove(account_id, task.to_uri, task_id)
 
                 updated: List[WatchTask] = []
                 for task_id, target_uri in plan.items():
@@ -764,7 +810,7 @@ class WatchManager:
                     task.to_uri = target_uri
                     if task.parent_uri is not None and task.parent_uri == old_parent:
                         task.parent_uri = _parent_uri(target_uri)
-                    self._uri_to_task[(account_id, target_uri)] = task_id
+                    self._index_add(account_id, target_uri, task_id)
                     updated.append(task)
 
                 await self._save_tasks()
@@ -849,8 +895,7 @@ class WatchManager:
                         )
 
                     self._tasks.pop(task_id, None)
-                    if task.to_uri:
-                        self._uri_to_task.pop((task.account_id, task.to_uri), None)
+                    self._index_remove(task.account_id, task.to_uri, task_id)
 
                     await self._save_tasks()
                     logger.info(
@@ -940,51 +985,29 @@ class WatchManager:
 
         Returns:
             WatchTask if found and accessible, None otherwise
+
+        Raises:
+            ConflictError: Several accessible Connector watches share *to_uri*;
+                address one by task_id instead.
         """
         async with self._uri_mutation_coordinator.access(account_id, [to_uri]):
             async with self._lock:
-                task_id = self._uri_to_task.get((account_id, to_uri))
-                if not task_id:
+                task_ids = {
+                    task_id
+                    for task_id in self._index_get(account_id, to_uri)
+                    if (task := self._tasks.get(task_id)) is not None
+                    and self._check_permission(task, account_id, user_id, role)
+                }
+                if not task_ids:
                     return None
-
-                task = self._tasks.get(task_id)
-                if not task:
-                    return None
-
-                if not self._check_permission(task, account_id, user_id, role):
-                    return None
-
-                return task
-
-    async def get_upsertable_task_by_uri(
-        self,
-        *,
-        path: str,
-        to_uri: str,
-        account_id: str,
-        user_id: str,
-        role: str,
-    ) -> Optional[WatchTask]:
-        """Return an existing task when this source may create or update its watch."""
-        async with self._uri_mutation_coordinator.access(account_id, [to_uri]):
-            async with self._lock:
-                task_id = self._uri_to_task.get((account_id, to_uri))
-                if not task_id:
-                    return None
-
-                task = self._tasks.get(task_id)
-                if not task or not self._check_permission(task, account_id, user_id, role):
+                if len(task_ids) > 1:
                     raise ConflictError(
-                        f"Target URI '{to_uri}' is already used by another task",
+                        f"Target URI '{to_uri}' has {len(task_ids)} watch tasks "
+                        f"({', '.join(sorted(task_ids))}); address one by task_id.",
                         resource=to_uri,
                     )
-                if task.is_active and task.path != path:
-                    raise ConflictError(
-                        f"Target URI '{to_uri}' is already being monitored by task "
-                        f"{task.task_id}. Please cancel the existing task first.",
-                        resource=to_uri,
-                    )
-                return task
+
+                return self._tasks[next(iter(task_ids))]
 
     async def update_execution_time(self, task_id: str) -> None:
         """Update task execution time after execution.

--- a/openviking/resource/watch_manager.py
+++ b/openviking/resource/watch_manager.py
@@ -406,10 +406,10 @@ class WatchManager:
         return ConnectorDelegate.is_watch_auth_state(auth_state)
 
     def _all_connector_tasks(self, task_ids: set[str]) -> bool:
+        if not task_ids or not task_ids <= self._tasks.keys():
+            return False
         return all(
-            self._is_connector_auth_state(self._tasks[task_id].auth_state)
-            for task_id in task_ids
-            if task_id in self._tasks
+            self._is_connector_auth_state(self._tasks[task_id].auth_state) for task_id in task_ids
         )
 
     def _blocking_task_ids(
@@ -477,8 +477,8 @@ class WatchManager:
                     # The target URI is the watch identity; only Connector watches
                     # may share one, and never with a native watch.
                     raise ConflictError(
-                        f"Target URI '{to_uri}' is already being monitored by task "
-                        f"{', '.join(sorted(blocking))}. Delete or update that watch first.",
+                        f"Target URI '{to_uri}' is already being monitored by an incompatible watch. "
+                        "Delete the conflicting watch or choose another target.",
                         resource=to_uri,
                     )
 
@@ -614,7 +614,8 @@ class WatchManager:
             auth_state=task.auth_state if auth_state is _UNSET else auth_state,
         ):
             raise ConflictError(
-                f"Target URI '{to_uri}' is already used by another task",
+                f"Target URI '{to_uri}' is already being monitored by an incompatible watch. "
+                "Delete the conflicting watch or choose another target.",
                 resource=to_uri,
             )
 
@@ -764,7 +765,8 @@ class WatchManager:
             occupants = (self._index_get(account_id, target_uri) - moving_task_ids) | movers
             if len(occupants) > 1 and not self._all_connector_tasks(occupants):
                 raise ConflictError(
-                    f"Target URI '{target_uri}' is already used by another task",
+                    f"Target URI '{target_uri}' is already being monitored by an incompatible watch. "
+                    "Delete the conflicting watch or choose another target.",
                     resource=target_uri,
                 )
         return plan

--- a/openviking/resource/watch_scheduler.py
+++ b/openviking/resource/watch_scheduler.py
@@ -327,7 +327,10 @@ class WatchScheduler:
                     bypass_acl=True,
                 )
 
-                if task.to_uri:
+                # Connector targets are materialized by the plugin's own writes: an
+                # empty first round leaves ``to`` absent and a deleted target is simply
+                # rebuilt next round, so only native watches are tied to its existence.
+                if task.to_uri and not connector_watch:
                     target_exists = await self._check_target_uri_exists(task.to_uri, ctx)
                     if target_exists is False:
                         should_deactivate = True

--- a/openviking/server/routers/resources.py
+++ b/openviking/server/routers/resources.py
@@ -74,9 +74,14 @@ class AddResourceRequest(BaseModel):
             - watch_interval < 0: Same as watch_interval = 0, cancels any existing watch task.
             Default is 0 (no monitoring).
 
-            Note: Re-adding the same source to the same target updates its active watch task.
-            A different source targeting an active watch raises ConflictError; cancel that
-            watch first with watch_interval <= 0. Connector imports create the Watch before
+            Note: The resolved target URI is the watch identity. A native watch owns its
+            target alone: any existing watch there, active or paused, rejects a new
+            native import with ConflictError; change or reactivate it through the
+            watches API (PATCH /watches/{id}), or delete it. Connector watches may share
+            one target with each other (never with a native watch); a shared target
+            must then be addressed by task_id, and ``?to_uri=`` lookups return 409.
+            The same source imported into a different target gets its own watch. With
+            ``parent`` the target is resolved after the import. Connector imports create the Watch before
             the import runs, so it is visible immediately and the conflict is reported at
             submission; the scheduler does not run it until the first round has recorded
             its result.

--- a/openviking/server/routers/resources.py
+++ b/openviking/server/routers/resources.py
@@ -66,25 +66,11 @@ class AddResourceRequest(BaseModel):
             pass {"feishu_access_token": "..."}. For Feishu user-token watches,
             also pass "feishu_refresh_token". The optional "feishu_app_id" and
             "feishu_app_secret" pair overrides the server app for that watch.
-        watch_interval: Watch interval in minutes for automatic resource monitoring.
-            - watch_interval > 0: Creates or updates a watch task. The resource will be
-              automatically re-processed at the specified interval.
-            - watch_interval = 0: No watch task is created. If a watch task exists for
-              this resource, it will be cancelled (deactivated).
-            - watch_interval < 0: Same as watch_interval = 0, cancels any existing watch task.
-            Default is 0 (no monitoring).
-
-            Note: The resolved target URI is the watch identity. A native watch owns its
-            target alone: any existing watch there, active or paused, rejects a new
-            native import with ConflictError; change or reactivate it through the
-            watches API (PATCH /watches/{id}), or delete it. Connector watches may share
-            one target with each other (never with a native watch); a shared target
-            must then be addressed by task_id, and ``?to_uri=`` lookups return 409.
-            The same source imported into a different target gets its own watch. With
-            ``parent`` the target is resolved after the import. Connector imports create the Watch before
-            the import runs, so it is visible immediately and the conflict is reported at
-            submission; the scheduler does not run it until the first round has recorded
-            its result.
+        watch_interval: Interval in minutes (default: 0). Positive values create a new
+            Watch using explicit ``to`` or the imported ``root_uri``. Nonpositive values
+            create no Watch: native imports with explicit ``to`` pause a single accessible
+            Watch (409 if ambiguous); Connector imports leave Watches untouched.
+            See the endpoint's Watch ownership rules.
         is_active: Initial Watch state for Connector and native Feishu imports. When false,
             requires watch_interval > 0 and an explicit to or parent target and creates the Watch
             paused; it stays paused until updated, regardless of the import result.
@@ -239,7 +225,16 @@ async def add_resource(
     request: AddResourceRequest,
     _ctx: RequestContext = Depends(get_request_context),
 ):
-    """Add resource to OpenViking."""
+    """Add resource to OpenViking.
+
+    Native Watches require an unoccupied resolved target and keep it while paused.
+    Connector Watches may share targets only with other Connector Watches; repeating
+    a source and target creates another independent task. Re-importing never updates
+    or resumes a Watch: use PATCH /api/v1/watches/{task_id}, or delete it first.
+    URI lookups return 409 for multiple accessible Watches; address them by task_id.
+    Connector Watches are visible before the initial import and held by the scheduler
+    until that import records its result.
+    """
     service = get_service()
     to_uri = resolve_path_variables(request.to).strip() if request.to else ""
     if to_uri:
@@ -379,6 +374,7 @@ async def add_skill(
             source_metadata["original_filename"] = resolved.original_filename
 
     source_path_hint = resolved.original_filename if resolved else None
+
     async def _add() -> dict[str, Any]:
         try:
             result = await service.resources.add_skill(

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -1506,12 +1506,20 @@ class ResourceService:
                 - watch_interval < 0: Same as watch_interval = 0, cancels any existing watch task.
                 Default is 0 (no monitoring).
 
-                Note: Re-adding the same source to the same target updates its active watch
-                task in place. A different source targeting an active watch raises
-                ConflictError; cancel that watch first with watch_interval <= 0. Connector
-                imports create the Watch before the import runs, so the conflict is reported
-                at submission and the Watch is visible at once; the scheduler holds it until
-                the first round records its result.
+                Note: The resolved target URI is the watch identity. A native watch owns
+                its target alone: any existing watch there, active or paused, rejects a
+                new native import with ConflictError; change or reactivate it through the
+                watches API, or delete it. Connector watches lay their files out under
+                the target themselves, so several Connector watches may share one target
+                (never with a native watch); a shared target must then be addressed by
+                task_id rather than by URI. The same source imported into a different
+                target gets its own watch. With ``parent`` the target is resolved after
+                the import. A Connector import without
+                watch_interval never pauses a watch already on its target (the native
+                watch_interval <= 0 cancel rule does not apply). Connector imports create the Watch before the
+                import runs, so the conflict is reported at submission and the Watch is
+                visible at once; the scheduler holds it until the first round records its
+                result.
             is_active: When false, the Connector or native Feishu Watch is created paused.
                 Requires watch_interval > 0 and an explicit to or parent target.
             enforce_public_remote_targets: When True, reject non-public remote hosts and
@@ -1740,26 +1748,10 @@ class ResourceService:
                 if on_complete is not None:
                     await on_complete("failed", None, str(exc))
                 raise
-            if not create_watch:
-                await self._manage_watch_if_needed(
-                    watch_manager=watch_manager,
-                    manage_watch=manage_watch,
-                    watch_interval=watch_interval,
-                    to=target_to,
-                    parent=target_parent,
-                    to_is_directory=to_is_directory,
-                    root_uri=target_to,
-                    path=path,
-                    reason=reason,
-                    instruction=instruction,
-                    build_index=build_index,
-                    summarize=summarize,
-                    processing_mode=processing_mode,
-                    processor_kwargs=connector_watch_processor_kwargs,
-                    watch_auth_state=watch_auth_state,
-                    ctx=ctx,
-                    source_type=resolved[0],
-                )
+            # A one-off Connector import (watch_interval <= 0) leaves any watch on the
+            # target alone: many imports share one folder, so the native
+            # "watch_interval=0 cancels the watch" rule would pause it as a side
+            # effect. Connector watches are paused or deleted only via the watches API.
             return result
 
         from openviking.parse.accessors.feishu_accessor import FeishuAccessor
@@ -2193,104 +2185,46 @@ class ResourceService:
         is_active: bool = True,
         hold_execution: bool = False,
     ) -> Optional["WatchTask"]:
-        """Handle creation or update of watch task.
+        """Create the watch task for the resolved target URI.
 
-        Args:
-            path: Resource path to monitor
-            to_uri: Target URI
-            parent_uri: Parent URI
-            reason: Reason for monitoring
-            instruction: Monitoring instruction
-            watch_interval: Monitoring interval in minutes
-            ctx: Request context with user identity
+        The target URI is the whole watch identity: ``create_task`` raises when any
+        watch already exists on it, whatever its source or active state. Callers
+        that resolve the target after ingestion (``parent`` imports) reach here with
+        the final root URI, so the same rule covers ``to`` and ``parent``.
 
         Raises:
-            ConflictError: If target URI is actively watched from a different source
+            ConflictError: If the target URI already has a watch task
         """
         watch_manager = self._get_watch_manager()
         if not watch_manager:
             return None
 
-        existing_task = await watch_manager.get_upsertable_task_by_uri(
+        task = await watch_manager.create_task(
             path=path,
-            to_uri=to_uri,
             account_id=ctx.account_id,
             user_id=ctx.user.user_id,
-            role=str(ctx.role),
+            original_role=str(ctx.role),
+            source_type=source_type,
+            to_uri=to_uri,
+            to_is_directory=to_is_directory,
+            parent_uri=parent_uri,
+            reason=reason,
+            instruction=instruction,
+            watch_interval=watch_interval,
+            build_index=build_index,
+            summarize=summarize,
+            processing_mode=processing_mode,
+            processor_kwargs=processor_kwargs,
+            auth_state=auth_state,
+            connector_states=connector_states,
+            is_active=is_active,
         )
-        held_task_id: Optional[str] = None
-        try:
-            if existing_task:
-                if hold_execution:
-                    if not await self._hold_watch_execution(existing_task.task_id):
-                        raise ConflictError(
-                            f"Watch task {existing_task.task_id} is already executing. "
-                            "Retry after it finishes.",
-                            resource=to_uri,
-                        )
-                    held_task_id = existing_task.task_id
-                was_active = existing_task.is_active
-                task = await watch_manager.update_task(
-                    task_id=existing_task.task_id,
-                    account_id=ctx.account_id,
-                    user_id=ctx.user.user_id,
-                    role=str(ctx.role),
-                    path=path,
-                    source_type=source_type,
-                    to_uri=to_uri,
-                    to_is_directory=to_is_directory,
-                    parent_uri=parent_uri,
-                    reason=reason,
-                    instruction=instruction,
-                    watch_interval=watch_interval,
-                    build_index=build_index,
-                    summarize=summarize,
-                    processing_mode=processing_mode,
-                    processor_kwargs=processor_kwargs,
-                    auth_state=auth_state,
-                    connector_states=connector_states,
-                    is_active=is_active,
-                )
-                logger.info(
-                    f"[ResourceService] "
-                    f"{'Updated active' if was_active else 'Reactivated and updated'} "
-                    f"watch task {existing_task.task_id} for {to_uri}"
-                )
-            else:
-                task = await watch_manager.create_task(
-                    path=path,
-                    account_id=ctx.account_id,
-                    user_id=ctx.user.user_id,
-                    original_role=str(ctx.role),
-                    source_type=source_type,
-                    to_uri=to_uri,
-                    to_is_directory=to_is_directory,
-                    parent_uri=parent_uri,
-                    reason=reason,
-                    instruction=instruction,
-                    watch_interval=watch_interval,
-                    build_index=build_index,
-                    summarize=summarize,
-                    processing_mode=processing_mode,
-                    processor_kwargs=processor_kwargs,
-                    auth_state=auth_state,
-                    connector_states=connector_states,
-                    is_active=is_active,
-                )
-                if hold_execution:
-                    if not await self._hold_watch_execution(task.task_id):
-                        raise ConflictError(
-                            f"Watch task {task.task_id} is already executing. "
-                            "Retry after it finishes.",
-                            resource=to_uri,
-                        )
-                    held_task_id = task.task_id
-                logger.info(f"[ResourceService] Created watch task {task.task_id} for {to_uri}")
-            return task
-        except BaseException:
-            if held_task_id is not None:
-                await self._release_watch_execution(held_task_id)
-            raise
+        if hold_execution:
+            # Brand-new task: the hold cannot be contended, it just parks the id
+            # until the caller's first round records its result.
+            await self._hold_watch_execution(task.task_id)
+        logger.info(f"[ResourceService] Created watch task {task.task_id} for {to_uri}")
+        return task
 
     async def _handle_watch_task_cancellation(self, to_uri: str, ctx: RequestContext) -> None:
         """Handle cancellation of watch task.

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -432,6 +432,8 @@ class ResourceService:
             elif to:
                 try:
                     await self._handle_watch_task_cancellation(to_uri=to, ctx=ctx)
+                except ConflictError:
+                    raise
                 except Exception as e:
                     logger.warning(f"[ResourceService] Failed to cancel watch task for {to}: {e}")
 
@@ -1474,6 +1476,16 @@ class ResourceService:
     ) -> Dict[str, Any]:
         """Validate and route one resource ingestion request.
 
+        Watch ownership:
+            Native Watches require an unoccupied resolved target and keep it while
+            paused. Connector Watches may share targets only with other Connector
+            Watches; repeating a source and target creates another independent task.
+            Re-importing never updates or resumes an existing Watch: use
+            PATCH /api/v1/watches/{task_id}, or delete it before creating a replacement.
+            URI lookup is ambiguous when multiple accessible Watches share a target;
+            address those tasks by task_id. Connector Watches are visible before the
+            initial import and held by the scheduler until it records its result.
+
         Args:
             path: Resource path (local file or URL)
             add_type: Explicitly declared Connector source type. Routes the
@@ -1498,28 +1510,11 @@ class ResourceService:
             build_index: Whether to build vector index immediately (default: True)
             summarize: Whether to generate summary (default: False)
             processing_mode: Post-ingest processing mode for semantic/vector work
-            watch_interval: Watch interval in minutes for automatic resource monitoring.
-                - watch_interval > 0: Creates or updates a watch task. The resource will be
-                  automatically re-processed at the specified interval by the scheduler.
-                - watch_interval = 0: No watch task is created. If a watch task exists for
-                  this resource, it will be cancelled (deactivated).
-                - watch_interval < 0: Same as watch_interval = 0, cancels any existing watch task.
-                Default is 0 (no monitoring).
-
-                Note: The resolved target URI is the watch identity. A native watch owns
-                its target alone: any existing watch there, active or paused, rejects a
-                new native import with ConflictError; change or reactivate it through the
-                watches API, or delete it. Connector watches lay their files out under
-                the target themselves, so several Connector watches may share one target
-                (never with a native watch); a shared target must then be addressed by
-                task_id rather than by URI. The same source imported into a different
-                target gets its own watch. With ``parent`` the target is resolved after
-                the import. A Connector import without
-                watch_interval never pauses a watch already on its target (the native
-                watch_interval <= 0 cancel rule does not apply). Connector imports create the Watch before the
-                import runs, so the conflict is reported at submission and the Watch is
-                visible at once; the scheduler holds it until the first round records its
-                result.
+            watch_interval: Interval in minutes (default: 0). Positive values create
+                a new Watch subject to target ownership rules, using explicit ``to``
+                or the imported ``root_uri``. Nonpositive values create no Watch:
+                native imports with explicit ``to`` pause a single accessible Watch
+                (ConflictError if ambiguous); Connector imports leave Watches untouched.
             is_active: When false, the Connector or native Feishu Watch is created paused.
                 Requires watch_interval > 0 and an explicit to or parent target.
             enforce_public_remote_targets: When True, reject non-public remote hosts and
@@ -1531,7 +1526,7 @@ class ResourceService:
             Processing result containing 'root_uri' and other metadata
 
         Raises:
-            ConflictError: If a different source targets an active watch task
+            ConflictError: Incompatible target occupancy or ambiguous cancellation by URI
             InvalidArgumentError: If the URI scope is not 'resources'
         """
         self._ensure_initialized()
@@ -2187,13 +2182,12 @@ class ResourceService:
     ) -> Optional["WatchTask"]:
         """Create the watch task for the resolved target URI.
 
-        The target URI is the whole watch identity: ``create_task`` raises when any
-        watch already exists on it, whatever its source or active state. Callers
-        that resolve the target after ingestion (``parent`` imports) reach here with
-        the final root URI, so the same rule covers ``to`` and ``parent``.
+        Native Watches require an unoccupied target; Connector Watches may share
+        only with other Connector Watches. Paused Watches retain ownership.
+        Callers using ``parent`` pass the root URI resolved after ingestion.
 
         Raises:
-            ConflictError: If the target URI already has a watch task
+            ConflictError: If the target URI has an incompatible Watch
         """
         watch_manager = self._get_watch_manager()
         if not watch_manager:

--- a/tests/integration/test_watch_e2e.py
+++ b/tests/integration/test_watch_e2e.py
@@ -135,18 +135,30 @@ class TestWatchE2EBasicFlow:
         assert task.watch_interval == 30.0
         task_id = task.task_id
 
+        # The target already has a watch, so re-adding (even the same source, even
+        # after pausing it) conflicts; the interval is changed through the watch itself.
         await service.resources.add_resource(
             ctx=ctx,
             path=str(watch_test_file),
             to=to_uri,
             watch_interval=0,
         )
+        with pytest.raises(ConflictError, match="already being monitored"):
+            await service.resources.add_resource(
+                ctx=ctx,
+                path=str(watch_test_file),
+                to=to_uri,
+                watch_interval=120.0,
+            )
 
-        await service.resources.add_resource(
-            ctx=ctx,
-            path=str(watch_test_file),
-            to=to_uri,
+        watch_manager = service.resources._watch_scheduler.watch_manager
+        await watch_manager.update_task(
+            task_id=task_id,
+            account_id=ctx.account_id,
+            user_id=ctx.user.user_id,
+            role=str(ctx.role),
             watch_interval=120.0,
+            is_active=True,
         )
 
         task = await get_watch_task(service, ctx, to_uri)
@@ -247,18 +259,33 @@ class TestWatchE2EConflictDetection:
         assert task is not None
         assert task.is_active is False
 
-        await service.resources.add_resource(
-            ctx=ctx,
-            path=str(watch_test_file),
-            to=to_uri,
+        # A paused watch still owns the target: re-adding conflicts, reactivation
+        # goes through the watch itself.
+        with pytest.raises(ConflictError, match="already being monitored"):
+            await service.resources.add_resource(
+                ctx=ctx,
+                path=str(watch_test_file),
+                to=to_uri,
+                reason="Reactivated reason",
+                watch_interval=45.0,
+            )
+
+        watch_manager = service.resources._watch_scheduler.watch_manager
+        await watch_manager.update_task(
+            task_id=task_id,
+            account_id=ctx.account_id,
+            user_id=ctx.user.user_id,
+            role=str(ctx.role),
             reason="Reactivated reason",
             watch_interval=45.0,
+            is_active=True,
         )
 
         task = await get_watch_task(service, ctx, to_uri)
         assert task is not None
         assert task.is_active is True
         assert task.watch_interval == 45.0
+        assert task.reason == "Reactivated reason"
         assert task.task_id == task_id
 
 

--- a/tests/resource/test_watch_manager.py
+++ b/tests/resource/test_watch_manager.py
@@ -445,7 +445,7 @@ class TestWatchManager:
             to_uri="viking://resources/test",
         )
 
-        with pytest.raises(ConflictError, match="already used by another task"):
+        with pytest.raises(ConflictError, match="already being monitored"):
             await watch_manager.create_task(
                 path="/test/path2",
                 to_uri="viking://resources/test",
@@ -882,3 +882,79 @@ class TestWatchManagerConcurrency:
 
         final_task = await watch_manager.get_task(task.task_id)
         assert final_task is not None
+
+
+_CONNECTOR_AUTH = {"provider": "connector_encrypted", "ciphertext": "unused"}
+
+
+class TestSharedConnectorTargets:
+    """Connector watches may share a target; native watches are exclusive."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("user_id", "role", "visible_indexes"),
+        [
+            ("carol", "user", ()),
+            ("bob", "user", (2,)),
+            ("alice", "user", (0, 1)),
+            ("bob", "admin", (0, 1, 2)),
+            ("bob", "root", (0, 1, 2)),
+        ],
+    )
+    async def test_uri_lookup_only_considers_visible_tasks(
+        self, watch_manager_no_fs: WatchManager, user_id, role, visible_indexes
+    ):
+        manager = watch_manager_no_fs
+        to_uri = "viking://resources/shared"
+        tasks = []
+        for index, owner in enumerate(("alice", "alice", "bob")):
+            tasks.append(
+                await manager.create_task(
+                    path=f"tos://bucket/{index}/",
+                    user_id=owner,
+                    to_uri=to_uri,
+                    auth_state=dict(_CONNECTOR_AUTH),
+                )
+            )
+
+        if len(visible_indexes) > 1:
+            with pytest.raises(
+                ConflictError, match=f"has {len(visible_indexes)} watch tasks"
+            ) as exc_info:
+                await manager.get_task_by_uri(to_uri, TEST_ACCOUNT_ID, user_id, role)
+            for index, task in enumerate(tasks):
+                assert (task.task_id in str(exc_info.value)) == (index in visible_indexes)
+        else:
+            task = await manager.get_task_by_uri(to_uri, TEST_ACCOUNT_ID, user_id, role)
+            assert task is (tasks[visible_indexes[0]] if visible_indexes else None)
+
+    @pytest.mark.asyncio
+    async def test_connector_watches_coexist_and_native_is_refused(self, watch_manager: WatchManager):
+        to_uri = "viking://resources/shared"
+        first = await watch_manager.create_task(
+            path="tos://bucket/a/", to_uri=to_uri, watch_interval=5, auth_state=dict(_CONNECTOR_AUTH)
+        )
+        second = await watch_manager.create_task(
+            path="tos://bucket/b/", to_uri=to_uri, watch_interval=5, auth_state=dict(_CONNECTOR_AUTH)
+        )
+        assert first.task_id != second.task_id
+
+        with pytest.raises(ConflictError, match="already being monitored"):
+            await watch_manager.create_task(path="/local/doc", to_uri=to_uri, watch_interval=5)
+
+        # Removing one Connector watch keeps the other addressable by URI again.
+        await watch_manager.delete_task(first.task_id, account_id="default", user_id="default", role="user")
+        remaining = await watch_manager.get_task_by_uri(
+            to_uri, account_id="default", user_id="default", role="user"
+        )
+        assert remaining is not None
+        assert remaining.task_id == second.task_id
+
+    @pytest.mark.asyncio
+    async def test_native_watch_blocks_connector_watch(self, watch_manager: WatchManager):
+        to_uri = "viking://resources/native"
+        await watch_manager.create_task(path="/local/doc", to_uri=to_uri, watch_interval=5)
+        with pytest.raises(ConflictError, match="already being monitored"):
+            await watch_manager.create_task(
+                path="tos://bucket/a/", to_uri=to_uri, watch_interval=5, auth_state=dict(_CONNECTOR_AUTH)
+            )

--- a/tests/resource/test_watch_manager.py
+++ b/tests/resource/test_watch_manager.py
@@ -498,7 +498,7 @@ class TestWatchManager:
             to_uri="viking://resources/test2",
         )
 
-        with pytest.raises(ConflictError, match="already used by another task"):
+        with pytest.raises(ConflictError, match="already being monitored"):
             await watch_manager.update_task(
                 task_id=task2.task_id,
                 account_id=TEST_ACCOUNT_ID,
@@ -891,6 +891,42 @@ class TestSharedConnectorTargets:
     """Connector watches may share a target; native watches are exclusive."""
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("with_connector", [False, True])
+    @pytest.mark.parametrize("operation", ["create", "update", "rewrite"])
+    async def test_missing_indexed_task_blocks_target_sharing(
+        self, watch_manager_no_fs: WatchManager, with_connector: bool, operation: str
+    ):
+        manager = watch_manager_no_fs
+        target = "viking://resources/shared"
+        source = "viking://resources/source"
+        if with_connector:
+            await manager.create_task(
+                path="tos://bucket/existing/", to_uri=target, auth_state=dict(_CONNECTOR_AUTH)
+            )
+        moving = await manager.create_task(
+            path="tos://bucket/moving/", to_uri=source, auth_state=dict(_CONNECTOR_AUTH)
+        )
+        manager._index_add(TEST_ACCOUNT_ID, target, "missing-task")
+        original_index = {key: set(ids) for key, ids in manager._uri_to_task.items()}
+        original_tasks = set(manager._tasks)
+
+        with pytest.raises(ConflictError, match="already being monitored"):
+            if operation == "create":
+                await manager.create_task(
+                    path="tos://bucket/new/", to_uri=target, auth_state=dict(_CONNECTOR_AUTH)
+                )
+            elif operation == "update":
+                await manager.update_task(
+                    moving.task_id, TEST_ACCOUNT_ID, TEST_USER_ID, TEST_ROLE, to_uri=target
+                )
+            else:
+                await manager.rewrite_target_prefix_internal(source, target, TEST_ACCOUNT_ID)
+
+        assert manager._uri_to_task == original_index
+        assert set(manager._tasks) == original_tasks
+        assert moving.to_uri == source
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ("user_id", "role", "visible_indexes"),
         [
@@ -929,13 +965,21 @@ class TestSharedConnectorTargets:
             assert task is (tasks[visible_indexes[0]] if visible_indexes else None)
 
     @pytest.mark.asyncio
-    async def test_connector_watches_coexist_and_native_is_refused(self, watch_manager: WatchManager):
+    async def test_connector_watches_coexist_and_native_is_refused(
+        self, watch_manager: WatchManager
+    ):
         to_uri = "viking://resources/shared"
         first = await watch_manager.create_task(
-            path="tos://bucket/a/", to_uri=to_uri, watch_interval=5, auth_state=dict(_CONNECTOR_AUTH)
+            path="tos://bucket/a/",
+            to_uri=to_uri,
+            watch_interval=5,
+            auth_state=dict(_CONNECTOR_AUTH),
         )
         second = await watch_manager.create_task(
-            path="tos://bucket/b/", to_uri=to_uri, watch_interval=5, auth_state=dict(_CONNECTOR_AUTH)
+            path="tos://bucket/b/",
+            to_uri=to_uri,
+            watch_interval=5,
+            auth_state=dict(_CONNECTOR_AUTH),
         )
         assert first.task_id != second.task_id
 
@@ -943,7 +987,9 @@ class TestSharedConnectorTargets:
             await watch_manager.create_task(path="/local/doc", to_uri=to_uri, watch_interval=5)
 
         # Removing one Connector watch keeps the other addressable by URI again.
-        await watch_manager.delete_task(first.task_id, account_id="default", user_id="default", role="user")
+        await watch_manager.delete_task(
+            first.task_id, account_id="default", user_id="default", role="user"
+        )
         remaining = await watch_manager.get_task_by_uri(
             to_uri, account_id="default", user_id="default", role="user"
         )
@@ -956,5 +1002,8 @@ class TestSharedConnectorTargets:
         await watch_manager.create_task(path="/local/doc", to_uri=to_uri, watch_interval=5)
         with pytest.raises(ConflictError, match="already being monitored"):
             await watch_manager.create_task(
-                path="tos://bucket/a/", to_uri=to_uri, watch_interval=5, auth_state=dict(_CONNECTOR_AUTH)
+                path="tos://bucket/a/",
+                to_uri=to_uri,
+                watch_interval=5,
+                auth_state=dict(_CONNECTOR_AUTH),
             )

--- a/tests/service/test_resource_service_connector.py
+++ b/tests/service/test_resource_service_connector.py
@@ -443,7 +443,7 @@ async def test_connector_watch_releases_hold_when_submission_is_cancelled(
 
 
 @pytest.mark.asyncio
-async def test_connector_watch_prechecks_only_active_conflicts(
+async def test_connector_watch_conflicts_with_any_watch_on_target(
     monkeypatch,
     connector_config,
     ctx,
@@ -490,6 +490,7 @@ async def test_connector_watch_prechecks_only_active_conflicts(
     connector_client.submit_doc_add.assert_not_awaited()
     tracker.create.assert_not_awaited()
 
+    # Pausing the watch does not free the target: the paused watch still owns it.
     await watch_manager.update_task(
         task_id=existing.task_id,
         account_id="acct",
@@ -497,37 +498,26 @@ async def test_connector_watch_prechecks_only_active_conflicts(
         role=str(Role.USER),
         is_active=False,
     )
-    release_monitor = asyncio.Event()
+    with pytest.raises(ConflictError, match="already being monitored"):
+        await service.add_resource(
+            path="tos://bucket/new/",
+            ctx=ctx,
+            to=to_uri,
+            watch_interval=5,
+        )
 
-    async def complete_monitor(**kwargs):
-        await release_monitor.wait()
-        await kwargs["on_success"]()
-        return {"status": "completed"}
-
-    monkeypatch.setattr(service._connector, "_monitor", complete_monitor)
-    await service.add_resource(
-        path="tos://bucket/new/",
-        ctx=ctx,
-        to=to_uri,
-        watch_interval=5,
-    )
-
-    # A paused watch on the same target is reactivated at submission, not after
-    # the import finishes.
-    assert existing.is_active is True
-    assert existing.path == "tos://bucket/new/"
-    assert existing.last_status is None
-    release_monitor.set()
-    await asyncio.gather(*list(service._background_tasks))
-    assert existing.is_active is True
-    assert existing.last_status == "completed"
+    connector_client.submit_doc_add.assert_not_awaited()
+    assert existing.is_active is False
+    assert existing.path == "tos://bucket/old/"
 
 
 @pytest.mark.asyncio
-async def test_connector_watch_rejects_overlapping_imports_at_submit(
+async def test_connector_watches_can_share_a_target(
     connector_config,
     ctx,
 ):
+    """Connector sources lay their files out under ``to`` themselves, so several
+    Connector watches may share one target; a native watch never can."""
     watch_manager = WatchManager()
     service = ResourceService(
         vikingdb=object(),
@@ -542,43 +532,43 @@ async def test_connector_watch_rejects_overlapping_imports_at_submit(
     service._connector.submit = AsyncMock(return_value={"status": "accepted"})
     to_uri = "viking://resources/x/y"
 
-    await service.add_resource(
-        path="tos://bucket/first/",
-        ctx=ctx,
-        to=to_uri,
-        watch_interval=5,
-    )
+    await service.add_resource(path="tos://bucket/first/", ctx=ctx, to=to_uri, watch_interval=5)
+    await service.add_resource(path="tos://bucket/second/", ctx=ctx, to=to_uri, watch_interval=5)
+
+    assert service._connector.submit.await_count == 2
+    tasks = await watch_manager.get_all_tasks("acct", "alice", str(Role.USER))
+    assert sorted(t.path for t in tasks if t.to_uri == to_uri) == [
+        "tos://bucket/first/",
+        "tos://bucket/second/",
+    ]
+    # A shared target can no longer be addressed by URI alone.
+    with pytest.raises(ConflictError, match="address one by task_id"):
+        await watch_manager.get_task_by_uri(
+            to_uri, account_id="acct", user_id="alice", role=str(Role.USER)
+        )
+    # A native watch (no Connector auth_state) may not join a shared target.
     with pytest.raises(ConflictError, match="already being monitored"):
-        await service.add_resource(
-            path="tos://bucket/second/",
-            ctx=ctx,
-            to=to_uri,
+        await watch_manager.create_task(
+            path="https://example.com/doc",
+            account_id="acct",
+            user_id="alice",
+            original_role=str(Role.USER),
+            to_uri=to_uri,
             watch_interval=5,
         )
 
-    # The second import never reaches the Connector, so nothing overlapping is written.
-    assert service._connector.submit.await_count == 1
-    task = await watch_manager.get_task_by_uri(
-        to_uri,
-        account_id="acct",
-        user_id="alice",
-        role=str(Role.USER),
-    )
-    assert task is not None
-    assert task.path == "tos://bucket/first/"
-
 
 @pytest.mark.asyncio
-async def test_connector_watch_rejects_same_source_while_first_import_is_running(
+async def test_same_source_connector_watches_are_independently_held(
     connector_config,
     ctx,
     service,
 ):
+    """Repeated imports create separate watches held during their first rounds."""
     scheduler = WatchScheduler(resource_service=service, check_interval=1)
     watch_manager = WatchManager()
     scheduler._watch_manager = watch_manager
     service._watch_scheduler = scheduler
-    service._connector.create_watch_auth_state = AsyncMock(return_value={"provider": "test"})
     service._connector.submit = AsyncMock(return_value={"status": "accepted"})
     to_uri = "viking://resources/x/y"
     path = "tos://bucket/docs/"
@@ -590,25 +580,25 @@ async def test_connector_watch_rejects_same_source_while_first_import_is_running
         reason="first",
         watch_interval=5,
     )
-    with pytest.raises(ConflictError, match="already executing"):
-        await service.add_resource(
-            path=path,
-            ctx=ctx,
-            to=to_uri,
-            reason="second",
-            watch_interval=5,
-        )
+    await service.add_resource(
+        path=path,
+        ctx=ctx,
+        to=to_uri,
+        reason="second",
+        watch_interval=5,
+    )
 
-    task = await watch_manager.get_task_by_uri(
-        to_uri,
+    tasks = await watch_manager.get_all_tasks(
         account_id="acct",
         user_id="alice",
         role=str(Role.USER),
     )
-    assert task is not None
-    assert task.reason == "first"
-    assert service._connector.submit.await_count == 1
-    assert scheduler._executing_tasks == {task.task_id}
+    assert len(tasks) == 2
+    assert {task.path for task in tasks} == {path}
+    assert {task.to_uri for task in tasks} == {to_uri}
+    assert {task.reason for task in tasks} == {"first", "second"}
+    assert service._connector.submit.await_count == 2
+    assert scheduler._executing_tasks == {task.task_id for task in tasks}
 
 
 @pytest.mark.asyncio
@@ -917,7 +907,37 @@ async def test_failed_connector_watch_keeps_previous_stream_states(connector_con
 
 
 @pytest.mark.asyncio
-async def test_connector_watch_deactivates_when_target_is_deleted():
+async def test_one_off_connector_import_leaves_existing_watch_untouched(
+    connector_config,
+    ctx,
+    service,
+):
+    """Many one-off imports share a folder; none of them may pause its watch."""
+    watch_manager = WatchManager()
+    service._watch_scheduler = SimpleNamespace(watch_manager=watch_manager)
+    service._connector.submit = AsyncMock(return_value={"status": "accepted"})
+    to_uri = "viking://resources/x/y"
+    existing = await watch_manager.create_task(
+        path="tos://bucket/watched/",
+        account_id="acct",
+        user_id="alice",
+        original_role=str(Role.USER),
+        to_uri=to_uri,
+        watch_interval=5,
+    )
+
+    await service.add_resource(path="tos://bucket/batch-1/", ctx=ctx, to=to_uri)
+    await service.add_resource(path="tos://bucket/batch-2/", ctx=ctx, to=to_uri, watch_interval=0)
+
+    assert service._connector.submit.await_count == 2
+    assert existing.is_active is True
+    assert existing.path == "tos://bucket/watched/"
+
+
+@pytest.mark.asyncio
+async def test_connector_watch_keeps_running_when_target_is_missing():
+    """A Connector target only exists once the plugin writes into it: an empty
+    first round (or a deleted target) must not deactivate the watch."""
     from openviking_cli.exceptions import NotFoundError
 
     class MissingTargetFS:
@@ -926,6 +946,7 @@ async def test_connector_watch_deactivates_when_target_is_deleted():
 
     service = ResourceService()
     service.refresh_resource = AsyncMock(return_value={"status": "completed"})
+    service._connector.restore_watch_request = AsyncMock(return_value=("secret", "tos", {}))
     scheduler = WatchScheduler(resource_service=service, viking_fs=MissingTargetFS())
     watch_manager = WatchManager()
     scheduler._watch_manager = watch_manager
@@ -942,8 +963,10 @@ async def test_connector_watch_deactivates_when_target_is_deleted():
 
     updated = await watch_manager.get_task(task.task_id)
     assert updated is not None
-    assert updated.is_active is False
-    service.refresh_resource.assert_not_awaited()
+    assert updated.is_active is True
+    assert updated.last_status == "completed"
+    service.refresh_resource.assert_awaited_once()
+    assert service.refresh_resource.await_args.kwargs["to"] == "viking://resources/x/y"
 
 
 @pytest.mark.asyncio

--- a/tests/service/test_resource_service_parse_mode.py
+++ b/tests/service/test_resource_service_parse_mode.py
@@ -95,7 +95,6 @@ async def test_no_split_is_forwarded_and_persisted_for_watch_replay(
     ctx: RequestContext,
 ):
     watch_manager = SimpleNamespace(
-        get_upsertable_task_by_uri=AsyncMock(return_value=None),
         create_task=AsyncMock(return_value=SimpleNamespace(task_id="watch-1")),
     )
     scheduler = SimpleNamespace(watch_manager=watch_manager)

--- a/tests/service/test_resource_service_watch.py
+++ b/tests/service/test_resource_service_watch.py
@@ -890,10 +890,38 @@ class TestWatchTaskConflict:
         assert to_uri in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_same_source_updates_active_task(
+    async def test_same_source_to_different_targets_creates_separate_tasks(
         self, resource_service: ResourceService, request_context: RequestContext
     ):
-        """Re-applying one source updates its active watch instead of conflicting."""
+        """Only the target decides: one source may be watched into several targets."""
+        source = "/test/shared-source"
+        first_to = "viking://resources/shared_source_a"
+        second_to = "viking://resources/shared_source_b"
+
+        await resource_service.add_resource(
+            path=source, ctx=request_context, to=first_to, watch_interval=30.0
+        )
+        await resource_service.add_resource(
+            path=source, ctx=request_context, to=second_to, watch_interval=45.0
+        )
+
+        first = await get_task_by_uri(resource_service, first_to, request_context)
+        second = await get_task_by_uri(resource_service, second_to, request_context)
+        assert first is not None and second is not None
+        assert first.task_id != second.task_id
+        assert first.path == second.path == source
+        assert (first.watch_interval, second.watch_interval) == (30.0, 45.0)
+        assert first.is_active and second.is_active
+
+    @pytest.mark.asyncio
+    async def test_same_source_conflicts_with_active_task(
+        self, resource_service: ResourceService, request_context: RequestContext
+    ):
+        """An active watch on the target rejects re-adding even the same source.
+
+        The kernel cannot tell whether two imports are the same source (Connector
+        types carry their identity in args), so only the target decides.
+        """
         to_uri = "viking://resources/idempotent_watch"
         source = "/test/same-path"
 
@@ -908,23 +936,23 @@ class TestWatchTaskConflict:
         original = await get_task_by_uri(resource_service, to_uri, request_context)
         assert original is not None
 
-        await resource_service.add_resource(
-            path=source,
-            ctx=request_context,
-            to=to_uri,
-            reason="Updated reason",
-            watch_interval=45.0,
-            args={"branch": "release"},
-        )
+        with pytest.raises(ConflictError, match="already being monitored"):
+            await resource_service.add_resource(
+                path=source,
+                ctx=request_context,
+                to=to_uri,
+                reason="Updated reason",
+                watch_interval=45.0,
+                args={"branch": "release"},
+            )
 
-        updated = await get_task_by_uri(resource_service, to_uri, request_context)
-        assert updated is not None
-        assert updated.task_id == original.task_id
-        assert updated.path == source
-        assert updated.reason == "Updated reason"
-        assert updated.watch_interval == 45.0
-        assert updated.processor_kwargs == {"branch": "release"}
-        assert updated.is_active is True
+        unchanged = await get_task_by_uri(resource_service, to_uri, request_context)
+        assert unchanged is not None
+        assert unchanged.task_id == original.task_id
+        assert unchanged.reason == "Original reason"
+        assert unchanged.watch_interval == 30.0
+        assert unchanged.processor_kwargs == {"branch": "main"}
+        assert unchanged.is_active is True
 
     @pytest.mark.asyncio
     async def test_conflict_does_not_create_async_task(
@@ -982,7 +1010,7 @@ class TestWatchTaskConflict:
                 watch_interval=45.0,
             )
 
-        assert "already used by another task" in str(exc_info.value)
+        assert "already being monitored" in str(exc_info.value)
         assert to_uri in str(exc_info.value)
 
         task = await get_task_by_uri(resource_service, to_uri, request_context)
@@ -1039,7 +1067,8 @@ class TestWatchTaskConflict:
         assert task is not None
         task_id = task.task_id
 
-        await resource_service._watch_scheduler.watch_manager.update_task(
+        watch_manager = resource_service._watch_scheduler.watch_manager
+        await watch_manager.update_task(
             task_id=task_id,
             account_id=request_context.account_id,
             user_id=request_context.user.user_id,
@@ -1047,18 +1076,31 @@ class TestWatchTaskConflict:
             is_active=False,
         )
 
-        await resource_service.add_resource(
-            path="/test/path2",
-            ctx=request_context,
-            to=to_uri,
+        # A paused watch still owns its target: re-adding conflicts, and the watch
+        # is reactivated through the watch itself.
+        with pytest.raises(ConflictError, match="already being monitored"):
+            await resource_service.add_resource(
+                path="/test/path2",
+                ctx=request_context,
+                to=to_uri,
+                reason="Updated reason",
+                watch_interval=45.0,
+            )
+
+        await watch_manager.update_task(
+            task_id=task_id,
+            account_id=request_context.account_id,
+            user_id=request_context.user.user_id,
+            role=str(request_context.role),
             reason="Updated reason",
             watch_interval=45.0,
+            is_active=True,
         )
 
         task = await get_task_by_uri(resource_service, to_uri, request_context)
         assert task is not None
         assert task.task_id == task_id
-        assert task.path == "/test/path2"
+        assert task.path == "/test/path1"
         assert task.reason == "Updated reason"
         assert task.watch_interval == 45.0
         assert task.is_active is True
@@ -1188,7 +1230,8 @@ class TestWatchTaskUpdate:
         assert task is not None
         original_task_id = task.task_id
 
-        await resource_service._watch_scheduler.watch_manager.update_task(
+        watch_manager = resource_service._watch_scheduler.watch_manager
+        await watch_manager.update_task(
             task_id=task.task_id,
             account_id=request_context.account_id,
             user_id=request_context.user.user_id,
@@ -1196,19 +1239,32 @@ class TestWatchTaskUpdate:
             is_active=False,
         )
 
-        await resource_service.add_resource(
-            path="/test/path2",
-            ctx=request_context,
-            to=to_uri,
+        # Parameters change through the watch, never by re-adding to its target.
+        with pytest.raises(ConflictError, match="already being monitored"):
+            await resource_service.add_resource(
+                path="/test/path2",
+                ctx=request_context,
+                to=to_uri,
+                reason="Updated reason",
+                instruction="Updated instruction",
+                watch_interval=60.0,
+            )
+
+        await watch_manager.update_task(
+            task_id=original_task_id,
+            account_id=request_context.account_id,
+            user_id=request_context.user.user_id,
+            role=str(request_context.role),
             reason="Updated reason",
             instruction="Updated instruction",
             watch_interval=60.0,
+            is_active=True,
         )
 
         task = await get_task_by_uri(resource_service, to_uri, request_context)
         assert task is not None
         assert task.task_id == original_task_id
-        assert task.path == "/test/path2"
+        assert task.path == "/test/path1"
         assert task.reason == "Updated reason"
         assert task.instruction == "Updated instruction"
         assert task.watch_interval == 60.0

--- a/tests/service/test_resource_service_watch.py
+++ b/tests/service/test_resource_service_watch.py
@@ -1016,6 +1016,8 @@ class TestWatchTaskConflict:
         task = await get_task_by_uri(resource_service, to_uri, request_context)
         assert task is not None
 
+        assert task.task_id not in str(exc_info.value)
+
     @pytest.mark.asyncio
     async def test_same_user_context_sees_existing_task(
         self, resource_service: ResourceService, request_context: RequestContext
@@ -1108,6 +1110,36 @@ class TestWatchTaskConflict:
 
 class TestWatchTaskCancellation:
     """Tests for watch task cancellation."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("watch_interval", [0, -5])
+    async def test_native_cancellation_reports_shared_target_conflict(
+        self, resource_service: ResourceService, request_context: RequestContext, watch_interval
+    ):
+        manager = resource_service._watch_scheduler.watch_manager
+        to_uri = "viking://resources/shared"
+        tasks = [
+            await manager.create_task(
+                path=f"tos://bucket/{index}/",
+                to_uri=to_uri,
+                account_id=request_context.account_id,
+                user_id=request_context.user.user_id,
+                auth_state={"provider": "connector_encrypted", "ciphertext": "unused"},
+            )
+            for index in range(2)
+        ]
+
+        with pytest.raises(ConflictError, match="address one by task_id") as exc_info:
+            await resource_service.add_resource(
+                path="/test/path",
+                ctx=request_context,
+                to=to_uri,
+                watch_interval=watch_interval,
+            )
+
+        assert all(task.is_active for task in tasks)
+        assert all(task.task_id in str(exc_info.value) for task in tasks)
+        resource_service._enqueue_add_resource_job.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_cancel_watch_task_with_zero_interval(


### PR DESCRIPTION
## Description

区分原生与 Connector Watch 的目标占用规则，支持多个 Connector Watch 共用目录，避免导入操作覆盖或暂停已有任务。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 同一账户下，原生 Watch 独占 `to`，暂停后仍占用目标，也不能与 Connector Watch 共用。
- 多个 Connector Watch 可共用 `to`，分别创建独立任务；相同 `path` 导入不同 `to` 也互不覆盖。
- 一次性 Connector 导入（`watch_interval <= 0`）不再暂停目标上的已有 Watch。
- 调度时目标不存在，不自动停用 Connector Watch，允许后续同步创建目标。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows


## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

多个 Watch 共用目标时，按 `to_uri` 定位返回 409，需通过 `task_id` 查询、更新或删除。原生 Watch 重新导入同一目标前需删除旧任务；修改配置或恢复任务使用 `PATCH /api/v1/watches/{task_id}`。
