### PR TITLE
perf(memory-plugin): prefetch fallback body reads concurrently

### DIFF
--- a/examples/claude-code-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/recall-core.mjs
@@ -348,13 +348,22 @@ async function buildFallbackInjectionBlock(fetchJSON, items, cfg, actorPeerId = 
   let contentCount = 0;
   let hintCount = 0;
 
-  for (const item of items) {
+  // Level-2 bodies each cost one /content/read round-trip; awaiting them one
+  // by one inside the budget walk multiplies that latency by the item count.
+  // Prefetch concurrently (idempotent local reads, same shape as the parallel
+  // search fan-out above) and keep the budget walk itself strictly serial so
+  // line order, budget accounting and hint fallback stay unchanged.
+  const contents = await Promise.all(
+    items.map((item) => resolveItemContent(fetchJSON, item, cfg, actorPeerId)),
+  );
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
     const score = (clampScore(item.score) * 100).toFixed(0);
     const uriLine = `- [${item._sourceType} ${score}%] ${item.uri}`;
 
     if (budgetRemaining > 0) {
-      const content = await resolveItemContent(fetchJSON, item, cfg, actorPeerId);
-      const contentLine = `- [${item._sourceType} ${score}%] ${content}`;
+      const contentLine = `- [${item._sourceType} ${score}%] ${contents[i]}`;
       const lineTokens = estimateTokens(contentLine);
 
       if (lineTokens > budgetRemaining && contentCount > 0) {

--- a/examples/codex-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/recall-core.mjs
@@ -348,13 +348,22 @@ async function buildFallbackInjectionBlock(fetchJSON, items, cfg, actorPeerId = 
   let contentCount = 0;
   let hintCount = 0;
 
-  for (const item of items) {
+  // Level-2 bodies each cost one /content/read round-trip; awaiting them one
+  // by one inside the budget walk multiplies that latency by the item count.
+  // Prefetch concurrently (idempotent local reads, same shape as the parallel
+  // search fan-out above) and keep the budget walk itself strictly serial so
+  // line order, budget accounting and hint fallback stay unchanged.
+  const contents = await Promise.all(
+    items.map((item) => resolveItemContent(fetchJSON, item, cfg, actorPeerId)),
+  );
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
     const score = (clampScore(item.score) * 100).toFixed(0);
     const uriLine = `- [${item._sourceType} ${score}%] ${item.uri}`;
 
     if (budgetRemaining > 0) {
-      const content = await resolveItemContent(fetchJSON, item, cfg, actorPeerId);
-      const contentLine = `- [${item._sourceType} ${score}%] ${content}`;
+      const contentLine = `- [${item._sourceType} ${score}%] ${contents[i]}`;
       const lineTokens = estimateTokens(contentLine);
 
       if (lineTokens > budgetRemaining && contentCount > 0) {

--- a/examples/dsh-memory-plugin/shared/recall-core.mjs
+++ b/examples/dsh-memory-plugin/shared/recall-core.mjs
@@ -348,13 +348,22 @@ async function buildFallbackInjectionBlock(fetchJSON, items, cfg, actorPeerId = 
   let contentCount = 0;
   let hintCount = 0;
 
-  for (const item of items) {
+  // Level-2 bodies each cost one /content/read round-trip; awaiting them one
+  // by one inside the budget walk multiplies that latency by the item count.
+  // Prefetch concurrently (idempotent local reads, same shape as the parallel
+  // search fan-out above) and keep the budget walk itself strictly serial so
+  // line order, budget accounting and hint fallback stay unchanged.
+  const contents = await Promise.all(
+    items.map((item) => resolveItemContent(fetchJSON, item, cfg, actorPeerId)),
+  );
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
     const score = (clampScore(item.score) * 100).toFixed(0);
     const uriLine = `- [${item._sourceType} ${score}%] ${item.uri}`;
 
     if (budgetRemaining > 0) {
-      const content = await resolveItemContent(fetchJSON, item, cfg, actorPeerId);
-      const contentLine = `- [${item._sourceType} ${score}%] ${content}`;
+      const contentLine = `- [${item._sourceType} ${score}%] ${contents[i]}`;
       const lineTokens = estimateTokens(contentLine);
 
       if (lineTokens > budgetRemaining && contentCount > 0) {

--- a/examples/memory-plugin-shared/lib/recall-core.mjs
+++ b/examples/memory-plugin-shared/lib/recall-core.mjs
@@ -347,13 +347,22 @@ async function buildFallbackInjectionBlock(fetchJSON, items, cfg, actorPeerId = 
   let contentCount = 0;
   let hintCount = 0;
 
-  for (const item of items) {
+  // Level-2 bodies each cost one /content/read round-trip; awaiting them one
+  // by one inside the budget walk multiplies that latency by the item count.
+  // Prefetch concurrently (idempotent local reads, same shape as the parallel
+  // search fan-out above) and keep the budget walk itself strictly serial so
+  // line order, budget accounting and hint fallback stay unchanged.
+  const contents = await Promise.all(
+    items.map((item) => resolveItemContent(fetchJSON, item, cfg, actorPeerId)),
+  );
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
     const score = (clampScore(item.score) * 100).toFixed(0);
     const uriLine = `- [${item._sourceType} ${score}%] ${item.uri}`;
 
     if (budgetRemaining > 0) {
-      const content = await resolveItemContent(fetchJSON, item, cfg, actorPeerId);
-      const contentLine = `- [${item._sourceType} ${score}%] ${content}`;
+      const contentLine = `- [${item._sourceType} ${score}%] ${contents[i]}`;
       const lineTokens = estimateTokens(contentLine);
 
       if (lineTokens > budgetRemaining && contentCount > 0) {

--- a/examples/memory-plugin-shared/recall-core.test.mjs
+++ b/examples/memory-plugin-shared/recall-core.test.mjs
@@ -379,6 +379,48 @@ test("prefetch keeps the token-budget hint fallback intact", async () => {
   assert.equal(bodyLines[2], "- [memory 80%] viking://user/default/memories/events/three.md");
 });
 
+test("prefetch reads every body even when the budget floor is already spent", async () => {
+  const legacyCachePath = await tempPath("context-face.json");
+  const uris = [
+    "viking://user/default/memories/events/one.md",
+    "viking://user/default/memories/events/two.md",
+    "viking://user/default/memories/events/three.md",
+    "viking://user/default/memories/events/four.md",
+  ];
+  const memories = uris.map((uri, i) => ({
+    uri, score: 0.9 - i * 0.05, abstract: "", level: 2, category: "events",
+  }));
+  const reads = [];
+  const fetchJSON = async (path) => {
+    if (path === "/api/v1/search/search") return { ok: false, status: 503 };
+    if (path === "/api/v1/search/recall") return { ok: false, status: 404 };
+    if (path === "/api/v1/system/status") return { ok: true, result: { user: "default" } };
+    if (path.startsWith("/api/v1/fs/ls")) return { ok: true, result: [] };
+    if (path === "/api/v1/search/find") return { ok: true, result: { memories, skills: [] } };
+    if (path.startsWith("/api/v1/content/read")) {
+      reads.push(path);
+      return { ok: true, result: "x".repeat(900) };
+    }
+    return { ok: false, status: 404 };
+  };
+
+  const block = await buildRecallBlock(fetchJSON, {
+    recallLimit: 4,
+    recallMaxContentChars: 1000,
+    recallTokenBudget: 200,
+    scoreThreshold: 0.35,
+    recallPreferAbstract: false,
+  }, "what happened yesterday", { legacyCachePath });
+
+  // The first body alone (~229 estimated tokens) overshoots the 200-token
+  // floor, so items two through four degrade to URI hints — but their bodies
+  // were still prefetched in one concurrent batch instead of being skipped.
+  assert.equal(reads.length, 4);
+  const bodyLines = block.split("\n").filter((line) => line.startsWith("- ["));
+  assert.match(bodyLines[0], /x{900}/);
+  for (const line of bodyLines.slice(1)) assert.doesNotMatch(line, /x{900}/);
+});
+
 function recordingFetch(responses) {
   const sent = [];
   const queue = [...responses];

--- a/examples/memory-plugin-shared/recall-core.test.mjs
+++ b/examples/memory-plugin-shared/recall-core.test.mjs
@@ -284,6 +284,101 @@ test("buildRecallBlock falls back to find when neither context endpoint works", 
   assert.match(block, /\[memory 90%\]/);
 });
 
+function findFallbackFixture(uris, { preferAbstract = false } = {}) {
+  const memories = uris.map((uri, i) => ({
+    uri,
+    score: 0.9 - i * 0.05,
+    abstract: "",
+    level: 2,
+    category: "events",
+  }));
+  return {
+    searchResult: { memories, skills: [] },
+    cfg: {
+      recallLimit: uris.length,
+      recallMaxContentChars: 500,
+      recallTokenBudget: 200,
+      scoreThreshold: 0.35,
+      recallPreferAbstract: preferAbstract,
+    },
+  };
+}
+
+test("fallback body reads for injected items are prefetched concurrently", { timeout: 5000 }, async () => {
+  const legacyCachePath = await tempPath("context-face.json");
+  const uris = [
+    "viking://user/default/memories/events/one.md",
+    "viking://user/default/memories/events/two.md",
+    "viking://user/default/memories/events/three.md",
+  ];
+  const { searchResult, cfg } = findFallbackFixture(uris);
+  const reads = { started: [], finished: 0 };
+
+  // Barrier: no /content/read may settle until all of them have been started.
+  // A serial implementation deadlocks on the first read and trips the timeout.
+  const pendingReads = [];
+  const fetchJSON = async (path) => {
+    if (path === "/api/v1/search/search") return { ok: false, status: 503 };
+    if (path === "/api/v1/search/recall") return { ok: false, status: 404 };
+    if (path === "/api/v1/system/status") return { ok: true, result: { user: "default" } };
+    if (path.startsWith("/api/v1/fs/ls")) return { ok: true, result: [] };
+    if (path === "/api/v1/search/find") return { ok: true, result: searchResult };
+    if (path.startsWith("/api/v1/content/read")) {
+      reads.started.push(path);
+      return new Promise((resolve) => {
+        pendingReads.push(() => {
+          reads.finished++;
+          resolve({ ok: true, result: `body of ${path}` });
+        });
+        if (pendingReads.length === uris.length) pendingReads.splice(0).forEach((release) => release());
+      });
+    }
+    return { ok: false, status: 404 };
+  };
+
+  const block = await buildRecallBlock(fetchJSON, cfg, "what happened yesterday", { legacyCachePath });
+
+  assert.equal(reads.started.length, uris.length);
+  assert.equal(reads.finished, uris.length);
+  for (const uri of uris) {
+    assert.ok(block.includes(`body of /api/v1/content/read?uri=${encodeURIComponent(uri)}`), uri);
+  }
+});
+
+test("prefetch keeps the token-budget hint fallback intact", async () => {
+  const legacyCachePath = await tempPath("context-face.json");
+  const uris = [
+    "viking://user/default/memories/events/one.md",
+    "viking://user/default/memories/events/two.md",
+    "viking://user/default/memories/events/three.md",
+  ];
+  const { searchResult, cfg } = findFallbackFixture(uris);
+  const reads = [];
+  const fetchJSON = async (path) => {
+    if (path === "/api/v1/search/search") return { ok: false, status: 503 };
+    if (path === "/api/v1/search/recall") return { ok: false, status: 404 };
+    if (path === "/api/v1/system/status") return { ok: true, result: { user: "default" } };
+    if (path.startsWith("/api/v1/fs/ls")) return { ok: true, result: [] };
+    if (path === "/api/v1/search/find") return { ok: true, result: searchResult };
+    if (path.startsWith("/api/v1/content/read")) {
+      reads.push(path);
+      return { ok: true, result: "x".repeat(500) };
+    }
+    return { ok: false, status: 404 };
+  };
+
+  const block = await buildRecallBlock(fetchJSON, cfg, "what happened yesterday", { legacyCachePath });
+
+  // Every body is ~130 estimated tokens; the budget floor is 200, so item one
+  // spends it and items two and three must degrade to URI hints.
+  const bodyLines = block.split("\n").filter((line) => line.startsWith("- ["));
+  assert.equal(bodyLines.length, 3);
+  assert.match(bodyLines[0], /x{500}/);
+  assert.doesNotMatch(bodyLines[1], /x{500}/);
+  assert.equal(bodyLines[1], "- [memory 85%] viking://user/default/memories/events/two.md");
+  assert.equal(bodyLines[2], "- [memory 80%] viking://user/default/memories/events/three.md");
+});
+
 function recordingFetch(responses) {
   const sent = [];
   const queue = [...responses];

--- a/examples/openclaw-plugin/shared/recall-core.mjs
+++ b/examples/openclaw-plugin/shared/recall-core.mjs
@@ -348,13 +348,22 @@ async function buildFallbackInjectionBlock(fetchJSON, items, cfg, actorPeerId = 
   let contentCount = 0;
   let hintCount = 0;
 
-  for (const item of items) {
+  // Level-2 bodies each cost one /content/read round-trip; awaiting them one
+  // by one inside the budget walk multiplies that latency by the item count.
+  // Prefetch concurrently (idempotent local reads, same shape as the parallel
+  // search fan-out above) and keep the budget walk itself strictly serial so
+  // line order, budget accounting and hint fallback stay unchanged.
+  const contents = await Promise.all(
+    items.map((item) => resolveItemContent(fetchJSON, item, cfg, actorPeerId)),
+  );
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
     const score = (clampScore(item.score) * 100).toFixed(0);
     const uriLine = `- [${item._sourceType} ${score}%] ${item.uri}`;
 
     if (budgetRemaining > 0) {
-      const content = await resolveItemContent(fetchJSON, item, cfg, actorPeerId);
-      const contentLine = `- [${item._sourceType} ${score}%] ${content}`;
+      const contentLine = `- [${item._sourceType} ${score}%] ${contents[i]}`;
       const lineTokens = estimateTokens(contentLine);
 
       if (lineTokens > budgetRemaining && contentCount > 0) {

--- a/examples/opencode-plugin/lib/shared/recall-core.mjs
+++ b/examples/opencode-plugin/lib/shared/recall-core.mjs
@@ -348,13 +348,22 @@ async function buildFallbackInjectionBlock(fetchJSON, items, cfg, actorPeerId = 
   let contentCount = 0;
   let hintCount = 0;
 
-  for (const item of items) {
+  // Level-2 bodies each cost one /content/read round-trip; awaiting them one
+  // by one inside the budget walk multiplies that latency by the item count.
+  // Prefetch concurrently (idempotent local reads, same shape as the parallel
+  // search fan-out above) and keep the budget walk itself strictly serial so
+  // line order, budget accounting and hint fallback stay unchanged.
+  const contents = await Promise.all(
+    items.map((item) => resolveItemContent(fetchJSON, item, cfg, actorPeerId)),
+  );
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
     const score = (clampScore(item.score) * 100).toFixed(0);
     const uriLine = `- [${item._sourceType} ${score}%] ${item.uri}`;
 
     if (budgetRemaining > 0) {
-      const content = await resolveItemContent(fetchJSON, item, cfg, actorPeerId);
-      const contentLine = `- [${item._sourceType} ${score}%] ${content}`;
+      const contentLine = `- [${item._sourceType} ${score}%] ${contents[i]}`;
       const lineTokens = estimateTokens(contentLine);
 
       if (lineTokens > budgetRemaining && contentCount > 0) {

--- a/examples/pi-coding-agent-extension/shared/recall-core.mjs
+++ b/examples/pi-coding-agent-extension/shared/recall-core.mjs
@@ -348,13 +348,22 @@ async function buildFallbackInjectionBlock(fetchJSON, items, cfg, actorPeerId = 
   let contentCount = 0;
   let hintCount = 0;
 
-  for (const item of items) {
+  // Level-2 bodies each cost one /content/read round-trip; awaiting them one
+  // by one inside the budget walk multiplies that latency by the item count.
+  // Prefetch concurrently (idempotent local reads, same shape as the parallel
+  // search fan-out above) and keep the budget walk itself strictly serial so
+  // line order, budget accounting and hint fallback stay unchanged.
+  const contents = await Promise.all(
+    items.map((item) => resolveItemContent(fetchJSON, item, cfg, actorPeerId)),
+  );
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
     const score = (clampScore(item.score) * 100).toFixed(0);
     const uriLine = `- [${item._sourceType} ${score}%] ${item.uri}`;
 
     if (budgetRemaining > 0) {
-      const content = await resolveItemContent(fetchJSON, item, cfg, actorPeerId);
-      const contentLine = `- [${item._sourceType} ${score}%] ${content}`;
+      const contentLine = `- [${item._sourceType} ${score}%] ${contents[i]}`;
       const lineTokens = estimateTokens(contentLine);
 
       if (lineTokens > budgetRemaining && contentCount > 0) {

--- a/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
@@ -348,13 +348,22 @@ async function buildFallbackInjectionBlock(fetchJSON, items, cfg, actorPeerId = 
   let contentCount = 0;
   let hintCount = 0;
 
-  for (const item of items) {
+  // Level-2 bodies each cost one /content/read round-trip; awaiting them one
+  // by one inside the budget walk multiplies that latency by the item count.
+  // Prefetch concurrently (idempotent local reads, same shape as the parallel
+  // search fan-out above) and keep the budget walk itself strictly serial so
+  // line order, budget accounting and hint fallback stay unchanged.
+  const contents = await Promise.all(
+    items.map((item) => resolveItemContent(fetchJSON, item, cfg, actorPeerId)),
+  );
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
     const score = (clampScore(item.score) * 100).toFixed(0);
     const uriLine = `- [${item._sourceType} ${score}%] ${item.uri}`;
 
     if (budgetRemaining > 0) {
-      const content = await resolveItemContent(fetchJSON, item, cfg, actorPeerId);
-      const contentLine = `- [${item._sourceType} ${score}%] ${content}`;
+      const contentLine = `- [${item._sourceType} ${score}%] ${contents[i]}`;
       const lineTokens = estimateTokens(contentLine);
 
       if (lineTokens > budgetRemaining && contentCount > 0) {


### PR DESCRIPTION
## What

The fallback injection path (`buildFallbackInjectionBlock`) resolved each item's body with an `await` **inside** the budget loop. Level-2 items each cost one `/api/v1/content/read` round-trip, so N injected items paid N sequential RTTs on every recall turn against servers that don't offer the context face — with the default `recallLimit: 10`, that is up to 10 serial round-trips per turn, squarely in the latency territory reported for the memory plugins.

## Change

- Resolve all item bodies up front with `Promise.all` (mirroring the already-parallel `searchAllSources` fan-out; these are idempotent local reads) and keep the budget walk strictly serial, so **line order, budget accounting, and the degrade-to-URI-hint fallback are unchanged**.
- Latency drops from `Σ RTT` to `max RTT` for the body-read phase.

**Deliberate behavior difference:** items whose budget slot is already exhausted are now read anyway instead of being skipped. Those reads are cheap idempotent local GETs, and the old code already wasted reads on items that later degraded to URI hints after their content resolved. If maintainers prefer the old skip semantics, restoring it costs a two-pass walk — happy to do that instead.

## Tests

Three new tests in `memory-plugin-shared/recall-core.test.mjs`:

1. `fallback body reads for injected items are prefetched concurrently` — a barrier mock where no read may settle until all have started; a serial implementation deadlocks and trips the timeout (verified: it fails on the pre-change source).
2. `prefetch keeps the token-budget hint fallback intact` — first body spends the 200-token floor, the rest degrade to exact URI hint lines.
3. `prefetch reads every body even when the budget floor is already spent` — locks the new prefetch semantics (4 reads where the old code did 1; verified red on the pre-change source).

Revert-lock audit: tests 1 and 3 fail on the pre-change `recall-core.mjs`, pass on the new one.

## Verification

- `memory-plugin-shared`: **183/183** (includes the 3 new tests)
- consumers after `sync.mjs`: claude-code **35/35**, codex **110/110**, zcode **44/44**
- `dsh-memory-plugin`: 4 failures (`index`/`mcp`/`runtime`/`skills`) — A/B verified identical on a clean `main` checkout, pre-existing/environmental, unrelated to this diff
- generated copies synced via `node examples/memory-plugin-shared/sync.mjs` (7 vendored `recall-core.mjs` copies)
