### PR TITLE
fix(utils): survive async client close on a dead event loop

### DIFF
--- a/integrations/langchain/src/langchain_openviking/_async_client_cache.py
+++ b/integrations/langchain/src/langchain_openviking/_async_client_cache.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import threading
+import warnings
 import weakref
 from collections.abc import Callable
 from typing import Any, Protocol
@@ -98,9 +99,29 @@ class LoopScopedAsyncClientCache:
             if client_id in seen:
                 continue
             seen.add(client_id)
-            result = close_client(client)
-            if inspect.isawaitable(result):
-                await result
+            try:
+                result = close_client(client)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception as exc:
+                # A client whose home event loop has already closed cannot run
+                # its async close callback: asyncio raises "Event loop is
+                # closed" once the transport schedules the close on the dead
+                # loop. One failing client must not abort the shutdown of the
+                # remaining ones, so fall back to any synchronous close() and
+                # leave leftover sockets to garbage-collection finalizers.
+                warnings.warn(
+                    f"async close failed for {type(client).__name__} ({exc!r}); "
+                    "falling back to synchronous close() where available",
+                    ResourceWarning,
+                    stacklevel=2,
+                )
+                sync_close = getattr(client, "close", None)
+                if callable(sync_close):
+                    try:
+                        sync_close()
+                    except Exception:
+                        pass
 
     def close_all(self, close_client: Callable[[Any], Any]) -> None:
         """Close and clear all cached clients on a best-effort basis."""

--- a/openviking/utils/async_client_cache.py
+++ b/openviking/utils/async_client_cache.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import threading
+import warnings
 import weakref
 from collections.abc import Callable
 from typing import Any, Protocol
@@ -97,9 +98,30 @@ class LoopScopedAsyncClientCache:
                 continue
             seen.add(client_id)
 
-            result = close_client(client)
-            if inspect.isawaitable(result):
-                await result
+            try:
+                result = close_client(client)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception as exc:
+                # A client whose home event loop has already closed (e.g. a
+                # queue-worker loop that exited after using the client) cannot
+                # run its async close callback: asyncio raises "Event loop is
+                # closed" once the transport schedules the close on the dead
+                # loop. One failing client must not abort the shutdown of the
+                # remaining ones, so fall back to any synchronous close() and
+                # leave leftover sockets to garbage-collection finalizers.
+                warnings.warn(
+                    f"async close failed for {type(client).__name__} ({exc!r}); "
+                    "falling back to synchronous close() where available",
+                    ResourceWarning,
+                    stacklevel=2,
+                )
+                sync_close = getattr(client, "close", None)
+                if callable(sync_close):
+                    try:
+                        sync_close()
+                    except Exception:
+                        pass
 
     def close_all(self, close_client: Callable[[Any], Any]) -> None:
         """Close and clear all cached clients on a best-effort basis."""

--- a/tests/utils/test_async_client_cache.py
+++ b/tests/utils/test_async_client_cache.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Tests for LoopScopedAsyncClientCache close semantics."""
+
+import asyncio
+import threading
+import warnings
+
+import pytest
+
+from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
+
+
+class StubAsyncClient:
+    """Stub async client; can simulate one bound to an already-closed loop."""
+
+    def __init__(self, aclose_error: Exception | None = None) -> None:
+        self.aclose_error = aclose_error
+        self.aclose_called = False
+        self.sync_close_called = False
+        self.sync_close_error: Exception | None = None
+
+    async def aclose(self) -> None:
+        self.aclose_called = True
+        if self.aclose_error is not None:
+            raise self.aclose_error
+
+    def close(self) -> None:
+        self.sync_close_called = True
+        if self.sync_close_error is not None:
+            raise self.sync_close_error
+
+
+def _seed_client_on_short_lived_loop(cache: LoopScopedAsyncClientCache, factory):
+    """Cache one client on a loop that is closed before the function returns.
+
+    Returns the (closed) loop object so the caller can keep a strong
+    reference: the WeakKeyDictionary entry must survive until close_all is
+    called, mirroring production where loops linger via reference cycles.
+    """
+
+    loop_holder: dict[str, asyncio.AbstractEventLoop] = {}
+
+    def run() -> None:
+        loop = asyncio.new_event_loop()
+        loop_holder["loop"] = loop
+
+        async def seed() -> None:
+            cache.get(factory)
+
+        try:
+            loop.run_until_complete(seed())
+        finally:
+            loop.close()
+
+    t = threading.Thread(target=run)
+    t.start()
+    t.join()
+    return loop_holder["loop"]
+
+
+def test_get_returns_per_loop_clients_and_cleans_up():
+    cache = LoopScopedAsyncClientCache()
+
+    async def use(factory):
+        return cache.get(factory)
+
+    loop = asyncio.new_event_loop()
+    a = StubAsyncClient()
+    b = StubAsyncClient()
+    try:
+        first = loop.run_until_complete(use(lambda: a))
+        second = loop.run_until_complete(use(lambda: b))
+        assert first is a
+        assert second is a  # same loop -> same cached client
+    finally:
+        loop.close()
+
+    other = asyncio.new_event_loop()
+    try:
+        third = other.run_until_complete(use(lambda: b))
+        assert third is b  # different loop -> fresh client
+    finally:
+        other.close()
+
+
+def test_close_all_does_not_raise_for_client_bound_to_closed_loop():
+    cache = LoopScopedAsyncClientCache()
+    dead = StubAsyncClient(aclose_error=RuntimeError("Event loop is closed"))
+
+    dead_loop = _seed_client_on_short_lived_loop(cache, lambda: dead)
+    assert dead_loop.is_closed()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ResourceWarning)
+        # Before the fix this raised RuntimeError("Event loop is closed")
+        # from asyncio.run(...) and aborted the whole shutdown sequence.
+        cache.close_all_with_aclose()
+
+    assert cache.has_clients() is False
+
+
+def test_close_all_continues_with_remaining_clients_after_one_fails():
+    cache = LoopScopedAsyncClientCache()
+    dead = StubAsyncClient(aclose_error=RuntimeError("Event loop is closed"))
+
+    dead_loop = _seed_client_on_short_lived_loop(cache, lambda: dead)
+    assert dead_loop.is_closed()
+
+    healthy = StubAsyncClient()
+    # seed the fallback client from a sync context (no running loop)
+    assert cache.get(lambda: healthy) is healthy
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cache.close_all_with_aclose()
+
+    assert dead.aclose_called
+    assert dead.sync_close_called  # fallback was attempted for the dead one
+    assert healthy.aclose_called  # healthy client still closed afterwards
+
+    leak_warnings = [w for w in caught if issubclass(w.category, ResourceWarning)]
+    assert len(leak_warnings) == 1
+    assert "StubAsyncClient" in str(leak_warnings[0].message)
+
+
+def test_sync_close_fallback_failure_is_swallowed():
+    cache = LoopScopedAsyncClientCache()
+    dead = StubAsyncClient(aclose_error=RuntimeError("Event loop is closed"))
+    dead.sync_close_error = RuntimeError("close also failed")
+
+    dead_loop = _seed_client_on_short_lived_loop(cache, lambda: dead)
+    assert dead_loop.is_closed()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ResourceWarning)
+        cache.close_all_with_aclose()  # must not raise either
+
+
+def test_close_all_with_close_uses_sync_close():
+    cache = LoopScopedAsyncClientCache()
+    client = StubAsyncClient()
+
+    async def seed():
+        cache.get(lambda: client)
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(seed())
+    finally:
+        loop.close()
+
+    # loop of the cached client is closed; sync path via close_all_from_loop-less call
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ResourceWarning)
+        cache.close_all_with_close()
+
+    assert client.sync_close_called
+    assert client.aclose_called is False


### PR DESCRIPTION
## Problem

`LoopScopedAsyncClientCache.close_all()` (openviking/utils/async_client_cache.py) closes cached async clients when called from a synchronous context by running `asyncio.run(self._close_clients(...))` on a **fresh** event loop. If one of the cached clients was last used on a loop that has **already closed** — e.g. a short-lived queue-worker loop (`asyncio.new_event_loop()` + `loop.close()` per job, the same family as #4726) — its asyncio transport cannot schedule the close callback on the dead loop and raises:

```
RuntimeError: Event loop is closed
  ... anyio/_backends/_asyncio.py:1397 in aclose -> self._transport.close()
  ... selector_events.py:875 -> self._loop.call_soon(self._call_connection_lost, None)
  ... base_events.py:545 -> self._check_closed()
```

Consequences, reproduced with a real `httpx.AsyncClient` holding a keep-alive connection against a local server:

1. `RuntimeError` propagates out of `close_all_with_aclose()` and aborts the caller's shutdown sequence — e.g. `dashscope_embedders.close()` closes `_async_openai_client_cache` first, so the `_async_httpx_client_cache` close on the next line never executes.
2. The remaining cached clients are never closed (one dead client poisons all of them).
3. The socket of the failing client is **not** closed either (`_call_connection_lost` never runs), so the fd leaks.

## Fix

`_close_clients` now wraps **each** client close individually:

- on failure: emit a `ResourceWarning` describing the client and the error,
- fall back to the client's synchronous `close()` when it has one (e.g. `openai.AsyncOpenAI.close()`),
- continue closing the remaining clients.

Sockets of clients bound to an already-closed loop cannot be closed through asyncio at all; they are left to garbage-collection finalizers, which close the fds once the client becomes unreferenced — verified end-to-end: after the fixed `close_all()` returns, the local server observes the connection close within the GC window (before the fix it never closes while the exception aborts everything).

The langchain integration ships a private copy of the same cache (`integrations/langchain/src/langchain_openviking/_async_client_cache.py`); the same fix is applied there. Note the langchain runnable layer already guards the sibling case correctly by raising `RuntimeError("... use await runnable.aclose()")` from its own `close()` — this PR fixes the cache layer's best-effort path that has no async alternative.

## Tests

`tests/utils/test_async_client_cache.py` (new, 5 tests, deterministic — no real network):

- `test_get_returns_per_loop_clients_and_cleans_up` — per-loop caching semantics (pre-existing behavior, regression guard)
- `test_close_all_does_not_raise_for_client_bound_to_closed_loop` — **the bug**: before the fix this raises `RuntimeError` (mutation-verified)
- `test_close_all_continues_with_remaining_clients_after_one_fails` — a healthy fallback client is still closed after the dead one fails, and exactly one `ResourceWarning` is emitted
- `test_sync_close_fallback_failure_is_swallowed` — double failure (aclose + close) still does not raise
- `test_close_all_with_close_uses_sync_close` — the sync-close path keeps working

Mutation check: reverting only the try/except in `_close_clients` makes exactly the 3 new tests fail and restoring makes all 5 pass; the 2 unrelated tests stay green in both states.

Local runs: `tests/utils/` 33 passed (2 pre-existing `test_circuit_breaker` failures reproduce identically on a clean `upstream/main` checkout), langchain consumer tests `test_langchain_async_integration.py` / `test_langchain_lifecycle_resources.py` 3 passed 2 skipped, no regressions.
