### PR TITLE
fix(plugins): treat camelCase isError as an error tool result

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -80,6 +80,7 @@ jobs:
             examples/memory-plugin-shared/workspace-registry.test.mjs \
             examples/memory-plugin-shared/plugin-known-keys.test.mjs \
             examples/memory-plugin-shared/uri-guard.test.mjs \
+            examples/memory-plugin-shared/capture-utils.test.mjs \
             examples/dsh-memory-plugin/*.test.mjs \
             examples/opencode-plugin/tests/*.test.mjs \
             examples/opencode-plugin/servers/mcp-proxy.test.mjs \

--- a/examples/claude-code-memory-plugin/scripts/shared/capture-utils.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/capture-utils.mjs
@@ -152,7 +152,7 @@ function toolId(block) {
 
 function toolStatus(block, kind) {
   if (kind === "call") return "running";
-  if (block?.is_error || block?.isError || block?.error || block?.state?.error) return "error";
+  if (block?.is_error || block?.isError || block?.state?.isError || block?.error || block?.state?.error) return "error";
   const status = oneLine(block?.status || block?.state?.status || "");
   return status || "completed";
 }

--- a/examples/claude-code-memory-plugin/scripts/shared/capture-utils.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/capture-utils.mjs
@@ -152,7 +152,7 @@ function toolId(block) {
 
 function toolStatus(block, kind) {
   if (kind === "call") return "running";
-  if (block?.is_error || block?.error || block?.state?.error) return "error";
+  if (block?.is_error || block?.isError || block?.error || block?.state?.error) return "error";
   const status = oneLine(block?.status || block?.state?.status || "");
   return status || "completed";
 }

--- a/examples/codex-memory-plugin/scripts/shared/capture-utils.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/capture-utils.mjs
@@ -152,7 +152,7 @@ function toolId(block) {
 
 function toolStatus(block, kind) {
   if (kind === "call") return "running";
-  if (block?.is_error || block?.isError || block?.error || block?.state?.error) return "error";
+  if (block?.is_error || block?.isError || block?.state?.isError || block?.error || block?.state?.error) return "error";
   const status = oneLine(block?.status || block?.state?.status || "");
   return status || "completed";
 }

--- a/examples/codex-memory-plugin/scripts/shared/capture-utils.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/capture-utils.mjs
@@ -152,7 +152,7 @@ function toolId(block) {
 
 function toolStatus(block, kind) {
   if (kind === "call") return "running";
-  if (block?.is_error || block?.error || block?.state?.error) return "error";
+  if (block?.is_error || block?.isError || block?.error || block?.state?.error) return "error";
   const status = oneLine(block?.status || block?.state?.status || "");
   return status || "completed";
 }

--- a/examples/dsh-memory-plugin/capture.test.mjs
+++ b/examples/dsh-memory-plugin/capture.test.mjs
@@ -79,6 +79,34 @@ test("preserves DSH tool call identity in captured tool results", () => {
   assert.equal(names.size, 0);
 });
 
+test("marks DSH tool-result errors with the error status", () => {
+  const names = new Map();
+  captureEvent({
+    type: "tool/call",
+    data: { callId: "call-err", name: "bash", arguments: "{\"command\":\"df\"}" },
+  }, CONFIG, names);
+
+  const captured = captureEvent({
+    type: "tool/result",
+    data: {
+      message: {
+        role: "user",
+        content: [{
+          type: "tool-result",
+          toolCallId: "call-err",
+          content: [{ type: "text", text: "bash: df: command not found" }],
+          isError: true,
+        }],
+        source: { kind: "tool", callId: "call-err" },
+      },
+    },
+  }, CONFIG, names);
+
+  assert.equal(captured.role, "user");
+  assert.equal(captured.parts[0].type, "tool");
+  assert.equal(captured.parts[0].tool_status, "error");
+});
+
 test("does not retain tool call names when tool-result capture is disabled", () => {
   const names = new Map();
   const config = { ...CONFIG, captureToolResults: false };

--- a/examples/dsh-memory-plugin/shared/capture-utils.mjs
+++ b/examples/dsh-memory-plugin/shared/capture-utils.mjs
@@ -152,7 +152,7 @@ function toolId(block) {
 
 function toolStatus(block, kind) {
   if (kind === "call") return "running";
-  if (block?.is_error || block?.isError || block?.error || block?.state?.error) return "error";
+  if (block?.is_error || block?.isError || block?.state?.isError || block?.error || block?.state?.error) return "error";
   const status = oneLine(block?.status || block?.state?.status || "");
   return status || "completed";
 }

--- a/examples/dsh-memory-plugin/shared/capture-utils.mjs
+++ b/examples/dsh-memory-plugin/shared/capture-utils.mjs
@@ -152,7 +152,7 @@ function toolId(block) {
 
 function toolStatus(block, kind) {
   if (kind === "call") return "running";
-  if (block?.is_error || block?.error || block?.state?.error) return "error";
+  if (block?.is_error || block?.isError || block?.error || block?.state?.error) return "error";
   const status = oneLine(block?.status || block?.state?.status || "");
   return status || "completed";
 }

--- a/examples/memory-plugin-shared/capture-utils.test.mjs
+++ b/examples/memory-plugin-shared/capture-utils.test.mjs
@@ -1,0 +1,46 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { extractPartsFromPayload } from "./lib/capture-utils.mjs"
+
+function toolPart(parts) {
+  return parts.find((part) => part?.type === "tool")
+}
+
+test("toolStatus marks a camelCase isError result as error", () => {
+  const parts = extractPartsFromPayload({
+    role: "user",
+    content: [{
+      type: "tool-result",
+      toolCallId: "call-1",
+      content: [{ type: "text", text: "bash: df: command not found" }],
+      isError: true,
+    }],
+  }, { toolNameById: { "call-1": "bash" } })
+  assert.equal(toolPart(parts).tool_status, "error")
+})
+
+test("toolStatus keeps snake_case is_error support", () => {
+  const parts = extractPartsFromPayload({
+    role: "user",
+    content: [{
+      type: "tool_result",
+      tool_use_id: "call-2",
+      is_error: true,
+      output: "connection refused",
+    }],
+  }, { toolNameById: { "call-2": "mysqladmin" } })
+  assert.equal(toolPart(parts).tool_status, "error")
+})
+
+test("toolStatus stays completed for a successful camelCase result", () => {
+  const parts = extractPartsFromPayload({
+    role: "user",
+    content: [{
+      type: "tool-result",
+      toolCallId: "call-3",
+      content: [{ type: "text", text: "ok" }],
+      isError: false,
+    }],
+  }, { toolNameById: { "call-3": "bash" } })
+  assert.equal(toolPart(parts).tool_status, "completed")
+})

--- a/examples/memory-plugin-shared/capture-utils.test.mjs
+++ b/examples/memory-plugin-shared/capture-utils.test.mjs
@@ -32,6 +32,19 @@ test("toolStatus keeps snake_case is_error support", () => {
   assert.equal(toolPart(parts).tool_status, "error")
 })
 
+test("toolStatus recognizes a camelCase isError nested under state", () => {
+  const parts = extractPartsFromPayload({
+    role: "user",
+    content: [{
+      type: "tool-result",
+      toolCallId: "call-2b",
+      state: { isError: true },
+      output: "connection refused",
+    }],
+  }, { toolNameById: { "call-2b": "mysqladmin" } })
+  assert.equal(toolPart(parts).tool_status, "error")
+})
+
 test("toolStatus stays completed for a successful camelCase result", () => {
   const parts = extractPartsFromPayload({
     role: "user",

--- a/examples/memory-plugin-shared/lib/capture-utils.mjs
+++ b/examples/memory-plugin-shared/lib/capture-utils.mjs
@@ -151,7 +151,7 @@ function toolId(block) {
 
 function toolStatus(block, kind) {
   if (kind === "call") return "running";
-  if (block?.is_error || block?.isError || block?.error || block?.state?.error) return "error";
+  if (block?.is_error || block?.isError || block?.state?.isError || block?.error || block?.state?.error) return "error";
   const status = oneLine(block?.status || block?.state?.status || "");
   return status || "completed";
 }

--- a/examples/memory-plugin-shared/lib/capture-utils.mjs
+++ b/examples/memory-plugin-shared/lib/capture-utils.mjs
@@ -151,7 +151,7 @@ function toolId(block) {
 
 function toolStatus(block, kind) {
   if (kind === "call") return "running";
-  if (block?.is_error || block?.error || block?.state?.error) return "error";
+  if (block?.is_error || block?.isError || block?.error || block?.state?.error) return "error";
   const status = oneLine(block?.status || block?.state?.status || "");
   return status || "completed";
 }

--- a/examples/opencode-plugin/lib/shared/capture-utils.mjs
+++ b/examples/opencode-plugin/lib/shared/capture-utils.mjs
@@ -152,7 +152,7 @@ function toolId(block) {
 
 function toolStatus(block, kind) {
   if (kind === "call") return "running";
-  if (block?.is_error || block?.isError || block?.error || block?.state?.error) return "error";
+  if (block?.is_error || block?.isError || block?.state?.isError || block?.error || block?.state?.error) return "error";
   const status = oneLine(block?.status || block?.state?.status || "");
   return status || "completed";
 }

--- a/examples/opencode-plugin/lib/shared/capture-utils.mjs
+++ b/examples/opencode-plugin/lib/shared/capture-utils.mjs
@@ -152,7 +152,7 @@ function toolId(block) {
 
 function toolStatus(block, kind) {
   if (kind === "call") return "running";
-  if (block?.is_error || block?.error || block?.state?.error) return "error";
+  if (block?.is_error || block?.isError || block?.error || block?.state?.error) return "error";
   const status = oneLine(block?.status || block?.state?.status || "");
   return status || "completed";
 }

--- a/examples/pi-coding-agent-extension/shared/capture-utils.mjs
+++ b/examples/pi-coding-agent-extension/shared/capture-utils.mjs
@@ -152,7 +152,7 @@ function toolId(block) {
 
 function toolStatus(block, kind) {
   if (kind === "call") return "running";
-  if (block?.is_error || block?.isError || block?.error || block?.state?.error) return "error";
+  if (block?.is_error || block?.isError || block?.state?.isError || block?.error || block?.state?.error) return "error";
   const status = oneLine(block?.status || block?.state?.status || "");
   return status || "completed";
 }

--- a/examples/pi-coding-agent-extension/shared/capture-utils.mjs
+++ b/examples/pi-coding-agent-extension/shared/capture-utils.mjs
@@ -152,7 +152,7 @@ function toolId(block) {
 
 function toolStatus(block, kind) {
   if (kind === "call") return "running";
-  if (block?.is_error || block?.error || block?.state?.error) return "error";
+  if (block?.is_error || block?.isError || block?.error || block?.state?.error) return "error";
   const status = oneLine(block?.status || block?.state?.status || "");
   return status || "completed";
 }

--- a/examples/zcode-memory-plugin/scripts/shared/capture-utils.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/capture-utils.mjs
@@ -152,7 +152,7 @@ function toolId(block) {
 
 function toolStatus(block, kind) {
   if (kind === "call") return "running";
-  if (block?.is_error || block?.isError || block?.error || block?.state?.error) return "error";
+  if (block?.is_error || block?.isError || block?.state?.isError || block?.error || block?.state?.error) return "error";
   const status = oneLine(block?.status || block?.state?.status || "");
   return status || "completed";
 }

--- a/examples/zcode-memory-plugin/scripts/shared/capture-utils.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/capture-utils.mjs
@@ -152,7 +152,7 @@ function toolId(block) {
 
 function toolStatus(block, kind) {
   if (kind === "call") return "running";
-  if (block?.is_error || block?.error || block?.state?.error) return "error";
+  if (block?.is_error || block?.isError || block?.error || block?.state?.error) return "error";
   const status = oneLine(block?.status || block?.state?.status || "");
   return status || "completed";
 }


### PR DESCRIPTION
## Problem

DSH emits `tool-result` content blocks with a **camelCase** `isError` field:

```json
{"type": "tool-result", "toolCallId": "call_x", "content": [{"type": "text", "text": "bash: df: command not found"}], "isError": true}
```

The shared `capture-utils.mjs` `toolStatus()` only recognizes `is_error` / `error` / `state.error`. A failed DSH result is therefore captured as `tool_status: "completed"` (with the error text still in `tool_output`).

## Impact

- **Memory extraction is not misled** — verified end-to-end with a synthetic session on server 0.4.17.1: a mislabeled failed call was still recorded as a failure in the extracted trajectory, because extraction is LLM-driven over the formatted output text.
- **Status-driven consumers are corrupted**:
  - `openviking/session/memory/experience_lineage.py:128` — failed reads counted as successfully consumed experiences in trajectory lineage (training provenance);
  - `openviking/usage_reporter/extractors.py:289` — usage events count non-completed calls;
  - `openviking/session/session.py:4131` — working-memory formatting labels the call `(completed)`;
  - `openviking/session/train/components/rollout_artifact_recorder.py` — training artifacts carry the wrong status.

## Change

- `examples/memory-plugin-shared/lib/capture-utils.mjs`: recognize `block?.isError` alongside `is_error`.
- Vendored copies regenerated with `node examples/memory-plugin-shared/sync.mjs` (claude-code, codex, dsh, opencode, pi, zcode).
- New regression tests:
  - `examples/memory-plugin-shared/capture-utils.test.mjs` (camelCase error, snake_case error, success stays completed);
  - `examples/dsh-memory-plugin/capture.test.mjs` — "marks DSH tool-result errors with the error status" using the real DSH wire shape.

## Verification

- Red-green: reverting the one-line fix makes the new camelCase test fail (1 fail / 3), restoring it passes 3/3.
- `node --test examples/memory-plugin-shared/*.test.mjs` → 183 pass / 0 fail.
- `node --test examples/dsh-memory-plugin/capture.test.mjs` → 7 pass / 0 fail.
- Remaining 4 dsh test files fail only in this bare checkout due to missing peer dep `@deepseek-ai/dsh-mcp-client` (environmental, untouched by this PR).