### PR TITLE
fix(memory-plugin): treat blank numeric env vars as unset and guard max_chars against NaN

### DIFF
--- a/examples/claude-code-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/recall-core.mjs
@@ -73,10 +73,15 @@ function codingQuotas(limit) {
 
 export function buildRecallEndpointBody(cfg = {}) {
   const limit = Math.max(Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT), 1);
+  // A non-numeric value must not leak NaN into the request: Math.max(NaN, 1000)
+  // stays NaN and JSON.stringify({ max_chars: NaN }) ships `"max_chars":null`.
+  // Fall back to 0 so the 1000-character floor restores the default budget.
+  const contentChars = Number(cfg.recallMaxContentChars || 0);
+  const maxChars = Number.isFinite(contentChars) ? contentChars : 0;
   const body = {
     query: "",
     quotas: legacyMemoryQuotas(limit),
-    max_chars: Math.max(Number(cfg.recallMaxContentChars || 0) * limit, 1000),
+    max_chars: Math.max(maxChars * limit, 1000),
     min_score: Number.isFinite(Number(cfg.scoreThreshold)) ? Number(cfg.scoreThreshold) : 0.35,
     render: true,
   };

--- a/examples/codex-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/recall-core.mjs
@@ -73,10 +73,15 @@ function codingQuotas(limit) {
 
 export function buildRecallEndpointBody(cfg = {}) {
   const limit = Math.max(Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT), 1);
+  // A non-numeric value must not leak NaN into the request: Math.max(NaN, 1000)
+  // stays NaN and JSON.stringify({ max_chars: NaN }) ships `"max_chars":null`.
+  // Fall back to 0 so the 1000-character floor restores the default budget.
+  const contentChars = Number(cfg.recallMaxContentChars || 0);
+  const maxChars = Number.isFinite(contentChars) ? contentChars : 0;
   const body = {
     query: "",
     quotas: legacyMemoryQuotas(limit),
-    max_chars: Math.max(Number(cfg.recallMaxContentChars || 0) * limit, 1000),
+    max_chars: Math.max(maxChars * limit, 1000),
     min_score: Number.isFinite(Number(cfg.scoreThreshold)) ? Number(cfg.scoreThreshold) : 0.35,
     render: true,
   };

--- a/examples/dsh-memory-plugin/shared/recall-core.mjs
+++ b/examples/dsh-memory-plugin/shared/recall-core.mjs
@@ -73,10 +73,15 @@ function codingQuotas(limit) {
 
 export function buildRecallEndpointBody(cfg = {}) {
   const limit = Math.max(Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT), 1);
+  // A non-numeric value must not leak NaN into the request: Math.max(NaN, 1000)
+  // stays NaN and JSON.stringify({ max_chars: NaN }) ships `"max_chars":null`.
+  // Fall back to 0 so the 1000-character floor restores the default budget.
+  const contentChars = Number(cfg.recallMaxContentChars || 0);
+  const maxChars = Number.isFinite(contentChars) ? contentChars : 0;
   const body = {
     query: "",
     quotas: legacyMemoryQuotas(limit),
-    max_chars: Math.max(Number(cfg.recallMaxContentChars || 0) * limit, 1000),
+    max_chars: Math.max(maxChars * limit, 1000),
     min_score: Number.isFinite(Number(cfg.scoreThreshold)) ? Number(cfg.scoreThreshold) : 0.35,
     render: true,
   };

--- a/examples/memory-plugin-shared/agent-hook-runtime.test.mjs
+++ b/examples/memory-plugin-shared/agent-hook-runtime.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   commitAgentSession,
+  loadAgentHookConfig,
   makeAgentFetchJSON,
 } from "./lib/agent-hook-runtime.mjs";
 
@@ -77,4 +78,50 @@ test("agent fetch and commit logging preserve response trace_id", async (t) => {
       error: "commit failed",
     },
   });
+});
+
+test("blank numeric env vars fall back to defaults instead of clamping to the minimum", () => {
+  // Shell rc files commonly export these as empty strings (`export OPENVIKING_TIMEOUT_MS=`).
+  // envBool already treats a blank value as unset; envNumber must agree, otherwise
+  // Number("") === 0 silently clamps every knob to its floor (recall limit 10 -> 1,
+  // timeout 15s -> 1s) with no warning.
+  const names = [
+    "OPENVIKING_RECALL_LIMIT",
+    "OPENVIKING_RECALL_TOKEN_BUDGET",
+    "OPENVIKING_RECALL_MAX_CONTENT_CHARS",
+    "OPENVIKING_SCORE_THRESHOLD",
+    "OPENVIKING_TIMEOUT_MS",
+    "OPENVIKING_PROFILE_TOKEN_BUDGET",
+    "OPENVIKING_COMMIT_TURN_THRESHOLD",
+  ];
+  const saved = Object.fromEntries(names.map((name) => [name, process.env[name]]));
+  for (const name of names) process.env[name] = "";
+  try {
+    const cfg = loadAgentHookConfig("test-client");
+    assert.equal(cfg.recallLimit, 10);
+    assert.equal(cfg.recallTokenBudget, 2000);
+    assert.equal(cfg.recallMaxContentChars, 500);
+    assert.equal(cfg.scoreThreshold, 0.35);
+    assert.equal(cfg.timeoutMs, 15000);
+    assert.equal(cfg.profileTokenBudget, 6000);
+    assert.equal(cfg.commitTurnThreshold, 8);
+    assert.equal(cfg.recallLimitConfigured, false);
+  } finally {
+    for (const [name, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
+});
+
+test("whitespace-only numeric env vars fall back to defaults too", () => {
+  const saved = process.env.OPENVIKING_TIMEOUT_MS;
+  process.env.OPENVIKING_TIMEOUT_MS = "   ";
+  try {
+    const cfg = loadAgentHookConfig("test-client");
+    assert.equal(cfg.timeoutMs, 15000);
+  } finally {
+    if (saved === undefined) delete process.env.OPENVIKING_TIMEOUT_MS;
+    else process.env.OPENVIKING_TIMEOUT_MS = saved;
+  }
 });

--- a/examples/memory-plugin-shared/lib/agent-hook-runtime.mjs
+++ b/examples/memory-plugin-shared/lib/agent-hook-runtime.mjs
@@ -24,7 +24,12 @@ function envBool(name, fallback) {
 }
 
 function envNumber(name, fallback, minimum = 0) {
-  const value = Number(process.env[name]);
+  const raw = process.env[name];
+  // A blank export (`export OPENVIKING_TIMEOUT_MS=` in a shell rc) means unset,
+  // same as envBool — otherwise Number("") === 0 would clamp the knob to its
+  // floor (timeout 15s -> 1s, recall limit 10 -> 1) without any warning.
+  if (raw == null || raw.trim() === "") return fallback;
+  const value = Number(raw);
   return Number.isFinite(value) ? Math.max(minimum, value) : fallback;
 }
 

--- a/examples/memory-plugin-shared/lib/recall-core.mjs
+++ b/examples/memory-plugin-shared/lib/recall-core.mjs
@@ -72,10 +72,15 @@ function codingQuotas(limit) {
 
 export function buildRecallEndpointBody(cfg = {}) {
   const limit = Math.max(Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT), 1);
+  // A non-numeric value must not leak NaN into the request: Math.max(NaN, 1000)
+  // stays NaN and JSON.stringify({ max_chars: NaN }) ships `"max_chars":null`.
+  // Fall back to 0 so the 1000-character floor restores the default budget.
+  const contentChars = Number(cfg.recallMaxContentChars || 0);
+  const maxChars = Number.isFinite(contentChars) ? contentChars : 0;
   const body = {
     query: "",
     quotas: legacyMemoryQuotas(limit),
-    max_chars: Math.max(Number(cfg.recallMaxContentChars || 0) * limit, 1000),
+    max_chars: Math.max(maxChars * limit, 1000),
     min_score: Number.isFinite(Number(cfg.scoreThreshold)) ? Number(cfg.scoreThreshold) : 0.35,
     render: true,
   };

--- a/examples/memory-plugin-shared/recall-core.test.mjs
+++ b/examples/memory-plugin-shared/recall-core.test.mjs
@@ -408,3 +408,16 @@ test("a legacy id equal to the effective one is not asked twice", async () => {
 
   assert.deepEqual(asked, ["same"]);
 });
+
+test("non-numeric max content chars config never emits a NaN max_chars budget", () => {
+  // cfg values reach buildRecallEndpointBody from several loaders; a string like
+  // "500 chars" makes Number() return NaN, Math.max(NaN, 1000) stays NaN, and
+  // JSON.stringify({ max_chars: NaN }) silently ships `"max_chars":null`.
+  const body = buildRecallEndpointBody({
+    recallLimit: 10,
+    recallMaxContentChars: "500 chars",
+  });
+  assert.ok(Number.isFinite(body.max_chars), `max_chars must be finite, got ${body.max_chars}`);
+  assert.ok(body.max_chars >= 1000, `max_chars must keep its floor, got ${body.max_chars}`);
+  assert.doesNotMatch(JSON.stringify(body), /"max_chars":null/);
+});

--- a/examples/openclaw-plugin/shared/recall-core.mjs
+++ b/examples/openclaw-plugin/shared/recall-core.mjs
@@ -73,10 +73,15 @@ function codingQuotas(limit) {
 
 export function buildRecallEndpointBody(cfg = {}) {
   const limit = Math.max(Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT), 1);
+  // A non-numeric value must not leak NaN into the request: Math.max(NaN, 1000)
+  // stays NaN and JSON.stringify({ max_chars: NaN }) ships `"max_chars":null`.
+  // Fall back to 0 so the 1000-character floor restores the default budget.
+  const contentChars = Number(cfg.recallMaxContentChars || 0);
+  const maxChars = Number.isFinite(contentChars) ? contentChars : 0;
   const body = {
     query: "",
     quotas: legacyMemoryQuotas(limit),
-    max_chars: Math.max(Number(cfg.recallMaxContentChars || 0) * limit, 1000),
+    max_chars: Math.max(maxChars * limit, 1000),
     min_score: Number.isFinite(Number(cfg.scoreThreshold)) ? Number(cfg.scoreThreshold) : 0.35,
     render: true,
   };

--- a/examples/opencode-plugin/lib/shared/recall-core.mjs
+++ b/examples/opencode-plugin/lib/shared/recall-core.mjs
@@ -73,10 +73,15 @@ function codingQuotas(limit) {
 
 export function buildRecallEndpointBody(cfg = {}) {
   const limit = Math.max(Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT), 1);
+  // A non-numeric value must not leak NaN into the request: Math.max(NaN, 1000)
+  // stays NaN and JSON.stringify({ max_chars: NaN }) ships `"max_chars":null`.
+  // Fall back to 0 so the 1000-character floor restores the default budget.
+  const contentChars = Number(cfg.recallMaxContentChars || 0);
+  const maxChars = Number.isFinite(contentChars) ? contentChars : 0;
   const body = {
     query: "",
     quotas: legacyMemoryQuotas(limit),
-    max_chars: Math.max(Number(cfg.recallMaxContentChars || 0) * limit, 1000),
+    max_chars: Math.max(maxChars * limit, 1000),
     min_score: Number.isFinite(Number(cfg.scoreThreshold)) ? Number(cfg.scoreThreshold) : 0.35,
     render: true,
   };

--- a/examples/pi-coding-agent-extension/shared/recall-core.mjs
+++ b/examples/pi-coding-agent-extension/shared/recall-core.mjs
@@ -73,10 +73,15 @@ function codingQuotas(limit) {
 
 export function buildRecallEndpointBody(cfg = {}) {
   const limit = Math.max(Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT), 1);
+  // A non-numeric value must not leak NaN into the request: Math.max(NaN, 1000)
+  // stays NaN and JSON.stringify({ max_chars: NaN }) ships `"max_chars":null`.
+  // Fall back to 0 so the 1000-character floor restores the default budget.
+  const contentChars = Number(cfg.recallMaxContentChars || 0);
+  const maxChars = Number.isFinite(contentChars) ? contentChars : 0;
   const body = {
     query: "",
     quotas: legacyMemoryQuotas(limit),
-    max_chars: Math.max(Number(cfg.recallMaxContentChars || 0) * limit, 1000),
+    max_chars: Math.max(maxChars * limit, 1000),
     min_score: Number.isFinite(Number(cfg.scoreThreshold)) ? Number(cfg.scoreThreshold) : 0.35,
     render: true,
   };

--- a/examples/zcode-memory-plugin/scripts/shared/agent-hook-runtime.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/agent-hook-runtime.mjs
@@ -25,7 +25,12 @@ function envBool(name, fallback) {
 }
 
 function envNumber(name, fallback, minimum = 0) {
-  const value = Number(process.env[name]);
+  const raw = process.env[name];
+  // A blank export (`export OPENVIKING_TIMEOUT_MS=` in a shell rc) means unset,
+  // same as envBool — otherwise Number("") === 0 would clamp the knob to its
+  // floor (timeout 15s -> 1s, recall limit 10 -> 1) without any warning.
+  if (raw == null || raw.trim() === "") return fallback;
+  const value = Number(raw);
   return Number.isFinite(value) ? Math.max(minimum, value) : fallback;
 }
 

--- a/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
@@ -73,10 +73,15 @@ function codingQuotas(limit) {
 
 export function buildRecallEndpointBody(cfg = {}) {
   const limit = Math.max(Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT), 1);
+  // A non-numeric value must not leak NaN into the request: Math.max(NaN, 1000)
+  // stays NaN and JSON.stringify({ max_chars: NaN }) ships `"max_chars":null`.
+  // Fall back to 0 so the 1000-character floor restores the default budget.
+  const contentChars = Number(cfg.recallMaxContentChars || 0);
+  const maxChars = Number.isFinite(contentChars) ? contentChars : 0;
   const body = {
     query: "",
     quotas: legacyMemoryQuotas(limit),
-    max_chars: Math.max(Number(cfg.recallMaxContentChars || 0) * limit, 1000),
+    max_chars: Math.max(maxChars * limit, 1000),
     min_score: Number.isFinite(Number(cfg.scoreThreshold)) ? Number(cfg.scoreThreshold) : 0.35,
     render: true,
   };


### PR DESCRIPTION
## Summary

Two small config-parsing fixes in `examples/memory-plugin-shared` that share one theme: values arriving from env/config are trusted more than they should be, and the failure is silent.

### 1. Blank numeric env vars were parsed as 0

`envNumber` in `lib/agent-hook-runtime.mjs` ran `Number(process.env[name])` before checking whether the variable was set at all. A blank export — a very common shell-rc leftover, e.g. `export OPENVIKING_TIMEOUT_MS=` — became `Number("") === 0`, which is finite, so every numeric knob was silently clamped to its floor:

| knob | default | blank env value |
|---|---|---|
| `OPENVIKING_RECALL_LIMIT` | 10 | 1 (recall near-empty) |
| `OPENVIKING_TIMEOUT_MS` | 15000 | 1000 (hook times out on slow networks) |
| `OPENVIKING_PROFILE_TOKEN_BUDGET` | 6000 | 500 |
| `OPENVIKING_RECALL_TOKEN_BUDGET` | 2000 | 200 |
| `OPENVIKING_COMMIT_TURN_THRESHOLD` | 8 | 1 |

`envBool` in the same file already treats `""` as unset; `envNumber` now agrees: `null`, `""`, or whitespace-only values fall back to the default instead of coercing to 0. (The codex plugin's own `num()` helper in `scripts/config.mjs` already had this exact guard, so this also removes an inconsistency between the two loaders.)

### 2. `buildRecallEndpointBody` could emit `max_chars: null`

In `lib/recall-core.mjs`, `Number(cfg.recallMaxContentChars)` was fed straight into `Math.max(...)`. A non-numeric string (e.g. `"500 chars"` from a hand-edited config) yields `NaN`, `Math.max(NaN, 1000)` stays `NaN`, and `JSON.stringify` silently ships `"max_chars": null` to the server. A non-finite value now falls back so the existing 1000-character floor restores the default budget.

## Testing

- New red-green tests in `agent-hook-runtime.test.mjs` (blank and whitespace-only env vars fall back to all seven numeric defaults) and `recall-core.test.mjs` (`max_chars` stays finite, keeps its floor, and the serialized body never contains `"max_chars":null`). Both failed on `main` and pass with the fixes.
- Full suite: `node --test examples/memory-plugin-shared/*.test.mjs` — 183/183 pass (includes `sync.test.mjs` verifying the vendored copies).
- Ran `node examples/memory-plugin-shared/sync.mjs` to propagate the two `lib/` changes to the vendored plugin copies.
