### PR TITLE
fix(bot): serialize concurrent turns per session key

### DIFF
--- a/bot/tests/test_session_turn_serialization.py
+++ b/bot/tests/test_session_turn_serialization.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Regression tests for per-session turn serialization (issue #4756).
+
+`process_direct` turns (cron ``on_job`` / heartbeat) enter the same
+``_process_message`` pipeline as bus turns but from their own asyncio
+task. Without a per-session turn lock, two turns mutate one cached
+Session concurrently: the pair that arrived first can be persisted
+behind the pair that interrupted it, and a turn released after ``/new``
+re-appends its pair to the cleared session (ghost history).
+
+Both tests park a turn inside the (fake) LLM call — deterministic, no
+sleeps at the LLM boundary.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from vikingbot.agent.loop import AgentLoop
+from vikingbot.bus.events import InboundMessage
+from vikingbot.bus.queue import MessageBus
+from vikingbot.config.schema import Config, SessionKey
+from vikingbot.providers.base import LLMProvider, LLMResponse
+
+
+class _ParkedProvider(LLMProvider):
+    """Parks every chat() call until release() — one turn inside at a time."""
+
+    def __init__(self):
+        super().__init__()
+        self.entered = asyncio.Event()
+        self.release = asyncio.Event()
+        self.n_inside = 0
+
+    async def chat(self, messages, tools=None, **kwargs):
+        self.n_inside += 1
+        self.entered.set()
+        await self.release.wait()
+        return LLMResponse(content=f"reply-{self.n_inside}")
+
+    def get_default_model(self) -> str:
+        return "fake-model"
+
+
+class _FakeSubagentManager:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def _make_loop(temp_dir: Path, provider: LLMProvider) -> AgentLoop:
+    return AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=temp_dir / "workspace",
+        config=Config(storage_workspace=str(temp_dir)),
+        max_iterations=2,
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_direct_waits_for_inflight_bus_turn(temp_dir: Path, monkeypatch):
+    """A cron turn cannot enter the LLM while a user turn is in flight, and
+    the user pair is persisted before the cron pair that arrived later."""
+    monkeypatch.setattr(AgentLoop, "_register_builtin_hooks", lambda self: None)
+    monkeypatch.setattr(AgentLoop, "_register_default_tools", lambda self: None)
+    monkeypatch.setattr("vikingbot.agent.loop.SubagentManager", _FakeSubagentManager)
+
+    key = SessionKey(type="cli", channel_id="default", chat_id="turn-order")
+    provider = _ParkedProvider()
+    loop = _make_loop(temp_dir, provider)
+
+    user_task = asyncio.create_task(
+        loop._process_message(
+            InboundMessage(
+                session_key=key, sender_id="alice", content="what is on my calendar today?"
+            )
+        )
+    )
+    await asyncio.wait_for(provider.entered.wait(), timeout=5)  # user turn parked in chat()
+
+    cron_task = asyncio.create_task(
+        loop.process_direct(
+            "[CRON TASK] scheduled reminder: standup in 10 minutes", session_key=key
+        )
+    )
+    await asyncio.sleep(0.1)
+    assert provider.n_inside == 1, "cron turn must wait for the in-flight user turn"
+
+    provider.release.set()
+    await asyncio.wait_for(user_task, timeout=10)
+    await asyncio.wait_for(cron_task, timeout=10)
+    await asyncio.sleep(0.1)  # let turn-end background tasks settle
+
+    session = loop.sessions.get_or_create(key)
+    user_contents = [m["content"] for m in session.messages if m["role"] == "user"]
+    assert user_contents == [
+        "what is on my calendar today?",
+        "[CRON TASK] scheduled reminder: standup in 10 minutes",
+    ], "the message received first must be persisted first"
+
+
+@pytest.mark.asyncio
+async def test_new_command_waits_for_inflight_cron_turn(temp_dir: Path, monkeypatch):
+    """`/new` cannot clear history while a cron turn is in flight; once the
+    cron pair has been persisted, the cleared session stays empty."""
+    monkeypatch.setattr(AgentLoop, "_register_builtin_hooks", lambda self: None)
+    monkeypatch.setattr(AgentLoop, "_register_default_tools", lambda self: None)
+    monkeypatch.setattr("vikingbot.agent.loop.SubagentManager", _FakeSubagentManager)
+
+    key = SessionKey(type="cli", channel_id="default", chat_id="new-ghost")
+    provider = _ParkedProvider()
+    loop = _make_loop(temp_dir, provider)
+
+    cron_task = asyncio.create_task(
+        loop.process_direct(
+            "[CRON TASK] scheduled reminder: standup in 10 minutes", session_key=key
+        )
+    )
+    await asyncio.wait_for(provider.entered.wait(), timeout=5)  # cron turn parked in chat()
+
+    new_task = asyncio.create_task(
+        loop._process_message(
+            InboundMessage(session_key=key, sender_id="alice", content="/new")
+        )
+    )
+    await asyncio.sleep(0.1)
+    assert not new_task.done(), "/new must wait for the in-flight cron turn"
+
+    provider.release.set()
+    await asyncio.wait_for(cron_task, timeout=10)
+    new_response = await asyncio.wait_for(new_task, timeout=10)
+    assert "New session started" in new_response.content
+
+    session = loop.sessions.get_or_create(key)
+    ghost = any("CRON TASK" in (m.get("content") or "") for m in session.messages)
+    assert not ghost, "history confirmed dropped must not be resurrected by the cron turn"

--- a/bot/vikingbot/agent/loop.py
+++ b/bot/vikingbot/agent/loop.py
@@ -1963,18 +1963,37 @@ class AgentLoop:
             raise ValueError("AGENT_OUTPUT_INVALID: Agent did not submit a valid Wiki bundle")
         return bundle, tools_used, token_usage, iteration
 
+    async def _process_message(self, msg: InboundMessage) -> OutboundMessage | None:
+        """
+        Process a single inbound message, serialized per session.
+
+        The bus loop already serializes its own messages, but
+        process_direct (cron on_job / heartbeat) enters the same
+        pipeline from its own asyncio task. Holding the per-session
+        turn lock for the whole turn keeps concurrent turns on one
+        cached Session from interleaving their history mutations
+        (pair-order inversion, /new ghost history — issue #4756).
+
+        Args:
+            msg: The inbound message to process.
+
+        Returns:
+            The response message, or None if no response needed.
+        """
+        async with self.sessions.get_turn_lock(msg.session_key):
+            return await self._process_message_turn(msg)
+
     @trace(
         name="process_message",
         extract_session_id=lambda msg: msg.session_key.safe_name(),
         extract_user_id=lambda msg: msg.sender_id,
     )
-    async def _process_message(self, msg: InboundMessage) -> OutboundMessage | None:
+    async def _process_message_turn(self, msg: InboundMessage) -> OutboundMessage | None:
         """
-        Process a single inbound message.
+        Process a single inbound message (caller holds the session turn lock).
 
         Args:
             msg: The inbound message to process.
-            session_key: Override session key (used by process_direct).
 
         Returns:
             The response message, or None if no response needed.

--- a/bot/vikingbot/session/manager.py
+++ b/bot/vikingbot/session/manager.py
@@ -24,6 +24,10 @@ T = TypeVar("T")
 
 _SESSION_LOCKS: dict[Path, asyncio.Lock] = {}
 
+# Serializes whole agent turns per SessionKey (turn-level), separate from
+# _SESSION_LOCKS which only guards the disk-write instant inside save().
+_TURN_LOCKS: dict[SessionKey, asyncio.Lock] = {}
+
 
 @dataclass
 class Session:
@@ -154,6 +158,21 @@ class SessionManager:
         if lock is None:
             lock = asyncio.Lock()
             _SESSION_LOCKS[path] = lock
+        return lock
+
+    def get_turn_lock(self, session_key: SessionKey) -> asyncio.Lock:
+        """Return the per-session lock serializing whole agent turns.
+
+        Distinct from ``_get_lock`` (which only guards the disk-write
+        instant inside ``save``): a turn holds this lock from entry to
+        completion, so ``process_direct`` turns (cron ``on_job`` /
+        heartbeat) cannot interleave with an in-flight bus turn on the
+        same cached Session (issue #4756).
+        """
+        lock = _TURN_LOCKS.get(session_key)
+        if lock is None:
+            lock = asyncio.Lock()
+            _TURN_LOCKS[session_key] = lock
         return lock
 
     def _get_session_path(self, session_key: SessionKey) -> Path:


### PR DESCRIPTION
## Summary

Fixes #4756.

`process_direct` turns (cron `on_job` / heartbeat) enter the same `_process_message` pipeline as bus turns, but from their own asyncio task — nothing serializes turns at the session level. `SessionManager.get_or_create` hands both turns the **same cached Session object**, so a cron turn firing mid-user-turn mutates the session concurrently:

- **pair-order inversion** — the pair that arrived first can be persisted *behind* the interrupting cron pair; every later turn (`_build_prompt_history`) reads the inverted history, compounding the damage
- **`/new` ghost history** — a turn released after `/new` confirmed the drop re-appends its pair to the cleared session

## Change

- `SessionManager.get_turn_lock(session_key)` — a per-`SessionKey` turn lock, held for the **whole turn**. Deliberately distinct from the per-path save lock (`_get_lock`, which only guards the disk-write instant inside `save`), so `save()` inside a turn cannot deadlock against the turn lock; lock order is always turn → save.
- `AgentLoop._process_message` becomes a thin wrapper that takes the turn lock and delegates to the renamed `_process_message_turn` (body unchanged). The bus loop already serializes its own messages; this closes the remaining `process_direct` entry. All existing callers (`run()`, `process_direct`, tests) go through the wrapper unchanged.

## Verification

- Two deterministic regression tests (`bot/tests/test_session_turn_serialization.py`) park a turn inside the (fake) LLM call — no sleeps at the LLM boundary:
  - `test_process_direct_waits_for_inflight_bus_turn` — cron turn cannot enter the LLM while a user turn is in flight; user pair persisted first
  - `test_new_command_waits_for_inflight_cron_turn` — `/new` waits for the in-flight cron turn; cleared history stays empty
- Mutation check: removing the lock turns both tests red precisely (`n_inside 2 == 1` inversion; `new_task.done()` inversion). Restored → green.
- Full local bot suite: 524 passed; new tests 2/2 green; the 9 failures that exist on a clean `f97ce530` checkout (compact-hook ×4, agent-loop ×3, compile-prompt ×1, portable-paths ×1 — test-side drift being fixed by #4746) are unchanged by this diff (stash-baseline verified).

### CI coverage note

Repo CI does not run the bot pytest suite yet (the `bot-tests` lane that would cover it is proposed in #4746, still open) — the bot/ suite is a known CI blind spot, so the verification above is local and reproducible: `PYTHONPATH=bot:. python -m pytest -o addopts="" bot/tests/ bot/vikingbot/tests/`.