### PR TITLE
refactor(openclaw-plugin): remove stale client-facade seam leftovers

### DIFF
--- a/examples/openclaw-plugin/client.ts
+++ b/examples/openclaw-plugin/client.ts
@@ -1,12 +1,3 @@
-import { randomUUID } from "node:crypto";
-import { once } from "node:events";
-import { createWriteStream } from "node:fs";
-import { mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { basename, dirname, join, relative } from "node:path";
-
-import { Zip, ZipDeflate } from "fflate";
-
 import { defaultHttpTransport, type HttpTransport } from "./adapters/http-transport.js";
 import {
   defaultResourcePackager,
@@ -255,37 +246,12 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-const MEMORY_URI_PATTERNS = [
-  /^viking:\/\/user\/(?:[^/]+\/)?memories(?:\/|$)/,
-];
-const REMOTE_RESOURCE_PREFIXES = ["http://", "https://", "git@", "ssh://", "git://"];
-
-export function isMemoryUri(uri: string): boolean {
-  return MEMORY_URI_PATTERNS.some((pattern) => pattern.test(uri));
-}
-
-function isRemoteResourceSource(source: string): boolean {
-  return REMOTE_RESOURCE_PREFIXES.some((prefix) => source.startsWith(prefix));
-}
-
-function toBlobPart(value: Buffer): ArrayBuffer {
-  return value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength) as ArrayBuffer;
-}
-
 function resolveWaitRequestTimeoutMs(defaultTimeoutMs: number, waitTimeoutSeconds?: number): number {
   const requestedMs =
     typeof waitTimeoutSeconds === "number" && Number.isFinite(waitTimeoutSeconds) && waitTimeoutSeconds > 0
       ? Math.ceil(waitTimeoutSeconds * 1000) + WAIT_REQUEST_TIMEOUT_BUFFER_MS
       : DEFAULT_WAIT_REQUEST_TIMEOUT_MS;
   return Math.max(defaultTimeoutMs, requestedMs);
-}
-
-async function cleanupUploadTempPath(path?: string): Promise<void> {
-  if (!path) {
-    return;
-  }
-  await rm(path, { force: true }).catch(() => undefined);
-  await rm(dirname(path), { recursive: true, force: true }).catch(() => undefined);
 }
 
 export class OpenVikingClient {
@@ -683,63 +649,6 @@ export class OpenVikingClient {
       throw new Error("OpenViking temp upload did not return temp_file_id");
     }
     return result.temp_file_id;
-  }
-
-  async zipDirectoryForUpload(dirPath: string): Promise<string> {
-    const rootStats = await stat(dirPath);
-    if (!rootStats.isDirectory()) {
-      throw new Error(`Not a directory: ${dirPath}`);
-    }
-
-    const zipDir = await mkdtemp(join(tmpdir(), "openviking-openclaw-upload-"));
-    const zipPath = join(zipDir, `${basename(dirPath).replace(/[^a-zA-Z0-9._-]/g, "_")}-${randomUUID()}.zip`);
-    const output = createWriteStream(zipPath);
-    const outputClosed = once(output, "close");
-    const outputErrored = once(output, "error").then(([err]) => Promise.reject(err));
-    const zip = new Zip((err, chunk, final) => {
-      if (err) {
-        output.destroy(err);
-        return;
-      }
-      if (chunk?.length) {
-        output.write(Buffer.from(chunk));
-      }
-      if (final) {
-        output.end();
-      }
-    });
-
-    const walk = async (currentDir: string) => {
-      const entries = await readdir(currentDir, { withFileTypes: true });
-      for (const entry of entries) {
-        const fullPath = join(currentDir, entry.name);
-        if (entry.isDirectory()) {
-          await walk(fullPath);
-          continue;
-        }
-        if (!entry.isFile()) {
-          continue;
-        }
-        const relPath = relative(dirPath, fullPath).replace(/\\/g, "/");
-        if (!relPath || relPath.startsWith("../") || relPath.includes("/../")) {
-          throw new Error(`Unsafe relative path while zipping: ${relPath}`);
-        }
-        const file = new ZipDeflate(relPath);
-        zip.add(file);
-        file.push(new Uint8Array(await readFile(fullPath)), true);
-      }
-    };
-    try {
-      await walk(dirPath);
-      zip.end();
-      await Promise.race([outputClosed, outputErrored]);
-    } catch (err) {
-      zip.terminate();
-      output.destroy(err as Error);
-      await cleanupUploadTempPath(zipPath);
-      throw err;
-    }
-    return zipPath;
   }
 
   async addResource(input: AddResourceInput, actorPeerId?: string): Promise<AddResourceResult> {

--- a/examples/openclaw-plugin/tests/ut/architecture-boundaries.test.ts
+++ b/examples/openclaw-plugin/tests/ut/architecture-boundaries.test.ts
@@ -73,7 +73,7 @@ describe("architecture boundaries", () => {
     const violations = collectSourceFiles(join(rootDir, "tests"), [".ts", ".tsx", ".js", ".mjs", ".cjs"])
       .flatMap((file) => {
         const source = readFileSync(file, "utf8");
-        const relativePath = relative(rootDir, file);
+        const relativePath = relative(rootDir, file).replace(/\\/g, "/");
         if (relativePath === "tests/ut/architecture-boundaries.test.ts") {
           return [];
         }


### PR DESCRIPTION
## Description

**Problem.** On a clean checkout of `main`, the plugin's own
`tests/ut/architecture-boundaries.test.ts` does not pass. A prior refactor
moved memory-URI classification into `routing/memory-uri.ts` and temp
upload/blob/zip packaging into `adapters/resource-packager.ts`, but the
pre-refactor copies were never removed from `client.ts`. The boundary guards
explicitly forbid the facade from defining those responsibilities, so they
fail against the leftover code (and one more fails on Windows for a path
reason). A red guard suite on `main` masks real regressions and leaves the
same logic duplicated on both the facade and its seams.

**Fix.** Finish the migration instead of re-litigating the design. This is a
code-health change with **no public API, config, or persistence change** and
no intended runtime behavior change. Note: the removed `isMemoryUri` copy was
a stale subset of the canonical `routing/memory-uri.ts` implementation (one
narrow URI pattern vs. five), so its removal also eliminates a latent
wrong-answer path for any future importer — no current consumers reference it,
verified plugin-wide:

- `client.ts` (−91/+0): drop `isMemoryUri`/`MEMORY_URI_PATTERNS` (canonical:
  `routing/memory-uri.ts`) and `isRemoteResourceSource`/`REMOTE_RESOURCE_PREFIXES`,
  `toBlobPart`, `cleanupUploadTempPath`, `zipDirectoryForUpload` (canonical:
  `adapters/resource-packager.ts`), plus the now-unused `node:*`/`fflate`
  imports. The class keeps delegating uploads to the injected
  `ResourcePackager` and keeps building `viking://~/sessions/...` URIs.
- `architecture-boundaries.test.ts` (−1/+1): normalize `path.relative()` to
  POSIX separators before the suite compares against its own POSIX-style path,
  so the test-self exclusion also holds on Windows. It is a no-op on POSIX,
  and it is the only comparison in the file against a separator-containing
  literal, so one site is the complete fix.

Deletion is safe: every consumer already uses the owning seam.
`plugin/openviking-memory-tools.ts` and `tests/ut/client.test.ts` import
`isMemoryUri` from `routing/memory-uri.js`, and uploads go through
`ResourcePackager`; a plugin-wide search finds no remaining reference to the
removed client symbols, and `tsc` is clean.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A. Internal cleanup confined to `examples/openclaw-plugin` with no public
REST/SDK/CLI/config or persistence change, so no design issue is required per
CONTRIBUTING.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Removed the migrated memory-URI and upload-packaging duplicates from the
  client facade, along with imports that became unused once they were gone.
- Made the boundary suite's self-exclusion path-portable (Windows + POSIX).
- Did not add a test file: the existing boundary guards are exactly the
  regression coverage for this ownership rule (CONTRIBUTING: prefer updating
  an existing test; do not add one by default).

## Testing

Environment: Windows, Node v20.20.2 / npm 10.8.2.

- `npx tsc -p tsconfig.json --noEmit` — pass (exit 0)
- `npx tsc -p tsconfig.build.json --noEmit` — pass (exit 0)
- `npx vitest run tests/ut/architecture-boundaries.test.ts` — 74/76 pass.

Named before/after for that suite:
- Now green (red on `main`): "keeps temp upload body construction inside the
  resource packager seam", "keeps memory URI classification on the routing
  seam instead of the client facade"; and, on Windows only, "keeps tests from
  carrying stale global fetch cleanup after transport seam migration" (its
  self-exclusion already passes on POSIX).
- Red both before and after, in files this PR does not touch: "keeps dead
  recall-trace resource helper compatibility exports removed" (root
  `recall-trace.ts` still exports `normalizeResourceTypes` /
  `resolveRecallSearchPlan`) and "keeps setup CLI free of direct network fetch
  logic" (`commands/setup.ts` still calls `fetch`/`AbortController`). These
  are separate, unfinished migrations called out below.
- Full `npx vitest run`: 763/766 locally. Beyond the same two pre-existing
  boundary failures, the only other failure is `tos-release-contract`, which
  shells out to `bash`/`git` and raises ENOENT on this Windows-only host; it
  is unaffected on Linux CI.

- [ ] Added new tests (not applicable — existing guards assert this seam)
- [ ] All new and existing tests pass locally (left unchecked honestly: two
  pre-existing, unrelated failures remain on `main`; details above)
- [x] Tested on: Windows  (Linux/macOS not executed locally; the sole test
  edit is a POSIX no-op, so it cannot change Linux/macOS behavior)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code (full diff re-read; plugin-wide
      search confirms no consumer of the removed symbols; byte-level readback)
- [ ] I have commented hard-to-understand areas (no new logic; existing JSDoc kept)
- [ ] Documentation changes (none needed — no public behavior change)
- [x] My changes generate no new warnings (`tsc` clean)
- [x] Any dependent changes have been merged (none; removed symbols had no
      remaining consumers, verified)

## Screenshots (if applicable)

N/A

## Additional Notes

- Explicit non-goal (one coherent problem per PR): the two remaining red guards
  are intentionally not touched, as each is a larger, independent migration —
  (1) move recall resource-type helpers off the root `recall-trace.ts`
  compatibility facade onto the registry, and (2) move `commands/setup.ts`
  direct `fetch`/`AbortController` onto the transport seam. They fail
  identically on pristine `main` and are best tracked in their own PRs; happy
  to follow up.
- No runtime/public-API/config/VFS/persistence change, hence no docs or
  migration note.
- cc @t0saki @ZaynJarvis (Integration / agent-plugins per the area map).