### PR TITLE
fix(memory-plugin): stop misclassifying unrelated 422s as unknown-field schema drift

### DIFF
--- a/examples/claude-code-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/recall-core.mjs
@@ -442,9 +442,48 @@ export async function markPeerScopeDowngrade(scope, status, path = peerScopeMemo
   });
 }
 
-function looksLikeUnknownField(res) {
-  const text = JSON.stringify(res?.error ?? res?.result ?? res?.detail ?? "").toLowerCase();
-  return text.includes("extra") || text.includes("mode") || text.includes("unexpected");
+// The phrases a schema rejection actually comes in: FastAPI/Pydantic v2
+// (extra_forbidden, "Extra inputs are not permitted"), Pydantic v1
+// ("extra fields not permitted", value_error.extra), and the plain-Python
+// or older-server wordings ("Extra inputs: mode", "unexpected keyword
+// argument", "unknown field").
+const UNKNOWN_FIELD_ERROR_PATTERNS = [
+  /extra_forbidden/i,
+  /extra inputs are not permitted/i,
+  /extra fields not permitted/i,
+  /value_error\.extra/i,
+  /extra inputs?\s*[:=]/i,
+  /unexpected keyword arguments?/i,
+  /(?:unknown|unrecognized|unexpected) (?:input|field|parameter)s?/i,
+];
+// Where those same messages carry the offending field name: inline after the
+// phrase, or as the last segment of a FastAPI detail's loc array.
+const NAMED_FIELD_PATTERNS = [
+  /extra inputs?\s*[:=]\s*['"`]?([a-z_][a-z0-9_]*)/i,
+  /unexpected keyword arguments?\s*['"`]?\s*([a-z_][a-z0-9_]*)/i,
+  /(?:unknown|unrecognized|unexpected) (?:input|field|parameter)s?\s*[:'"`]?\s*([a-z_][a-z0-9_]*)/i,
+  /"loc"\s*:\s*\[[^\]]*"([a-z_][a-z0-9_]*)"\s*\]/,
+];
+
+/**
+ * Whether a 400/422 means "this server predates a field we sent". Deciding
+ * this from bare substrings ("extra", "mode", "unexpected") let any error
+ * that merely contained one of those words — a value rejection of a field we
+ * did send ("invalid mode parameter", a FastAPI literal_error whose loc names
+ * the field), or a generic "unexpected server error" — pin a six-hour legacy
+ * downgrade and silently degrade recall. So the message must read like a
+ * schema rejection, and when it names the offending field, that name must be
+ * one the caller actually sent.
+ */
+function looksLikeUnknownField(res, sentKeys = []) {
+  const text = String(JSON.stringify(res?.error ?? res?.result ?? res?.detail ?? ""));
+  if (!UNKNOWN_FIELD_ERROR_PATTERNS.some((pattern) => pattern.test(text))) return false;
+  const keys = new Set(sentKeys.filter(Boolean));
+  const named = NAMED_FIELD_PATTERNS
+    .map((pattern) => text.match(pattern)?.[1])
+    .filter(Boolean);
+  if (!named.length) return true;
+  return named.some((name) => keys.has(name));
 }
 
 function wrapContext(body) {
@@ -490,7 +529,7 @@ export async function fetchAssembledContext(fetchJSON, cfg, query, options = {})
 
   if (!res.ok) {
     const status = res.status || 0;
-    if ((status === 400 || status === 422) && looksLikeUnknownField(res)) {
+    if ((status === 400 || status === 422) && looksLikeUnknownField(res, Object.keys(body))) {
       await markContextFaceLegacy(options.legacyCachePath);
       log("recall_context_face_unsupported", { status });
     } else {
@@ -602,7 +641,7 @@ export async function postRecall(fetchJSON, body, opts = {}) {
   // Only an unknown-field rejection means "this server predates peer_scope".
   // Retrying every other 400/422 without it silently widens the search from
   // the caller's own peer to the whole user root.
-  if (!looksLikeUnknownField(res)) {
+  if (!looksLikeUnknownField(res, Object.keys(request))) {
     log("recall_peer_scope_error", { status: res.status || 0 });
     return res;
   }

--- a/examples/codex-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/recall-core.mjs
@@ -442,9 +442,48 @@ export async function markPeerScopeDowngrade(scope, status, path = peerScopeMemo
   });
 }
 
-function looksLikeUnknownField(res) {
-  const text = JSON.stringify(res?.error ?? res?.result ?? res?.detail ?? "").toLowerCase();
-  return text.includes("extra") || text.includes("mode") || text.includes("unexpected");
+// The phrases a schema rejection actually comes in: FastAPI/Pydantic v2
+// (extra_forbidden, "Extra inputs are not permitted"), Pydantic v1
+// ("extra fields not permitted", value_error.extra), and the plain-Python
+// or older-server wordings ("Extra inputs: mode", "unexpected keyword
+// argument", "unknown field").
+const UNKNOWN_FIELD_ERROR_PATTERNS = [
+  /extra_forbidden/i,
+  /extra inputs are not permitted/i,
+  /extra fields not permitted/i,
+  /value_error\.extra/i,
+  /extra inputs?\s*[:=]/i,
+  /unexpected keyword arguments?/i,
+  /(?:unknown|unrecognized|unexpected) (?:input|field|parameter)s?/i,
+];
+// Where those same messages carry the offending field name: inline after the
+// phrase, or as the last segment of a FastAPI detail's loc array.
+const NAMED_FIELD_PATTERNS = [
+  /extra inputs?\s*[:=]\s*['"`]?([a-z_][a-z0-9_]*)/i,
+  /unexpected keyword arguments?\s*['"`]?\s*([a-z_][a-z0-9_]*)/i,
+  /(?:unknown|unrecognized|unexpected) (?:input|field|parameter)s?\s*[:'"`]?\s*([a-z_][a-z0-9_]*)/i,
+  /"loc"\s*:\s*\[[^\]]*"([a-z_][a-z0-9_]*)"\s*\]/,
+];
+
+/**
+ * Whether a 400/422 means "this server predates a field we sent". Deciding
+ * this from bare substrings ("extra", "mode", "unexpected") let any error
+ * that merely contained one of those words — a value rejection of a field we
+ * did send ("invalid mode parameter", a FastAPI literal_error whose loc names
+ * the field), or a generic "unexpected server error" — pin a six-hour legacy
+ * downgrade and silently degrade recall. So the message must read like a
+ * schema rejection, and when it names the offending field, that name must be
+ * one the caller actually sent.
+ */
+function looksLikeUnknownField(res, sentKeys = []) {
+  const text = String(JSON.stringify(res?.error ?? res?.result ?? res?.detail ?? ""));
+  if (!UNKNOWN_FIELD_ERROR_PATTERNS.some((pattern) => pattern.test(text))) return false;
+  const keys = new Set(sentKeys.filter(Boolean));
+  const named = NAMED_FIELD_PATTERNS
+    .map((pattern) => text.match(pattern)?.[1])
+    .filter(Boolean);
+  if (!named.length) return true;
+  return named.some((name) => keys.has(name));
 }
 
 function wrapContext(body) {
@@ -490,7 +529,7 @@ export async function fetchAssembledContext(fetchJSON, cfg, query, options = {})
 
   if (!res.ok) {
     const status = res.status || 0;
-    if ((status === 400 || status === 422) && looksLikeUnknownField(res)) {
+    if ((status === 400 || status === 422) && looksLikeUnknownField(res, Object.keys(body))) {
       await markContextFaceLegacy(options.legacyCachePath);
       log("recall_context_face_unsupported", { status });
     } else {
@@ -602,7 +641,7 @@ export async function postRecall(fetchJSON, body, opts = {}) {
   // Only an unknown-field rejection means "this server predates peer_scope".
   // Retrying every other 400/422 without it silently widens the search from
   // the caller's own peer to the whole user root.
-  if (!looksLikeUnknownField(res)) {
+  if (!looksLikeUnknownField(res, Object.keys(request))) {
     log("recall_peer_scope_error", { status: res.status || 0 });
     return res;
   }

--- a/examples/dsh-memory-plugin/shared/recall-core.mjs
+++ b/examples/dsh-memory-plugin/shared/recall-core.mjs
@@ -442,9 +442,48 @@ export async function markPeerScopeDowngrade(scope, status, path = peerScopeMemo
   });
 }
 
-function looksLikeUnknownField(res) {
-  const text = JSON.stringify(res?.error ?? res?.result ?? res?.detail ?? "").toLowerCase();
-  return text.includes("extra") || text.includes("mode") || text.includes("unexpected");
+// The phrases a schema rejection actually comes in: FastAPI/Pydantic v2
+// (extra_forbidden, "Extra inputs are not permitted"), Pydantic v1
+// ("extra fields not permitted", value_error.extra), and the plain-Python
+// or older-server wordings ("Extra inputs: mode", "unexpected keyword
+// argument", "unknown field").
+const UNKNOWN_FIELD_ERROR_PATTERNS = [
+  /extra_forbidden/i,
+  /extra inputs are not permitted/i,
+  /extra fields not permitted/i,
+  /value_error\.extra/i,
+  /extra inputs?\s*[:=]/i,
+  /unexpected keyword arguments?/i,
+  /(?:unknown|unrecognized|unexpected) (?:input|field|parameter)s?/i,
+];
+// Where those same messages carry the offending field name: inline after the
+// phrase, or as the last segment of a FastAPI detail's loc array.
+const NAMED_FIELD_PATTERNS = [
+  /extra inputs?\s*[:=]\s*['"`]?([a-z_][a-z0-9_]*)/i,
+  /unexpected keyword arguments?\s*['"`]?\s*([a-z_][a-z0-9_]*)/i,
+  /(?:unknown|unrecognized|unexpected) (?:input|field|parameter)s?\s*[:'"`]?\s*([a-z_][a-z0-9_]*)/i,
+  /"loc"\s*:\s*\[[^\]]*"([a-z_][a-z0-9_]*)"\s*\]/,
+];
+
+/**
+ * Whether a 400/422 means "this server predates a field we sent". Deciding
+ * this from bare substrings ("extra", "mode", "unexpected") let any error
+ * that merely contained one of those words — a value rejection of a field we
+ * did send ("invalid mode parameter", a FastAPI literal_error whose loc names
+ * the field), or a generic "unexpected server error" — pin a six-hour legacy
+ * downgrade and silently degrade recall. So the message must read like a
+ * schema rejection, and when it names the offending field, that name must be
+ * one the caller actually sent.
+ */
+function looksLikeUnknownField(res, sentKeys = []) {
+  const text = String(JSON.stringify(res?.error ?? res?.result ?? res?.detail ?? ""));
+  if (!UNKNOWN_FIELD_ERROR_PATTERNS.some((pattern) => pattern.test(text))) return false;
+  const keys = new Set(sentKeys.filter(Boolean));
+  const named = NAMED_FIELD_PATTERNS
+    .map((pattern) => text.match(pattern)?.[1])
+    .filter(Boolean);
+  if (!named.length) return true;
+  return named.some((name) => keys.has(name));
 }
 
 function wrapContext(body) {
@@ -490,7 +529,7 @@ export async function fetchAssembledContext(fetchJSON, cfg, query, options = {})
 
   if (!res.ok) {
     const status = res.status || 0;
-    if ((status === 400 || status === 422) && looksLikeUnknownField(res)) {
+    if ((status === 400 || status === 422) && looksLikeUnknownField(res, Object.keys(body))) {
       await markContextFaceLegacy(options.legacyCachePath);
       log("recall_context_face_unsupported", { status });
     } else {
@@ -602,7 +641,7 @@ export async function postRecall(fetchJSON, body, opts = {}) {
   // Only an unknown-field rejection means "this server predates peer_scope".
   // Retrying every other 400/422 without it silently widens the search from
   // the caller's own peer to the whole user root.
-  if (!looksLikeUnknownField(res)) {
+  if (!looksLikeUnknownField(res, Object.keys(request))) {
     log("recall_peer_scope_error", { status: res.status || 0 });
     return res;
   }

--- a/examples/memory-plugin-shared/lib/recall-core.mjs
+++ b/examples/memory-plugin-shared/lib/recall-core.mjs
@@ -441,9 +441,48 @@ export async function markPeerScopeDowngrade(scope, status, path = peerScopeMemo
   });
 }
 
-function looksLikeUnknownField(res) {
-  const text = JSON.stringify(res?.error ?? res?.result ?? res?.detail ?? "").toLowerCase();
-  return text.includes("extra") || text.includes("mode") || text.includes("unexpected");
+// The phrases a schema rejection actually comes in: FastAPI/Pydantic v2
+// (extra_forbidden, "Extra inputs are not permitted"), Pydantic v1
+// ("extra fields not permitted", value_error.extra), and the plain-Python
+// or older-server wordings ("Extra inputs: mode", "unexpected keyword
+// argument", "unknown field").
+const UNKNOWN_FIELD_ERROR_PATTERNS = [
+  /extra_forbidden/i,
+  /extra inputs are not permitted/i,
+  /extra fields not permitted/i,
+  /value_error\.extra/i,
+  /extra inputs?\s*[:=]/i,
+  /unexpected keyword arguments?/i,
+  /(?:unknown|unrecognized|unexpected) (?:input|field|parameter)s?/i,
+];
+// Where those same messages carry the offending field name: inline after the
+// phrase, or as the last segment of a FastAPI detail's loc array.
+const NAMED_FIELD_PATTERNS = [
+  /extra inputs?\s*[:=]\s*['"`]?([a-z_][a-z0-9_]*)/i,
+  /unexpected keyword arguments?\s*['"`]?\s*([a-z_][a-z0-9_]*)/i,
+  /(?:unknown|unrecognized|unexpected) (?:input|field|parameter)s?\s*[:'"`]?\s*([a-z_][a-z0-9_]*)/i,
+  /"loc"\s*:\s*\[[^\]]*"([a-z_][a-z0-9_]*)"\s*\]/,
+];
+
+/**
+ * Whether a 400/422 means "this server predates a field we sent". Deciding
+ * this from bare substrings ("extra", "mode", "unexpected") let any error
+ * that merely contained one of those words — a value rejection of a field we
+ * did send ("invalid mode parameter", a FastAPI literal_error whose loc names
+ * the field), or a generic "unexpected server error" — pin a six-hour legacy
+ * downgrade and silently degrade recall. So the message must read like a
+ * schema rejection, and when it names the offending field, that name must be
+ * one the caller actually sent.
+ */
+function looksLikeUnknownField(res, sentKeys = []) {
+  const text = String(JSON.stringify(res?.error ?? res?.result ?? res?.detail ?? ""));
+  if (!UNKNOWN_FIELD_ERROR_PATTERNS.some((pattern) => pattern.test(text))) return false;
+  const keys = new Set(sentKeys.filter(Boolean));
+  const named = NAMED_FIELD_PATTERNS
+    .map((pattern) => text.match(pattern)?.[1])
+    .filter(Boolean);
+  if (!named.length) return true;
+  return named.some((name) => keys.has(name));
 }
 
 function wrapContext(body) {
@@ -489,7 +528,7 @@ export async function fetchAssembledContext(fetchJSON, cfg, query, options = {})
 
   if (!res.ok) {
     const status = res.status || 0;
-    if ((status === 400 || status === 422) && looksLikeUnknownField(res)) {
+    if ((status === 400 || status === 422) && looksLikeUnknownField(res, Object.keys(body))) {
       await markContextFaceLegacy(options.legacyCachePath);
       log("recall_context_face_unsupported", { status });
     } else {
@@ -601,7 +640,7 @@ export async function postRecall(fetchJSON, body, opts = {}) {
   // Only an unknown-field rejection means "this server predates peer_scope".
   // Retrying every other 400/422 without it silently widens the search from
   // the caller's own peer to the whole user root.
-  if (!looksLikeUnknownField(res)) {
+  if (!looksLikeUnknownField(res, Object.keys(request))) {
     log("recall_peer_scope_error", { status: res.status || 0 });
     return res;
   }

--- a/examples/memory-plugin-shared/recall-core.test.mjs
+++ b/examples/memory-plugin-shared/recall-core.test.mjs
@@ -244,6 +244,70 @@ test("unrelated request errors do not mark the server as legacy", async () => {
   assert.equal(await isContextFaceLegacy(legacyCachePath), false);
 });
 
+test("a value rejection of a sent field does not mark the context face as legacy", async () => {
+  // FastAPI validates a field we DID send (its name appears in loc) and
+  // rejects the value: schema drift is not the diagnosis, so pinning a 6h
+  // legacy downgrade would silently degrade recall to the /recall preset.
+  const legacyCachePath = await tempPath("context-face.json");
+  const fetchJSON = async (path) => {
+    if (path === "/api/v1/search/search") {
+      return {
+        ok: false,
+        status: 422,
+        detail: [{
+          type: "literal_error",
+          loc: ["body", "mode"],
+          msg: "Input should be 'context' or 'list'",
+        }],
+      };
+    }
+    if (path === "/api/v1/search/recall") return { ok: true, result: { rendered: "ok" } };
+    return { ok: false, status: 404 };
+  };
+
+  await buildRecallBlock(fetchJSON, {}, "hello", { legacyCachePath });
+
+  assert.equal(await isContextFaceLegacy(legacyCachePath), false);
+});
+
+test("an 'invalid mode parameter' message does not mark the context face as legacy", async () => {
+  const legacyCachePath = await tempPath("context-face.json");
+  const fetchJSON = async (path) => {
+    if (path === "/api/v1/search/search") {
+      return { ok: false, status: 400, error: { message: "invalid mode parameter: expected 'context'" } };
+    }
+    if (path === "/api/v1/search/recall") return { ok: true, result: { rendered: "ok" } };
+    return { ok: false, status: 404 };
+  };
+
+  await buildRecallBlock(fetchJSON, {}, "hello", { legacyCachePath });
+
+  assert.equal(await isContextFaceLegacy(legacyCachePath), false);
+});
+
+test("a Pydantic v2 extra_forbidden on a sent field still marks the server as legacy", async () => {
+  const legacyCachePath = await tempPath("context-face.json");
+  const fetchJSON = async (path) => {
+    if (path === "/api/v1/search/search") {
+      return {
+        ok: false,
+        status: 422,
+        detail: [{
+          type: "extra_forbidden",
+          loc: ["body", "purpose"],
+          msg: "Extra inputs are not permitted",
+        }],
+      };
+    }
+    if (path === "/api/v1/search/recall") return { ok: true, result: { rendered: "ok" } };
+    return { ok: false, status: 404 };
+  };
+
+  await buildRecallBlock(fetchJSON, {}, "hello", { legacyCachePath });
+
+  assert.equal(await isContextFaceLegacy(legacyCachePath), true);
+});
+
 test("buildRecallBlock falls back to find when neither context endpoint works", async () => {
   const calls = [];
   const legacyCachePath = await tempPath("context-face.json");
@@ -325,6 +389,19 @@ test("postRecall keeps peer_scope when a 400 is about something else", async () 
 
   assert.equal(res.ok, false);
   assert.equal(sent.length, 1, "an unrelated 400 must not be retried at a wider scope");
+  assert.equal(await readPeerScopeDowngrade(memoPath), null);
+});
+
+test("postRecall keeps peer_scope when the 422 is a generic unexpected error", async () => {
+  const memoPath = await tempPath("peer-scope.json");
+  const { sent, fetchJSON } = recordingFetch([
+    { ok: false, status: 422, error: "unexpected server error" },
+  ]);
+
+  const res = await postRecall(fetchJSON, { query: "q", peer_scope: "actor" }, { peerScopeMemoPath: memoPath });
+
+  assert.equal(res.ok, false);
+  assert.equal(sent.length, 1, "a generic error must not be retried at a wider scope");
   assert.equal(await readPeerScopeDowngrade(memoPath), null);
 });
 

--- a/examples/openclaw-plugin/shared/recall-core.mjs
+++ b/examples/openclaw-plugin/shared/recall-core.mjs
@@ -442,9 +442,48 @@ export async function markPeerScopeDowngrade(scope, status, path = peerScopeMemo
   });
 }
 
-function looksLikeUnknownField(res) {
-  const text = JSON.stringify(res?.error ?? res?.result ?? res?.detail ?? "").toLowerCase();
-  return text.includes("extra") || text.includes("mode") || text.includes("unexpected");
+// The phrases a schema rejection actually comes in: FastAPI/Pydantic v2
+// (extra_forbidden, "Extra inputs are not permitted"), Pydantic v1
+// ("extra fields not permitted", value_error.extra), and the plain-Python
+// or older-server wordings ("Extra inputs: mode", "unexpected keyword
+// argument", "unknown field").
+const UNKNOWN_FIELD_ERROR_PATTERNS = [
+  /extra_forbidden/i,
+  /extra inputs are not permitted/i,
+  /extra fields not permitted/i,
+  /value_error\.extra/i,
+  /extra inputs?\s*[:=]/i,
+  /unexpected keyword arguments?/i,
+  /(?:unknown|unrecognized|unexpected) (?:input|field|parameter)s?/i,
+];
+// Where those same messages carry the offending field name: inline after the
+// phrase, or as the last segment of a FastAPI detail's loc array.
+const NAMED_FIELD_PATTERNS = [
+  /extra inputs?\s*[:=]\s*['"`]?([a-z_][a-z0-9_]*)/i,
+  /unexpected keyword arguments?\s*['"`]?\s*([a-z_][a-z0-9_]*)/i,
+  /(?:unknown|unrecognized|unexpected) (?:input|field|parameter)s?\s*[:'"`]?\s*([a-z_][a-z0-9_]*)/i,
+  /"loc"\s*:\s*\[[^\]]*"([a-z_][a-z0-9_]*)"\s*\]/,
+];
+
+/**
+ * Whether a 400/422 means "this server predates a field we sent". Deciding
+ * this from bare substrings ("extra", "mode", "unexpected") let any error
+ * that merely contained one of those words — a value rejection of a field we
+ * did send ("invalid mode parameter", a FastAPI literal_error whose loc names
+ * the field), or a generic "unexpected server error" — pin a six-hour legacy
+ * downgrade and silently degrade recall. So the message must read like a
+ * schema rejection, and when it names the offending field, that name must be
+ * one the caller actually sent.
+ */
+function looksLikeUnknownField(res, sentKeys = []) {
+  const text = String(JSON.stringify(res?.error ?? res?.result ?? res?.detail ?? ""));
+  if (!UNKNOWN_FIELD_ERROR_PATTERNS.some((pattern) => pattern.test(text))) return false;
+  const keys = new Set(sentKeys.filter(Boolean));
+  const named = NAMED_FIELD_PATTERNS
+    .map((pattern) => text.match(pattern)?.[1])
+    .filter(Boolean);
+  if (!named.length) return true;
+  return named.some((name) => keys.has(name));
 }
 
 function wrapContext(body) {
@@ -490,7 +529,7 @@ export async function fetchAssembledContext(fetchJSON, cfg, query, options = {})
 
   if (!res.ok) {
     const status = res.status || 0;
-    if ((status === 400 || status === 422) && looksLikeUnknownField(res)) {
+    if ((status === 400 || status === 422) && looksLikeUnknownField(res, Object.keys(body))) {
       await markContextFaceLegacy(options.legacyCachePath);
       log("recall_context_face_unsupported", { status });
     } else {
@@ -602,7 +641,7 @@ export async function postRecall(fetchJSON, body, opts = {}) {
   // Only an unknown-field rejection means "this server predates peer_scope".
   // Retrying every other 400/422 without it silently widens the search from
   // the caller's own peer to the whole user root.
-  if (!looksLikeUnknownField(res)) {
+  if (!looksLikeUnknownField(res, Object.keys(request))) {
     log("recall_peer_scope_error", { status: res.status || 0 });
     return res;
   }

--- a/examples/opencode-plugin/lib/shared/recall-core.mjs
+++ b/examples/opencode-plugin/lib/shared/recall-core.mjs
@@ -442,9 +442,48 @@ export async function markPeerScopeDowngrade(scope, status, path = peerScopeMemo
   });
 }
 
-function looksLikeUnknownField(res) {
-  const text = JSON.stringify(res?.error ?? res?.result ?? res?.detail ?? "").toLowerCase();
-  return text.includes("extra") || text.includes("mode") || text.includes("unexpected");
+// The phrases a schema rejection actually comes in: FastAPI/Pydantic v2
+// (extra_forbidden, "Extra inputs are not permitted"), Pydantic v1
+// ("extra fields not permitted", value_error.extra), and the plain-Python
+// or older-server wordings ("Extra inputs: mode", "unexpected keyword
+// argument", "unknown field").
+const UNKNOWN_FIELD_ERROR_PATTERNS = [
+  /extra_forbidden/i,
+  /extra inputs are not permitted/i,
+  /extra fields not permitted/i,
+  /value_error\.extra/i,
+  /extra inputs?\s*[:=]/i,
+  /unexpected keyword arguments?/i,
+  /(?:unknown|unrecognized|unexpected) (?:input|field|parameter)s?/i,
+];
+// Where those same messages carry the offending field name: inline after the
+// phrase, or as the last segment of a FastAPI detail's loc array.
+const NAMED_FIELD_PATTERNS = [
+  /extra inputs?\s*[:=]\s*['"`]?([a-z_][a-z0-9_]*)/i,
+  /unexpected keyword arguments?\s*['"`]?\s*([a-z_][a-z0-9_]*)/i,
+  /(?:unknown|unrecognized|unexpected) (?:input|field|parameter)s?\s*[:'"`]?\s*([a-z_][a-z0-9_]*)/i,
+  /"loc"\s*:\s*\[[^\]]*"([a-z_][a-z0-9_]*)"\s*\]/,
+];
+
+/**
+ * Whether a 400/422 means "this server predates a field we sent". Deciding
+ * this from bare substrings ("extra", "mode", "unexpected") let any error
+ * that merely contained one of those words — a value rejection of a field we
+ * did send ("invalid mode parameter", a FastAPI literal_error whose loc names
+ * the field), or a generic "unexpected server error" — pin a six-hour legacy
+ * downgrade and silently degrade recall. So the message must read like a
+ * schema rejection, and when it names the offending field, that name must be
+ * one the caller actually sent.
+ */
+function looksLikeUnknownField(res, sentKeys = []) {
+  const text = String(JSON.stringify(res?.error ?? res?.result ?? res?.detail ?? ""));
+  if (!UNKNOWN_FIELD_ERROR_PATTERNS.some((pattern) => pattern.test(text))) return false;
+  const keys = new Set(sentKeys.filter(Boolean));
+  const named = NAMED_FIELD_PATTERNS
+    .map((pattern) => text.match(pattern)?.[1])
+    .filter(Boolean);
+  if (!named.length) return true;
+  return named.some((name) => keys.has(name));
 }
 
 function wrapContext(body) {
@@ -490,7 +529,7 @@ export async function fetchAssembledContext(fetchJSON, cfg, query, options = {})
 
   if (!res.ok) {
     const status = res.status || 0;
-    if ((status === 400 || status === 422) && looksLikeUnknownField(res)) {
+    if ((status === 400 || status === 422) && looksLikeUnknownField(res, Object.keys(body))) {
       await markContextFaceLegacy(options.legacyCachePath);
       log("recall_context_face_unsupported", { status });
     } else {
@@ -602,7 +641,7 @@ export async function postRecall(fetchJSON, body, opts = {}) {
   // Only an unknown-field rejection means "this server predates peer_scope".
   // Retrying every other 400/422 without it silently widens the search from
   // the caller's own peer to the whole user root.
-  if (!looksLikeUnknownField(res)) {
+  if (!looksLikeUnknownField(res, Object.keys(request))) {
     log("recall_peer_scope_error", { status: res.status || 0 });
     return res;
   }

--- a/examples/pi-coding-agent-extension/shared/recall-core.mjs
+++ b/examples/pi-coding-agent-extension/shared/recall-core.mjs
@@ -442,9 +442,48 @@ export async function markPeerScopeDowngrade(scope, status, path = peerScopeMemo
   });
 }
 
-function looksLikeUnknownField(res) {
-  const text = JSON.stringify(res?.error ?? res?.result ?? res?.detail ?? "").toLowerCase();
-  return text.includes("extra") || text.includes("mode") || text.includes("unexpected");
+// The phrases a schema rejection actually comes in: FastAPI/Pydantic v2
+// (extra_forbidden, "Extra inputs are not permitted"), Pydantic v1
+// ("extra fields not permitted", value_error.extra), and the plain-Python
+// or older-server wordings ("Extra inputs: mode", "unexpected keyword
+// argument", "unknown field").
+const UNKNOWN_FIELD_ERROR_PATTERNS = [
+  /extra_forbidden/i,
+  /extra inputs are not permitted/i,
+  /extra fields not permitted/i,
+  /value_error\.extra/i,
+  /extra inputs?\s*[:=]/i,
+  /unexpected keyword arguments?/i,
+  /(?:unknown|unrecognized|unexpected) (?:input|field|parameter)s?/i,
+];
+// Where those same messages carry the offending field name: inline after the
+// phrase, or as the last segment of a FastAPI detail's loc array.
+const NAMED_FIELD_PATTERNS = [
+  /extra inputs?\s*[:=]\s*['"`]?([a-z_][a-z0-9_]*)/i,
+  /unexpected keyword arguments?\s*['"`]?\s*([a-z_][a-z0-9_]*)/i,
+  /(?:unknown|unrecognized|unexpected) (?:input|field|parameter)s?\s*[:'"`]?\s*([a-z_][a-z0-9_]*)/i,
+  /"loc"\s*:\s*\[[^\]]*"([a-z_][a-z0-9_]*)"\s*\]/,
+];
+
+/**
+ * Whether a 400/422 means "this server predates a field we sent". Deciding
+ * this from bare substrings ("extra", "mode", "unexpected") let any error
+ * that merely contained one of those words — a value rejection of a field we
+ * did send ("invalid mode parameter", a FastAPI literal_error whose loc names
+ * the field), or a generic "unexpected server error" — pin a six-hour legacy
+ * downgrade and silently degrade recall. So the message must read like a
+ * schema rejection, and when it names the offending field, that name must be
+ * one the caller actually sent.
+ */
+function looksLikeUnknownField(res, sentKeys = []) {
+  const text = String(JSON.stringify(res?.error ?? res?.result ?? res?.detail ?? ""));
+  if (!UNKNOWN_FIELD_ERROR_PATTERNS.some((pattern) => pattern.test(text))) return false;
+  const keys = new Set(sentKeys.filter(Boolean));
+  const named = NAMED_FIELD_PATTERNS
+    .map((pattern) => text.match(pattern)?.[1])
+    .filter(Boolean);
+  if (!named.length) return true;
+  return named.some((name) => keys.has(name));
 }
 
 function wrapContext(body) {
@@ -490,7 +529,7 @@ export async function fetchAssembledContext(fetchJSON, cfg, query, options = {})
 
   if (!res.ok) {
     const status = res.status || 0;
-    if ((status === 400 || status === 422) && looksLikeUnknownField(res)) {
+    if ((status === 400 || status === 422) && looksLikeUnknownField(res, Object.keys(body))) {
       await markContextFaceLegacy(options.legacyCachePath);
       log("recall_context_face_unsupported", { status });
     } else {
@@ -602,7 +641,7 @@ export async function postRecall(fetchJSON, body, opts = {}) {
   // Only an unknown-field rejection means "this server predates peer_scope".
   // Retrying every other 400/422 without it silently widens the search from
   // the caller's own peer to the whole user root.
-  if (!looksLikeUnknownField(res)) {
+  if (!looksLikeUnknownField(res, Object.keys(request))) {
     log("recall_peer_scope_error", { status: res.status || 0 });
     return res;
   }

--- a/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
@@ -442,9 +442,48 @@ export async function markPeerScopeDowngrade(scope, status, path = peerScopeMemo
   });
 }
 
-function looksLikeUnknownField(res) {
-  const text = JSON.stringify(res?.error ?? res?.result ?? res?.detail ?? "").toLowerCase();
-  return text.includes("extra") || text.includes("mode") || text.includes("unexpected");
+// The phrases a schema rejection actually comes in: FastAPI/Pydantic v2
+// (extra_forbidden, "Extra inputs are not permitted"), Pydantic v1
+// ("extra fields not permitted", value_error.extra), and the plain-Python
+// or older-server wordings ("Extra inputs: mode", "unexpected keyword
+// argument", "unknown field").
+const UNKNOWN_FIELD_ERROR_PATTERNS = [
+  /extra_forbidden/i,
+  /extra inputs are not permitted/i,
+  /extra fields not permitted/i,
+  /value_error\.extra/i,
+  /extra inputs?\s*[:=]/i,
+  /unexpected keyword arguments?/i,
+  /(?:unknown|unrecognized|unexpected) (?:input|field|parameter)s?/i,
+];
+// Where those same messages carry the offending field name: inline after the
+// phrase, or as the last segment of a FastAPI detail's loc array.
+const NAMED_FIELD_PATTERNS = [
+  /extra inputs?\s*[:=]\s*['"`]?([a-z_][a-z0-9_]*)/i,
+  /unexpected keyword arguments?\s*['"`]?\s*([a-z_][a-z0-9_]*)/i,
+  /(?:unknown|unrecognized|unexpected) (?:input|field|parameter)s?\s*[:'"`]?\s*([a-z_][a-z0-9_]*)/i,
+  /"loc"\s*:\s*\[[^\]]*"([a-z_][a-z0-9_]*)"\s*\]/,
+];
+
+/**
+ * Whether a 400/422 means "this server predates a field we sent". Deciding
+ * this from bare substrings ("extra", "mode", "unexpected") let any error
+ * that merely contained one of those words — a value rejection of a field we
+ * did send ("invalid mode parameter", a FastAPI literal_error whose loc names
+ * the field), or a generic "unexpected server error" — pin a six-hour legacy
+ * downgrade and silently degrade recall. So the message must read like a
+ * schema rejection, and when it names the offending field, that name must be
+ * one the caller actually sent.
+ */
+function looksLikeUnknownField(res, sentKeys = []) {
+  const text = String(JSON.stringify(res?.error ?? res?.result ?? res?.detail ?? ""));
+  if (!UNKNOWN_FIELD_ERROR_PATTERNS.some((pattern) => pattern.test(text))) return false;
+  const keys = new Set(sentKeys.filter(Boolean));
+  const named = NAMED_FIELD_PATTERNS
+    .map((pattern) => text.match(pattern)?.[1])
+    .filter(Boolean);
+  if (!named.length) return true;
+  return named.some((name) => keys.has(name));
 }
 
 function wrapContext(body) {
@@ -490,7 +529,7 @@ export async function fetchAssembledContext(fetchJSON, cfg, query, options = {})
 
   if (!res.ok) {
     const status = res.status || 0;
-    if ((status === 400 || status === 422) && looksLikeUnknownField(res)) {
+    if ((status === 400 || status === 422) && looksLikeUnknownField(res, Object.keys(body))) {
       await markContextFaceLegacy(options.legacyCachePath);
       log("recall_context_face_unsupported", { status });
     } else {
@@ -602,7 +641,7 @@ export async function postRecall(fetchJSON, body, opts = {}) {
   // Only an unknown-field rejection means "this server predates peer_scope".
   // Retrying every other 400/422 without it silently widens the search from
   // the caller's own peer to the whole user root.
-  if (!looksLikeUnknownField(res)) {
+  if (!looksLikeUnknownField(res, Object.keys(request))) {
     log("recall_peer_scope_error", { status: res.status || 0 });
     return res;
   }


### PR DESCRIPTION
## Problem

`looksLikeUnknownField` in `examples/memory-plugin-shared/lib/recall-core.mjs` decided whether a 400/422 meant "this server predates a field we sent" by matching **bare substrings** against the error text:

```js
const text = JSON.stringify(res?.error ?? res?.result ?? res?.detail ?? "").toLowerCase();
return text.includes("extra") || text.includes("mode") || text.includes("unexpected");
```

Any unrelated rejection that merely contained one of those words was treated as schema drift, which pins a **six-hour** downgrade (`LEGACY_CACHE_TTL_MS`):

- **Context face** (`fetchAssembledContext`): a value rejection of a field the caller *did* send — e.g. `"invalid mode parameter: expected 'context'"`, or a FastAPI 422 whose `loc` names the field with a `literal_error` (the field name appears in the error, so the bare `"mode"` substring matches) — marked the deployment as having no context face. For the next six hours every recall silently fell back to the deprecated `/recall` preset (worse assembly, no tiering/dedup), with no doctor-visible signal to explain the degraded results.
- **`peer_scope`** (`postRecall`): a generic `"unexpected server error"` on `/api/v1/search/recall` silently widened the search from the caller's own peer to the whole user root for six hours, retrying every turn at a scope the user never asked for.

## Fix

Two-step tightening, both directions preserved for real schema drift:

1. The message must now read like a **schema rejection**, in the shapes FastAPI/Pydantic v1/v2 and the server's own handlers actually emit: `extra_forbidden`, `"extra inputs are not permitted"`, `"extra fields not permitted"`, `value_error.extra`, `"Extra inputs: <field>"`, `"unexpected keyword argument"`, `"unknown/unrecognized/unexpected input|field|parameter"`.
2. When the error **names the offending field** — inline after the phrase, or as the last segment of a FastAPI detail `loc` — that name must be one of the keys the caller actually sent (`Object.keys(body)`), otherwise the rejection is not evidence about our request.

## Evidence

- New red-then-green tests in `examples/memory-plugin-shared/recall-core.test.mjs`:
  - FastAPI `literal_error` on `mode` (field sent, value rejected) → no legacy pin;
  - `"invalid mode parameter"` message → no legacy pin;
  - generic `"unexpected server error"` on `/recall` → `peer_scope` kept, no memo, no wider retry;
  - positive guard: Pydantic v2 `extra_forbidden` on a sent field (`purpose`) → legacy pin still happens.
- Behavioral checks: FastAPI v2 `extra_forbidden` with `loc: ["body","peer_scope"]` still downgrades and records the memo; the same error naming a field we never sent (`internal_state`) no longer downgrades.
- Existing corpus (`"Extra inputs: mode"`, `"unexpected keyword argument 'peer_scope'"`, `"extra fields not permitted"`) passes unchanged: `node --test examples/memory-plugin-shared/*.test.mjs` → 184/184 pass.
- `lib/` is the source of the vendored copies; ran `node examples/memory-plugin-shared/sync.mjs` so all eight `recall-core.mjs` copies and the sync guard test stay consistent.
