### PR TITLE
fix(memory-plugins): report client-side MCP proxy timeouts as -32004 instead of unreachable

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,6 +70,7 @@ jobs:
             examples/memory-plugin-shared/setup-wizard.test.mjs \
             examples/memory-plugin-shared/sync.test.mjs \
             examples/memory-plugin-shared/mcp-proxy-config.test.mjs \
+            examples/memory-plugin-shared/mcp-proxy-core.test.mjs \
             examples/memory-plugin-shared/recall-compress-core.test.mjs \
             examples/memory-plugin-shared/recall-core.test.mjs \
             examples/memory-plugin-shared/recall-session-wiring.test.mjs \

--- a/agent-plugins/servers/shared/mcp-proxy-core.mjs
+++ b/agent-plugins/servers/shared/mcp-proxy-core.mjs
@@ -292,6 +292,18 @@ export function createOpenVikingMcpProxy({
       );
     }
     const msg = err instanceof Error ? err.message : String(err);
+    if (err && err.name === "AbortError") {
+      // Client-side timeout, not an outage: the server may be healthy and
+      // still computing (rerank-inclusive find/search can legitimately take
+      // longer than the default budget). Keep -32001 for genuine
+      // connection failures so the two are not misdiagnosed as each other.
+      return errorResponse(
+        id,
+        -32004,
+        `OpenViking MCP request timed out after ${proxyConfig.timeoutMs}ms (${proxyConfig.mcpUrl}). The server may still be processing (rerank can be slow) — check /health or raise OPENVIKING_TIMEOUT_MS.`,
+        { timeoutMs: proxyConfig.timeoutMs, mcpUrl: proxyConfig.mcpUrl, cause: msg },
+      );
+    }
     return errorResponse(
       id,
       -32001,

--- a/examples/claude-code-memory-plugin/scripts/shared/mcp-proxy-core.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/mcp-proxy-core.mjs
@@ -292,6 +292,18 @@ export function createOpenVikingMcpProxy({
       );
     }
     const msg = err instanceof Error ? err.message : String(err);
+    if (err && err.name === "AbortError") {
+      // Client-side timeout, not an outage: the server may be healthy and
+      // still computing (rerank-inclusive find/search can legitimately take
+      // longer than the default budget). Keep -32001 for genuine
+      // connection failures so the two are not misdiagnosed as each other.
+      return errorResponse(
+        id,
+        -32004,
+        `OpenViking MCP request timed out after ${proxyConfig.timeoutMs}ms (${proxyConfig.mcpUrl}). The server may still be processing (rerank can be slow) — check /health or raise OPENVIKING_TIMEOUT_MS.`,
+        { timeoutMs: proxyConfig.timeoutMs, mcpUrl: proxyConfig.mcpUrl, cause: msg },
+      );
+    }
     return errorResponse(
       id,
       -32001,

--- a/examples/codex-memory-plugin/scripts/shared/mcp-proxy-core.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/mcp-proxy-core.mjs
@@ -292,6 +292,18 @@ export function createOpenVikingMcpProxy({
       );
     }
     const msg = err instanceof Error ? err.message : String(err);
+    if (err && err.name === "AbortError") {
+      // Client-side timeout, not an outage: the server may be healthy and
+      // still computing (rerank-inclusive find/search can legitimately take
+      // longer than the default budget). Keep -32001 for genuine
+      // connection failures so the two are not misdiagnosed as each other.
+      return errorResponse(
+        id,
+        -32004,
+        `OpenViking MCP request timed out after ${proxyConfig.timeoutMs}ms (${proxyConfig.mcpUrl}). The server may still be processing (rerank can be slow) — check /health or raise OPENVIKING_TIMEOUT_MS.`,
+        { timeoutMs: proxyConfig.timeoutMs, mcpUrl: proxyConfig.mcpUrl, cause: msg },
+      );
+    }
     return errorResponse(
       id,
       -32001,

--- a/examples/dsh-memory-plugin/shared/mcp-proxy-core.mjs
+++ b/examples/dsh-memory-plugin/shared/mcp-proxy-core.mjs
@@ -292,6 +292,18 @@ export function createOpenVikingMcpProxy({
       );
     }
     const msg = err instanceof Error ? err.message : String(err);
+    if (err && err.name === "AbortError") {
+      // Client-side timeout, not an outage: the server may be healthy and
+      // still computing (rerank-inclusive find/search can legitimately take
+      // longer than the default budget). Keep -32001 for genuine
+      // connection failures so the two are not misdiagnosed as each other.
+      return errorResponse(
+        id,
+        -32004,
+        `OpenViking MCP request timed out after ${proxyConfig.timeoutMs}ms (${proxyConfig.mcpUrl}). The server may still be processing (rerank can be slow) — check /health or raise OPENVIKING_TIMEOUT_MS.`,
+        { timeoutMs: proxyConfig.timeoutMs, mcpUrl: proxyConfig.mcpUrl, cause: msg },
+      );
+    }
     return errorResponse(
       id,
       -32001,

--- a/examples/memory-plugin-shared/lib/mcp-proxy-core.mjs
+++ b/examples/memory-plugin-shared/lib/mcp-proxy-core.mjs
@@ -291,6 +291,18 @@ export function createOpenVikingMcpProxy({
       );
     }
     const msg = err instanceof Error ? err.message : String(err);
+    if (err && err.name === "AbortError") {
+      // Client-side timeout, not an outage: the server may be healthy and
+      // still computing (rerank-inclusive find/search can legitimately take
+      // longer than the default budget). Keep -32001 for genuine
+      // connection failures so the two are not misdiagnosed as each other.
+      return errorResponse(
+        id,
+        -32004,
+        `OpenViking MCP request timed out after ${proxyConfig.timeoutMs}ms (${proxyConfig.mcpUrl}). The server may still be processing (rerank can be slow) — check /health or raise OPENVIKING_TIMEOUT_MS.`,
+        { timeoutMs: proxyConfig.timeoutMs, mcpUrl: proxyConfig.mcpUrl, cause: msg },
+      );
+    }
     return errorResponse(
       id,
       -32001,

--- a/examples/memory-plugin-shared/mcp-proxy-core.test.mjs
+++ b/examples/memory-plugin-shared/mcp-proxy-core.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createOpenVikingMcpProxy } from "./lib/mcp-proxy-core.mjs";
+
+function buildHarness({ fetchImpl, timeoutMs = 40 }) {
+  const lines = [];
+  const stdout = {
+    write(line, cb) {
+      lines.push(line);
+      if (cb) cb();
+      return true;
+    },
+  };
+  const proxy = createOpenVikingMcpProxy({
+    stdin: process.stdin,
+    stdout,
+    fetchImpl,
+    readConfig: () => ({
+      mcpUrl: "http://127.0.0.1:1933/mcp",
+      timeoutMs,
+      watchedPaths: [],
+    }),
+    loggerFactory: () => ({ log() {}, logError() {} }),
+  });
+  const responses = () => lines.map((l) => JSON.parse(l));
+  const send = (obj) => proxy.handleMessage(obj);
+  const waitFor = async (predicate, label) => {
+    for (let i = 0; i < 100; i++) {
+      const found = responses().find(predicate);
+      if (found) return found;
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    throw new Error(`timed out waiting for ${label}; got: ${lines.join("|")}`);
+  };
+  return { proxy, send, waitFor, responses };
+}
+
+test("an aborted request maps to -32004 naming the timeout budget", async () => {
+  const harness = buildHarness({
+    // Stalls until aborted, like a real signal-aware fetch against a slow server.
+    fetchImpl: (_url, { signal } = {}) =>
+      new Promise((_resolve, reject) => {
+        signal.addEventListener("abort", () => {
+          const err = new Error("This operation was aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      }),
+    timeoutMs: 40,
+  });
+  harness.send({ jsonrpc: "2.0", id: 7, method: "initialize", params: {} });
+  const res = await harness.waitFor(
+    (m) => m.id === 7 && m.error,
+    "timeout error response",
+  );
+  assert.equal(res.error.code, -32004);
+  assert.match(res.error.message, /timed out after 40ms/);
+  assert.match(res.error.message, /OPENVIKING_TIMEOUT_MS/);
+  assert.equal(res.error.data.timeoutMs, 40);
+  assert.equal(res.error.data.mcpUrl, "http://127.0.0.1:1933/mcp");
+});
+
+test("a genuine connection failure still maps to -32001", async () => {
+  const harness = buildHarness({
+    fetchImpl: () => {
+      throw new TypeError("fetch failed");
+    },
+  });
+  harness.send({ jsonrpc: "2.0", id: 8, method: "initialize", params: {} });
+  const res = await harness.waitFor(
+    (m) => m.id === 8 && m.error,
+    "connection error response",
+  );
+  assert.equal(res.error.code, -32001);
+  assert.match(res.error.message, /reachable/);
+});

--- a/examples/opencode-plugin/lib/shared/mcp-proxy-core.mjs
+++ b/examples/opencode-plugin/lib/shared/mcp-proxy-core.mjs
@@ -292,6 +292,18 @@ export function createOpenVikingMcpProxy({
       );
     }
     const msg = err instanceof Error ? err.message : String(err);
+    if (err && err.name === "AbortError") {
+      // Client-side timeout, not an outage: the server may be healthy and
+      // still computing (rerank-inclusive find/search can legitimately take
+      // longer than the default budget). Keep -32001 for genuine
+      // connection failures so the two are not misdiagnosed as each other.
+      return errorResponse(
+        id,
+        -32004,
+        `OpenViking MCP request timed out after ${proxyConfig.timeoutMs}ms (${proxyConfig.mcpUrl}). The server may still be processing (rerank can be slow) — check /health or raise OPENVIKING_TIMEOUT_MS.`,
+        { timeoutMs: proxyConfig.timeoutMs, mcpUrl: proxyConfig.mcpUrl, cause: msg },
+      );
+    }
     return errorResponse(
       id,
       -32001,

--- a/examples/zcode-memory-plugin/scripts/shared/mcp-proxy-core.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/mcp-proxy-core.mjs
@@ -292,6 +292,18 @@ export function createOpenVikingMcpProxy({
       );
     }
     const msg = err instanceof Error ? err.message : String(err);
+    if (err && err.name === "AbortError") {
+      // Client-side timeout, not an outage: the server may be healthy and
+      // still computing (rerank-inclusive find/search can legitimately take
+      // longer than the default budget). Keep -32001 for genuine
+      // connection failures so the two are not misdiagnosed as each other.
+      return errorResponse(
+        id,
+        -32004,
+        `OpenViking MCP request timed out after ${proxyConfig.timeoutMs}ms (${proxyConfig.mcpUrl}). The server may still be processing (rerank can be slow) — check /health or raise OPENVIKING_TIMEOUT_MS.`,
+        { timeoutMs: proxyConfig.timeoutMs, mcpUrl: proxyConfig.mcpUrl, cause: msg },
+      );
+    }
     return errorResponse(
       id,
       -32001,


### PR DESCRIPTION
## Summary

- In `mcp-proxy-core.mjs`, a request aborted by the proxy's own `AbortController` (the `timeoutMs` budget, default 15 s) fell into `mapError()`'s final catch-all and returned `-32001` with the "check the configured URL … server reachable" message — even when the server was healthy and still computing. Rerank-inclusive `find`/`search` legitimately takes tens of seconds, so on the default budget every such call was mislabeled as an outage and actively misdirected diagnosis (#4739).
- Adds an `AbortError` branch before the catch-all: timeout now returns a dedicated **`-32004`** whose message names the elapsed budget and the endpoint and points at `OPENVIKING_TIMEOUT_MS`; `data` carries `timeoutMs` and `mcpUrl`. `-32001` keeps its meaning of a genuine connection failure.
- Note on the code number: the issue's suggested snippet proposed `-32003`, but that code is already used by the "upstream returned an empty response" error (`mcp-proxy-core.mjs`, empty-response branch), so timeouts take the next free code, `-32004`.
- The fix is applied to the shared lib source and propagated to all six generated copies via `sync.mjs`.

## Issue

Closes #4739 (main fix). The optional companion knob suggested there (`OPENVIKING_RECALL_MIN_PROMPT_CHARS` in `agent-hook-runtime.mjs`) is deliberately left out to keep this PR focused; happy to split it into a separate PR if the maintainers want it.

## Validation

- New `examples/memory-plugin-shared/mcp-proxy-core.test.mjs` (registered in the `plugin-tests` list in `pr.yml`): a signal-aware stalled `fetchImpl` aborted at 40 ms maps to `-32004` with the budget/endpoint in message and data, and a `TypeError: fetch failed` still maps to `-32001` — both driven through the real `handleMessage` path with a mock stdout.
- `node --test` on the new test + `mcp-proxy-config.test.mjs` + `sync.test.mjs`: 18 pass / 0 fail.
- `node examples/memory-plugin-shared/sync.mjs` run; `git status` shows exactly the lib source, the six vendor copies, the new test, and the `pr.yml` registration.