### PR TITLE
test(bot): realign stale unit tests with main and run the suite in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -198,7 +198,7 @@ jobs:
           enable-cache: true
 
       - name: Install bot dependencies
-        run: uv sync --frozen --extra bot
+        run: uv sync --frozen --extra bot --extra test
 
       - name: Run VikingBot unit tests
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -101,6 +101,7 @@ jobs:
       deps_changed: ${{ steps.check.outputs.deps_changed }}
       cuvs_changed: ${{ steps.check.outputs.cuvs_changed }}
       langchain_changed: ${{ steps.check.outputs.langchain_changed }}
+      bot_changed: ${{ steps.check.outputs.bot_changed }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -152,6 +153,20 @@ jobs:
             echo "langchain_changed=false" >> $GITHUB_OUTPUT
           fi
 
+          # Run the VikingBot unit test suites when bot code, its dependency
+          # set, or this workflow change.
+          BOT_PATTERN="^bot/|pyproject\.toml|uv\.lock|\.github/workflows/pr\.yml"
+          BOT_CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }} HEAD | grep -E "$BOT_PATTERN" || true)
+
+          if [ -n "$BOT_CHANGED_FILES" ]; then
+            echo "Bot changes detected:"
+            echo "$BOT_CHANGED_FILES"
+            echo "bot_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "No bot changes detected."
+            echo "bot_changed=false" >> $GITHUB_OUTPUT
+          fi
+
   build:
     needs: check-deps
     if: ${{ needs.check-deps.outputs.deps_changed == 'true' }}
@@ -164,6 +179,30 @@ jobs:
     with:
       os_json: '["ubuntu-24.04"]'
       python_json: '["3.11"]'
+
+  bot-tests:
+    needs: check-deps
+    if: ${{ needs.check-deps.outputs.bot_changed == 'true' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install bot dependencies
+        run: uv sync --frozen --extra bot
+
+      - name: Run VikingBot unit tests
+        run: |
+          uv run python -m pytest -q -o addopts='' bot/tests bot/vikingbot
 
   langchain-tests:
     needs: check-deps

--- a/bot/tests/test_agent_loop_outcome.py
+++ b/bot/tests/test_agent_loop_outcome.py
@@ -616,7 +616,12 @@ async def test_agent_loop_makes_final_no_tool_call_when_iteration_limit_reached(
         "tool result: useful context",
         "tool result: useful context",
     ]
-    assert token_usage == {"prompt_tokens": 17, "completion_tokens": 7, "total_tokens": 24}
+    assert token_usage == {
+        "prompt_tokens": 17,
+        "completion_tokens": 7,
+        "total_tokens": 24,
+        "cache_read_input_tokens": 0,
+    }
 
 
 @pytest.mark.asyncio
@@ -643,7 +648,7 @@ async def test_agent_loop_evaluates_previous_response_outcome_before_openviking_
         agents={
             "session_context_enabled": True,
             "commit_token_threshold": 1,
-            "commit_keep_recent_count": 0,
+            "commit_keep_recent_turn_count": 0,
         },
     )
     loop = AgentLoop(
@@ -1031,7 +1036,7 @@ async def test_agent_loop_commits_openviking_before_model_when_pending_tokens_re
             (
                 "hook",
                 kwargs["force_commit"],
-                kwargs.get("keep_recent_count"),
+                kwargs.get("keep_recent_turn_count"),
                 kwargs.get("commit_message_threshold"),
             )
         )
@@ -1078,7 +1083,7 @@ async def test_agent_loop_commits_openviking_before_model_when_pending_tokens_re
             "session_context_enabled": True,
             "session_context_token_budget": 321,
             "commit_token_threshold": 100,
-            "commit_keep_recent_count": 2,
+            "commit_keep_recent_turn_count": 2,
         },
     )
     loop = AgentLoop(
@@ -1137,7 +1142,7 @@ async def test_agent_loop_commits_openviking_before_model_when_memory_window_rea
             (
                 "hook",
                 kwargs["force_commit"],
-                kwargs.get("keep_recent_count"),
+                kwargs.get("keep_recent_turn_count"),
                 kwargs.get("commit_message_threshold"),
             )
         )
@@ -1182,7 +1187,7 @@ async def test_agent_loop_commits_openviking_before_model_when_memory_window_rea
             "session_context_enabled": True,
             "session_context_token_budget": 321,
             "commit_token_threshold": 1000,
-            "commit_keep_recent_count": 2,
+            "commit_keep_recent_turn_count": 2,
         },
     )
     loop = AgentLoop(
@@ -1249,7 +1254,7 @@ async def test_agent_loop_does_not_precommit_again_after_memory_window_commit(
         agents={
             "session_context_enabled": True,
             "commit_token_threshold": 1000,
-            "commit_keep_recent_count": 2,
+            "commit_keep_recent_turn_count": 2,
         },
     )
     loop = AgentLoop(

--- a/bot/tests/test_compile.py
+++ b/bot/tests/test_compile.py
@@ -2184,7 +2184,7 @@ def test_compile_prompt_describes_editable_target_checkout():
     assert "update existing files in place" in system
     assert "submit_wiki_bundle with no arguments" in system
     assert "complete UTF-8 OKF Markdown file" in system
-    assert "commits only validated changes" in system
+    assert "scans and validates the complete tree" in system
     assert "Inspect the editable target checkout" in user
 
 

--- a/bot/tests/test_openviking_api_key_type.py
+++ b/bot/tests/test_openviking_api_key_type.py
@@ -71,7 +71,13 @@ class _DummyHTTPClient:
     async def batch_add_messages(self, session_id, messages):
         return {"session_id": session_id, "added": len(messages), "message_count": len(messages)}
 
-    async def commit_session(self, session_id, keep_recent_count=0, telemetry=False):
+    async def commit_session(
+        self,
+        session_id,
+        keep_recent_count=0,
+        telemetry=False,
+        **_retention_kwargs,
+    ):
         return {
             "session_id": session_id,
             "status": "committed",
@@ -129,6 +135,7 @@ def _make_config(api_key_type: str, mode: str = "remote", **ov_overrides):
         "session_context_token_budget": 12000,
         "commit_token_threshold": 6000,
         "commit_keep_recent_count": 10,
+        "commit_keep_recent_turn_count": 3,
     }
     agent_overrides = {}
     for key in tuple(agent_defaults):
@@ -1195,7 +1202,7 @@ async def test_compact_hook_session_context_commits_single_session_with_peer_mes
             "root",
             session_context_enabled=True,
             commit_token_threshold=100,
-            commit_keep_recent_count=2,
+            commit_keep_recent_turn_count=2,
         ),
     )
 
@@ -1238,7 +1245,14 @@ async def test_compact_hook_session_context_commits_single_session_with_peer_mes
             user_id=None,
             **_retention_kwargs,
         ):
-            self.commit_calls.append((session_id, keep_recent_count, user_id))
+            self.commit_calls.append(
+                (
+                    session_id,
+                    _retention_kwargs.get("retention_mode"),
+                    _retention_kwargs.get("keep_recent_turn_count"),
+                    user_id,
+                )
+            )
             return {"session_id": session_id, "status": "accepted"}
 
     fake_client = _FakeClient()
@@ -1284,7 +1298,7 @@ async def test_compact_hook_session_context_commits_single_session_with_peer_mes
             "admin",
         )
     ]
-    assert fake_client.commit_calls == [(storage_session_id, 0, "admin")]
+    assert fake_client.commit_calls == [(storage_session_id, "turn_budget", 2, "admin")]
     assert {session_id for session_id, _user_id in fake_client.session_calls} == {
         storage_session_id
     }
@@ -1346,7 +1360,7 @@ async def test_compact_hook_force_commit_does_not_resync_already_synced_messages
             "root",
             session_context_enabled=True,
             commit_token_threshold=100,
-            commit_keep_recent_count=2,
+            commit_keep_recent_turn_count=2,
         ),
     )
 
@@ -1371,8 +1385,21 @@ async def test_compact_hook_force_commit_does_not_resync_already_synced_messages
         async def get_session(self, session_id, user_id=None):
             return {"session_id": session_id, "pending_tokens": 120}
 
-        async def commit_session(self, session_id, keep_recent_count=0, user_id=None):
-            self.commit_calls.append((session_id, keep_recent_count, user_id))
+        async def commit_session(
+            self,
+            session_id,
+            keep_recent_count=0,
+            user_id=None,
+            **_retention_kwargs,
+        ):
+            self.commit_calls.append(
+                (
+                    session_id,
+                    _retention_kwargs.get("retention_mode"),
+                    _retention_kwargs.get("keep_recent_turn_count"),
+                    user_id,
+                )
+            )
             return {"session_id": session_id, "status": "accepted"}
 
     fake_client = _FakeClient()
@@ -1406,7 +1433,7 @@ async def test_compact_hook_force_commit_does_not_resync_already_synced_messages
 
     assert result["success"] is True
     assert fake_client.append_calls == [("cli__default__chat-1", ["new reply"])]
-    assert fake_client.commit_calls == [("cli__default__chat-1", 2, "admin")]
+    assert fake_client.commit_calls == [("cli__default__chat-1", "turn_budget", 2, "admin")]
     assert session.metadata["openviking"]["last_synced_local_index"] == 1
     assert session.metadata["openviking"]["last_commit_local_index"] == 1
 
@@ -1424,7 +1451,7 @@ async def test_compact_hook_force_commit_commits_current_session_without_unsynce
             "root",
             session_context_enabled=True,
             commit_token_threshold=1000,
-            commit_keep_recent_count=2,
+            commit_keep_recent_turn_count=2,
         ),
     )
 
@@ -1449,8 +1476,21 @@ async def test_compact_hook_force_commit_commits_current_session_without_unsynce
         async def get_session(self, session_id, user_id=None):
             return {"session_id": session_id, "pending_tokens": 120}
 
-        async def commit_session(self, session_id, keep_recent_count=0, user_id=None):
-            self.commit_calls.append((session_id, keep_recent_count, user_id))
+        async def commit_session(
+            self,
+            session_id,
+            keep_recent_count=0,
+            user_id=None,
+            **_retention_kwargs,
+        ):
+            self.commit_calls.append(
+                (
+                    session_id,
+                    _retention_kwargs.get("retention_mode"),
+                    _retention_kwargs.get("keep_recent_turn_count"),
+                    user_id,
+                )
+            )
             return {"session_id": session_id, "status": "accepted"}
 
     fake_client = _FakeClient()
@@ -1484,7 +1524,7 @@ async def test_compact_hook_force_commit_commits_current_session_without_unsynce
 
     assert result["success"] is True
     assert fake_client.append_calls == []
-    assert fake_client.commit_calls == [("cli__default__chat-1", 2, "admin")]
+    assert fake_client.commit_calls == [("cli__default__chat-1", "turn_budget", 2, "admin")]
     assert session.metadata["openviking"]["last_commit_performed"] is True
 
 
@@ -1501,7 +1541,7 @@ async def test_compact_hook_session_context_append_failure_does_not_advance_sync
             "root",
             session_context_enabled=True,
             commit_token_threshold=100,
-            commit_keep_recent_count=2,
+            commit_keep_recent_turn_count=2,
         ),
     )
 
@@ -1528,8 +1568,21 @@ async def test_compact_hook_session_context_append_failure_does_not_advance_sync
         async def get_session(self, session_id, user_id=None):
             return {"session_id": session_id, "pending_tokens": 120}
 
-        async def commit_session(self, session_id, keep_recent_count=0, user_id=None):
-            self.commit_calls.append((session_id, keep_recent_count, user_id))
+        async def commit_session(
+            self,
+            session_id,
+            keep_recent_count=0,
+            user_id=None,
+            **_retention_kwargs,
+        ):
+            self.commit_calls.append(
+                (
+                    session_id,
+                    _retention_kwargs.get("retention_mode"),
+                    _retention_kwargs.get("keep_recent_turn_count"),
+                    user_id,
+                )
+            )
             return {"session_id": session_id, "status": "accepted"}
 
     fake_client = _FakeClient()
@@ -1581,7 +1634,7 @@ async def test_compact_hook_session_context_commits_when_message_threshold_reach
             "root",
             session_context_enabled=True,
             commit_token_threshold=1000,
-            commit_keep_recent_count=2,
+            commit_keep_recent_turn_count=2,
         ),
     )
 
@@ -1606,8 +1659,21 @@ async def test_compact_hook_session_context_commits_when_message_threshold_reach
         async def get_session(self, session_id, user_id=None):
             return {"session_id": session_id, "pending_tokens": 0}
 
-        async def commit_session(self, session_id, keep_recent_count=0, user_id=None):
-            self.commit_calls.append((session_id, keep_recent_count, user_id))
+        async def commit_session(
+            self,
+            session_id,
+            keep_recent_count=0,
+            user_id=None,
+            **_retention_kwargs,
+        ):
+            self.commit_calls.append(
+                (
+                    session_id,
+                    _retention_kwargs.get("retention_mode"),
+                    _retention_kwargs.get("keep_recent_turn_count"),
+                    user_id,
+                )
+            )
             return {"session_id": session_id, "status": "accepted"}
 
     fake_client = _FakeClient()
@@ -1644,7 +1710,7 @@ async def test_compact_hook_session_context_commits_when_message_threshold_reach
     assert result["success"] is True
     assert result["admin_result"]["committed"] is True
     assert fake_client.append_calls == [("cli__default__chat-1", ["m3"])]
-    assert fake_client.commit_calls == [("cli__default__chat-1", 2, "admin")]
+    assert fake_client.commit_calls == [("cli__default__chat-1", "turn_budget", 2, "admin")]
     assert session.metadata["openviking"]["last_commit_local_index"] == 2
 
 
@@ -1661,7 +1727,7 @@ async def test_compact_hook_session_commit_failure_retries_without_resyncing_mes
             "root",
             session_context_enabled=True,
             commit_token_threshold=100,
-            commit_keep_recent_count=2,
+            commit_keep_recent_turn_count=2,
         ),
     )
 
@@ -1687,8 +1753,21 @@ async def test_compact_hook_session_commit_failure_retries_without_resyncing_mes
         async def get_session(self, session_id, user_id=None):
             return {"session_id": session_id, "pending_tokens": 120}
 
-        async def commit_session(self, session_id, keep_recent_count=0, user_id=None):
-            self.commit_calls.append((session_id, keep_recent_count, user_id))
+        async def commit_session(
+            self,
+            session_id,
+            keep_recent_count=0,
+            user_id=None,
+            **_retention_kwargs,
+        ):
+            self.commit_calls.append(
+                (
+                    session_id,
+                    _retention_kwargs.get("retention_mode"),
+                    _retention_kwargs.get("keep_recent_turn_count"),
+                    user_id,
+                )
+            )
             if session_id == "cli__default__chat-1" and self.fail_session_commit:
                 raise RuntimeError("session commit failed")
             return {"session_id": session_id, "status": "accepted"}
@@ -1719,7 +1798,7 @@ async def test_compact_hook_session_commit_failure_retries_without_resyncing_mes
     assert first["success"] is False
     assert "session commit failed" in first["error"]
     assert fake_client.append_calls == [("cli__default__chat-1", ["u1 asks", "u1 reply"])]
-    assert fake_client.commit_calls == [("cli__default__chat-1", 2, "admin")]
+    assert fake_client.commit_calls == [("cli__default__chat-1", "turn_budget", 2, "admin")]
     state = session.metadata["openviking"]
     assert state["last_sync_status"] == "error"
     assert state["last_synced_local_index"] == 1
@@ -1733,7 +1812,7 @@ async def test_compact_hook_session_commit_failure_retries_without_resyncing_mes
 
     assert second["success"] is True
     assert fake_client.append_calls == []
-    assert fake_client.commit_calls == [("cli__default__chat-1", 2, "admin")]
+    assert fake_client.commit_calls == [("cli__default__chat-1", "turn_budget", 2, "admin")]
     assert session.metadata["openviking"]["last_commit_performed"] is True
 
 
@@ -1750,7 +1829,7 @@ async def test_compact_hook_session_context_skips_message_threshold_after_recent
             "root",
             session_context_enabled=True,
             commit_token_threshold=1000,
-            commit_keep_recent_count=2,
+            commit_keep_recent_turn_count=2,
         ),
     )
 
@@ -1775,8 +1854,21 @@ async def test_compact_hook_session_context_skips_message_threshold_after_recent
         async def get_session(self, session_id, user_id=None):
             return {"session_id": session_id, "pending_tokens": 0}
 
-        async def commit_session(self, session_id, keep_recent_count=0, user_id=None):
-            self.commit_calls.append((session_id, keep_recent_count, user_id))
+        async def commit_session(
+            self,
+            session_id,
+            keep_recent_count=0,
+            user_id=None,
+            **_retention_kwargs,
+        ):
+            self.commit_calls.append(
+                (
+                    session_id,
+                    _retention_kwargs.get("retention_mode"),
+                    _retention_kwargs.get("keep_recent_turn_count"),
+                    user_id,
+                )
+            )
             return {"session_id": session_id, "status": "accepted"}
 
     fake_client = _FakeClient()

--- a/bot/tests/test_session_portable_paths.py
+++ b/bot/tests/test_session_portable_paths.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import os
 import unicodedata
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -310,12 +311,15 @@ def test_sandbox_and_heartbeat_reuse_existing_legacy_workspace(tmp_path):
     assert sandbox_manager.to_workspace_id(key) == legacy_name
     assert sandbox_manager.get_workspace_path(key) == legacy_path
 
+    # Recent timestamps so the session never crosses the heartbeat staleness
+    # window (STALE_SESSION_THRESHOLD) no matter when the suite runs.
+    last_active = datetime.now(timezone.utc) - timedelta(minutes=5)
     session_manager = SimpleNamespace(
         list_sessions=lambda: [
             {
                 "key": key,
-                "created_at": "2026-08-20T00:00:00",
-                "updated_at": "2026-08-20T00:00:01",
+                "created_at": last_active.isoformat(),
+                "updated_at": last_active.isoformat(),
                 "metadata": {},
             }
         ]


### PR DESCRIPTION
## Summary

The VikingBot unit test suites (`bot/tests/` + `bot/vikingbot/`, 531 tests) are not executed by any workflow in the repo — no job sets `working-directory: bot` or invokes pytest on bot paths. As a result the suite drifted red silently: **12 of 531 tests were failing on current `main`** (verified on `f97ce530`), in some cases for weeks:

| Family | Count | Root cause | Since |
|---|---|---|---|
| compact-hook (`test_openviking_api_key_type.py`) | 4 | `commit_session` now sends turn-budget retention kwargs (`retention_mode="turn_budget"`, `keep_recent_turn_count`, …) from #3380; test fakes had strict signatures → `TypeError` → `success=False` | ~6 weeks |
| agent-loop outcome (`test_agent_loop_outcome.py`) | 3 | `token_usage` now includes `cache_read_input_tokens` (#4059); the pre-model hook kwarg was renamed `keep_recent_count` → `keep_recent_turn_count` | #4059 |
| compile prompt (`test_compile.py`) | 1 | checkout rule text changed from "commits only validated changes" to "scans and validates the complete tree" (#4059) | #4059 |
| legacy workspace (`test_session_portable_paths.py`) | 1 | hardcoded `2026-08-20` timestamps crossed the 2-day `STALE_SESSION_THRESHOLD` — a time-bomb test, failing since ~08-22 | #4162 |

All 12 are **test-side drift against intentional main behavior — no production code is changed by this PR**. Each was triaged against the introducing commit before updating the expectation.

### What the tests now pin (notable)

- The compact-hook tests previously recorded only the deprecated physical-message `keep_recent_count`. They now record the full retention contract: `(session_id, retention_mode, keep_recent_turn_count, user_id)`, with configs migrated to the active `commit_keep_recent_turn_count` field (`commit_keep_recent_count` remains in `AgentsConfig` as the documented deprecated field).
- The heartbeat test derives its timestamps relative to `now` so it can never cross the staleness window again, instead of rotting on a fixed date.

## CI lane

Adds a path-gated `bot-tests` job to `01. Pull Request Checks`:

- **Gate**: runs when `bot/**`, `pyproject.toml`, `uv.lock`, or the workflow itself change (same `check-deps` outputs pattern as `cuvs-tests` / `langchain-tests`).
- **Install**: `uv sync --frozen --extra bot` — the documented bot dependency set (`README` installs `openviking[bot]`); `vikingbot` is a packaged module of the main distribution (`[tool.setuptools.packages.find] where = [".", "bot"]`), so no `PYTHONPATH` tricks are needed.
- **Run**: `uv run python -m pytest -q -o addopts='' bot/tests bot/vikingbot` (coverage addopts disabled for this lane — the `--cov=openviking` default measures the wrong package for a bot run).

## Verification

- Clean checkout of `main` @ `f97ce530`: `519 passed, 12 failed`.
- With this branch: **`531 passed`** (`bot/tests` + `bot/vikingbot`, Python 3.12).
- `uv.lock` `provides-extras` includes `bot`; bot-only deps (`croniter`, `lark-oapi`, `gradio`, …) are present in the lockfile, so `uv sync --frozen --extra bot` resolves offline-pinned.
- Workflow YAML structure validated (job graph: `check-deps` → `bot-tests`, outputs wired).

This closes the fifth known CI blind-spot family for this suite (after openclaw vitest, dsh plugin tests, web-studio vitest, and the plugin-tests manifest).
