### PR TITLE
fix(queuefs): keep completion accounting correct under clock jumps and drain cancels

### DIFF
--- a/openviking/storage/queuefs/named_queue.py
+++ b/openviking/storage/queuefs/named_queue.py
@@ -189,6 +189,18 @@ class NamedQueue:
             if len(self._errors) > self.MAX_ERRORS:
                 self._errors = self._errors[-self.MAX_ERRORS :]
 
+    def _on_process_abandoned(self) -> None:
+        """Release an in_progress slot for work abandoned without a terminal result.
+
+        Used when the concurrent worker cancels an in-flight task during the
+        shutdown drain: the message is deliberately left un-acked so
+        RecoverStale re-queues it on next startup, but the runtime
+        in_progress counter must still return to zero so
+        is_complete()/wait_complete() can observe an idle queue.
+        """
+        with self._lock:
+            self._in_progress -= 1
+
     async def get_status(self) -> QueueStatus:
         """Get queue status."""
         pending = await self.size()

--- a/openviking/storage/queuefs/queue_manager.py
+++ b/openviking/storage/queuefs/queue_manager.py
@@ -247,11 +247,17 @@ class QueueManager:
             loop.close()
 
     async def _worker_async_concurrent(
-        self, queue: NamedQueue, stop_event: threading.Event, max_concurrent: int
+        self,
+        queue: NamedQueue,
+        stop_event: threading.Event,
+        max_concurrent: int,
+        drain_timeout: float = 5.0,
     ) -> None:
         """Concurrent worker: drains the queue and processes items in parallel.
 
-        A Semaphore caps inflight tasks at max_concurrent.
+        A Semaphore caps inflight tasks at max_concurrent. On stop, in-flight
+        tasks are drained for up to ``drain_timeout`` seconds before being
+        cancelled.
         """
         poll_interval = (
             self._SESSION_COMMIT_POLL_INTERVAL
@@ -262,17 +268,27 @@ class QueueManager:
         active_tasks: Set[asyncio.Task] = set()
 
         async def process_one(data: Dict[str, Any]) -> None:
-            async with sem:
-                msg_id = data.get("id", "") if isinstance(data, dict) else ""
-                try:
-                    await queue.process_dequeued(data)
-                    # Ack after successful processing (delete from persistent storage).
-                    await queue.ack(msg_id, data)
-                except Exception as e:
-                    # Handler did not call report_error; decrement in_progress manually.
-                    # Do NOT ack — let RecoverStale re-queue on next startup.
-                    queue._on_process_error(str(e), data)
-                    logger.error(f"[QueueManager] Concurrent worker error for {queue.name}: {e}")
+            try:
+                async with sem:
+                    msg_id = data.get("id", "") if isinstance(data, dict) else ""
+                    try:
+                        await queue.process_dequeued(data)
+                        # Ack after successful processing (delete from persistent storage).
+                        await queue.ack(msg_id, data)
+                    except Exception as e:
+                        # Handler did not call report_error; decrement in_progress manually.
+                        # Do NOT ack — let RecoverStale re-queue on next startup.
+                        queue._on_process_error(str(e), data)
+                        logger.error(
+                            f"[QueueManager] Concurrent worker error for {queue.name}: {e}"
+                        )
+            except asyncio.CancelledError:
+                # Shutdown drain cancels in-flight tasks. Release the
+                # in_progress slot claimed at dispatch without recording an
+                # error (this is not a processing failure); the message stays
+                # un-acked so RecoverStale re-queues it on next startup.
+                queue._on_process_abandoned()
+                raise
 
         while not stop_event.is_set():
             # Prune completed tasks
@@ -306,7 +322,7 @@ class QueueManager:
             try:
                 await asyncio.wait_for(
                     asyncio.gather(*active_tasks, return_exceptions=True),
-                    timeout=5.0,
+                    timeout=drain_timeout,
                 )
             except asyncio.TimeoutError:
                 logger.warning(
@@ -446,10 +462,13 @@ class QueueManager:
         poll_interval: float = 0.5,
     ) -> Dict[str, QueueStatus]:
         """Wait for completion and return final status."""
-        start = time.time()
+        # Monotonic clock: a wall-clock jump (NTP correction, VM snapshot
+        # restore) must not turn an in-flight wait into a false TimeoutError
+        # or make the deadline unreachable.
+        start = time.monotonic()
         while True:
             if await self.is_all_complete(queue_name):
                 return await self.check_status(queue_name)
-            if timeout and (time.time() - start) > timeout:
+            if timeout and (time.monotonic() - start) > timeout:
                 raise TimeoutError(f"Queue processing not complete after {timeout}s")
             await asyncio.sleep(poll_interval)

--- a/tests/storage/test_queue_completion_accounting.py
+++ b/tests/storage/test_queue_completion_accounting.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Completion-accounting correctness for queue waits and the shutdown drain.
+
+Covers two invariants of the queuefs completion signal:
+
+1. ``QueueManager.wait_complete`` must measure its deadline with a monotonic
+   clock: a wall-clock jump (NTP correction, VM snapshot restore) must not
+   turn an in-flight wait into a false ``TimeoutError`` nor make the
+   deadline unreachable.
+2. When the concurrent worker's shutdown drain cancels an in-flight task,
+   the ``in_progress`` slot claimed at dispatch must be released (without
+   recording a processing error) so ``is_complete()``/``wait_complete()``
+   can still observe an idle queue. The message itself stays un-acked, so
+   at-least-once delivery via RecoverStale is preserved.
+"""
+
+import asyncio
+import json
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from openviking.storage.queuefs import queue_manager as queue_manager_module
+from openviking.storage.queuefs.named_queue import DequeueHandlerBase, NamedQueue
+from openviking.storage.queuefs.queue_manager import QueueManager
+
+
+class FakeAGFS:
+    """Minimal sync AGFS client fake for the queue control files."""
+
+    def __init__(self, messages: List[Dict[str, Any]]):
+        self.messages = list(messages)
+        self.acked: List[str] = []
+
+    def mkdir(self, path: str, ctx: Optional[Dict[str, str]] = None, **kw) -> Dict[str, Any]:
+        return {}
+
+    def read(self, path: str, ctx: Optional[Dict[str, str]] = None, **kw) -> Any:
+        if path.endswith("/dequeue"):
+            if self.messages:
+                return json.dumps(self.messages.pop(0)).encode("utf-8")
+            return b""
+        if path.endswith("/size"):
+            return str(len(self.messages)).encode("utf-8")
+        return b""
+
+    def write(self, path: str, data: bytes, ctx: Optional[Dict[str, str]] = None, **kw) -> str:
+        if path.endswith("/ack"):
+            self.acked.append(data.decode("utf-8"))
+        return "written"
+
+
+class FakeClock:
+    """Stand-in for the ``time`` module binding inside queue_manager.
+
+    Each read advances the corresponding clock by ``time_step`` /
+    ``monotonic_step``, simulating a wall-clock jump while the monotonic
+    clock keeps its normal cadence.
+    """
+
+    def __init__(self, *, time_step: float = 0.0, monotonic_step: float = 0.0):
+        self._t = 1_000_000.0
+        self._m = 500.0
+        self._time_step = time_step
+        self._monotonic_step = monotonic_step
+
+    def time(self) -> float:
+        self._t += self._time_step
+        return self._t
+
+    def monotonic(self) -> float:
+        self._m += self._monotonic_step
+        return self._m
+
+
+class BlockingHandler(DequeueHandlerBase):
+    """Handler that never finishes on its own; only cancellation unblocks it."""
+
+    async def on_dequeue(self, data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        await asyncio.Event().wait()
+        return data
+
+
+async def test_wait_complete_ignores_wall_clock_jumps(monkeypatch) -> None:
+    manager = QueueManager(agfs=FakeAGFS([]))
+    queue = manager.get_queue("TestQ", allow_create=True)
+    queue._on_dequeue_start()  # queue is busy; finished shortly after
+
+    async def _finish_later() -> None:
+        await asyncio.sleep(0.15)
+        queue._on_process_success()
+
+    finisher = asyncio.create_task(_finish_later())
+    # Wall clock jumps forward by 5000s on every read; monotonic stays sane.
+    monkeypatch.setattr(
+        queue_manager_module, "time", FakeClock(time_step=5000.0)
+    )
+
+    statuses = await manager.wait_complete("TestQ", timeout=30.0, poll_interval=0.02)
+
+    await finisher
+    assert statuses["TestQ"].is_complete
+    assert statuses["TestQ"].in_progress == 0
+
+
+async def test_wait_complete_still_times_out_on_a_stuck_queue() -> None:
+    manager = QueueManager(agfs=FakeAGFS([]))
+    queue = manager.get_queue("TestQ", allow_create=True)
+    queue._on_dequeue_start()  # stuck busy forever
+
+    with pytest.raises(TimeoutError):
+        await manager.wait_complete("TestQ", timeout=0.3, poll_interval=0.05)
+
+    queue._on_process_success()  # rebalance the counter for teardown
+
+
+async def test_drain_cancel_releases_in_progress_without_error() -> None:
+    agfs = FakeAGFS([{"id": "m1", "task_id": "t1"}])
+    queue = NamedQueue(agfs, "/queue", "Embedding", dequeue_handler=BlockingHandler())
+    manager = QueueManager(agfs=agfs)
+    stop = threading.Event()
+
+    worker = asyncio.create_task(
+        manager._worker_async_concurrent(queue, stop, max_concurrent=1, drain_timeout=0.1)
+    )
+
+    # Wait until the message has been dispatched (in_progress claimed).
+    deadline = time.monotonic() + 5.0
+    while queue._in_progress < 1 and time.monotonic() < deadline:
+        await asyncio.sleep(0.01)
+    assert queue._in_progress == 1, "message must be dispatched to the handler"
+
+    stop.set()
+    await asyncio.wait_for(worker, timeout=10.0)
+
+    status = await queue.get_status()
+    assert status.in_progress == 0, "cancelled drain must release the in_progress slot"
+    assert status.error_count == 0, "a cancelled drain is not a processing failure"
+    assert agfs.acked == [], "message must stay un-acked so RecoverStale can retry it"


### PR DESCRIPTION
## Summary

Two small correctness fixes around the queuefs completion signal, found while auditing the completion-accounting paths adjacent to #4745:

**1. `QueueManager.wait_complete()` used the wall clock (`time.time`) for its deadline.** A wall-clock jump (NTP correction, VM snapshot restore, manual clock change) could:
- jump forward → an in-flight wait fires a **false `TimeoutError`** even though the real budget hasn't elapsed, or
- jump backward → the deadline moves further away and a stuck queue **hangs past its timeout**.

Now uses `time.monotonic()`, matching `SemanticQueue`'s existing monotonic usage (`semantic_queue.py` already does this).

**2. Cancelled shutdown drain leaked the `in_progress` counter.** When `_worker_async_concurrent`'s drain times out and cancels in-flight tasks, `process_one()` only had an `except Exception` arm — which does not catch `asyncio.CancelledError` — so the `in_progress` slot claimed at dispatch was never released, and `is_complete()` / `wait_complete()` could no longer observe an idle queue afterwards.

Fixed by releasing the slot via a new `NamedQueue._on_process_abandoned()` (decrements `in_progress` only — a cancelled drain is deliberately **not** recorded as a processing error, since the task itself didn't fail). The message stays un-acked so `RecoverStale` re-queues it on next startup: at-least-once delivery is preserved unchanged.

Also lifted the hardcoded 5s drain timeout into a `drain_timeout` parameter (default `5.0`, behavior unchanged) so the cancel path can be exercised in tests without waiting real seconds.

## Testing

New `tests/storage/test_queue_completion_accounting.py`:

| Test | Locks |
|---|---|
| `test_wait_complete_ignores_wall_clock_jumps` | fake wall clock jumping +5000s per read must NOT fire the timeout (fails on the old `time.time()` implementation) |
| `test_wait_complete_still_times_out_on_a_stuck_queue` | a genuinely stuck queue still times out on the real clock (behavior preserved) |
| `test_drain_cancel_releases_in_progress_without_error` | cancelled drain → `in_progress == 0`, `error_count == 0`, message un-acked (fails on the old implementation) |

Local verification:
- New tests: **3/3 passed**; revert audit (checkout base implementation) → exactly the two lock tests turn red, confirming the tests pin the new behavior.
- `tests/storage/` A/B against `main` (f97ce5300): failure lists **identical** (13 pre-existing environment failures — native engine missing, config-dependent), zero regressions.
- Adjacent queuefs tests (`test_queue_manager.py`, `test_queue_observer.py`, `test_memory_semantic_stall.py`): 10/10 passed.

Related: #4745 fixes the same `_in_progress` balance invariant for the **serial** dequeue path (unreported handler exception); this PR covers the **concurrent** worker's drain-cancel path plus the wait deadline clock. The two are complementary and merge-order independent.
