### PR TITLE
fix(storage): dedupe and bound multi-query search aggregation

### DIFF
--- a/openviking/storage/viking_fs/_semantic.py
+++ b/openviking/storage/viking_fs/_semantic.py
@@ -23,6 +23,72 @@ from openviking.utils.image_search import build_multimodal_embedding_input
 from openviking_cli.exceptions import NotFoundError
 
 
+MAX_TYPED_QUERIES = 5
+"""Hard cap on typed queries per search.
+
+The intent-analysis prompt already asks for at most five queries; this cap
+only enforces that contract when a model over-emits, bounding the fan-out
+cost of the concurrent retrieve() calls.
+"""
+
+
+def _cap_typed_queries(queries: List["TypedQuery"]) -> List["TypedQuery"]:
+    """Bound the typed-query fan-out to MAX_TYPED_QUERIES."""
+    if len(queries) <= MAX_TYPED_QUERIES:
+        return queries
+    logger.warning(
+        "Intent analysis returned %d queries; running only the first %d",
+        len(queries),
+        MAX_TYPED_QUERIES,
+    )
+    return queries[:MAX_TYPED_QUERIES]
+
+
+def _merge_query_results(
+    query_results: List["QueryResult"],
+    limit: int,
+) -> tuple:
+    """Merge per-typed-query results into deduped, score-ordered buckets.
+
+    Intent analysis routinely emits near-duplicate phrasings, so the same
+    URI can surface under several typed queries. Keep the best-scoring
+    occurrence per URI (mirroring the dedupe in ``_find_by_filter``: a
+    duplicate would inflate the total and eat two of the caller's limit
+    slots for one result), order each bucket by score instead of by which
+    query block an item happened to land in, and honor the caller's limit
+    per bucket.
+    """
+    from openviking_cli.retrieve import ContextType
+
+    buckets = {
+        ContextType.MEMORY: [],
+        ContextType.RESOURCE: [],
+        ContextType.SKILL: [],
+    }
+    for result in query_results:
+        for matched in result.matched_contexts:
+            bucket = buckets.get(matched.context_type)
+            if bucket is not None:
+                bucket.append(matched)
+
+    merged = {}
+    for context_type, items in buckets.items():
+        best: Dict[str, Any] = {}
+        for item in items:
+            previous = best.get(item.uri)
+            if previous is None or item.score > previous.score:
+                best[item.uri] = item
+        merged[context_type] = sorted(
+            best.values(), key=lambda m: m.score, reverse=True
+        )[: max(0, limit)]
+
+    return (
+        merged[ContextType.MEMORY],
+        merged[ContextType.RESOURCE],
+        merged[ContextType.SKILL],
+    )
+
+
 class _SemanticMixin:
     """Abstract/overview/find/search semantic retrieval layer."""
 
@@ -449,7 +515,7 @@ class _SemanticMixin:
                     current_message=query,
                     target_abstract=target_abstract,
                 )
-            typed_queries = query_plan.queries
+            typed_queries = _cap_typed_queries(query_plan.queries)
             for tq in typed_queries:
                 tq.target_directories = retrieval_targets.target_directories
         else:
@@ -492,16 +558,10 @@ class _SemanticMixin:
 
         query_results = await asyncio.gather(*[_execute(tq) for tq in typed_queries])
 
-        # Aggregate results to FindResult
-        memories, resources, skills = [], [], []
-        for result in query_results:
-            for ctx in result.matched_contexts:
-                if ctx.context_type == ContextType.MEMORY:
-                    memories.append(ctx)
-                elif ctx.context_type == ContextType.RESOURCE:
-                    resources.append(ctx)
-                elif ctx.context_type == ContextType.SKILL:
-                    skills.append(ctx)
+        # Aggregate results to FindResult: dedupe by URI across typed queries
+        # (keep the best score), order each bucket by score, and honor the
+        # caller's limit per bucket.
+        memories, resources, skills = _merge_query_results(query_results, limit)
 
         find_result = FindResult(
             memories=memories,

--- a/tests/retrieve/test_search_result_aggregation.py
+++ b/tests/retrieve/test_search_result_aggregation.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Multi-typed-query search aggregation tests.
+
+Intent analysis emits several near-duplicate phrasings, so the same URI can
+surface under multiple typed queries. These tests pin the aggregation
+contract: dedupe by URI keeping the best score, order each bucket by score
+(not by query block position), and honor the caller's limit per bucket.
+"""
+
+from openviking.storage.viking_fs._semantic import (
+    MAX_TYPED_QUERIES,
+    _cap_typed_queries,
+    _merge_query_results,
+)
+from openviking_cli.retrieve.types import (
+    ContextType,
+    MatchedContext,
+    QueryResult,
+    TypedQuery,
+)
+
+
+def _matched(uri, score, context_type=ContextType.MEMORY):
+    return MatchedContext(uri=uri, context_type=context_type, score=score)
+
+
+def _query_result(*contexts):
+    return QueryResult(
+        query=TypedQuery(query="q", context_type=None, intent=""),
+        matched_contexts=list(contexts),
+        searched_directories=[],
+    )
+
+
+def test_same_uri_across_queries_kept_once_with_best_score():
+    merged = _merge_query_results(
+        [
+            _query_result(_matched("viking://a/m1", 0.6)),
+            _query_result(_matched("viking://a/m1", 0.8)),
+        ],
+        limit=10,
+    )
+    memories = merged[0]
+    assert [m.uri for m in memories] == ["viking://a/m1"]
+    assert memories[0].score == 0.8
+
+
+def test_tie_keeps_first_seen_occurrence():
+    merged = _merge_query_results(
+        [
+            _query_result(_matched("viking://a/m1", 0.5, context_type=ContextType.RESOURCE)),
+            _query_result(_matched("viking://a/m1", 0.5, context_type=ContextType.RESOURCE)),
+        ],
+        limit=10,
+    )
+    resources = merged[1]
+    assert len(resources) == 1
+
+
+def test_buckets_are_score_ordered_across_queries():
+    # A later query's high-scoring hit must outrank an earlier query's
+    # low-scoring hit; the merge may not preserve query-block order.
+    merged = _merge_query_results(
+        [
+            _query_result(_matched("viking://a/low", 0.4)),
+            _query_result(_matched("viking://a/high", 0.9)),
+        ],
+        limit=10,
+    )
+    assert [m.uri for m in merged[0]] == ["viking://a/high", "viking://a/low"]
+
+
+def test_each_bucket_honors_limit_after_dedupe():
+    # Two queries each returning four distinct memories; limit=3 must bound
+    # the merged bucket regardless of how many queries contributed.
+    merged = _merge_query_results(
+        [
+            _query_result(*[_matched("viking://a/m%d" % i, 0.9 - i * 0.1) for i in range(4)]),
+            _query_result(*[_matched("viking://a/n%d" % i, 0.85 - i * 0.1) for i in range(4)]),
+        ],
+        limit=3,
+    )
+    memories = merged[0]
+    assert len(memories) == 3
+    scores = [m.score for m in memories]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_cross_bucket_independence():
+    merged = _merge_query_results(
+        [
+            _query_result(
+                _matched("viking://a/m1", 0.9, context_type=ContextType.MEMORY),
+                _matched("viking://a/r1", 0.8, context_type=ContextType.RESOURCE),
+                _matched("viking://a/s1", 0.7, context_type=ContextType.SKILL),
+            ),
+        ],
+        limit=1,
+    )
+    memories, resources, skills = merged
+    assert len(memories) == 1
+    assert len(resources) == 1
+    assert len(skills) == 1
+
+
+def test_cap_typed_queries_bounds_fanout():
+    queries = [
+        TypedQuery(query="q%d" % i, context_type=None, intent="") for i in range(6)
+    ]
+    capped = _cap_typed_queries(queries)
+    assert len(capped) == MAX_TYPED_QUERIES
+    assert capped[0].query == "q0"
+
+
+def test_cap_typed_queries_returns_input_within_bound():
+    queries = [
+        TypedQuery(query="q%d" % i, context_type=None, intent="") for i in range(3)
+    ]
+    assert _cap_typed_queries(queries) is queries


### PR DESCRIPTION
## Summary

`VikingFS.search()` with session context runs intent analysis, which emits N typed queries, each independently retrieving up to `limit` results. The aggregation concatenated the per-query blocks verbatim into the FindResult buckets:

- **Duplicate URIs** — near-duplicate phrasings from intent analysis regularly surface the same document from several typed queries, and the same URI was appended once per query that matched it. Downstream consumers (`/api/v1/search` response, MCP `search` list mode) do not dedupe, so callers saw repeats.
- **Limit overrun** — each bucket could hold up to `N × limit` items (5 queries × limit=10 → 50 per bucket), breaking the documented `limit: Return count` contract.
- **Block-order ranking** — ordering followed query-block position rather than score, so a later query's high-scoring hit ranked below an earlier query's low-scoring one.

## Fix

- Merge per-query results with a URI-level dedupe that keeps the best-scoring occurrence — mirroring the dedupe `_find_by_filter` already applies to tag-level duplicates ("inflating the total and eating two of the caller's limit slots for one result").
- Order each bucket by score (descending) and truncate each bucket to the caller's `limit`.
- Cap the typed-query fan-out at `MAX_TYPED_QUERIES = 5` with a `logger.warning` when a model over-emits. The intent-analysis prompt already asks for at most five queries, so this only enforces the existing contract; normal plans are unchanged (`≤ 5` returns the input as-is).
- `FindResult.query_results` keeps the raw per-query results unchanged, so thinking-trace/diagnostic consumers are unaffected.

Single-query paths (no session, intent disabled, image search) are unaffected: their buckets were already within `limit`, and the merge is a no-op on them.

## Tests

New `tests/retrieve/test_search_result_aggregation.py` (7 tests, pure-function, no fixtures):

- same URI across queries kept once with the best score
- tie keeps first-seen occurrence
- buckets are score-ordered across queries (later query's high hit outranks earlier query's low hit)
- each bucket honors `limit` after dedupe
- cross-bucket independence
- cap bounds a 6-query plan to 5
- cap returns the input unchanged within the bound

Verification: `tests/retrieve/` A/B — base `58 passed`, this branch `65 passed` (zero regressions); the new tests fail at collection on base (ImportError) so the behavior is structurally locked.

## Context

The context-assembly path already applies equivalent governance (`context_assembler/expansion.py` caps planned queries at `MAX_PLANNED_QUERIES`; `gather.py` dedupes by URI keeping the best score) — this brings the list-mode `search()` path to the same standard.
