### PR TITLE
test(codex-plugin): remove startup race in auto-recall compressor test

### DIFF
--- a/examples/codex-memory-plugin/scripts/auto-recall.test.mjs
+++ b/examples/codex-memory-plugin/scripts/auto-recall.test.mjs
@@ -192,7 +192,13 @@ async function runEndpointCompressionCase({
           OPENVIKING_CLI_CONFIG_FILE: join(stateDir, "missing-ovcli.conf"),
           OPENVIKING_CREDENTIAL_SOURCE: "env",
           OPENVIKING_RECALL_COMPRESS: "1",
-          OPENVIKING_RECALL_TIMEOUT_MS: "10000",
+          // With recallTimeoutMs=10000 the compressor child inherits only
+          // max(1000, recallTimeoutMs - 10000) = 1000ms, which a fresh
+          // `node` cold start intermittently exceeds (seen in CI as
+          // compress_timeout → SIGKILL → empty args log). Give the fake
+          // codex subprocess a budget that cannot race with process startup.
+          OPENVIKING_RECALL_TIMEOUT_MS: "60000",
+          OPENVIKING_RECALL_COMPRESS_TIMEOUT_MS: "30000",
           OPENVIKING_MIN_QUERY_LENGTH: "1",
           OPENVIKING_SCORE_THRESHOLD: "0",
           OPENVIKING_TIMEOUT_MS: "5000",


### PR DESCRIPTION
## Problem

`auto-recall passes the configured compressor base URL to Codex` (and the other endpoint-compression cases in `examples/codex-memory-plugin/scripts/auto-recall.test.mjs`) flakes on CI: the assertions on `compressorArgs` see an empty args log because the fake codex subprocess never got to write it.

## Root cause

The shared `runEndpointCompressionCase` helper sets `OPENVIKING_RECALL_TIMEOUT_MS=10000`. In `config.mjs` the compressor child then inherits:

```js
defaultRecallCompressTimeoutMs = Math.max(1000, recallTimeoutMs - 10000)  // = 1000ms
```

so `runCodexCompressor` gives the fake codex — a real `node` process launched through a `#!/usr/bin/env node` shebang — a hard 1000ms budget before SIGKILL. On a loaded CI runner the cold start of a fresh node process intermittently exceeds 1000ms: the child is killed before it appends its args log (`compress_timeout "timed out after 1000ms"` shows up in the hook's debug log), auto-recall falls back to the deterministic digest, and the base_url assertions fail.

This is a test-side timing assumption, not a product bug — the product's graceful degradation on compressor timeout works as designed.

## Fix

Set explicit budgets in the test helper so the timing cannot race process startup:

- `OPENVIKING_RECALL_TIMEOUT_MS: 60000`
- `OPENVIKING_RECALL_COMPRESS_TIMEOUT_MS: 30000`

The behaviour under test (base_url propagation into `codex exec` args) is unchanged.

## Evidence

| Scenario | Before | After |
|---|---|---|
| Standalone loop, no load | 1/51 runs failed (real cold-start flake; debug log shows `compress_timeout` at 1000ms) | 0/30 |
| Deterministic 1200ms injected cold-start delay | 3/3 failed | 3/3 passed |
| `node --test auto-recall.test.mjs` loop | — | 10/10 passed |
| Full codex-memory-plugin suite (CI file list) | — | 122/122 passed |

Addresses the flake seen in a red run of #4365 (job 100754097084); unrelated to the marker race fixed by #4668.
