### PR TITLE
fix(fs): create default directory abstracts under a pathlock

### DIFF
--- a/docs/en/api/03-filesystem.md
+++ b/docs/en/api/03-filesystem.md
@@ -464,7 +464,7 @@ Create a directory.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | uri | str | Yes | - | Viking URI for the new directory |
-| description | str | No | `null` | Initial directory description. When omitted, the directory name is used as the default L0; when provided, this description is used. Both forms write `.abstract.md` and queue L0 vectorization. |
+| description | str | No | `null` | Initial directory description. When omitted, the directory name is used as the default L0; when provided, this description is used. Default creation preserves an existing `.abstract.md` under the storage pathlock and queues L0 vectorization only when it creates the file. An explicit description still replaces the abstract and queues vectorization. |
 
 
 **Python HTTP SDK**

--- a/docs/en/api/03-filesystem.md
+++ b/docs/en/api/03-filesystem.md
@@ -464,7 +464,7 @@ Create a directory.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | uri | str | Yes | - | Viking URI for the new directory |
-| description | str | No | `null` | Initial directory description. When omitted, the directory name is used as the default L0; when provided, this description is used. Default creation preserves an existing `.abstract.md` under the storage pathlock and queues L0 vectorization only when it creates the file. An explicit description still replaces the abstract and queues vectorization. |
+| description | str | No | `null` | Initial directory description. When omitted, the directory name is used as the default L0; when provided, this description is used. Default creation preserves an existing `.abstract.md` under the storage pathlock and queues L0 vectorization only when it creates the file. An explicit description still replaces the abstract and queues vectorization. If a concurrent writer holds the default abstract lock, creation raises a retryable `ResourceBusyError`; retry after that writer finishes. |
 
 
 **Python HTTP SDK**

--- a/docs/zh/api/03-filesystem.md
+++ b/docs/zh/api/03-filesystem.md
@@ -494,7 +494,7 @@ openviking attrs set-tags viking://resources/docs --tags team=search --mode appe
 | 参数 | 类型 | 必填 | 默认值 | 说明 |
 |------|------|------|--------|------|
 | uri | str | 是 | - | 新目录的 Viking URI |
-| description | str | 否 | `null` | 目录初始说明。未传入时使用目录名作为默认 L0；传入后使用该说明。两种情况都会写入 `.abstract.md` 并进入 L0 向量化队列。 |
+| description | str | 否 | `null` | 目录初始说明。未传入时使用目录名作为默认 L0；传入后使用该说明。默认创建在存储路径锁内保留已有的 `.abstract.md`，仅在新建文件时进入 L0 向量化队列。显式传入说明仍会替换摘要并触发向量化。 |
 
 
 **Python HTTP SDK**

--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -283,32 +283,32 @@ class FSService:
         await viking_fs.mkdir(uri, ctx=ctx)
 
         abstract = self._normalize_directory_description(description)
+        create_default = not abstract
         if not abstract:
-            if await viking_fs.exists(abstract_uri, ctx=ctx):
-                return
             abstract = f"# {uri_leaf_name(directory_uri)}"
 
-        await viking_fs.write_file(
-            abstract_uri,
-            render_abstract_overview(
-                ContextLevel.ABSTRACT,
-                directory_uri,
-                abstract,
-                {
-                    "generated_by": {
-                        "component": "FSService",
-                        "trigger": "mkdir",
-                    },
-                    "freshness": {
-                        "total_entries": 0,
-                        "sampled_entries": 0,
-                        "unsampled_entries": 0,
-                        "pending_child_changes": 0,
-                    },
+        content = render_abstract_overview(
+            ContextLevel.ABSTRACT,
+            directory_uri,
+            abstract,
+            {
+                "generated_by": {
+                    "component": "FSService",
+                    "trigger": "mkdir",
                 },
-            ),
-            ctx=ctx,
+                "freshness": {
+                    "total_entries": 0,
+                    "sampled_entries": 0,
+                    "unsampled_entries": 0,
+                    "pending_child_changes": 0,
+                },
+            },
         )
+        if create_default:
+            if not await viking_fs.write_file_if_absent(abstract_uri, content, ctx=ctx):
+                return
+        else:
+            await viking_fs.write_file(abstract_uri, content, ctx=ctx)
         await vectorize_directory_meta(
             uri=directory_uri,
             abstract=abstract,

--- a/openviking/storage/viking_fs/_ops.py
+++ b/openviking/storage/viking_fs/_ops.py
@@ -6,7 +6,7 @@ import asyncio
 import uuid
 from dataclasses import replace
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
 from openviking.core.context import ContextLevel
 from openviking.core.namespace import (
@@ -67,6 +67,10 @@ class TransferRollbackError(RuntimeError):
         super().__init__(message)
         self.phase = phase
         self.residual_uri = residual_uri
+
+
+if TYPE_CHECKING:
+    from openviking.storage.viking_fs import VikingFS
 
 
 class _OpsMixin:
@@ -1556,6 +1560,26 @@ class _OpsMixin:
             fs_ctx=self._pathlock_fs_ctx(ctx, lease_ref),
             auto_pathlock=auto_pathlock,
         )
+
+    async def write_file_if_absent(
+        self,
+        uri: str,
+        content: Union[str, bytes],
+        ctx: Optional[RequestContext] = None,
+    ) -> bool:
+        """Create a file under an exact pathlock; return False if it already exists."""
+        fs = cast("VikingFS", self)
+        await fs._ensure_access(uri, ctx, action=AclAction.WRITE)
+        path = fs._uri_to_path(uri, ctx=ctx)
+        await fs._ensure_parent_dirs(path, ctx=ctx)
+        lease = await fs._async_agfs.pathlock_acquire_exact(path)
+        try:
+            if await fs.exists(uri, ctx=ctx):
+                return False
+            await fs.write_file(uri, content, ctx=ctx, lease_ref=lease)
+            return True
+        finally:
+            await fs._async_agfs.pathlock_release(lease)
 
     async def read_file(
         self,

--- a/openviking/storage/viking_fs/_ops.py
+++ b/openviking/storage/viking_fs/_ops.py
@@ -1567,12 +1567,21 @@ class _OpsMixin:
         content: Union[str, bytes],
         ctx: Optional[RequestContext] = None,
     ) -> bool:
-        """Create a file under an exact pathlock; return False if it already exists."""
+        """Create under an exact pathlock, returning False only for an existing file.
+
+        Contention raises retryable ResourceBusyError: a lock holder might fail
+        before publishing, so contention alone does not prove the file exists.
+        """
+        from openviking.storage.errors import LockAcquisitionError, ResourceBusyError
+
         fs = cast("VikingFS", self)
         await fs._ensure_access(uri, ctx, action=AclAction.WRITE)
         path = fs._uri_to_path(uri, ctx=ctx)
         await fs._ensure_parent_dirs(path, ctx=ctx)
-        lease = await fs._async_agfs.pathlock_acquire_exact(path)
+        try:
+            lease = await fs._async_agfs.pathlock_acquire_exact(path)
+        except LockAcquisitionError as exc:
+            raise ResourceBusyError(f"Resource is being processed: {uri}", uri=uri) from exc
         try:
             if await fs.exists(uri, ctx=ctx):
                 return False

--- a/tests/storage/test_viking_fs_write_locking.py
+++ b/tests/storage/test_viking_fs_write_locking.py
@@ -317,3 +317,91 @@ async def test_directory_mv_reuses_parent_tree_for_failed_copy_cleanup(monkeypat
             "owned": True,
         },
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("competing_write", ["default", "direct", "description"])
+async def test_default_mkdir_preserves_concurrent_abstract(monkeypatch, competing_write):
+    """Defaults are created once and cannot overwrite a concurrent explicit write."""
+    import asyncio
+
+    from openviking.service.fs_service import FSService
+
+    uri = "viking://resources/shared"
+    abstract_uri = uri + "/.abstract.md"
+    lock = asyncio.Lock()
+    storage = {}
+    writes = []
+
+    class ConcurrentAGFS:
+        async def pathlock_acquire_exact(self, path):
+            await lock.acquire()
+            return {"lease_ref": "held"}
+
+        async def pathlock_release(self, lease):
+            lock.release()
+
+        async def write(self, path, data, fs_ctx=None, auto_pathlock=True):
+            owned = not (fs_ctx and fs_ctx.get("lease_ref") == "held")
+            if owned:
+                await lock.acquire()
+            try:
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+                storage[path] = data
+                writes.append(data)
+            finally:
+                if owned:
+                    lock.release()
+
+    fs = VikingFS(agfs=_FakeAGFS())
+    fs._async_agfs = ConcurrentAGFS()
+    monkeypatch.setattr(fs, "_ensure_access", AsyncMock())
+    monkeypatch.setattr(fs, "_ensure_parent_dirs", AsyncMock())
+    monkeypatch.setattr(fs, "_uri_to_path", lambda value, **kw: value)
+    monkeypatch.setattr(fs, "mkdir", AsyncMock())
+
+    async def exists(value, ctx=None):
+        present = value in storage
+        await asyncio.sleep(0)
+        return present
+
+    monkeypatch.setattr(fs, "exists", exists)
+    vectorize = AsyncMock()
+    monkeypatch.setattr("openviking.service.fs_service.vectorize_directory_meta", vectorize)
+    service = FSService(viking_fs=fs)
+    ctx = _default_ctx()
+    if competing_write == "direct":
+        other = fs.write_file(abstract_uri, "custom", ctx=ctx)
+    else:
+        other = service.mkdir(
+            uri, ctx, description="custom" if competing_write == "description" else None
+        )
+    await asyncio.gather(other, service.mkdir(uri, ctx))
+    await service.mkdir(uri, ctx)  # A later default also preserves the stored abstract.
+
+    assert len(writes) == 1
+    assert vectorize.await_count == (0 if competing_write == "direct" else 1)
+    if competing_write != "default":
+        assert b"custom" in storage[abstract_uri]
+    assert not lock.locked()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["exists", "write_file"])
+async def test_create_if_absent_releases_lease_on_failure(monkeypatch, failure):
+    fs = VikingFS(agfs=_FakeAGFS())
+    backend = _AsyncAppendAGFS()
+    fs._async_agfs = backend
+    monkeypatch.setattr(fs, "_ensure_access", AsyncMock())
+    monkeypatch.setattr(fs, "_ensure_parent_dirs", AsyncMock())
+    monkeypatch.setattr(fs, "exists", AsyncMock(return_value=False))
+    monkeypatch.setattr(fs, "write_file", AsyncMock())
+    monkeypatch.setattr(fs, failure, AsyncMock(side_effect=OSError("backend unavailable")))
+
+    with pytest.raises(OSError, match="backend unavailable"):
+        await fs.write_file_if_absent("viking://resources/note.md", "default", _default_ctx())
+
+    assert backend.events[-1] == ("release", {"lease_ref": "lease-1"})
+    if failure == "exists":
+        fs.write_file.assert_not_awaited()

--- a/tests/storage/test_viking_fs_write_locking.py
+++ b/tests/storage/test_viking_fs_write_locking.py
@@ -334,7 +334,11 @@ async def test_default_mkdir_preserves_concurrent_abstract(monkeypatch, competin
     writes = []
 
     class ConcurrentAGFS:
-        async def pathlock_acquire_exact(self, path):
+        async def pathlock_acquire_exact(self, path, timeout_secs=0.0):
+            from openviking.storage.errors import LockAcquisitionError
+
+            if lock.locked() and timeout_secs == 0.0:
+                raise LockAcquisitionError("path is locked")
             await lock.acquire()
             return {"lease_ref": "held"}
 
@@ -377,7 +381,13 @@ async def test_default_mkdir_preserves_concurrent_abstract(monkeypatch, competin
         other = service.mkdir(
             uri, ctx, description="custom" if competing_write == "description" else None
         )
-    await asyncio.gather(other, service.mkdir(uri, ctx))
+    from openviking.storage.errors import ResourceBusyError
+
+    outcomes = await asyncio.gather(other, service.mkdir(uri, ctx), return_exceptions=True)
+    assert not isinstance(outcomes[0], BaseException)
+    assert isinstance(outcomes[1], ResourceBusyError)
+    assert outcomes[1].retryable
+    assert outcomes[1].uri == abstract_uri
     await service.mkdir(uri, ctx)  # A later default also preserves the stored abstract.
 
     assert len(writes) == 1
@@ -405,3 +415,30 @@ async def test_create_if_absent_releases_lease_on_failure(monkeypatch, failure):
     assert backend.events[-1] == ("release", {"lease_ref": "lease-1"})
     if failure == "exists":
         fs.write_file.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_if_absent_maps_contention_without_claiming_success(monkeypatch):
+    from openviking.storage.errors import LockAcquisitionError, ResourceBusyError
+
+    fs = VikingFS(agfs=_FakeAGFS())
+    fs._async_agfs = _AsyncAppendAGFS()
+    fs._async_agfs.pathlock_acquire_exact = AsyncMock(
+        side_effect=LockAcquisitionError("path is locked")
+    )
+    fs._async_agfs.pathlock_release = AsyncMock()
+    monkeypatch.setattr(fs, "_ensure_access", AsyncMock())
+    monkeypatch.setattr(fs, "_ensure_parent_dirs", AsyncMock())
+    monkeypatch.setattr(fs, "exists", AsyncMock(return_value=False))
+    monkeypatch.setattr(fs, "write_file", AsyncMock())
+    uri = "viking://resources/note.md"
+
+    with pytest.raises(ResourceBusyError) as error:
+        await fs.write_file_if_absent(uri, "default", _default_ctx())
+
+    assert error.value.uri == uri
+    assert error.value.retryable
+    assert isinstance(error.value.__cause__, LockAcquisitionError)
+    fs.exists.assert_not_awaited()
+    fs.write_file.assert_not_awaited()
+    fs._async_agfs.pathlock_release.assert_not_awaited()


### PR DESCRIPTION
## Description

Concurrent `mkdir` calls can both observe a missing `.abstract.md`, write a default, and enqueue duplicate L0 vectorization. A default can also overwrite an explicit description written during the existence-check/write gap.

Move create-if-absent into `VikingFS.write_file_if_absent`, holding the existing exact pathlock across the existence check and write and forwarding that lease through the normal write path. `FSService.mkdir` only vectorizes a default when it created the file; explicit descriptions retain overwrite behavior.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4283.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Preserve namespace/access checks, parent creation, normal write/encryption handling, and existing lock error behavior in the storage owner.
- Exercise the real `FSService.mkdir` and `VikingFS.write_file` methods with a controlled concurrent backend: competing defaults, direct writes, explicit descriptions, subsequent defaults, and backend-error lease release.
- Clarify default-versus-explicit description behavior in both filesystem API documentation translations. No storage schema or configuration migration is needed.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation with Python 3.12:
- The original default/default and direct-write/default regressions both failed before the fix.
- `OPENVIKING_CONFIG_FILE=<isolated empty JSON config> python -m pytest tests/storage/test_viking_fs_write_locking.py tests/service/test_fs_service.py tests/misc/test_vikingfs_uri_guard.py -q --no-cov`: **97 passed**.
- Ruff check and format check on all three changed Python files: passed. `git diff --check`: passed.
- `mypy openviking/service/fs_service.py openviking/storage/viking_fs/_ops.py`: 1,466 diagnostics in 198 files on both unchanged base and final change; the diagnostic multiset, ignoring shifted line numbers, has no additions.
- Additional `tests/server/test_filesystem_router.py` run has the same three baseline problems: two fixtures require the unavailable native RAGFS binding; one existing `fake_stat` rejects `skip_count`. These were also reproduced with the unchanged base source.

The concurrency tests model the existing pathlock/lease contract; a live native-backend or multi-process stress run was not performed. This does not add distributed-lock guarantees, automatic retries, or a transaction spanning file writes and vectorization. Existing Pydantic deprecation warnings remain.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published
