### PR TITLE
docs(helper): explain the accountId vs userId access-denied symptom

### DIFF
--- a/docs/en/agent-integrations/14-openviking-helper.md
+++ b/docs/en/agent-integrations/14-openviking-helper.md
@@ -56,6 +56,19 @@ After syncing, you can browse the server-side memory categories and content from
 
 Helper reads the relevant local agent configuration and data to display integration status, sessions, and memories. Content is sent to the active OpenViking service only when you sync it or use a service-backed capability. Before syncing, confirm the service address and review the selected content for sensitive information.
 
+## Troubleshooting
+
+### Memory or Sessions content is empty with "Access denied for viking://user/..."
+
+On self-hosted services where the account ID and the user ID differ, requests that address another principal's user namespace are rejected by the server. A Helper version that builds these URIs from the account ID then shows an empty Memory tab (every category reports no entries) and a status-bar error such as `Access denied for viking://user/default/memories`; the Sessions tab may degrade to an unknown sync status for the same reason.
+
+To check whether this applies to your setup:
+
+1. Open Helper's connection settings file (`~/Library/Application Support/openviking-helper/openviking-helper.json` on macOS) and compare `accountId` with `userId`. The symptom only appears when the two values differ.
+2. Confirm that the same server, API key, and machine work from the `ov` CLI and from Web Studio. Those clients resolve the signed-in identity server-side, so they are unaffected.
+
+User namespaces are addressed by user ID, not by the account ID. Explicit user paths therefore use `viking://user/{user_id}/...`, and clients that do not know the user ID should use the home alias `viking://~/...`, which the server expands from the authenticated identity (see [Resource URIs](../api/02-resources.md)). If the two IDs differ in your Helper configuration and the tabs stay empty, report it on the project issue tracker together with both identity values so the Helper build can be corrected.
+
 ## See also
 
 - [Capability Reference](./16-capability-reference.md)

--- a/docs/zh/agent-integrations/14-openviking-helper.md
+++ b/docs/zh/agent-integrations/14-openviking-helper.md
@@ -56,6 +56,19 @@ Helper 会按 Agent 和项目展示本地 memory、rule 文件及 `SKILL.md` 技
 
 为展示接入状态、会话和记忆，Helper 会读取本机对应 Agent 的配置与本地数据。只有执行同步或使用 OpenViking 服务能力时，相关内容才会发送到当前激活的服务配置。同步前请确认服务地址，并检查待同步内容是否包含敏感信息。
 
+## 故障排查
+
+### Memory / Sessions 内容为空，提示 "Access denied for viking://user/..."
+
+在 account ID 与 user ID 不一致的自部署服务上，服务端会正确拒绝访问其他主体的用户命名空间。如果 Helper 版本用 account ID 构造这类 URI，Memory 页签会整页为空（每个分类都显示"暂无 memory 条目"），状态栏报 `Access denied for viking://user/default/memories` 之类的错误；Sessions 页签也可能因同一原因退化为未知的同步状态。
+
+排查方法：
+
+1. 打开 Helper 的连接配置文件（macOS 为 `~/Library/Application Support/openviking-helper/openviking-helper.json`），对比 `accountId` 与 `userId`。两者相同时不会出现该症状。
+2. 确认同一服务、同一 API key、同一台机器上 `ov` CLI 与 Web Studio 均可正常访问。这类客户端在服务端解析登录身份，不受影响。
+
+用户命名空间按 user ID 寻址，与 account ID 无关。显式用户路径应使用 `viking://user/{user_id}/...`；不知道 user ID 的客户端应使用家目录别名 `viking://~/...`，服务端会基于认证身份展开为 canonical 路径（参见[资源 URI](../api/02-resources.md)）。若你的 Helper 配置中两个 ID 不同且页签持续为空，请携带两个身份值到项目 issue 跟踪器上报，以便修正对应 Helper 版本。
+
 ## 参见
 
 - [集成能力参考](./16-capability-reference.md)


### PR DESCRIPTION
## Summary

- Adds a **Troubleshooting** section to the OpenViking Helper guide (English and Chinese) covering the symptom from #4722: on self-hosted services where `accountId != userId`, a Helper build that derives user URIs from the account ID gets an empty Memory tab plus `Access denied for viking://user/<accountId>/memories`, and the Sessions tab can degrade to an unknown sync status.
- Documents how to compare the two identity values in Helper's connection settings file, and why the `ov` CLI and Web Studio are unaffected (they resolve the signed-in identity server-side).
- States the two correct URI forms for integrators that build user paths themselves: explicit `viking://user/{user_id}/...`, or the `viking://~/...` home alias the server expands from the authenticated identity (linking the existing API reference).

## Issue

Closes #4722 (documentation side). Helper itself is a closed-source desktop app — the code fix belongs to its private repo, but this repo can document the failure mode so users can self-diagnose the mismatch and integrators avoid the footgun. Root cause on the server side: user namespaces are addressed by `user_id` (`openviking/core/namespace.py`), and an explicit owner mismatch is denied by design; the account ID is not a valid stand-in.

## Validation

- `docs/en/agent-integrations/14-openviking-helper.md` and `docs/zh/agent-integrations/14-openviking-helper.md` render as standard Markdown; the relative link `../api/02-resources.md` resolves in both language trees (verified the file exists in both).
- Content cross-checked against `docs/en/api/02-resources.md` ("Resource targets may use ... the home alias `viking://~/resources/...`") and the reporter's repro in #4722 (`viking://~/memories` and the `user_id` path both return 200, only the `accountId` path is denied).