### PR TITLE
fix(observability): keep original SQLite error when auto-rollback empties the transaction

### DIFF
--- a/openviking/observability/usage_audit/sqlite_store.py
+++ b/openviking/observability/usage_audit/sqlite_store.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import sqlite3
 from datetime import date, datetime, time, timedelta, timezone, tzinfo
 from pathlib import Path
@@ -21,7 +22,33 @@ from openviking.observability.events import ObservabilityEvent
 from .projection import UsageAuditProjection, project_events, safe_int
 from .schema import RESET_ON_SCHEMA_UPGRADE_TABLES, SCHEMA_VERSION, SQLITE_SCHEMA
 
+logger = logging.getLogger(__name__)
+
 UTC = timezone.utc
+
+
+def _rollback_safely(conn: sqlite3.Connection, *, context: str) -> None:
+    """Roll back the active transaction without masking the original error.
+
+    SQLite auto-rolls-back a transaction after certain fatal errors (e.g.
+    SQLITE_FULL / SQLITE_IOERR). By the time the ``except`` block runs there
+    is no transaction left, so a bare ``conn.execute("ROLLBACK")`` raises
+    ``OperationalError: cannot rollback - no transaction is active`` and
+    replaces the underlying failure with a misleading secondary error.
+    Skip the rollback when nothing is active and never let rollback failures
+    shadow the exception being handled.
+    """
+    if not conn.in_transaction:
+        logger.debug(
+            "Usage/Audit %s: transaction already auto-rolled-back by SQLite; "
+            "skipping explicit ROLLBACK",
+            context,
+        )
+        return
+    try:
+        conn.execute("ROLLBACK")
+    except sqlite3.Error as exc:
+        logger.warning("Usage/Audit %s: ROLLBACK failed: %s", context, exc)
 
 
 def _date_range(start_date: str, end_date: str) -> Iterable[str]:
@@ -123,7 +150,7 @@ class SQLiteUsageAuditStore:
                     conn.execute(f"ALTER TABLE request_audit ADD COLUMN {name} TEXT")
             conn.execute("COMMIT")
         except Exception:
-            conn.execute("ROLLBACK")
+            _rollback_safely(conn, context="v4->v5 migration")
             raise
 
     async def close(self) -> None:
@@ -158,7 +185,7 @@ class SQLiteUsageAuditStore:
             }
             self._conn.execute("COMMIT")
         except Exception:
-            self._conn.execute("ROLLBACK")
+            _rollback_safely(self._conn, context="delete_user_data")
             raise
         return deleted
 
@@ -183,7 +210,7 @@ class SQLiteUsageAuditStore:
             self._trim_audit_rows(conn, projection.touched_audit_accounts)
             conn.execute("COMMIT")
         except Exception:
-            conn.execute("ROLLBACK")
+            _rollback_safely(conn, context="record_batch")
             raise
 
     @staticmethod

--- a/openviking/observability/usage_audit/worker.py
+++ b/openviking/observability/usage_audit/worker.py
@@ -116,10 +116,14 @@ class UsageAuditWorker:
         try:
             await self._store.record_batch(batch)
         except Exception as exc:  # noqa: BLE001
+            # Always include the traceback: flush failures are rare and usually
+            # indicate storage-level faults whose root cause must survive in
+            # the logs for post-mortems (a bare message loses the origin).
             logger.warning(
-                "Usage/Audit batch flush failed: %s",
+                "Usage/Audit batch flush failed (%d events): %s",
+                len(batch),
                 exc,
-                exc_info=logger.isEnabledFor(logging.DEBUG),
+                exc_info=True,
             )
 
     async def flush(self) -> None:

--- a/tests/observability/test_usage_audit_rollback_resilience.py
+++ b/tests/observability/test_usage_audit_rollback_resilience.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co. Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Rollback-resilience tests for the Usage/Audit SQLite store.
+
+SQLite auto-rolls-back a transaction after certain fatal errors (SQLITE_FULL,
+SQLITE_IOERR). The store's error paths used to issue a bare
+``conn.execute("ROLLBACK")`` which then raised
+``OperationalError: cannot rollback - no transaction is active`` and replaced
+the underlying storage failure with a misleading secondary error (seen in
+production as issue #4303). These tests pin the fixed behaviour: the original
+exception must survive, and a still-active transaction must still be rolled
+back.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from openviking.observability.usage_audit.projection import UsageAuditProjection
+from openviking.observability.usage_audit.sqlite_store import SQLiteUsageAuditStore
+
+
+def _make_store(tmp_path: Path) -> SQLiteUsageAuditStore:
+    store = SQLiteUsageAuditStore(tmp_path / "usage_audit.sqlite3")
+    asyncio.run(store.initialize())
+    return store
+
+
+def _projection_with_token_row() -> UsageAuditProjection:
+    projection = UsageAuditProjection()
+    projection.token_rows[
+        ("acct-1", "user-1", "2026-05-12", 1, "vlm", "input", "prov", "model")
+    ] = 5
+    return projection
+
+
+class _AutoRollbackInsertFailure:
+    """Simulate a fatal SQLite write error that auto-rolled-back the txn."""
+
+    def __init__(self, *, auto_rollback: bool) -> None:
+        self.auto_rollback = auto_rollback
+
+    def __call__(self, conn, rows, updated_at):  # signature of _write_token_rows
+        if self.auto_rollback:
+            conn.execute("ROLLBACK")
+        raise sqlite3.OperationalError("disk I/O error")
+
+
+def test_record_batch_preserves_original_error_when_sqlite_auto_rolled_back(
+    tmp_path, monkeypatch
+):
+    store = _make_store(tmp_path)
+    monkeypatch.setattr(
+        SQLiteUsageAuditStore,
+        "_write_token_rows",
+        staticmethod(_AutoRollbackInsertFailure(auto_rollback=True)),
+    )
+
+    with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+        store._record_projection_sync(_projection_with_token_row())
+
+
+def test_record_batch_still_rolls_back_active_transaction(tmp_path, monkeypatch):
+    store = _make_store(tmp_path)
+    conn = store._conn
+    assert conn is not None
+    monkeypatch.setattr(
+        SQLiteUsageAuditStore,
+        "_write_token_rows",
+        staticmethod(_AutoRollbackInsertFailure(auto_rollback=False)),
+    )
+
+    with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+        store._record_projection_sync(_projection_with_token_row())
+
+    assert conn.in_transaction is False
+
+
+def test_record_batch_recovers_after_transient_failure(tmp_path, monkeypatch):
+    store = _make_store(tmp_path)
+    monkeypatch.setattr(
+        SQLiteUsageAuditStore,
+        "_write_token_rows",
+        staticmethod(_AutoRollbackInsertFailure(auto_rollback=True)),
+    )
+
+    with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+        store._record_projection_sync(_projection_with_token_row())
+
+    # A later batch must succeed on the same connection once the transient
+    # storage fault is gone — the failed path must not wedge the store.
+    monkeypatch.undo()
+    store._record_projection_sync(_projection_with_token_row())
+
+
+class _DeleteFailingConn:
+    """Connection proxy whose first DELETE simulates an auto-rollback fault."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        self._failed = False
+
+    def execute(self, sql, *args):
+        if not self._failed and sql.lstrip().upper().startswith("DELETE"):
+            self._failed = True
+            self._conn.execute("ROLLBACK")
+            raise sqlite3.OperationalError("disk I/O error")
+        return self._conn.execute(sql, *args)
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+
+def test_delete_user_data_preserves_original_error_when_sqlite_auto_rolled_back(tmp_path):
+    store = _make_store(tmp_path)
+    conn = store._conn
+    assert conn is not None
+    store._conn = _DeleteFailingConn(conn)  # type: ignore[assignment]
+
+    with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+        store._delete_user_data_sync("acct-1", "user-1")
+
+    assert conn.in_transaction is False


### PR DESCRIPTION
## Problem

Production incident in #4303: the whole async worker pool went silent for 47 minutes (460 pending jobs untouched, `in_progress` frozen, `/health` still 200) after a storage disruption during a model-swap rollout. The only diagnostic in the server logs was:

```
cannot rollback - no transaction is active
```

That message is not the root cause — it is this repository's own error path **masking** the root cause.

## Root cause chain (code-level)

`SQLiteUsageAuditStore` wraps every write batch in an explicit transaction:

```python
conn.execute("BEGIN")
try:
    ...
    conn.execute("COMMIT")
except Exception:
    conn.execute("ROLLBACK")   # <-- here
    raise
```

SQLite **auto-rolls-back** the active transaction after fatal errors (`SQLITE_FULL`, `SQLITE_IOERR`, …). When that happens on a PVC/network-backed volume (the reporter's environment: K8s/Talos + Ceph RBD), by the time the `except` block runs there is no transaction left, so `conn.execute("ROLLBACK")")` itself raises `sqlite3.OperationalError: cannot rollback - no transaction is active` — which **replaces** the real storage error (`disk I/O error`, etc.) via the standard exception-replacement rule. Three call sites were affected:

- `_record_projection_sync` (the batch flush path — the one that fired in #4303)
- `_delete_user_data_sync`
- `_migrate_v4_to_v5_sync`

Additionally, the audit worker logged flush failures with `exc_info=logger.isEnabledFor(logging.DEBUG)`, so at production log levels even the surviving message had **no traceback** — contributing to the "silent" post-mortem.

## Fix

- New `_rollback_safely(conn, context=...)` helper: skips the explicit `ROLLBACK` when `conn.in_transaction` is already `False` (SQLite already rolled back), and converts a failing `ROLLBACK` into a warning instead of letting it shadow the exception being handled. Applied to all three sites.
- `UsageAuditWorker._flush` now always logs the traceback for flush failures.

The store's asyncio lock is released and the worker loop keeps running in both cases, so after this fix a transient storage fault leaves behind the **original** error in the logs and the next batch succeeds on the same connection.

## Testing

New `tests/observability/test_usage_audit_rollback_resilience.py` (conftest-free):

- auto-rollback fault during a batch → the raised exception is the original `disk I/O error`, not `cannot rollback`
- fault without auto-rollback → the still-active transaction **is** rolled back (`in_transaction` False afterwards)
- transient fault → a later batch succeeds on the same connection (no wedged store)
- same guarantee for the `delete_user_data` path

All 4 tests fail on `main` (they surface `cannot rollback - no transaction is active`) and pass with this change; existing suites (`test_usage_audit_store.py`, `test_usage_audit_worker.py`, `test_usage_audit_runtime.py`) stay green (13 passed).

## Relation to #4303

This fixes the **diagnostic-masking** half of the incident: the reporter only ever saw the rollback error, never the underlying storage fault. The other halves are tracked in the cross-referenced chain: worker-liveness detection (#3542), manual recovery while wedged (#4627), orphaned-row hardening (#3989 / #4621), and the Python-side in-progress bookkeeping leak (#4745). A runtime (non-mount-time-only) stale sweep for QueueFS remains the open gap.

Closes #4303 (diagnostic half).
