### PR TITLE
feat(feishu): add recursive wiki materialization

### DIFF
--- a/openviking/parse/accessors/feishu_accessor.py
+++ b/openviking/parse/accessors/feishu_accessor.py
@@ -233,6 +233,17 @@ class FeishuDocument:
     media_download_extras: _MediaDownloadExtras = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class _FeishuWikiTreeNode:
+    """Wiki node tree identity plus its backing content object."""
+
+    wiki_node_token: str
+    space_id: str
+    title: str
+    obj_type: Optional[str] = None
+    obj_token: Optional[str] = None
+
+
 class FeishuAccessor(DataAccessor):
     """
     Accessor for Feishu/Lark cloud documents.
@@ -437,6 +448,52 @@ class FeishuAccessor(DataAccessor):
                         "feishu_doc_type": doc_type,
                         "feishu_token": token,
                         "original_filename": _safe_path_segment(folder_name, fallback=token),
+                        "feishu_folder_skipped_items": skipped_items,
+                    },
+                    is_temporary=True,
+                )
+
+            if doc_type == "wiki" and bool(kwargs.get("feishu_recursive", False)):
+                temp_dir = Path(tempfile.mkdtemp(prefix="ov_feishu_wiki_"))
+                skipped_items: list[dict[str, Any]] = []
+                try:
+                    root = await asyncio.to_thread(
+                        self._resolve_wiki_tree_root,
+                        source_str,
+                        feishu_access_token=feishu_access_token,
+                    )
+                    root_dir = await self._materialize_wiki_tree_node(
+                        root,
+                        temp_dir,
+                        feishu_access_token=feishu_access_token,
+                        skipped_items=skipped_items,
+                        strict=bool(kwargs.get("strict", False)),
+                        visited=set(),
+                        depth=0,
+                        max_depth=self._positive_int_option(
+                            kwargs.get("feishu_max_depth"),
+                            default=20,
+                        ),
+                        max_nodes_state=[0],
+                        max_nodes=self._positive_int_option(
+                            kwargs.get("feishu_max_nodes"),
+                            default=5000,
+                        ),
+                    )
+                except Exception:
+                    shutil.rmtree(temp_dir, ignore_errors=True)
+                    raise
+                return LocalResource(
+                    path=root_dir,
+                    source_type=SourceType.FEISHU,
+                    original_source=source_str,
+                    meta={
+                        "feishu_doc_type": "wiki",
+                        "feishu_token": token,
+                        "feishu_title": root.title,
+                        "original_filename": _title_as_filename(root.title),
+                        "_cleanup_path": str(temp_dir),
+                        "wiki_resolved": True,
                         "feishu_folder_skipped_items": skipped_items,
                     },
                     is_temporary=True,
@@ -897,6 +954,205 @@ class FeishuAccessor(DataAccessor):
         finally:
             seen.discard(folder_token)
 
+    async def _materialize_wiki_tree_node(
+        self,
+        node: _FeishuWikiTreeNode,
+        target_dir: Path,
+        *,
+        feishu_access_token: Optional[str] = None,
+        skipped_items: Optional[list[dict[str, Any]]] = None,
+        strict: bool = False,
+        visited: Optional[set[str]] = None,
+        depth: int = 0,
+        max_depth: int = 20,
+        max_nodes_state: Optional[list[int]] = None,
+        max_nodes: int = 5000,
+    ) -> Path:
+        """Expand a Feishu Wiki node tree into a local directory tree."""
+        target_dir.mkdir(parents=True, exist_ok=True)
+        seen = visited if visited is not None else set()
+        if node.wiki_node_token in seen:
+            logger.warning(
+                "[FeishuAccessor] Skipping recursive Wiki node %s",
+                node.wiki_node_token,
+            )
+            return target_dir
+        seen.add(node.wiki_node_token)
+        try:
+            state = max_nodes_state if max_nodes_state is not None else [0]
+            state[0] += 1
+            if state[0] > max_nodes:
+                error = RuntimeError(f"Feishu Wiki node limit exceeded: {max_nodes}")
+                self._record_skipped_wiki_node(
+                    skipped_items,
+                    node=node,
+                    target_dir=target_dir,
+                    error=error,
+                )
+                if strict:
+                    raise error
+                return target_dir
+
+            children: List[_FeishuWikiTreeNode] = []
+            children_known = False
+            if depth < max_depth:
+                try:
+                    children = await asyncio.to_thread(
+                        self._list_wiki_node_children,
+                        node.space_id,
+                        node.wiki_node_token,
+                        feishu_access_token=feishu_access_token,
+                    )
+                    children_known = True
+                except Exception as exc:
+                    self._record_skipped_wiki_node(
+                        skipped_items,
+                        node=node,
+                        target_dir=target_dir,
+                        error=exc,
+                    )
+                    if strict:
+                        raise
+
+            content_dir = target_dir
+            if children or not children_known:
+                content_dir = self._unique_child_path(
+                    target_dir,
+                    self._wiki_node_dir_name(node),
+                )
+                content_dir.mkdir(parents=True, exist_ok=True)
+
+            try:
+                content_path = await self._write_wiki_node_content(
+                    node,
+                    content_dir,
+                    feishu_access_token=feishu_access_token,
+                )
+            except Exception as exc:
+                self._record_skipped_wiki_node(
+                    skipped_items,
+                    node=node,
+                    target_dir=content_dir,
+                    error=exc,
+                )
+                if strict:
+                    raise
+                content_path = None
+
+            for child in children:
+                await self._materialize_wiki_tree_node(
+                    child,
+                    content_dir,
+                    feishu_access_token=feishu_access_token,
+                    skipped_items=skipped_items,
+                    strict=strict,
+                    visited=seen,
+                    depth=depth + 1,
+                    max_depth=max_depth,
+                    max_nodes_state=state,
+                    max_nodes=max_nodes,
+                )
+            return content_dir if children or not children_known else content_path or target_dir
+        finally:
+            seen.discard(node.wiki_node_token)
+
+    async def _write_wiki_node_content(
+        self,
+        node: _FeishuWikiTreeNode,
+        target_dir: Path,
+        *,
+        feishu_access_token: Optional[str] = None,
+    ) -> Optional[Path]:
+        doc_type = self._normalize_wiki_obj_type(node.obj_type)
+        if not doc_type or not node.obj_token:
+            return None
+
+        if doc_type == "file":
+            content, content_type, downloaded_name = await asyncio.to_thread(
+                self._download_drive_file,
+                node.obj_token,
+                feishu_access_token=feishu_access_token,
+                filename_hint=node.title,
+            )
+            file_path = self._unique_child_path(
+                target_dir,
+                self._drive_file_name(
+                    node.obj_token,
+                    content,
+                    content_type,
+                    filename_hint=downloaded_name or node.title,
+                ),
+            )
+            file_path.write_bytes(content)
+            return file_path
+
+        if doc_type not in self._DOC_TYPE_HANDLERS:
+            raise ValueError(f"Unsupported Feishu Wiki node object type: {node.obj_type}")
+
+        doc = await self._fetch_document(
+            self._build_feishu_doc_url(doc_type, node.obj_token),
+            feishu_access_token=feishu_access_token,
+        )
+        markdown_content, downloaded_images = await asyncio.to_thread(
+            self._resolve_image_refs,
+            doc.markdown_content,
+            feishu_access_token=feishu_access_token,
+            media_download_extras=doc.media_download_extras,
+        )
+        markdown_path = self._unique_child_path(
+            target_dir,
+            self._markdown_file_name(node.title),
+        )
+        markdown_path.write_text(markdown_content, encoding="utf-8")
+        for rel_path, image_bytes in downloaded_images.items():
+            image_path = markdown_path.parent / rel_path
+            image_path.parent.mkdir(parents=True, exist_ok=True)
+            image_path.write_bytes(image_bytes)
+        return markdown_path
+
+    @staticmethod
+    def _record_skipped_wiki_node(
+        skipped_items: Optional[list[dict[str, Any]]],
+        *,
+        node: _FeishuWikiTreeNode,
+        target_dir: Path,
+        error: Exception,
+    ) -> None:
+        message = str(error).replace("\n", " ")
+        logger.warning(
+            "[FeishuAccessor] Skipping Wiki node %s under %s: %s",
+            node.wiki_node_token,
+            target_dir,
+            message,
+        )
+        if skipped_items is None:
+            return
+        token = node.obj_token or node.wiki_node_token
+        skipped_items.append(
+            {
+                "path": str(target_dir / _safe_path_segment(node.title or token, fallback=token)),
+                "name": node.title or token,
+                "type": node.obj_type or "wiki_node",
+                "token": token,
+                "wiki_node_token": node.wiki_node_token,
+                "reason": message,
+            }
+        )
+
+    @staticmethod
+    def _wiki_node_dir_name(node: _FeishuWikiTreeNode) -> str:
+        if node.obj_type == "file" and Path(node.title).suffix:
+            return Path(node.title).stem
+        return node.title
+
+    @staticmethod
+    def _positive_int_option(value: Any, *, default: int) -> int:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return default
+        return parsed if parsed > 0 else default
+
     @staticmethod
     def _record_skipped_drive_item(
         skipped_items: Optional[list[dict[str, Any]]],
@@ -1085,7 +1341,7 @@ class FeishuAccessor(DataAccessor):
             .token_types({token_type})
             .build()
         )
-        response = self._call_api(client.request, raw_req, feishu_access_token)
+        response = self._call_raw_api(client, raw_req, feishu_access_token)
         if not response.success():
             _raise_from_lark_response(
                 response,
@@ -1291,19 +1547,65 @@ class FeishuAccessor(DataAccessor):
         option = self._user_request_option(feishu_access_token)
         return method(request) if option is None else method(request, option)
 
+    @classmethod
+    def _raw_feishu_error(cls, raw_resp: Any) -> Optional[Tuple[int, str]]:
+        content_type = cls._response_content_type(raw_resp)
+        if not content_type or "application/json" not in content_type.lower():
+            return None
+        content = getattr(raw_resp, "content", None)
+        if not content:
+            return None
+        if isinstance(content, bytes):
+            try:
+                content = content.decode("utf-8")
+            except UnicodeDecodeError:
+                return None
+        if not isinstance(content, str):
+            return None
+        try:
+            payload = json.loads(content)
+        except (TypeError, json.JSONDecodeError):
+            return None
+        if not isinstance(payload, dict):
+            return None
+        code = payload.get("code")
+        if not isinstance(code, int) or code == 0:
+            return None
+        msg = payload.get("msg") or payload.get("message") or "Feishu API request failed"
+        return code, str(msg)
+
+    def _call_raw_api(self, client, request, feishu_access_token: Optional[str] = None):
+        """Execute a raw Lark request without JSON-decoding successful file bodies."""
+        from lark_oapi.core.http import Transport
+        from lark_oapi.core.model import BaseResponse, RequestOption
+        from lark_oapi.core.token import verify
+
+        option = self._user_request_option(feishu_access_token) or RequestOption()
+        verify(client._config, request, option)
+        raw_resp = Transport.execute(client._config, request, option)
+
+        response = BaseResponse()
+        feishu_error = self._raw_feishu_error(raw_resp)
+        if feishu_error:
+            response.code, response.msg = feishu_error
+        elif 200 <= raw_resp.status_code < 300:
+            response.code = 0
+        else:
+            response.code = raw_resp.status_code
+            content = getattr(raw_resp, "content", b"")
+            if isinstance(content, bytes):
+                content = content.decode("utf-8", errors="replace")
+            response.msg = str(content)
+        response.raw = raw_resp
+        return response
+
     # ========== Wiki Resolution ==========
 
-    def _resolve_wiki_node(
+    def _fetch_wiki_node(
         self,
         token: str,
         feishu_access_token: Optional[str] = None,
-    ) -> Tuple[str, str, Optional[str]]:
-        """
-        Resolve wiki token to actual document type, token, and title.
-
-        Returns:
-            (doc_type, obj_token, title)
-        """
+    ) -> Any:
         from lark_oapi.api.wiki.v2 import GetNodeSpaceRequest
 
         client = self._get_client(use_user_token=bool(feishu_access_token))
@@ -1319,15 +1621,154 @@ class FeishuAccessor(DataAccessor):
                 operation=f"resolve wiki node {token}",
                 resource=token,
             )
-        node = response.data.node
-        obj_type = node.obj_type or ""
-        obj_token = node.obj_token or ""
-        title = node.title
+        return response.data.node
+
+    def _resolve_wiki_node(
+        self,
+        token: str,
+        feishu_access_token: Optional[str] = None,
+    ) -> Tuple[str, str, Optional[str]]:
+        """
+        Resolve wiki token to actual document type, token, and title.
+
+        Returns:
+            (doc_type, obj_token, title)
+        """
+        node = self._fetch_wiki_node(token, feishu_access_token)
+        obj_type = _getattr_safe(node, "obj_type", "") or ""
+        obj_token = _getattr_safe(node, "obj_token", "") or ""
+        title = _getattr_safe(node, "title", None)
 
         # Normalize type names
-        doc_type = self._WIKI_TYPE_MAP.get(obj_type, obj_type)
+        doc_type = self._normalize_wiki_obj_type(obj_type) or ""
 
         return doc_type, obj_token, title
+
+    def _resolve_wiki_tree_root(
+        self,
+        url: str,
+        *,
+        feishu_access_token: Optional[str] = None,
+    ) -> _FeishuWikiTreeNode:
+        doc_type, token = self._parse_feishu_url(url)
+        if doc_type != "wiki":
+            raise ValueError(f"Feishu recursive import only supports wiki URLs, got: {doc_type}")
+        node = self._fetch_wiki_node(token, feishu_access_token)
+        return self._wiki_tree_node_from_api_node(node, fallback_token=token)
+
+    def _fetch_wiki_node_children_page(
+        self,
+        space_id: str,
+        parent_node_token: str,
+        *,
+        feishu_access_token: Optional[str] = None,
+        page_token: Optional[str] = None,
+        page_size: int = 50,
+    ) -> tuple[List[Any], bool, Optional[str]]:
+        import lark_oapi as lark
+
+        if not space_id:
+            raise ValueError(f"Feishu Wiki node {parent_node_token} has no space_id")
+
+        client = self._get_client(use_user_token=bool(feishu_access_token))
+        token_type = (
+            lark.AccessTokenType.USER if feishu_access_token else lark.AccessTokenType.TENANT
+        )
+        raw_req = (
+            lark.BaseRequest.builder()
+            .http_method(lark.HttpMethod.GET)
+            .uri(f"/open-apis/wiki/v2/spaces/{space_id}/nodes")
+            .token_types({token_type})
+            .build()
+        )
+        raw_req.add_query("parent_node_token", parent_node_token)
+        raw_req.add_query("page_size", page_size)
+        if page_token:
+            raw_req.add_query("page_token", page_token)
+
+        response = self._call_api(client.request, raw_req, feishu_access_token)
+        if not response.success():
+            _raise_from_lark_response(
+                response,
+                operation=f"list Wiki node children {parent_node_token}",
+                resource=parent_node_token,
+            )
+
+        data = self._raw_response_data(response)
+        items = _getattr_safe(data, "items", None) or _getattr_safe(data, "nodes", None) or []
+        has_more = bool(_getattr_safe(data, "has_more", False))
+        next_page_token = _getattr_safe(data, "page_token", None) or _getattr_safe(
+            data,
+            "next_page_token",
+            None,
+        )
+        return list(items), has_more, next_page_token
+
+    def _list_wiki_node_children(
+        self,
+        space_id: str,
+        wiki_node_token: str,
+        *,
+        feishu_access_token: Optional[str] = None,
+    ) -> List[_FeishuWikiTreeNode]:
+        children: List[_FeishuWikiTreeNode] = []
+        page_token = None
+        while True:
+            items, has_more, page_token = self._fetch_wiki_node_children_page(
+                space_id,
+                wiki_node_token,
+                feishu_access_token=feishu_access_token,
+                page_token=page_token,
+            )
+            for item in items:
+                children.append(
+                    self._wiki_tree_node_from_api_node(
+                        item,
+                        fallback_token=wiki_node_token,
+                        fallback_space_id=space_id,
+                    )
+                )
+            if not has_more:
+                break
+            if not page_token:
+                raise RuntimeError(
+                    f"Feishu returned more Wiki children for {wiki_node_token} "
+                    "without a page token"
+                )
+        return children
+
+    @classmethod
+    def _wiki_tree_node_from_api_node(
+        cls,
+        node: Any,
+        *,
+        fallback_token: str,
+        fallback_space_id: Optional[str] = None,
+    ) -> _FeishuWikiTreeNode:
+        node_token = str(
+            _getattr_safe(node, "node_token", None)
+            or _getattr_safe(node, "token", None)
+            or fallback_token
+        )
+        space_id = str(_getattr_safe(node, "space_id", None) or fallback_space_id or "")
+        title = str(_getattr_safe(node, "title", None) or node_token)
+        raw_obj_type = _getattr_safe(node, "obj_type", None)
+        obj_type = cls._normalize_wiki_obj_type(str(raw_obj_type)) if raw_obj_type else None
+        obj_token = _getattr_safe(node, "obj_token", None)
+        return _FeishuWikiTreeNode(
+            wiki_node_token=node_token,
+            space_id=space_id,
+            title=title,
+            obj_type=obj_type,
+            obj_token=str(obj_token) if obj_token else None,
+        )
+
+    @classmethod
+    def _normalize_wiki_obj_type(cls, obj_type: Optional[str]) -> Optional[str]:
+        if not obj_type:
+            return None
+        value = str(obj_type).lower()
+        return cls._WIKI_TYPE_MAP.get(value, value)
 
     # ========== Legacy Doc Parsing ==========
 
@@ -1760,18 +2201,10 @@ class FeishuAccessor(DataAccessor):
             return None
         return content, self._response_content_type(raw)
 
-    @staticmethod
-    def _response_content_type(raw) -> Optional[str]:
+    @classmethod
+    def _response_content_type(cls, raw) -> Optional[str]:
         """Best-effort extraction of the Content-Type header from a lark raw response."""
-        headers = getattr(raw, "headers", None)
-        if not headers:
-            return None
-        # lark's raw.headers may be a plain dict or a case-insensitive mapping.
-        try:
-            get = headers.get
-        except AttributeError:
-            return None
-        return get("Content-Type") or get("content-type")
+        return cls._response_header(raw, "content-type")
 
     def _resolve_image_refs(
         self,

--- a/tests/parse/test_feishu_accessor.py
+++ b/tests/parse/test_feishu_accessor.py
@@ -5,6 +5,7 @@
 import asyncio
 import json
 import sys
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -13,7 +14,9 @@ import pytest
 from openviking.parse.accessors.feishu_accessor import (
     _MAX_MEDIA_DOWNLOAD_CONTEXTS,
     FeishuAccessor,
+    _FeishuWikiTreeNode,
 )
+from openviking_cli.exceptions import OpenVikingError
 
 
 class _SuccessResponse:
@@ -46,6 +49,16 @@ class _FakeRequestOptionBuilder:
 
     def build(self):
         return self._option
+
+
+class _FakeBaseResponse:
+    def __init__(self):
+        self.code = None
+        self.msg = ""
+        self.raw = None
+
+    def success(self):
+        return self.code == 0
 
 
 class _FakeBaseRequest:
@@ -102,6 +115,20 @@ class _FakeMediaResponse:
         return self._success
 
 
+class _FakeTransport:
+    response = None
+    calls = []
+
+    @classmethod
+    def execute(cls, config, request, option):
+        cls.calls.append((config, request, option))
+        return cls.response
+
+
+def _fake_verify(config, request, option):
+    return None
+
+
 class _FakeListDocumentBlockRequest:
     @staticmethod
     def builder():
@@ -148,6 +175,8 @@ class _FakeTypedRequestBuilder:
 
 
 def _install_fake_lark_modules(monkeypatch):
+    _FakeTransport.response = None
+    _FakeTransport.calls = []
     lark = ModuleType("lark_oapi")
     lark.BaseRequest = _FakeBaseRequest
     lark.HttpMethod = SimpleNamespace(GET="GET")
@@ -161,12 +190,19 @@ def _install_fake_lark_modules(monkeypatch):
     bitable_v1.ListAppTableFieldRequest = _FakeTypedRequest
     bitable_v1.ListAppTableRecordRequest = _FakeTypedRequest
     core_model = ModuleType("lark_oapi.core.model")
+    core_model.BaseResponse = _FakeBaseResponse
     core_model.RequestOption = _FakeRequestOption
+    core_http = ModuleType("lark_oapi.core.http")
+    core_http.Transport = _FakeTransport
+    core_token = ModuleType("lark_oapi.core.token")
+    core_token.verify = _fake_verify
     monkeypatch.setitem(sys.modules, "lark_oapi", lark)
     monkeypatch.setitem(sys.modules, "lark_oapi.api.docx.v1", docx_v1)
     monkeypatch.setitem(sys.modules, "lark_oapi.api.wiki.v2", wiki_v2)
     monkeypatch.setitem(sys.modules, "lark_oapi.api.bitable.v1", bitable_v1)
     monkeypatch.setitem(sys.modules, "lark_oapi.core.model", core_model)
+    monkeypatch.setitem(sys.modules, "lark_oapi.core.http", core_http)
+    monkeypatch.setitem(sys.modules, "lark_oapi.core.token", core_token)
 
 
 def test_feishu_api_lists_paginated_content_with_user_token(monkeypatch):
@@ -213,6 +249,64 @@ def test_feishu_api_lists_paginated_content_with_user_token(monkeypatch):
     assert option.user_access_token == "u-test"
     assert list_drive.call_args_list[1].args[0].queries["page_token"] == "page-2"
     assert all(call.args[1].user_access_token == "u-test" for call in list_drive.call_args_list)
+
+
+def test_feishu_api_lists_paginated_wiki_children_with_user_token(monkeypatch):
+    _install_fake_lark_modules(monkeypatch)
+    list_wiki_children = MagicMock(
+        side_effect=[
+            _SuccessResponse(
+                SimpleNamespace(
+                    items=[
+                        SimpleNamespace(
+                            space_id="space",
+                            node_token="child-doc",
+                            title="Child Doc",
+                            obj_type="docx",
+                            obj_token="doc_token",
+                        )
+                    ],
+                    has_more=True,
+                    page_token="page-2",
+                )
+            ),
+            _SuccessResponse(
+                SimpleNamespace(
+                    items=[
+                        SimpleNamespace(
+                            space_id="space",
+                            node_token="child-file",
+                            title="Attachment.pdf",
+                            obj_type="file",
+                            obj_token="file_token",
+                        )
+                    ],
+                    has_more=False,
+                    page_token=None,
+                )
+            ),
+        ]
+    )
+    accessor = FeishuAccessor()
+    accessor._user_token_client = SimpleNamespace(request=list_wiki_children)
+
+    children = accessor._list_wiki_node_children(
+        "space",
+        "parent",
+        feishu_access_token="u-test",
+    )
+
+    assert [child.wiki_node_token for child in children] == ["child-doc", "child-file"]
+    assert [child.obj_type for child in children] == ["docx", "file"]
+    assert list_wiki_children.call_args_list[0].args[0].uri == (
+        "/open-apis/wiki/v2/spaces/space/nodes"
+    )
+    assert list_wiki_children.call_args_list[0].args[0].queries["parent_node_token"] == "parent"
+    assert list_wiki_children.call_args_list[1].args[0].queries["page_token"] == "page-2"
+    assert all(
+        call.args[1].user_access_token == "u-test"
+        for call in list_wiki_children.call_args_list
+    )
 
 
 def test_resolve_image_refs_respects_download_images_disabled():
@@ -405,14 +499,12 @@ def test_download_image_advertises_user_token_when_provided(monkeypatch):
 
 def test_access_downloads_drive_file_with_user_token(monkeypatch):
     _install_fake_lark_modules(monkeypatch)
-    request = MagicMock(
-        return_value=_FakeMediaResponse(
-            b"%PDF-1.7",
-            headers={"content-type": "application/pdf"},
-        )
+    _FakeTransport.response = _FakeRawResponse(
+        b"%PDF-1.7",
+        headers={"content-type": "application/pdf"},
     )
     accessor = FeishuAccessor()
-    accessor._user_token_client = SimpleNamespace(request=request)
+    accessor._user_token_client = SimpleNamespace(_config=SimpleNamespace())
     url = "https://bytedance.larkoffice.com/file/file_token"
 
     assert accessor.can_handle(url)
@@ -422,11 +514,64 @@ def test_access_downloads_drive_file_with_user_token(monkeypatch):
         assert resource.path.name == "file_token.pdf"
         assert resource.meta["feishu_doc_type"] == "file"
         assert resource.meta["feishu_token"] == "file_token"
-        raw_request, option = request.call_args.args
+        _, raw_request, option = _FakeTransport.calls[-1]
         assert raw_request.uri == "/open-apis/drive/v1/files/file_token/download"
         assert option.user_access_token == "u-test"
     finally:
         resource.cleanup()
+
+
+def test_access_downloads_json_drive_file_as_raw_bytes(monkeypatch):
+    _install_fake_lark_modules(monkeypatch)
+    _FakeTransport.response = _FakeRawResponse(
+        b'[{"question":"q","answer":"a"}]',
+        headers={"content-type": "application/json"},
+    )
+    accessor = FeishuAccessor()
+    accessor._user_token_client = SimpleNamespace(_config=SimpleNamespace())
+
+    resource = asyncio.run(
+        accessor.access(
+            "https://bytedance.larkoffice.com/file/json_file_token",
+            feishu_access_token="u-test",
+        )
+    )
+    try:
+        assert resource.path.read_bytes() == b'[{"question":"q","answer":"a"}]'
+        assert resource.path.name == "json_file_token.json"
+        _, raw_request, option = _FakeTransport.calls[-1]
+        assert raw_request.uri == "/open-apis/drive/v1/files/json_file_token/download"
+        assert option.user_access_token == "u-test"
+    finally:
+        resource.cleanup()
+
+
+def test_access_rejects_raw_feishu_error_envelope(monkeypatch):
+    _install_fake_lark_modules(monkeypatch)
+    _FakeTransport.response = _FakeRawResponse(
+        json.dumps(
+            {
+                "code": 131006,
+                "msg": "permission denied",
+                "data": {},
+            }
+        ).encode("utf-8"),
+        headers={"content-type": "application/json; charset=utf-8"},
+    )
+    accessor = FeishuAccessor()
+    accessor._user_token_client = SimpleNamespace(_config=SimpleNamespace())
+
+    with pytest.raises(OpenVikingError) as exc_info:
+        asyncio.run(
+            accessor.access(
+                "https://bytedance.larkoffice.com/file/json_error_token",
+                feishu_access_token="u-test",
+            )
+        )
+
+    assert exc_info.value.code == "PERMISSION_DENIED"
+    assert exc_info.value.details["feishu_code"] == 131006
+    assert "permission denied" in str(exc_info.value)
 
 
 def test_access_materializes_drive_folder_contract(monkeypatch):
@@ -495,6 +640,122 @@ def test_access_materializes_drive_folder_contract(monkeypatch):
         assert [(item["name"], item["token"], item["reason"]) for item in skipped] == [
             ("Blocked.pptx", "blocked", "HTTP 403")
         ]
+    finally:
+        resource.cleanup()
+
+
+def test_access_wiki_recursive_materializes_mixed_tree(monkeypatch):
+    from openviking.parse.accessors.feishu_accessor import FeishuDocument
+
+    accessor = FeishuAccessor()
+    nodes = {
+        "wiki_root": _FeishuWikiTreeNode("wiki_root", "space", "飞书文档", "docx", "doc_root"),
+        "wiki_pdf": _FeishuWikiTreeNode("wiki_pdf", "space", "非飞书文档.pdf", "file", "file_pdf"),
+        "wiki_doc": _FeishuWikiTreeNode("wiki_doc", "space", "飞书文档", "docx", "doc_child"),
+        "wiki_leaf_doc": _FeishuWikiTreeNode("wiki_leaf_doc", "space", "子文档1", "docx", "doc_leaf"),
+        "wiki_bin": _FeishuWikiTreeNode("wiki_bin", "space", "非飞书文档.bin", "file", "file_bin"),
+    }
+    children = {
+        "wiki_root": [nodes["wiki_leaf_doc"], nodes["wiki_pdf"]],
+        "wiki_pdf": [nodes["wiki_doc"]],
+        "wiki_doc": [nodes["wiki_bin"]],
+        "wiki_leaf_doc": [],
+        "wiki_bin": [],
+    }
+
+    async def fake_fetch_document(url, **_kwargs):
+        doc_type, token = accessor._parse_feishu_url(url)
+        return FeishuDocument(
+            doc_type=doc_type,
+            token=token,
+            markdown_content=f"# {token}",
+            title=token,
+            meta={},
+        )
+
+    def fake_download(file_token, **_kwargs):
+        if file_token == "file_pdf":
+            return b"%PDF-1.7", "application/pdf", "非飞书文档.pdf"
+        return b"binary", "application/octet-stream", "非飞书文档.bin"
+
+    monkeypatch.setattr(
+        accessor,
+        "_resolve_wiki_tree_root",
+        lambda *_args, **_kwargs: nodes["wiki_root"],
+    )
+    monkeypatch.setattr(
+        accessor,
+        "_list_wiki_node_children",
+        lambda _space_id, node_token, **_kwargs: children[node_token],
+    )
+    monkeypatch.setattr(accessor, "_fetch_document", fake_fetch_document)
+    monkeypatch.setattr(accessor, "_download_drive_file", fake_download)
+    monkeypatch.setattr(
+        accessor,
+        "_resolve_image_refs",
+        lambda markdown, **_kwargs: (markdown, {}),
+    )
+
+    resource = asyncio.run(
+        accessor.access(
+            "https://example.feishu.cn/wiki/wiki_root",
+            feishu_access_token="u-test",
+            feishu_recursive=True,
+        )
+    )
+    cleanup_path = Path(resource.meta["_cleanup_path"])
+    try:
+        assert resource.path.name == "飞书文档"
+        assert (resource.path / "飞书文档.md").read_text(encoding="utf-8") == "# doc_root"
+        assert (resource.path / "子文档1.md").read_text(encoding="utf-8") == "# doc_leaf"
+        assert not (resource.path / "子文档1" / "子文档1.md").exists()
+        assert (
+            resource.path / "非飞书文档" / "非飞书文档.pdf"
+        ).read_bytes() == b"%PDF-1.7"
+        assert (
+            resource.path / "非飞书文档" / "飞书文档" / "飞书文档.md"
+        ).read_text(encoding="utf-8") == "# doc_child"
+        assert (
+            resource.path / "非飞书文档" / "飞书文档" / "非飞书文档.bin"
+        ).read_bytes() == b"binary"
+        assert resource.meta["original_filename"] == "飞书文档"
+        assert not (resource.path / "飞书文档" / "飞书文档.md").exists()
+        assert cleanup_path.exists()
+        assert resource.meta["feishu_folder_skipped_items"] == []
+    finally:
+        resource.cleanup()
+        assert not cleanup_path.exists()
+
+
+def test_access_wiki_without_recursive_keeps_single_document_behavior(monkeypatch):
+    from openviking.parse.accessors.feishu_accessor import FeishuDocument
+
+    accessor = FeishuAccessor()
+    recursive_root = MagicMock()
+
+    async def fake_fetch_document(*_args, **_kwargs):
+        return FeishuDocument(
+            doc_type="docx",
+            token="doc_token",
+            markdown_content="# single",
+            title="Single Wiki",
+            meta={"wiki_resolved": True},
+        )
+
+    monkeypatch.setattr(accessor, "_resolve_wiki_tree_root", recursive_root)
+    monkeypatch.setattr(accessor, "_fetch_document", fake_fetch_document)
+    monkeypatch.setattr(
+        accessor,
+        "_resolve_image_refs",
+        lambda markdown, **_kwargs: (markdown, {}),
+    )
+
+    resource = asyncio.run(accessor.access("https://example.feishu.cn/wiki/wiki_token"))
+    try:
+        assert resource.path.is_file()
+        assert resource.path.read_text(encoding="utf-8") == "# single"
+        assert resource.meta["original_filename"] == "Single Wiki"
+        recursive_root.assert_not_called()
     finally:
         resource.cleanup()
 


### PR DESCRIPTION
## Description

本 PR 为飞书 Wiki 导入增加递归物化能力。原先处理 `wiki/xxx` 链接时，只会下载入口 Wiki 页面自身，不会继续发现和访问其下挂载的子节点。因此当飞书 Wiki 中存在“目录文档下挂子文档、PDF/JSON 等普通文件，普通文件节点下又继续挂子文档”的结构时，入口页面之外的子文档和文件会被漏掉，导入到 OV 后内容不完整。

本次实现将飞书导入保持为两个阶段：第一阶段由飞书访问层把远端 Wiki 树完整下载到本地临时目录；第二阶段继续复用 OV 现有的本地目录导入流程，将临时目录解析、切分并写入最终资源库。这样不需要为 Wiki 单独重写后续导入链路，只在远端下载阶段补齐结构物化能力。

物化策略采用方案：尽量还原飞书 Wiki 的原始层级。只有存在子节点的 Wiki 节点才生成目录，并在目录中保存节点自身内容；没有子节点的文档或文件直接保存到父目录下。

同时修复 Drive 文件下载的一类问题：部分普通文件本身就是 JSON，旧下载方式会经过 Lark SDK 的通用 JSON 解包路径，导致 JSON 数组文件被误当作 OpenAPI 响应处理并失败。现在 Drive 文件下载改为 raw bytes 保存；只有响应明确是飞书标准错误 envelope 且 `code != 0` 时，才转成业务错误抛出。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

暂无。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 增加飞书 Wiki 递归导入开关，开启后从入口 Wiki 节点开始递归发现子节点，并将完整树结构下载到本地临时目录。
- 调整 Wiki 节点本地物化规则：有子节点的节点生成目录并保存自身内容，叶子节点直接保存为父目录下的同名文件，避免不必要的同名目录嵌套和额外摘要文件。
- 支持混合结构递归物化，包括飞书文档、Drive 普通文件、PDF、JSON 文件，以及普通文件节点下继续挂载 Wiki 子节点的场景。
- 增加递归深度、节点数和循环引用保护，避免异常 Wiki 结构导致无限递归或失控下载。
- 将 Drive 文件下载切换为 raw bytes 路径，避免 JSON 文件被 SDK 误当成 OpenAPI 响应解析，同时保留飞书业务错误识别。
- 补充单元测试，覆盖 Wiki 子节点分页、用户 token 透传、递归混合结构物化、非递归 Wiki 行为保持不变、JSON 文件 raw 下载，以及 raw 响应中的飞书业务错误处理。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

本地验证命令：

```bash
uv run ruff check openviking/parse/accessors/feishu_accessor.py tests/parse/test_feishu_accessor.py
HOME=/Users/bytedance/ragexp/ov-base/.tmp/test-home OV_CONFIG_DIR=/Users/bytedance/ragexp/ov-base/.tmp/test-config uv run pytest tests/parse/test_feishu_accessor.py -q
```

验证结果：

- `ruff` 通过。
- `tests/parse/test_feishu_accessor.py` 通过，结果为 `29 passed`。
- 已完成真实飞书 Wiki 人工端到端验收，最终导入成功，`root_uri` 为 `viking://resources/目录文档1`，`failed_files` 为空。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

飞书wiki结构
<img width="282" height="329" alt="image" src="https://github.com/user-attachments/assets/953a098c-abfb-40ba-b792-c0d177e811a4" />
入库结果
<img width="466" height="1143" alt="image" src="https://github.com/user-attachments/assets/713e0495-b725-44ae-b0f5-ad9bb2724e7d" />



## Additional Notes

本 PR 没有改变默认的 Wiki 单文档导入行为；只有显式开启递归导入参数时，才会进入新的递归物化流程。

权限方面，真实飞书 Wiki 递归导入需要用户或应用具备 Wiki 节点读取、文档读取和 Drive 文件下载相关权限。文档内图片下载仍依赖现有图片下载权限配置。