### PR TITLE
fix(memory-plugin): survive a detached worker that exits before draining its stdin

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -60,6 +60,7 @@ jobs:
             examples/zcode-memory-plugin/scripts/zcode-hooks.test.mjs \
             examples/zcode-memory-plugin/scripts/zcode-turns.test.mjs \
             examples/memory-plugin-shared/agent-hook-runtime.test.mjs \
+            examples/memory-plugin-shared/async-writer.test.mjs \
             examples/memory-plugin-shared/batch-send.test.mjs \
             examples/memory-plugin-shared/doctor-core.test.mjs \
             examples/memory-plugin-shared/install-agent-hooks.test.mjs \

--- a/examples/claude-code-memory-plugin/scripts/shared/async-writer.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/async-writer.mjs
@@ -48,6 +48,12 @@ export async function maybeDetach(cfg, { approve }) {
     process.env.OPENVIKING_HOOK_STDIN_CACHE = raw.toString();
     return false;
   }
+  // A worker that dies before draining its stdin turns the still-pending write
+  // below into an asynchronous EPIPE on this socket. The try/catch cannot see
+  // that — the failure arrives later, as an 'error' event, by which time
+  // approve() has already run — and an unhandled 'error' would take the whole
+  // hook down with a non-zero exit for a write path that is fire-and-forget.
+  child.stdin.on("error", () => { /* the worker is gone; nothing to recover */ });
 
   // Approve first, then write to the detached child. Ordering matters for
   // harnesses that read stdout before waiting for the hook process to exit.

--- a/examples/codex-memory-plugin/scripts/shared/async-writer.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/async-writer.mjs
@@ -48,6 +48,12 @@ export async function maybeDetach(cfg, { approve }) {
     process.env.OPENVIKING_HOOK_STDIN_CACHE = raw.toString();
     return false;
   }
+  // A worker that dies before draining its stdin turns the still-pending write
+  // below into an asynchronous EPIPE on this socket. The try/catch cannot see
+  // that — the failure arrives later, as an 'error' event, by which time
+  // approve() has already run — and an unhandled 'error' would take the whole
+  // hook down with a non-zero exit for a write path that is fire-and-forget.
+  child.stdin.on("error", () => { /* the worker is gone; nothing to recover */ });
 
   // Approve first, then write to the detached child. Ordering matters for
   // harnesses that read stdout before waiting for the hook process to exit.

--- a/examples/memory-plugin-shared/async-writer.test.mjs
+++ b/examples/memory-plugin-shared/async-writer.test.mjs
@@ -1,0 +1,96 @@
+/**
+ * The detached write path must survive a worker that never reads its payload.
+ *
+ * maybeDetach spawns the hook again with OV_HOOK_WORKER=1, approves the host's
+ * hook protocol, and only then forwards the drained stdin payload. When the
+ * worker dies before draining it, the pending write surfaces asynchronously as
+ * an EPIPE 'error' event on the socket — after approve() has already run. An
+ * unhandled 'error' there crashes the hook with a non-zero exit, turning a
+ * fire-and-forget write path into a host-visible hook failure.
+ */
+
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ASYNC_WRITER = join(HERE, "lib", "async-writer.mjs");
+
+function runDriver(driverPath, payload) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [driverPath], { stdio: ["pipe", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("close", (code, signal) => resolve({ code, signal, stdout, stderr }));
+    child.stdin.end(payload);
+  });
+}
+
+test("a worker that exits before draining its stdin does not crash the parent after approve", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "ov-async-writer-"));
+  // The worker exits without ever reading stdin, the way a real worker does
+  // when it is killed or crashes during startup.
+  const worker = join(dir, "die-without-reading.mjs");
+  await writeFile(worker, "process.exit(0);\n");
+  const driver = join(dir, "driver.mjs");
+  await writeFile(driver, [
+    `import { maybeDetach } from ${JSON.stringify(ASYNC_WRITER)};`,
+    `process.argv[1] = ${JSON.stringify(worker)};`,
+    "const detached = await maybeDetach({ writePathAsync: true }, { approve: () => console.log('APPROVED') });",
+    "if (!detached) throw new Error('expected the detach path to run');",
+    // Stay alive past the worker's exit so a stray unhandled 'error' still has
+    // time to surface and fail this test.
+    "setTimeout(() => console.log('SURVIVED'), 500);",
+    "",
+  ].join("\n"));
+
+  // 256 KiB exceeds the pipe buffer, so the forwarded write is still pending
+  // when the worker exits — the EPIPE is guaranteed, not timing-dependent.
+  const result = await runDriver(driver, "x".repeat(256 * 1024));
+
+  assert.equal(result.code, 0, `driver crashed (stderr: ${result.stderr})`);
+  assert.match(result.stdout, /APPROVED/);
+  assert.match(result.stdout, /SURVIVED/);
+  assert.ok(!result.stderr.includes("EPIPE"), `unhandled EPIPE leaked to stderr: ${result.stderr}`);
+});
+
+test("the worker payload round-trips when the worker reads its stdin", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "ov-async-writer-"));
+  // A worker that echoes its stdin back through a file proves the forwarded
+  // payload is intact when the write path is healthy.
+  const received = join(dir, "received.txt");
+  const worker = join(dir, "echo-worker.mjs");
+  await writeFile(worker, [
+    "import { writeFileSync } from 'node:fs';",
+    "const chunks = [];",
+    "for await (const chunk of process.stdin) chunks.push(chunk);",
+    `writeFileSync(${JSON.stringify(received)}, Buffer.concat(chunks));`,
+    "",
+  ].join("\n"));
+  const driver = join(dir, "driver.mjs");
+  await writeFile(driver, [
+    `import { maybeDetach } from ${JSON.stringify(ASYNC_WRITER)};`,
+    `process.argv[1] = ${JSON.stringify(worker)};`,
+    "const detached = await maybeDetach({ writePathAsync: true }, { approve: () => {} });",
+    "if (!detached) throw new Error('expected the detach path to run');",
+    "",
+  ].join("\n"));
+
+  const payload = `{"prompt":"${"y".repeat(96 * 1024)}"}`;
+  const result = await runDriver(driver, payload);
+  assert.equal(result.code, 0, `driver crashed (stderr: ${result.stderr})`);
+
+  // The detached worker needs a moment after the parent exits; poll briefly.
+  const { readFile } = await import("node:fs/promises");
+  let forwarded = "";
+  for (let i = 0; i < 40; i++) {
+    try { forwarded = await readFile(received, "utf8"); break; } catch { await new Promise((r) => setTimeout(r, 100)); }
+  }
+  assert.equal(forwarded, payload, "the worker did not receive the exact payload");
+});

--- a/examples/memory-plugin-shared/lib/async-writer.mjs
+++ b/examples/memory-plugin-shared/lib/async-writer.mjs
@@ -47,6 +47,12 @@ export async function maybeDetach(cfg, { approve }) {
     process.env.OPENVIKING_HOOK_STDIN_CACHE = raw.toString();
     return false;
   }
+  // A worker that dies before draining its stdin turns the still-pending write
+  // below into an asynchronous EPIPE on this socket. The try/catch cannot see
+  // that — the failure arrives later, as an 'error' event, by which time
+  // approve() has already run — and an unhandled 'error' would take the whole
+  // hook down with a non-zero exit for a write path that is fire-and-forget.
+  child.stdin.on("error", () => { /* the worker is gone; nothing to recover */ });
 
   // Approve first, then write to the detached child. Ordering matters for
   // harnesses that read stdout before waiting for the hook process to exit.

--- a/examples/zcode-memory-plugin/scripts/shared/async-writer.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/async-writer.mjs
@@ -48,6 +48,12 @@ export async function maybeDetach(cfg, { approve }) {
     process.env.OPENVIKING_HOOK_STDIN_CACHE = raw.toString();
     return false;
   }
+  // A worker that dies before draining its stdin turns the still-pending write
+  // below into an asynchronous EPIPE on this socket. The try/catch cannot see
+  // that — the failure arrives later, as an 'error' event, by which time
+  // approve() has already run — and an unhandled 'error' would take the whole
+  // hook down with a non-zero exit for a write path that is fire-and-forget.
+  child.stdin.on("error", () => { /* the worker is gone; nothing to recover */ });
 
   // Approve first, then write to the detached child. Ordering matters for
   // harnesses that read stdout before waiting for the hook process to exit.


### PR DESCRIPTION
## Summary

`maybeDetach` (the default `writePathAsync: true` write path for the hook-based memory plugins — Claude Code, Codex, ZCode) respawns the hook as a detached `OV_HOOK_WORKER`, emits the harness `approve()` output, and only then forwards the drained stdin payload to the worker. If that worker dies before draining the payload, the still-pending write surfaces later as an `EPIPE` `'error'` event on the worker's stdin socket, and nothing handles it.

## Root cause

`child.stdin.write(raw)` failing on a dead reader is delivered **asynchronously** as an EventEmitter `'error'`, not as a synchronous throw. The existing guard,

```js
try {
  child.stdin.write(raw);
  child.stdin.end();
} catch { /* worker may have already exited; nothing useful to recover */ }
```

only covers the synchronous failure mode, so the async EPIPE is unhandled. It also fires **after `approve()` has already run**, so the hook process — which by design has already answered the host — dies with a non-zero exit and a traceback:

```
node:events:497
      throw er; // Unhandled 'error' event
      ^
Error: write EPIPE
    at WriteWrap.onWriteComplete [as onWriteComplete] ...
Emitted 'error' event on Socket instance at:
  ...
```

Hosts that surface hook exit codes then report a hook failure for a write path that is explicitly fire-and-forget.

This is reachable with any payload larger than the pipe buffer whose worker exits during startup (killed, OOM, corrupted install) — the write is still pending when the read end closes.

## Fix

Attach an error handler to the worker's stdin socket so the EPIPE is absorbed, exactly matching the stance the synchronous catch already documents ("worker may have already exited; nothing useful to recover"):

```js
child.stdin.on("error", () => { /* the worker is gone; nothing to recover */ });
```

No behavior change on the healthy path. Vendored copies regenerated with `node examples/memory-plugin-shared/sync.mjs` (claude-code, codex, zcode).

## Test evidence

New `examples/memory-plugin-shared/async-writer.test.mjs` drives `maybeDetach` through a real subprocess:

1. **Crash regression test** — a worker script that `process.exit(0)`s without reading stdin, plus a 256 KiB payload (above the pipe buffer, so the forwarded write is guaranteed still pending when the worker exits — deterministic, not timing-dependent). Before this fix the driver dies to the unhandled EPIPE (exit 1, no `SURVIVED` marker); after it, `approve()` runs and the parent exits 0:
   - unfixed lib: `not ok 1 - a worker that exits before draining its stdin does not crash the parent after approve` (`Error: write EPIPE`)
   - fixed lib: `ok 1` / `ok 2`
2. **Healthy-path test** — a worker that echoes stdin to a file still receives the exact payload byte-for-byte.

Full suites on this branch: `examples/memory-plugin-shared` 182/182, `claude-code-memory-plugin` 35/35, `codex-memory-plugin` 122/122, `zcode-memory-plugin` 44/44. The new test file is added to the explicit list in `.github/workflows/pr.yml`.
