### PR TITLE
fix(queuefs): give SemanticMsg a per-instance creation timestamp

### DIFF
--- a/openviking/storage/queuefs/semantic_msg.py
+++ b/openviking/storage/queuefs/semantic_msg.py
@@ -47,7 +47,7 @@ class SemanticMsg:
     uri: str  # Directory URI
     context_type: str  # resource, memory, skill, session
     status: str = "pending"  # pending/processing/completed
-    timestamp: int = int(datetime.now().timestamp())
+    timestamp: int = field(default_factory=lambda: int(datetime.now().timestamp()))
     recursive: bool = True  # Whether to recursively process subdirectories
     account_id: str = "default"
     user_id: str = "default"
@@ -102,6 +102,7 @@ class SemanticMsg:
         copy_source_uri: str = "",
     ):
         self.id = str(uuid4())
+        self.timestamp = int(datetime.now().timestamp())
         self.uri = uri
         self.context_type = context_type
         self.recursive = recursive

--- a/tests/storage/test_semantic_msg_timestamp.py
+++ b/tests/storage/test_semantic_msg_timestamp.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""SemanticMsg.timestamp must reflect per-instance creation time.
+
+Regression guard: the field default used to be evaluated once at class
+definition (module import), so every message created by a long-running
+process carried the process-start timestamp instead of its own creation
+time.
+"""
+
+from datetime import datetime
+
+from openviking.storage.queuefs.semantic_msg import SemanticMsg
+
+
+def _now_epoch() -> int:
+    return int(datetime.now().timestamp())
+
+
+def test_new_message_timestamp_is_own_creation_time():
+    before = _now_epoch()
+    msg = SemanticMsg(uri="viking://res/a", context_type="resource")
+    after = _now_epoch()
+
+    # Instance-level attribute (falls back to the class attribute only when
+    # unset — the frozen-timestamp regression is exactly that fallback).
+    assert "timestamp" in msg.__dict__
+    assert before <= msg.timestamp <= after
+
+
+def test_messages_do_not_share_a_frozen_timestamp():
+    first = SemanticMsg(uri="viking://res/a", context_type="resource")
+    first.timestamp = 1111111111  # mutate one instance only
+
+    second = SemanticMsg(uri="viking://res/b", context_type="memory")
+    assert second.timestamp != 1111111111
+    assert second.timestamp != first.timestamp
+
+
+def test_to_dict_carries_creation_timestamp():
+    msg = SemanticMsg(uri="viking://res/a", context_type="resource")
+    data = msg.to_dict()
+    assert data["timestamp"] == msg.timestamp
+    assert abs(data["timestamp"] - _now_epoch()) <= 5
+
+
+def test_from_dict_preserves_stored_timestamp():
+    msg = SemanticMsg.from_dict(
+        {"uri": "viking://res/a", "context_type": "resource", "timestamp": 1234567890}
+    )
+    assert msg.timestamp == 1234567890
+
+
+def test_from_dict_without_timestamp_still_gets_fresh_one():
+    msg = SemanticMsg.from_dict({"uri": "viking://res/a", "context_type": "resource"})
+    assert "timestamp" in msg.__dict__
+    assert abs(msg.timestamp - _now_epoch()) <= 5


### PR DESCRIPTION
## Problem

`SemanticMsg.timestamp` is documented as the *creation timestamp*, but every message constructed by a long-running process carries the **module-import epoch** instead of its own creation time.

Root cause (two parts):

1. The dataclass field default is evaluated **once at class-definition time**:
   ```python
   timestamp: int = int(datetime.now().timestamp())   # frozen at import
   ```
2. The custom `__init__` (which supersedes the dataclass-generated one) **never assigns `self.timestamp`**, so instance lookups fall through to that shared class attribute.

Minimal repro against `main`:

```python
m1 = SemanticMsg(uri="a", context_type="resource")
time.sleep(1.1)
m2 = SemanticMsg(uri="b", context_type="memory")
assert m1.timestamp == m2.timestamp          # passes — both frozen
assert "timestamp" not in m1.__dict__        # class fallback, not instance
```

The frozen value leaks into every serialized queue message via `to_dict()`/`asdict()` and the on-disk JSON payload, so observability/audit data reports wrong creation times for every message enqueued after process start. (Today no production code reads `.timestamp` back for control flow — grep-verified — so this is a data-correctness fix plus defense before a future consumer trips on it.)

## Fix

- Assign the epoch in `__init__` so each instance owns its creation time.
- Turn the class-level default into `field(default_factory=...)` so any construction path that bypasses the custom `__init__` also gets a *fresh* timestamp instead of silently sharing a frozen one.

`from_dict` behavior preserved: a stored `timestamp` is restored verbatim; messages restored **without** one now get the restore-time epoch (previously: the process-start epoch).

## Verification

- New regression tests (`tests/storage/test_semantic_msg_timestamp.py`, 5 tests): instance-level attribute, no cross-instance sharing, `to_dict` round-trip, both `from_dict` paths. **Mutation check**: reverting the `__init__` assignment fails 4/5 tests precisely.
- Existing SemanticMsg consumer suites green: `test_semantic_msg_ingest_options`, `test_memory_semantic_stall`, `test_semantic_parent_bubbling`, `test_semantic_processor_identity`, `test_memory_batching` (17 passed, 1 skipped), plus the `semantic_processor`/`dedupe` consumer chain (44 passed).
- Full `tests/storage` failure set is byte-identical with and without this change (environment-specific failures on the dev machine, baseline-compared via `git stash`).
