### PR TITLE
feat(bot): process independent sessions concurrently

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -137,6 +137,7 @@ jobs:
       cuvs_changed: ${{ steps.check.outputs.cuvs_changed }}
       langchain_changed: ${{ steps.check.outputs.langchain_changed }}
       openclaw_changed: ${{ steps.check.outputs.openclaw_changed }}
+      bot_changed: ${{ steps.check.outputs.bot_changed }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -200,6 +201,20 @@ jobs:
             echo "openclaw_changed=false" >> $GITHUB_OUTPUT
           fi
 
+          # Focused VikingBot suite. #4746 may widen this job to the full
+          # bot test tree once stale tests are realigned.
+          BOT_PATTERN="^bot/|pyproject\.toml|uv\.lock|\.github/workflows/pr\.yml"
+          BOT_CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }} HEAD | grep -E "$BOT_PATTERN" || true)
+
+          if [ -n "$BOT_CHANGED_FILES" ]; then
+            echo "Bot changes detected:"
+            echo "$BOT_CHANGED_FILES"
+            echo "bot_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "No bot changes detected."
+            echo "bot_changed=false" >> $GITHUB_OUTPUT
+          fi
+
   build:
     needs: check-deps
     if: ${{ needs.check-deps.outputs.deps_changed == 'true' }}
@@ -212,6 +227,31 @@ jobs:
     with:
       os_json: '["ubuntu-24.04"]'
       python_json: '["3.11"]'
+
+  bot-tests:
+    needs: check-deps
+    if: ${{ needs.check-deps.outputs.bot_changed == 'true' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install bot dependencies
+        run: uv sync --frozen --extra bot --extra test
+
+      - name: Run VikingBot concurrency tests
+        run: |
+          uv run python -m pytest -q -o addopts='' \
+            bot/vikingbot/tests/unit/test_agent_message_concurrency.py
 
   langchain-tests:
     needs: check-deps

--- a/bot/README.md
+++ b/bot/README.md
@@ -314,6 +314,7 @@ Restart `vikingbot gateway` after changing the configuration.
 | `bot.agents.timeout` | Inherits `vlm.timeout` | Timeout for one model request |
 | `bot.agents.max_tool_iterations` | `50` | Maximum tool iterations in one turn |
 | `bot.agents.memory_window` | `50` | Local history window and session commit message threshold |
+| `bot.agents.message_max_concurrency` | `4` | Maximum number of agent turns running at once across sessions |
 | `bot.agents.subagent_enabled` | `true` | Whether to expose the `spawn` tool |
 | `bot.agents.subagent_max_concurrency` | `4` | Maximum number of background subagents running at once |
 | `bot.gateway.host` | `127.0.0.1` | Gateway listen address |

--- a/bot/README_CN.md
+++ b/bot/README_CN.md
@@ -311,6 +311,7 @@ export OPENVIKING_CONFIG_FILE=/path/to/ov.conf
 | `bot.agents.timeout` | 继承 `vlm.timeout` | 单次模型请求超时 |
 | `bot.agents.max_tool_iterations` | `50` | 单轮最大工具迭代数 |
 | `bot.agents.memory_window` | `50` | 本地历史窗口和会话提交消息阈值 |
+| `bot.agents.message_max_concurrency` | `4` | 跨会话同时处理的 Agent 轮次上限 |
 | `bot.agents.subagent_enabled` | `true` | 是否提供 `spawn` 工具 |
 | `bot.agents.subagent_max_concurrency` | `4` | 同时运行的后台子 Agent 数量上限 |
 | `bot.gateway.host` | `127.0.0.1` | Gateway 监听地址 |

--- a/bot/docs/en/concepts/01-architecture.md
+++ b/bot/docs/en/concepts/01-architecture.md
@@ -86,7 +86,7 @@ Each model call may return normal text or one or more tool calls. AgentLoop:
 5. appends the tool result to the current message context;
 6. calls the model again until it produces a final answer or reaches `max_tool_iterations`.
 
-Queue mode uses a single AgentLoop consumer to process inbound messages in order. CLI, Cron, and Heartbeat can invoke the same execution logic directly through `process_direct()`.
+Queue mode processes independent sessions concurrently, bounded by `bot.agents.message_max_concurrency`, and serializes turns on the same `SessionKey`. CLI, Cron, and Heartbeat call `process_direct()`, which uses the same per-session lock and global semaphore as the bus consumer. MCP servers are connected once per AgentLoop and shared across concurrent sessions.
 
 ## Model Adaptation
 

--- a/bot/docs/zh/concepts/01-architecture.md
+++ b/bot/docs/zh/concepts/01-architecture.md
@@ -85,7 +85,7 @@ Agent 处理过程中还会产生 reasoning、content delta、tool call、tool r
 5. 把工具结果追加到当前消息上下文；
 6. 再次调用模型，直到生成最终回答或达到 `max_tool_iterations`。
 
-队列模式由单个 AgentLoop 消费者按入站顺序处理消息。CLI、Cron 和 Heartbeat 也可以通过 `process_direct()` 直接触发相同的执行逻辑。
+队列模式会并发处理独立会话（上限为 `bot.agents.message_max_concurrency`），同一 `SessionKey` 上的轮次串行。CLI、Cron 和 Heartbeat 通过 `process_direct()` 走同一把会话锁和全局信号量。MCP 服务按 AgentLoop 连接一次，并在并发会话之间共享。
 
 ## 模型适配
 

--- a/bot/vikingbot/agent/loop.py
+++ b/bot/vikingbot/agent/loop.py
@@ -419,8 +419,9 @@ class AgentLoop:
         )
 
         self._running = False
-        message_max_concurrency = getattr(
-            getattr(config, "agents", None), "message_max_concurrency", 4
+        self._idle_wakeup = asyncio.Event()
+        message_max_concurrency = (
+            config.agents.message_max_concurrency if config is not None else 4
         )
         self._message_semaphore = asyncio.Semaphore(message_max_concurrency)
         self._message_tasks: set[asyncio.Task] = set()
@@ -435,6 +436,10 @@ class AgentLoop:
 
     async def _connect_mcp(self) -> None:
         """Connect to configured MCP servers (one-time, lazy, retryable on failure).
+
+        The resulting tool clients live on this AgentLoop and are shared by
+        every concurrent session. Session isolation is SessionKey-scoped in
+        the loop, not in the MCP client.
 
         Ported from HKUDS/nanobot v0.1.5.
         """
@@ -1115,6 +1120,24 @@ class AgentLoop:
             await self.sessions.save(session)
         return True
 
+    def _retain_session_lock(self, session_key: SessionKey) -> asyncio.Lock:
+        lock = self._session_locks.setdefault(session_key, asyncio.Lock())
+        self._session_lock_users[session_key] = (
+            self._session_lock_users.get(session_key, 0) + 1
+        )
+        return lock
+
+    def _release_session_lock(self, session_key: SessionKey) -> None:
+        users = self._session_lock_users.get(session_key)
+        if users is None:
+            self._session_locks.pop(session_key, None)
+            return
+        if users > 1:
+            self._session_lock_users[session_key] = users - 1
+            return
+        self._session_lock_users.pop(session_key, None)
+        self._session_locks.pop(session_key, None)
+
     async def _process_queued_message(
         self, msg: InboundMessage, session_lock: asyncio.Lock
     ) -> None:
@@ -1140,47 +1163,69 @@ class AgentLoop:
                                 f"Error publishing failure response: {publish_error}"
                             )
         finally:
-            users = self._session_lock_users[msg.session_key] - 1
-            if users:
-                self._session_lock_users[msg.session_key] = users
-            else:
-                self._session_lock_users.pop(msg.session_key)
-                self._session_locks.pop(msg.session_key)
+            self._release_session_lock(msg.session_key)
 
     async def run(self) -> None:
         """Run the agent loop, processing independent sessions concurrently."""
         self._running = True
+        self._idle_wakeup.clear()
         await self._connect_mcp()
         logger.info("Agent loop started")
 
         try:
             while self._running:
+                consume = asyncio.create_task(self.bus.consume_inbound())
+                wake = asyncio.create_task(self._idle_wakeup.wait())
                 try:
-                    msg = await asyncio.wait_for(self.bus.consume_inbound(), timeout=1.0)
-                except asyncio.TimeoutError:
+                    done, pending = await asyncio.wait(
+                        {consume, wake},
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                except asyncio.CancelledError:
+                    if (
+                        consume.done()
+                        and not consume.cancelled()
+                        and consume.exception() is None
+                    ):
+                        await self.bus.publish_inbound(consume.result())
+                    else:
+                        consume.cancel()
+                    wake.cancel()
+                    await asyncio.gather(consume, wake, return_exceptions=True)
+                    raise
+                for task in pending:
+                    task.cancel()
+                await asyncio.gather(*pending, return_exceptions=True)
+
+                if consume not in done or consume.cancelled():
+                    break
+                if consume.exception() is not None:
+                    if not self._running:
+                        break
                     continue
+                msg = consume.result()
 
                 if not self._running:
+                    # Already consumed from the bus; put it back so a restarted
+                    # loop can pick it up instead of dropping the turn.
                     await self.bus.publish_inbound(msg)
                     break
 
-                session_lock = self._session_locks.setdefault(
-                    msg.session_key, asyncio.Lock()
-                )
-                self._session_lock_users[msg.session_key] = (
-                    self._session_lock_users.get(msg.session_key, 0) + 1
-                )
+                session_lock = self._retain_session_lock(msg.session_key)
                 task = asyncio.create_task(self._process_queued_message(msg, session_lock))
                 self._message_tasks.add(task)
                 task.add_done_callback(self._message_tasks.discard)
         finally:
             self._running = False
             if self._message_tasks:
-                await asyncio.gather(*self._message_tasks)
+                await asyncio.shield(
+                    asyncio.gather(*self._message_tasks, return_exceptions=True)
+                )
 
     def stop(self) -> None:
-        """Stop the agent loop."""
+        """Stop accepting new bus messages and let in-flight turns drain."""
         self._running = False
+        self._idle_wakeup.set()
         logger.info("Agent loop stopping")
 
     async def _compact_tool_loop(
@@ -2879,7 +2924,11 @@ Respond with ONLY valid JSON, no markdown fences."""
         metadata: dict[str, object] | None = None,
     ) -> str:
         """
-        Process a message directly (for CLI or cron usage).
+        Process a message directly (CLI, cron, or heartbeat).
+
+        Uses the same per-session lock and global semaphore as the bus
+        consumer, so a direct call cannot race a queued turn on the same
+        SessionKey or bypass ``message_max_concurrency``.
 
         Args:
             content: The message content.
@@ -2895,6 +2944,11 @@ Respond with ONLY valid JSON, no markdown fences."""
             content=content,
             metadata=metadata or {},
         )
-
-        response = await self._process_message(msg)
-        return response.content if response else ""
+        session_lock = self._retain_session_lock(msg.session_key)
+        try:
+            async with session_lock:
+                async with self._message_semaphore:
+                    response = await self._process_message(msg)
+                    return response.content if response else ""
+        finally:
+            self._release_session_lock(msg.session_key)

--- a/bot/vikingbot/agent/loop.py
+++ b/bot/vikingbot/agent/loop.py
@@ -419,6 +419,13 @@ class AgentLoop:
         )
 
         self._running = False
+        message_max_concurrency = getattr(
+            getattr(config, "agents", None), "message_max_concurrency", 4
+        )
+        self._message_semaphore = asyncio.Semaphore(message_max_concurrency)
+        self._message_tasks: set[asyncio.Task] = set()
+        self._session_locks: dict[SessionKey, asyncio.Lock] = {}
+        self._session_lock_users: dict[SessionKey, int] = {}
         self._mcp_servers = mcp_servers or {}
         self._mcp_stack: AsyncExitStack | None = None
         self._mcp_connected = False
@@ -1108,34 +1115,68 @@ class AgentLoop:
             await self.sessions.save(session)
         return True
 
+    async def _process_queued_message(
+        self, msg: InboundMessage, session_lock: asyncio.Lock
+    ) -> None:
+        try:
+            async with session_lock:
+                async with self._message_semaphore:
+                    try:
+                        response = await self._process_message(msg)
+                        if response:
+                            await self.bus.publish_outbound(response)
+                    except Exception as e:
+                        logger.exception(f"Error processing message: {e}")
+                        try:
+                            await self.bus.publish_outbound(
+                                OutboundMessage(
+                                    session_key=msg.session_key,
+                                    content=f"Sorry, I encountered an error: {str(e)}",
+                                    metadata=msg.metadata,
+                                )
+                            )
+                        except Exception as publish_error:
+                            logger.exception(
+                                f"Error publishing failure response: {publish_error}"
+                            )
+        finally:
+            users = self._session_lock_users[msg.session_key] - 1
+            if users:
+                self._session_lock_users[msg.session_key] = users
+            else:
+                self._session_lock_users.pop(msg.session_key)
+                self._session_locks.pop(msg.session_key)
+
     async def run(self) -> None:
-        """Run the agent loop, processing messages from the bus."""
+        """Run the agent loop, processing independent sessions concurrently."""
         self._running = True
         await self._connect_mcp()
         logger.info("Agent loop started")
 
-        while self._running:
-            try:
-                # Wait for next message
-                msg = await asyncio.wait_for(self.bus.consume_inbound(), timeout=1.0)
-
-                # Process it
+        try:
+            while self._running:
                 try:
-                    response = await self._process_message(msg)
-                    if response:
-                        await self.bus.publish_outbound(response)
-                except Exception as e:
-                    logger.exception(f"Error processing message: {e}")
-                    # Send error response
-                    await self.bus.publish_outbound(
-                        OutboundMessage(
-                            session_key=msg.session_key,
-                            content=f"Sorry, I encountered an error: {str(e)}",
-                            metadata=msg.metadata,
-                        )
-                    )
-            except asyncio.TimeoutError:
-                continue
+                    msg = await asyncio.wait_for(self.bus.consume_inbound(), timeout=1.0)
+                except asyncio.TimeoutError:
+                    continue
+
+                if not self._running:
+                    await self.bus.publish_inbound(msg)
+                    break
+
+                session_lock = self._session_locks.setdefault(
+                    msg.session_key, asyncio.Lock()
+                )
+                self._session_lock_users[msg.session_key] = (
+                    self._session_lock_users.get(msg.session_key, 0) + 1
+                )
+                task = asyncio.create_task(self._process_queued_message(msg, session_lock))
+                self._message_tasks.add(task)
+                task.add_done_callback(self._message_tasks.discard)
+        finally:
+            self._running = False
+            if self._message_tasks:
+                await asyncio.gather(*self._message_tasks)
 
     def stop(self) -> None:
         """Stop the agent loop."""

--- a/bot/vikingbot/cli/commands.py
+++ b/bot/vikingbot/cli/commands.py
@@ -530,10 +530,16 @@ def gateway(
         ]
         try:
             await asyncio.gather(*tasks)
+        except asyncio.CancelledError:
+            agent_loop.stop()
+            raise
         finally:
             await agent_loop.close_mcp()
 
-    asyncio.run(run())
+    try:
+        asyncio.run(run())
+    except KeyboardInterrupt:
+        console.print("\nGoodbye!")
 
 
 def prepare_agent_loop(config, bus, session_manager, cron, quiet: bool = False, eval: bool = False):
@@ -908,7 +914,11 @@ def chat(
                 tasks.append(channels.start_all())
                 tasks.append(agent_loop.run())
 
-                await asyncio.gather(*tasks)
+                try:
+                    await asyncio.gather(*tasks)
+                except asyncio.CancelledError:
+                    agent_loop.stop()
+                    raise
         finally:
             await agent_loop.close_mcp()
 

--- a/bot/vikingbot/config/schema.py
+++ b/bot/vikingbot/config/schema.py
@@ -466,6 +466,11 @@ class AgentsConfig(BaseModel):
     )
     max_tool_iterations: int = 50
     memory_window: int = 50
+    message_max_concurrency: int = Field(
+        default=4,
+        ge=1,
+        description="Maximum number of inbound messages processed at once.",
+    )
     subagent_enabled: bool = Field(
         default=True,
         description="Enable the spawn tool so the main agent can start background subagents.",

--- a/bot/vikingbot/config/schema.py
+++ b/bot/vikingbot/config/schema.py
@@ -469,7 +469,10 @@ class AgentsConfig(BaseModel):
     message_max_concurrency: int = Field(
         default=4,
         ge=1,
-        description="Maximum number of inbound messages processed at once.",
+        description=(
+            "Maximum number of agent turns processed at once across the "
+            "message bus, CLI, cron, and heartbeat."
+        ),
     )
     subagent_enabled: bool = Field(
         default=True,

--- a/bot/vikingbot/tests/unit/test_agent_message_concurrency.py
+++ b/bot/vikingbot/tests/unit/test_agent_message_concurrency.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 from vikingbot.agent.loop import AgentLoop
-from vikingbot.bus.events import InboundMessage
+from vikingbot.bus.events import InboundMessage, OutboundMessage
 from vikingbot.bus.queue import MessageBus
 from vikingbot.config.schema import AgentsConfig, SessionKey
 
@@ -21,6 +21,7 @@ def _loop(max_concurrency: int) -> AgentLoop:
     loop = AgentLoop.__new__(AgentLoop)
     loop.bus = MessageBus()
     loop._running = False
+    loop._idle_wakeup = asyncio.Event()
     loop._message_semaphore = asyncio.Semaphore(max_concurrency)
     loop._message_tasks = set()
     loop._session_locks = {}
@@ -80,3 +81,157 @@ async def test_agent_loop_runs_sessions_concurrently_but_serializes_each_session
         "end:a2",
         "end:b1",
     }
+
+
+@pytest.mark.asyncio
+async def test_semaphore_caps_cross_session_concurrency():
+    loop = _loop(max_concurrency=2)
+    current = 0
+    peak = 0
+    release = asyncio.Event()
+    started = asyncio.Event()
+
+    async def process(msg: InboundMessage):
+        nonlocal current, peak
+        current += 1
+        peak = max(peak, current)
+        if current >= 2:
+            started.set()
+        await release.wait()
+        current -= 1
+        return None
+
+    loop._process_message = process
+    for name in ("a", "b", "c"):
+        await loop.bus.publish_inbound(_message(name, name))
+
+    run_task = asyncio.create_task(loop.run())
+    await asyncio.wait_for(started.wait(), timeout=1)
+    await asyncio.sleep(0)
+    assert peak == 2
+    assert current == 2
+
+    release.set()
+    loop.stop()
+    await asyncio.wait_for(run_task, timeout=2.5)
+    assert peak == 2
+
+
+@pytest.mark.asyncio
+async def test_error_in_one_session_does_not_block_another():
+    loop = _loop(max_concurrency=2)
+    finished = asyncio.Event()
+
+    async def process(msg: InboundMessage):
+        if msg.content == "boom":
+            raise RuntimeError("boom")
+        finished.set()
+        return None
+
+    loop._process_message = process
+    await loop.bus.publish_inbound(_message("a", "boom"))
+    await loop.bus.publish_inbound(_message("b", "ok"))
+
+    run_task = asyncio.create_task(loop.run())
+    await asyncio.wait_for(finished.wait(), timeout=1)
+    error = await asyncio.wait_for(loop.bus.consume_outbound(), timeout=1)
+    loop.stop()
+    await asyncio.wait_for(run_task, timeout=1)
+
+    assert "boom" in error.content
+    assert error.session_key.chat_id == "a"
+
+
+@pytest.mark.asyncio
+async def test_process_direct_serializes_with_same_session_bus_message():
+    loop = _loop(max_concurrency=2)
+    release = asyncio.Event()
+    started = asyncio.Event()
+    events: list[str] = []
+
+    async def process(msg: InboundMessage):
+        events.append(f"start:{msg.content}")
+        started.set()
+        await release.wait()
+        events.append(f"end:{msg.content}")
+        return None
+
+    loop._process_message = process
+    await loop.bus.publish_inbound(_message("a", "bus"))
+    run_task = asyncio.create_task(loop.run())
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    direct = asyncio.create_task(loop.process_direct("direct", _message("a", "direct").session_key))
+    await asyncio.sleep(0)
+    assert events == ["start:bus"]
+
+    release.set()
+    await asyncio.wait_for(direct, timeout=1)
+    loop.stop()
+    await asyncio.wait_for(run_task, timeout=2.5)
+
+    assert events.index("end:bus") < events.index("start:direct")
+
+
+@pytest.mark.asyncio
+async def test_process_direct_shares_global_semaphore_with_bus():
+    loop = _loop(max_concurrency=1)
+    release = asyncio.Event()
+    started = asyncio.Event()
+    events: list[str] = []
+
+    async def process(msg: InboundMessage):
+        events.append(f"start:{msg.content}")
+        started.set()
+        await release.wait()
+        events.append(f"end:{msg.content}")
+        return None
+
+    loop._process_message = process
+    await loop.bus.publish_inbound(_message("a", "bus"))
+    run_task = asyncio.create_task(loop.run())
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    direct = asyncio.create_task(loop.process_direct("direct", _message("b", "direct").session_key))
+    await asyncio.sleep(0)
+    assert events == ["start:bus"]
+
+    release.set()
+    await asyncio.wait_for(direct, timeout=1)
+    loop.stop()
+    await asyncio.wait_for(run_task, timeout=2.5)
+
+    assert events.index("end:bus") < events.index("start:direct")
+
+
+@pytest.mark.asyncio
+async def test_cancel_run_still_drains_in_flight_turn():
+    loop = _loop(max_concurrency=1)
+    release = asyncio.Event()
+    started = asyncio.Event()
+    events: list[str] = []
+
+    async def process(msg: InboundMessage):
+        events.append("start")
+        started.set()
+        await release.wait()
+        events.append("end")
+        return OutboundMessage(session_key=msg.session_key, content="done")
+
+    loop._process_message = process
+    await loop.bus.publish_inbound(_message("a", "a1"))
+    run_task = asyncio.create_task(loop.run())
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    run_task.cancel()
+    await asyncio.sleep(0)
+    assert not run_task.done()
+    assert events == ["start"]
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(run_task, timeout=1)
+
+    assert events == ["start", "end"]
+    outbound = await asyncio.wait_for(loop.bus.consume_outbound(), timeout=1)
+    assert outbound.content == "done"

--- a/bot/vikingbot/tests/unit/test_agent_message_concurrency.py
+++ b/bot/vikingbot/tests/unit/test_agent_message_concurrency.py
@@ -1,0 +1,82 @@
+import asyncio
+
+import pytest
+from pydantic import ValidationError
+
+from vikingbot.agent.loop import AgentLoop
+from vikingbot.bus.events import InboundMessage
+from vikingbot.bus.queue import MessageBus
+from vikingbot.config.schema import AgentsConfig, SessionKey
+
+
+def _message(chat_id: str, content: str) -> InboundMessage:
+    return InboundMessage(
+        sender_id="user",
+        content=content,
+        session_key=SessionKey(type="test", channel_id="channel", chat_id=chat_id),
+    )
+
+
+def _loop(max_concurrency: int) -> AgentLoop:
+    loop = AgentLoop.__new__(AgentLoop)
+    loop.bus = MessageBus()
+    loop._running = False
+    loop._message_semaphore = asyncio.Semaphore(max_concurrency)
+    loop._message_tasks = set()
+    loop._session_locks = {}
+    loop._session_lock_users = {}
+
+    async def connect_mcp() -> None:
+        return None
+
+    loop._connect_mcp = connect_mcp
+    return loop
+
+
+def test_message_concurrency_config_defaults_to_four_and_rejects_zero():
+    assert AgentsConfig().message_max_concurrency == 4
+    with pytest.raises(ValidationError):
+        AgentsConfig(message_max_concurrency=0)
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_runs_sessions_concurrently_but_serializes_each_session():
+    loop = _loop(max_concurrency=2)
+    release = asyncio.Event()
+    started = asyncio.Event()
+    events: list[str] = []
+
+    async def process(msg: InboundMessage):
+        events.append(f"start:{msg.content}")
+        if len([event for event in events if event.startswith("start:")]) == 2:
+            started.set()
+        await release.wait()
+        events.append(f"end:{msg.content}")
+        return None
+
+    loop._process_message = process
+    await loop.bus.publish_inbound(_message("a", "a1"))
+    await loop.bus.publish_inbound(_message("a", "a2"))
+    await loop.bus.publish_inbound(_message("b", "b1"))
+
+    run_task = asyncio.create_task(loop.run())
+    await asyncio.wait_for(started.wait(), timeout=1)
+    while len(loop._message_tasks) < 3:
+        await asyncio.sleep(0)
+
+    assert set(events) == {"start:a1", "start:b1"}
+
+    run_task.cancel()
+    await asyncio.sleep(0)
+    assert not run_task.done()
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(run_task, timeout=1)
+
+    assert events.index("end:a1") < events.index("start:a2")
+    assert {event for event in events if event.startswith("end:")} == {
+        "end:a1",
+        "end:a2",
+        "end:b1",
+    }


### PR DESCRIPTION
## Description

Allow VikingBot to process independent sessions concurrently without allowing turns from the same session to race.

The shared `AgentLoop` previously awaited every message before consuming the next one, so a slow model or tool call blocked unrelated chats across all channels.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4735

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Dispatch inbound messages as tracked async tasks, bounded by `bot.agents.message_max_concurrency`.
- Serialize processing by `SessionKey` so session history and replies remain ordered.
- Drain messages already accepted by the loop during shutdown and leave later queued messages on the bus.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Command: `python -m pytest bot/vikingbot/tests/unit -q --no-cov`

Result: 70 passed. The four emitted Pydantic deprecation warnings pre-exist this change.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

This PR intentionally proposes two configuration semantics for maintainer review:

1. **Default concurrency: `4`.** This is conservative enough to bound model/tool pressure while allowing several independent conversations to progress. If maintainers prefer `2` or another value, the default is isolated to one schema field.
2. **Shutdown: graceful drain.** Once shutdown starts, the loop accepts no new messages but waits for already accepted messages to finish. This avoids losing replies or partially persisting turns. If fast shutdown with immediate cancellation is preferred, that policy can be changed independently of the per-session ordering design.

The existing per-channel `max_concurrent_requests` remains unchanged; it controls HTTP request admission, while `message_max_concurrency` controls Agent message execution across all channels.
