### PR TITLE
fix(queuefs): keep in_progress balanced when a serial dequeue handler raises

### DIFF
--- a/openviking/storage/queuefs/named_queue.py
+++ b/openviking/storage/queuefs/named_queue.py
@@ -326,7 +326,21 @@ class NamedQueue:
             raw_data = data
             if self._dequeue_handler:
                 self._on_dequeue_start()
-                data = await self.process_dequeued(data)
+                try:
+                    data = await self.process_dequeued(data)
+                except Exception as e:
+                    # Handler did not call report_error; decrement in_progress
+                    # manually (mirrors the concurrent worker in QueueManager).
+                    # Without this, a handler that raises without reporting leaks
+                    # the in_progress counter, so is_complete()/wait_complete()
+                    # never observe an idle queue again.
+                    # Do NOT ack — let RecoverStale re-queue on next startup.
+                    self._on_process_error(str(e), raw_data)
+                    logger.error(
+                        f"[NamedQueue] Handler failed for {self.name} msg_id={msg_id}: {e}",
+                        exc_info=True,
+                    )
+                    raise
             # Ack unconditionally after handler returns (success or handled error).
             # If on_dequeue raises, the exception propagates and ack is skipped —
             # the message will be recovered on next startup.

--- a/tests/storage/test_named_queue_dequeue_accounting.py
+++ b/tests/storage/test_named_queue_dequeue_accounting.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Serial dequeue must keep in_progress accounting balanced.
+
+The concurrent worker in QueueManager compensates when a handler raises
+without calling report_error ("Handler did not call report_error; decrement
+in_progress manually"). NamedQueue.dequeue() — used by the serial worker
+path (e.g. the UserDeletion queue) — must do the same, otherwise a single
+unreported handler failure leaks the in_progress counter and
+is_complete()/wait_complete() never observe an idle queue again.
+"""
+
+import json
+from typing import Any, Dict, List, Optional
+
+from openviking.storage.queuefs.named_queue import DequeueHandlerBase, NamedQueue
+
+
+class FakeAGFS:
+    """Minimal sync AGFS client fake for the queue control files."""
+
+    def __init__(self, messages: List[Dict[str, Any]]):
+        self.messages = list(messages)
+        self.acked: List[str] = []
+
+    def mkdir(self, path: str, ctx: Optional[Dict[str, str]] = None, **kw) -> Dict[str, Any]:
+        return {}
+
+    def read(self, path: str, ctx: Optional[Dict[str, str]] = None, **kw) -> Any:
+        if path.endswith("/dequeue"):
+            if self.messages:
+                return json.dumps(self.messages.pop(0)).encode("utf-8")
+            return b""
+        if path.endswith("/size"):
+            return str(len(self.messages)).encode("utf-8")
+        return b""
+
+    def write(self, path: str, data: bytes, ctx: Optional[Dict[str, str]] = None, **kw) -> str:
+        if path.endswith("/ack"):
+            self.acked.append(data.decode("utf-8"))
+        return "written"
+
+
+class ExplodingHandler(DequeueHandlerBase):
+    """Handler that raises without reporting (e.g. _UserDeletionProcessor
+    when _process hits an await outside its stage try/excepts)."""
+
+    async def on_dequeue(self, data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        raise RuntimeError("transient tracker storage failure")
+
+
+class ReportingHandler(DequeueHandlerBase):
+    async def on_dequeue(self, data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        self.report_error("handled failure")
+        return None
+
+
+class SuccessHandler(DequeueHandlerBase):
+    async def on_dequeue(self, data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        self.report_success()
+        return data
+
+
+async def test_dequeue_handler_exception_does_not_leak_in_progress():
+    agfs = FakeAGFS([{"id": "m1", "task_id": "t1"}])
+    queue = NamedQueue(agfs, "/queue", "UserDeletion", dequeue_handler=ExplodingHandler())
+
+    result = await queue.dequeue()
+
+    assert result is None  # exception is still swallowed by dequeue()
+    status = await queue.get_status()
+    assert status.in_progress == 0, "in_progress must be balanced after an unreported failure"
+    assert status.error_count == 1, "unreported failure must land in the error history"
+    assert agfs.acked == [], "message must not be acked so RecoverStale can retry it"
+
+
+async def test_dequeue_handler_exception_keeps_queue_completeobservable():
+    """Two failed dequeues must leave is_all_complete() able to report idle."""
+    agfs = FakeAGFS([{"id": "m1", "task_id": "t1"}, {"id": "m2", "task_id": "t2"}])
+    queue = NamedQueue(agfs, "/queue", "UserDeletion", dequeue_handler=ExplodingHandler())
+
+    await queue.dequeue()
+    await queue.dequeue()
+
+    status = await queue.get_status()
+    assert status.pending == 0
+    assert status.in_progress == 0
+    assert status.is_complete is True
+
+
+async def test_dequeue_reported_error_still_balances_and_acks():
+    agfs = FakeAGFS([{"id": "m1", "task_id": "t1"}])
+    queue = NamedQueue(agfs, "/queue", "UserDeletion", dequeue_handler=ReportingHandler())
+
+    result = await queue.dequeue()
+
+    assert result is None
+    status = await queue.get_status()
+    assert status.in_progress == 0
+    assert status.error_count == 1
+    assert agfs.acked == ["m1"], "handled errors are acked (terminal) as before"
+
+
+async def test_dequeue_success_path_unchanged():
+    agfs = FakeAGFS([{"id": "m1", "task_id": "t1"}])
+    queue = NamedQueue(agfs, "/queue", "UserDeletion", dequeue_handler=SuccessHandler())
+
+    result = await queue.dequeue()
+
+    assert result == {"id": "m1", "task_id": "t1"}
+    status = await queue.get_status()
+    assert status.in_progress == 0
+    assert status.processed == 1
+    assert status.error_count == 0
+    assert agfs.acked == ["m1"]


### PR DESCRIPTION
## Summary

`NamedQueue.dequeue()` (the serial consume path used by the worker loop when `max_concurrent == 1` — e.g. the `UserDeletion` queue, which is hard-wired to concurrency 1) increments `in_progress` before invoking the handler, but when the handler **raises without calling `report_error`**, the exception is swallowed by `dequeue()`'s own `except Exception` and the counter is never decremented.

The concurrent worker in `QueueManager._worker_async_concurrent` already compensates for exactly this case:

```python
except Exception as e:
    # Handler did not call report_error; decrement in_progress manually.
    # Do NOT ack — let RecoverStale re-queue on next startup.
    queue._on_process_error(str(e), data)
```

The serial path had no such compensation.

## Root cause

```python
if self._dequeue_handler:
    self._on_dequeue_start()          # in_progress += 1
    data = await self.process_dequeued(data)   # raises → swallowed below
await self.ack(msg_id, raw_data)
...
except Exception as e:
    logger.debug(...)                 # in_progress stays +1 forever
    return None
```

## Impact

`_UserDeletionProcessor.on_dequeue` propagates exceptions from `UserDeletionService._process` whenever an await outside its stage `try/except` blocks fails (e.g. transient task-tracker storage errors during `tracker.create` / `tracker.update_stage` / `tracker.complete`). After one such failure:

- `QueueStatus.in_progress` stays ≥ 1 for the rest of the process lifetime, so `is_complete` / `is_all_complete` never return `True` again.
- `wait_complete()` — used by `add_resource` with `wait=true`, the `wait_processed` API and the fs sync flush — blocks until its timeout and then raises `DeadlineExceededError`, even though every queue is actually idle.
- The failure itself was only logged at DEBUG level and left no entry in the queue error history, making the root cause very hard to spot (the visible symptom is a mysterious permanent "busy" queue).

## Fix

Mirror the concurrent worker's compensation inside `NamedQueue.dequeue()`:

- record the failure via `_on_process_error` (balances `in_progress` and adds the error to the history),
- log at ERROR level with traceback,
- still skip `ack` so RecoverStale re-queues the message on next startup (at-least-once semantics unchanged).

## Tests

New `tests/storage/test_named_queue_dequeue_accounting.py`:

- handler raising without reporting → `in_progress` back to 0, `error_count == 1`, **not** acked;
- two failed dequeues → `is_complete` is `True` again;
- regression guards: handler-reported error still balances and acks; success path unchanged.

Without the fix, the first two tests fail with `in_progress=1` leaked; with the fix all four pass. Full `tests/storage` suite shows identical results before/after the patch (no regressions).

## Notes

- Delivery semantics are unchanged: the message is still not acked on handler failure, so recovery behavior is the same as the concurrent path.
- No linked issue found for the in-process counter leak; related-but-different: #4303 covers persistent backend rows surviving restarts, whereas this leak resets on every restart and re-accumulates at runtime.
