### PR TITLE
ci(openclaw): run the plugin Vitest suite when the plugin or the lane changes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -95,12 +95,43 @@ jobs:
           bash -n examples/codex-memory-plugin/setup-helper/install.sh
           bash -n examples/codex-memory-plugin/setup-helper/tos-install.sh
 
+  openclaw-tests:
+    needs: check-deps
+    if: ${{ needs.check-deps.outputs.openclaw_changed == 'true' }}
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: examples/openclaw-plugin
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install plugin dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run the OpenClaw plugin Vitest suite
+        # The suite is otherwise never exercised by CI, so regressions in
+        # examples/openclaw-plugin only surface in user installs.
+        # tests/ut/architecture-boundaries.test.ts is excluded until its 4
+        # pre-existing main failures are resolved (see #4720 / #4731 / #4732);
+        # every other file passes on main (44 files / 690 tests).
+        # The node_modules exclude restores vitest's default filters, which a
+        # custom --exclude replaces.
+        run: >
+          npm test --
+          --exclude "tests/ut/architecture-boundaries.test.ts"
+          --exclude "**/node_modules/**"
+
   check-deps:
     runs-on: ubuntu-24.04
     outputs:
       deps_changed: ${{ steps.check.outputs.deps_changed }}
       cuvs_changed: ${{ steps.check.outputs.cuvs_changed }}
       langchain_changed: ${{ steps.check.outputs.langchain_changed }}
+      openclaw_changed: ${{ steps.check.outputs.openclaw_changed }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -150,6 +181,18 @@ jobs:
           else
             echo "No LangChain integration changes detected."
             echo "langchain_changed=false" >> $GITHUB_OUTPUT
+          fi
+
+          OPENCLAW_PATTERN="examples/openclaw-plugin/|\.github/workflows/pr\.yml"
+          OPENCLAW_CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }} HEAD | grep -E "$OPENCLAW_PATTERN" || true)
+
+          if [ -n "$OPENCLAW_CHANGED_FILES" ]; then
+            echo "OpenClaw plugin changes detected:"
+            echo "$OPENCLAW_CHANGED_FILES"
+            echo "openclaw_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "No OpenClaw plugin changes detected."
+            echo "openclaw_changed=false" >> $GITHUB_OUTPUT
           fi
 
   build:


### PR DESCRIPTION
## Motivation

The OpenClaw plugin's Vitest suite (**45 files / 766 tests**) is never exercised by repo CI. No workflow runs vitest under `examples/openclaw-plugin`, so regressions there only surface in user installs. This came up while reviewing #4727, where the green `01. Pull Request Checks` check carries no signal for the plugin's own suite — the gap was independently confirmed there by both reviewer and author.

The most striking evidence of the gap: `tests/ut/architecture-boundaries.test.ts` has had 4 failing tests on `main` for weeks with nobody noticing, precisely because nothing in CI runs them.

## What this adds

A path-gated `openclaw-tests` job in `pr.yml`, following the existing `cuvs-tests` / `langchain-tests` pattern (`needs: check-deps` + a new `openclaw_changed` output):

- **Pattern**: `examples/openclaw-plugin/` plus `.github/workflows/pr.yml` — the latter so the lane self-validates on its own PR (this PR's CI run will execute the new lane as its first run).
- **Lane**: `npm ci --ignore-scripts` + `npm test` (i.e. `vitest run`), Node 24, matching `plugin-tests`.
- **One exclusion**: `tests/ut/architecture-boundaries.test.ts` stays out until its 4 pre-existing `main` failures are resolved — the fixes are already in flight (#4720 fixes two of them, #4731 and #4732 fix the remaining two). Once those merge, the exclusion line can be dropped and the file's 76 tests join the lane.

## Verification

On current `main` (`f97ce530`), Node 26 locally:

| command | result |
|---|---|
| `npm test` (bare, current CI-equivalent = never runs) | 762 pass / **4 fail** — all in `architecture-boundaries.test.ts` |
| `npm test -- --exclude tests/ut/architecture-boundaries.test.ts --exclude "**/node_modules/**"` (the new lane command) | **44 files / 690 tests, all pass** |

The second `--exclude` restores vitest's default `node_modules` filter — a custom `--exclude` replaces the default exclude list, so it must be re-supplied explicitly.

YAML validated by parse + structural assertions (job wiring, output reference, working-directory); the `check-deps` script block validated with `bash -n`; gate pattern behavior spot-checked (matches `examples/openclaw-plugin/**` and `pr.yml`, does not match unrelated paths).

Fixes nothing on its own — it makes the next OpenClaw regression visible in CI instead of in a user install.