### PR TITLE
fix(web-studio): give vitest a Node storage file and run the suite in PR CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -101,6 +101,7 @@ jobs:
       deps_changed: ${{ steps.check.outputs.deps_changed }}
       cuvs_changed: ${{ steps.check.outputs.cuvs_changed }}
       langchain_changed: ${{ steps.check.outputs.langchain_changed }}
+      web_studio_changed: ${{ steps.check.outputs.web_studio_changed }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -150,6 +151,19 @@ jobs:
           else
             echo "No LangChain integration changes detected."
             echo "langchain_changed=false" >> $GITHUB_OUTPUT
+          fi
+
+          # Run the web-studio Vitest suite when the frontend or its lane changes.
+          WEB_STUDIO_PATTERN="web-studio/|\.github/workflows/pr\.yml"
+          WEB_STUDIO_CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }} HEAD | grep -E "$WEB_STUDIO_PATTERN" || true)
+
+          if [ -n "$WEB_STUDIO_CHANGED_FILES" ]; then
+            echo "web-studio changes detected:"
+            echo "$WEB_STUDIO_CHANGED_FILES"
+            echo "web_studio_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "No web-studio changes detected."
+            echo "web_studio_changed=false" >> $GITHUB_OUTPUT
           fi
 
   build:
@@ -241,3 +255,21 @@ jobs:
           "${GITHUB_WORKSPACE}/.langchain-wheel-venv/bin/python" \
             "${GITHUB_WORKSPACE}/integrations/langchain/tests/installed_smoke.py"
           uv pip check --python "${GITHUB_WORKSPACE}/.langchain-wheel-venv/bin/python"
+
+  web-studio-tests:
+    needs: check-deps
+    if: ${{ needs.check-deps.outputs.web_studio_changed == 'true' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: web-studio/package-lock.json
+
+      - run: npm ci --prefix web-studio
+
+      - name: Run web-studio tests
+        run: npm test --prefix web-studio

--- a/web-studio/.gitignore
+++ b/web-studio/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.vitest-localstorage*
 .DS_Store
 dist
 dist-ssr

--- a/web-studio/package.json
+++ b/web-studio/package.json
@@ -9,7 +9,7 @@
     "dev": "vite dev --port 3000",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run",
+    "test": "NODE_OPTIONS=\"--localstorage-file=.vitest-localstorage\" vitest run",
     "lint": "eslint src --ignore-pattern 'src/gen/**' --ignore-pattern 'src/routeTree.gen.ts' --ignore-pattern 'src/components/ui/**'",
     "format": "prettier --check 'src/**/*.{ts,tsx}'",
     "check": "prettier --write 'src/**/*.{ts,tsx}' && eslint src --fix --ignore-pattern 'src/gen/**' --ignore-pattern 'src/routeTree.gen.ts' --ignore-pattern 'src/components/ui/**'",


### PR DESCRIPTION
## Summary

Fixes #4734 — two things in one PR, because they only work together:

1. **Fix the 5 jsdom test failures on `main`** — `web-studio`'s test script now runs vitest with Node's `--localstorage-file`, so the native experimental `localStorage` getter (Node ≥ 22.4) returns a real `Storage` instead of `undefined` inside the jsdom environment. Root-cause analysis in the issue: vitest's jsdom environment aliases `window = globalThis` and does not install jsdom's storage over Node's pre-existing lazy getter, so `window.localStorage` resolves to Node's getter → `undefined` without the flag → `TypeError: Cannot read properties of undefined (reading 'clear')` in the playground tests.
2. **Add the missing `web-studio-tests` job to PR validation** — no CI workflow ran the web-studio Vitest suite at all, which is why these 5 failures have been invisible (same coverage-gap family as the unit-test lane discussed in #4734).

## Changes

- `web-studio/package.json` — `test` script: `NODE_OPTIONS="--localstorage-file=.vitest-localstorage" vitest run` (the existing scripts already assume a POSIX shell, e.g. `gen-server-client`).
- `web-studio/.gitignore` — ignore the storage file created at the repo's `web-studio/` root.
- `.github/workflows/pr.yml` — new `web-studio-tests` job (`ubuntu-24.04`, Node 22 to match the web-studio build lane in `_build.yml`, `npm ci --prefix web-studio` + `npm test --prefix web-studio`), gated by a new `web_studio_changed` output in `check-deps` (`web-studio/` or `pr.yml` touched), mirroring the existing `langchain_changed` pattern.

## Verification

On a clean checkout of `main` @ `0c5147ca` (Node v26.5.0):

- Before: `Test Files 2 failed | 57 passed (59)`, `Tests 5 failed | 265 passed (270)` — reproduced.
- After this change: **270/270 green** (`npm test`).
- `pr.yml` and `package.json` both parse cleanly (yaml.safe_load / json.load).
- The storage file lands at `web-studio/.vitest-localstorage` and is gitignored.

## Notes for reviewers

- The fix is intentionally the minimal one (issue option 1); per-test `vi.stubGlobal` stubs (option 2) were verified too but are more invasive.
- Node 22 is ≥ 22.4, so CI hits the same native-getter behavior — the job genuinely exercises the fixed path rather than accidentally passing on a different Node.
- The `WEB_STUDIO_PATTERN` includes `pr.yml` itself (same convention as `LANGCHAIN_PATTERN`) so edits to this lane still get validated.
