### PR TITLE
docs(retrieval): clarify score threshold and hotness semantics

### DIFF
--- a/docs/en/api/06-retrieval.md
+++ b/docs/en/api/06-retrieval.md
@@ -398,7 +398,7 @@ The `search()` method adds session context understanding and intent analysis cap
 | context_type | str \| List[str] | No | None | Limit results to one or more `ContextType` values: `memory`, `resource`, or `skill` |
 | tags | List[str] | No | None | Explicit retrieval tags in strict `k=v` form (lowercase letters/digits/`_`/`-`/`.`, starting with a letter or digit, key<=64, value<=128). Multiple tags are combined with AND; a result must contain every requested tag |
 | node_limit | int | No | None | Maximum number of results |
-| score_threshold | float | No | None | Minimum relevance score threshold |
+| score_threshold | float | No | None | Minimum retrieval relevance score, applied before optional hotness blending. When hotness weighting is applied, the returned `score` is the blended ranking score and may be lower than this threshold |
 | filter | Dict | No | None | Metadata filter |
 | since | str | No | None | Lower time bound, accepts `2h` or ISO 8601 / `YYYY-MM-DD`. Timezone-less values are interpreted as UTC. CLI `--after` maps to this field |
 | until | str | No | None | Upper time bound, accepts `30m` or ISO 8601 / `YYYY-MM-DD`. Timezone-less values are interpreted as UTC. CLI `--before` maps to this field |

--- a/docs/zh/api/06-retrieval.md
+++ b/docs/zh/api/06-retrieval.md
@@ -400,7 +400,7 @@ openviking find "红色海报风格" --image ./poster.png --uri "viking://resour
 | tags | List[str] | 否 | None | 显式检索标签，必须是严格的 `k=v` 格式（小写字母/数字/`_`/`-`/`.`，以字母或数字开头，key≤64、value≤128）。多个 tags 之间是 AND 关系，结果必须同时包含所有请求的标签 |
 | limit | int | 否 | 10 | 最大返回结果数 |
 | node_limit | int | 否 | None | 可选 HTTP 别名；如果提供，会覆盖 limit |
-| score_threshold | float | 否 | None | 最低相关性分数阈值 |
+| score_threshold | float | 否 | None | 检索相关性分数的最低阈值，在可选的热度混合之前应用。启用热度加权时，返回的 `score` 是混合后的排序分，可能低于该阈值 |
 | filter | Dict | 否 | None | 元数据过滤器 |
 | since | str | 否 | None | 时间下界，支持 `2h` 或 ISO 8601 / `YYYY-MM-DD`。不带时区的值按 UTC 解释。CLI `--after` 会映射到这个字段 |
 | until | str | 否 | None | 时间上界，支持 `30m` 或 ISO 8601 / `YYYY-MM-DD`。不带时区的值按 UTC 解释。CLI `--before` 会映射到这个字段 |


### PR DESCRIPTION
## Description

Clarify the current `search()` scoring behavior: `score_threshold` is applied to retrieval relevance before optional hotness blending, while the returned `score` is the blended ranking score when hotness weighting is active. This explains why a returned score can be lower than the configured threshold without changing runtime behavior.

The wording is synchronized across the English and Chinese API references. This documents the existing ordering introduced by #297 and asks maintainers to confirm that the public contract matches that implementation.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

No related issue. Related implementation history: #297.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Clarify when `search.score_threshold` is applied.
- Distinguish the pre-hotness relevance score from the returned blended ranking score.
- Keep the English and Chinese API references aligned.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Documentation API reference check passed: `npm run check:api`
- [x] `git diff --check` passed

## Checklist

- [x] My code follows the project coding style
- [x] I have performed a self-review of my changes
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

This PR changes documentation only. It does not change threshold filtering, hotness calculation, ranking, or API response fields.