### PR TITLE
fix(storage): close worker loop async clients

### DIFF
--- a/openviking/storage/queuefs/queue_manager.py
+++ b/openviking/storage/queuefs/queue_manager.py
@@ -13,6 +13,7 @@ import traceback
 from typing import Any, Dict, Optional, Set, Union
 
 from openviking.service.task_work_index import TaskWorkIndex
+from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
 from openviking_cli.utils.logger import get_logger
 
 from .embedding_queue import EmbeddingQueue
@@ -244,7 +245,13 @@ class QueueManager:
                         traceback.print_exc()
                         stop_event.wait(poll_interval)
         finally:
-            loop.close()
+            try:
+                loop.run_until_complete(LoopScopedAsyncClientCache.close_current_loop_clients())
+            except Exception:
+                logger.exception("[QueueManager] Failed to close worker-loop async clients")
+            finally:
+                asyncio.set_event_loop(None)
+                loop.close()
 
     async def _worker_async_concurrent(
         self, queue: NamedQueue, stop_event: threading.Event, max_concurrent: int

--- a/openviking/utils/async_client_cache.py
+++ b/openviking/utils/async_client_cache.py
@@ -28,6 +28,14 @@ def _aclose_client(client: AsyncCloseable) -> Any:
     return client.aclose()
 
 
+def _close_async_client(client: Any) -> Any:
+    """Prefer an async close method for a client owned by a running loop."""
+    close = getattr(client, "aclose", None)
+    if close is None:
+        close = getattr(client, "close", None)
+    return close() if close is not None else None
+
+
 class LoopScopedAsyncClientCache:
     """Cache async clients per running event loop.
 
@@ -36,12 +44,17 @@ class LoopScopedAsyncClientCache:
     across worker threads with separate event loops can then fail at runtime.
     """
 
+    _instances: weakref.WeakSet[LoopScopedAsyncClientCache] = weakref.WeakSet()
+    _instances_lock = threading.Lock()
+
     def __init__(self) -> None:
         self._clients_by_loop: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, Any] = (
             weakref.WeakKeyDictionary()
         )
         self._fallback_client: Any = None
         self._lock = threading.Lock()
+        with self._instances_lock:
+            self._instances.add(self)
 
     def __copy__(self) -> LoopScopedAsyncClientCache:
         """Return an empty cache instead of sharing live async clients."""
@@ -88,6 +101,12 @@ class LoopScopedAsyncClientCache:
                 self._fallback_client = None
             return clients
 
+    def pop_for_loop(self, loop: asyncio.AbstractEventLoop) -> list[Any]:
+        """Remove and return the client owned by ``loop``, if one exists."""
+        with self._lock:
+            client = self._clients_by_loop.pop(loop, None)
+            return [] if client is None else [client]
+
     @staticmethod
     async def _close_clients(clients: list[Any], close_client: Callable[[Any], Any]) -> None:
         seen: set[int] = set()
@@ -100,6 +119,15 @@ class LoopScopedAsyncClientCache:
             result = close_client(client)
             if inspect.isawaitable(result):
                 await result
+
+    @classmethod
+    async def close_current_loop_clients(cls) -> None:
+        """Close every cached client owned by the current event loop."""
+        loop = asyncio.get_running_loop()
+        with cls._instances_lock:
+            caches = list(cls._instances)
+        clients = [client for cache in caches for client in cache.pop_for_loop(loop)]
+        await cls._close_clients(clients, _close_async_client)
 
     def close_all(self, close_client: Callable[[Any], Any]) -> None:
         """Close and clear all cached clients on a best-effort basis."""

--- a/openviking/utils/async_client_cache.py
+++ b/openviking/utils/async_client_cache.py
@@ -122,7 +122,11 @@ class LoopScopedAsyncClientCache:
 
     @classmethod
     async def close_current_loop_clients(cls) -> None:
-        """Close every cached client owned by the current event loop."""
+        """Close cached clients owned by the current event loop.
+
+        The no-loop fallback client is managed separately by ``close_all`` or
+        ``close_all_async``; it is not owned by the current loop.
+        """
         loop = asyncio.get_running_loop()
         with cls._instances_lock:
             caches = list(cls._instances)

--- a/tests/storage/test_queue_manager.py
+++ b/tests/storage/test_queue_manager.py
@@ -2,11 +2,14 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Focused tests for QueueManager concurrency selection."""
 
+import asyncio
 import os
 import subprocess
 import sys
+import threading
 
 from openviking.storage.queuefs.queue_manager import QueueManager
+from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
 
 
 def test_queuefs_package_imports_in_a_clean_process(tmp_path) -> None:
@@ -34,3 +37,30 @@ def test_queue_concurrency_uses_separate_configured_values() -> None:
     assert manager._max_concurrent_for_queue(manager.EXTERNAL_PARSE) == 9
     assert manager._max_concurrent_for_queue(manager.ADD_RESOURCE) == 7
     assert manager._max_concurrent_for_queue(manager.SESSION_COMMIT) == 5
+
+
+def test_queue_worker_closes_loop_scoped_clients_before_its_loop() -> None:
+    events = []
+    cache = LoopScopedAsyncClientCache()
+
+    class Client:
+        async def aclose(self):
+            events.append(("clients", asyncio.get_running_loop().is_closed()))
+
+    class Queue:
+        name = QueueManager.EMBEDDING
+
+        async def size(self):
+            cache.get(Client)
+            stop_event.set()
+            return 0
+
+        def has_dequeue_handler(self):
+            return False
+
+    manager = QueueManager(agfs=object())
+    stop_event = threading.Event()
+
+    manager._queue_worker_loop(Queue(), stop_event)
+
+    assert events == [("clients", False)]

--- a/tests/unit/test_async_client_cache.py
+++ b/tests/unit/test_async_client_cache.py
@@ -59,3 +59,34 @@ def test_loop_scoped_async_client_cache_copies_without_live_clients():
     assert cache.has_clients()
     assert not shallow.has_clients()
     assert not deep.has_clients()
+
+
+def test_close_current_loop_clients_closes_only_clients_owned_by_that_loop():
+    cache = LoopScopedAsyncClientCache()
+    closed = []
+
+    class Client:
+        async def aclose(self):
+            closed.append(threading.get_ident())
+
+    async def get_client():
+        return cache.get(Client)
+
+    async def get_and_close_current_loop():
+        cache.get(Client)
+        await LoopScopedAsyncClientCache.close_current_loop_clients()
+
+    retained_loop = asyncio.new_event_loop()
+    closing_loop = asyncio.new_event_loop()
+    try:
+        retained_loop.run_until_complete(get_client())
+        closing_loop.run_until_complete(get_and_close_current_loop())
+
+        assert closed == [threading.get_ident()]
+        assert cache.has_clients()
+
+        retained_loop.run_until_complete(LoopScopedAsyncClientCache.close_current_loop_clients())
+        assert not cache.has_clients()
+    finally:
+        retained_loop.close()
+        closing_loop.close()


### PR DESCRIPTION
## Description

Queue workers previously closed their private event loop while `LoopScopedAsyncClientCache` instances still retained clients created on that loop. Later garbage collection could attempt to close an OpenAI/httpx transport against the dead loop and raise `RuntimeError: Event loop is closed` in unrelated work.

This change registers loop-scoped caches weakly and closes only the clients owned by the current worker loop before `loop.close()`. Clients belonging to other active loops remain available.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4726

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Track live `LoopScopedAsyncClientCache` instances with weak references.
- Add current-loop cleanup that prefers `aclose()` and falls back to `close()`.
- Run that cleanup on each queue worker before closing its event loop.
- Cover loop isolation and the real queue-worker shutdown path.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands:

```text
PYTHONPATH=$PWD /Users/song-eun-u/Documents/github/oss-contributions/OpenViking/.venv/bin/python -m pytest -q --no-cov tests/unit/test_async_client_cache.py tests/storage/test_queue_manager.py
/Users/song-eun-u/Documents/github/oss-contributions/OpenViking/.venv/bin/ruff check openviking/utils/async_client_cache.py openviking/storage/queuefs/queue_manager.py tests/unit/test_async_client_cache.py tests/storage/test_queue_manager.py
/Users/song-eun-u/Documents/github/oss-contributions/OpenViking/.venv/bin/ruff format --check openviking/utils/async_client_cache.py openviking/storage/queuefs/queue_manager.py tests/unit/test_async_client_cache.py tests/storage/test_queue_manager.py
PYTHONPATH=$PWD /Users/song-eun-u/Documents/github/oss-contributions/OpenViking/.venv/bin/mypy openviking/utils/async_client_cache.py openviking/storage/queuefs/queue_manager.py
```

Result: 6 focused tests passed; Ruff and mypy passed. The first `uv run pytest` attempt could not build the editable package because Cargo was unavailable locally, so the focused checks used the existing project virtual environment with the worktree on `PYTHONPATH`.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The change affects only internal client lifecycle behavior. It does not alter public APIs, configuration, or persisted data.
