### PR TITLE
refactor(openclaw-plugin): remove dead recall-trace compat exports

### DIFF
--- a/examples/openclaw-plugin/recall-trace.ts
+++ b/examples/openclaw-plugin/recall-trace.ts
@@ -1,7 +1,7 @@
 import { appendFile, mkdir, readFile, readdir, unlink } from "node:fs/promises";
 import { join } from "node:path";
 
-export type RecallResourceType = "resource" | "session" | "user" | "agent";
+import type { RecallResourceType } from "./registries/recall-resource-types.js";
 
 export type RecallTraceSource = "auto_recall" | "memory_recall" | "ov_search" | "ov_archive_search";
 
@@ -27,7 +27,9 @@ export type RecallTraceEntry = {
   agentId?: string;
   source: RecallTraceSource;
   operationType: RecallTraceOperationType;
-  resourceTypes: RecallResourceType[];
+  // "session" labels archive-grep traces over session history; recall targets
+  // stay in the registry's narrower union and never include it.
+  resourceTypes: Array<RecallResourceType | "session">;
   trigger: {
     rawUserTextPreview?: string;
     query: string;
@@ -92,78 +94,6 @@ export type RecallTraceFlushResult = {
   warnings: string[];
 };
 
-const ALLOWED_RESOURCE_TYPES: RecallResourceType[] = ["resource", "user", "agent"];
-const DEFAULT_RESOURCE_TYPES: RecallResourceType[] = ["user", "agent"];
-
-function toResourceTypeEntries(value: unknown): string[] {
-  if (Array.isArray(value)) {
-    return value
-      .filter((entry): entry is string => typeof entry === "string")
-      .map((entry) => entry.trim())
-      .filter(Boolean);
-  }
-  if (typeof value === "string") {
-    return value
-      .split(/[,\n]/)
-      .map((entry) => entry.trim())
-      .filter(Boolean);
-  }
-  return [];
-}
-
-export function normalizeResourceTypes(value: unknown): RecallResourceType[] {
-  const entries = toResourceTypeEntries(value);
-  if (entries.length === 0) {
-    return [...DEFAULT_RESOURCE_TYPES];
-  }
-
-  const seen = new Set<RecallResourceType>();
-  const normalized: RecallResourceType[] = [];
-  const invalid: string[] = [];
-  for (const entry of entries) {
-    if ((ALLOWED_RESOURCE_TYPES as string[]).includes(entry)) {
-      const typed = entry as RecallResourceType;
-      if (!seen.has(typed)) {
-        seen.add(typed);
-        normalized.push(typed);
-      }
-    } else {
-      invalid.push(entry);
-    }
-  }
-
-  if (invalid.length > 0) {
-    throw new Error(`invalid resourceTypes: ${invalid.join(", ")}`);
-  }
-
-  return normalized.length > 0 ? normalized : [...DEFAULT_RESOURCE_TYPES];
-}
-
-export function resolveRecallSearchPlan(
-  resourceTypes: unknown,
-  _ctx: { ovSessionId?: string; agentId?: string },
-): {
-  resourceTypes: RecallResourceType[];
-  searches: Array<{ resourceType: RecallResourceType; targetUri?: string; contextType: "memory" | "resource" }>;
-  skipped: Array<{ resourceType: RecallResourceType; reason: "missing_session" }>;
-} {
-  const normalized = normalizeResourceTypes(resourceTypes);
-  const searches: Array<{ resourceType: RecallResourceType; targetUri?: string; contextType: "memory" | "resource" }> = [];
-  const skipped: Array<{ resourceType: RecallResourceType; reason: "missing_session" }> = [];
-  let addedMemorySearch = false;
-
-  for (const resourceType of normalized) {
-    if (resourceType === "resource") {
-      searches.push({ resourceType, contextType: "resource" });
-    } else if ((resourceType === "user" || resourceType === "agent") && !addedMemorySearch) {
-      searches.push({ resourceType: "user", contextType: "memory" });
-      addedMemorySearch = true;
-    }
-  }
-
-  return { resourceTypes: normalized, searches, skipped };
-}
-
 export class RecallTraceMemoryStore {
   private readonly maxEntries: number;
   private readonly entries: RecallTraceEntry[] = [];
@@ -183,7 +113,7 @@ export class RecallTraceMemoryStore {
     const limit = Math.max(1, Math.floor(query.limit ?? 20));
     const turn = query.turn ?? "latest";
     const resourceTypes = query.resourceTypes && query.resourceTypes.length > 0
-      ? new Set(query.resourceTypes)
+      ? new Set<string>(query.resourceTypes)
       : undefined;
 
     const filtered = this.entries

--- a/examples/openclaw-plugin/tests/ut/recall-resource-types.test.ts
+++ b/examples/openclaw-plugin/tests/ut/recall-resource-types.test.ts
@@ -22,6 +22,7 @@ describe("recall resource type registry", () => {
       "agent",
     ]);
     expect(() => normalizeRecallResourceTypes(["user", "project"])).toThrow("invalid resourceTypes: project");
+    expect(() => normalizeRecallResourceTypes(["session", "user"])).toThrow("invalid resourceTypes: session");
   });
 
   it("builds context-type search plans without deprecated agent/session URI paths", () => {

--- a/examples/openclaw-plugin/tests/ut/recall-trace.test.ts
+++ b/examples/openclaw-plugin/tests/ut/recall-trace.test.ts
@@ -7,8 +7,6 @@ import {
   RecallTraceJsonlStore,
   RecallTraceMemoryStore,
   RecallTraceRecorder,
-  normalizeResourceTypes,
-  resolveRecallSearchPlan,
   type RecallTraceEntry,
 } from "../../recall-trace.js";
 
@@ -52,58 +50,6 @@ function makeTrace(overrides: Partial<RecallTraceEntry> = {}): RecallTraceEntry 
     ...overrides,
   };
 }
-
-describe("normalizeResourceTypes()", () => {
-  it("defaults missing, empty array, and empty string to the backward-compatible memory recall set", () => {
-    expect(normalizeResourceTypes(undefined)).toEqual(["user", "agent"]);
-    expect(normalizeResourceTypes([])).toEqual(["user", "agent"]);
-    expect(normalizeResourceTypes("  ")).toEqual(["user", "agent"]);
-  });
-
-  it("normalizes comma-separated strings, trims entries, and deduplicates", () => {
-    expect(normalizeResourceTypes(" user,agent\nuser ")).toEqual(["user", "agent"]);
-  });
-
-  it("rejects unknown resource types instead of falling back to defaults", () => {
-    expect(() => normalizeResourceTypes(["user", "project"])).toThrow(
-      "invalid resourceTypes: project",
-    );
-  });
-});
-
-describe("resolveRecallSearchPlan()", () => {
-  it("builds the default backward-compatible memory recall search plan", () => {
-    const plan = resolveRecallSearchPlan(undefined, {
-      ovSessionId: "ov-session-1",
-      agentId: "agent-1",
-    });
-
-    expect(plan.searches).toEqual([
-      { resourceType: "user", contextType: "memory" },
-    ]);
-    expect(plan.skipped).toEqual([]);
-    expect(plan.resourceTypes).toEqual(["user", "agent"]);
-  });
-
-  it("builds resource/user/agent searches only when explicitly requested", () => {
-    const plan = resolveRecallSearchPlan(["resource", "user", "agent"], {
-      ovSessionId: "ov-session-1",
-      agentId: "agent-1",
-    });
-
-    expect(plan.searches).toEqual([
-      { resourceType: "resource", contextType: "resource" },
-      { resourceType: "user", contextType: "memory" },
-    ]);
-    expect(plan.skipped).toEqual([]);
-  });
-
-  it("rejects session as a semantic recall target", () => {
-    expect(() => resolveRecallSearchPlan(["session", "user"], { agentId: "agent-1" })).toThrow(
-      "invalid resourceTypes: session",
-    );
-  });
-});
 
 describe("RecallTraceMemoryStore", () => {
   it("keeps a bounded ring buffer and returns matching traces by timestamp descending", () => {


### PR DESCRIPTION
Follow-up to the #4720 discussion (thanks @ralf003 for offering to review): this takes the `recall-trace.ts` compat-exports guard, tracked separately as suggested.

## What

`recall-trace.ts` still exported `RecallResourceType`, `normalizeResourceTypes`, and `resolveRecallSearchPlan` even though `registries/recall-resource-types.ts` is the canonical home and every production consumer already imports from the registry.

- Delete the dead exports; wire the trace schema's internal uses to the registry type.
- **Typing find**: the facade union included a `"session"` member that `ALLOWED_RESOURCE_TYPES` always rejected at runtime. It only existed so archive-grep traces could label `entry.resourceTypes: ["session"]` (`plugin/openviking-archive-tools.ts`). That single legitimate use is now typed honestly at the field level — `Array<RecallResourceType | "session">` — mirroring how `searches`/`results` already extend the union with `"archive"`. No trace payload or behavior change; with the lying union gone, tsc now verifies the rest of the tree against the narrow union (it caught exactly this one assignment).
- Duplicate `describe` blocks in `tests/ut/recall-trace.test.ts` are removed; their coverage already lives in `tests/ut/recall-resource-types.test.ts` against the registry, and the `"session"`-rejection case is preserved there.

## Verification (note: the openclaw Vitest suite does not run in repo CI)

- `tsc -p tsconfig.json --noEmit` and `tsc -p tsconfig.build.json --noEmit`: clean.
- Full `vitest run` (lockfile 4.1.0, `npm ci --ignore-scripts`): **760 tests, 757 passed** — the only 3 failures are the architecture-boundaries guards outside this PR's scope (setup CLI fetch, plus the two client-facade guards #4720 fixes).
- `keeps dead recall-trace resource helper compatibility exports removed` and `keeps recall resource type consumers wired to the registry`: **red on main → green here**.

Together with #4720 and the sibling setup-CLI PR, the architecture-boundaries suite goes fully green on main.