### PR TITLE
refactor(acl): model protection state as modes

### DIFF
--- a/docs/en/api/12-acl.md
+++ b/docs/en/api/12-acl.md
@@ -47,7 +47,7 @@ The caller supplies the account-unique, stable `group_id` through the [Admin API
 ```json
 {
   "uri": "viking://resources/project-a",
-  "acl_enabled": true,
+  "acl_mode": "inherit",
   "direct_entries": [
     {"principal": "user:bob", "level": "read"}
   ],
@@ -66,7 +66,7 @@ The caller supplies the account-unique, stable `group_id` through the [Admin API
 | `direct_entries` | Entries set directly on this node |
 | `inherited_entries` | Merged direct ACLs from all ancestors |
 | `effective_entries` | The merged direct and inherited entries |
-| `acl_enabled` | `true` when this node or an ancestor has a direct ACL; read-only and derived |
+| `acl_mode` | `none` when ACL does not control the node; `inherit` when direct and inherited ACLs apply; read-only and derived |
 
 The account `ADMIN` implicit `manage` permission is not included in these lists.
 
@@ -259,7 +259,7 @@ The API checks manage permission before confirming existence to an authorized ca
 | ACL mutation targets a URI without a context record | `INVALID_ARGUMENT`; index it first |
 | Invalid `principal` syntax or `group:*` | `INVALID_ARGUMENT` |
 | Level is not `read/write/manage` | `INVALID_ARGUMENT` |
-| Request includes unknown fields such as `acl_enabled` | `INVALID_ARGUMENT` |
+| Request includes read-only fields such as `acl_mode` | `INVALID_ARGUMENT` |
 
 Direct and inherited ACL fields are both stored in context records. An update changes the target direct ACL and recalculates descendant inherited ACLs in one subtree batch; a failed write restores the previous context ACL fields.
 

--- a/docs/en/concepts/15-acl.md
+++ b/docs/en/concepts/15-acl.md
@@ -61,7 +61,7 @@ The effective permissions on `report.md` are:
 
 Removing the group's direct ACL from `A/B` does not remove entries from `A` or `report.md`. Descendants only lose the permissions contributed by that entry.
 
-## Default Behavior and `acl_enabled`
+## Default Behavior and `acl_mode`
 
 The account-level `acl.enabled` setting is disabled by default. While disabled,
 shared resources keep the existing URI namespace visibility and write rules.
@@ -80,10 +80,10 @@ does not change its direct ACL.
 When the node or any ancestor has a direct ACL, the node enters the ACL-controlled domain:
 
 ```text
-acl_enabled = true
+acl_mode = "inherit"
 ```
 
-`acl_enabled` is derived by the system and cannot be set by an API caller. It returns to `false` automatically after the last applicable direct ACL is removed.
+`acl_mode` is derived by the system and cannot be set by an API caller. The base modes are `none` and `inherit`: `none` means ACL does not control the node, while `inherit` means both direct and inherited ACLs apply. It returns to `none` automatically after the last applicable direct ACL is removed.
 
 ## File Operations
 
@@ -117,14 +117,14 @@ For a directory, `stat.count` uses the same path and ACL scalar filter and repor
 ACL data exists only in the context collection. Each context record stores direct and inherited permissions in native scalar fields:
 
 ```text
-acl_enabled
+acl_mode
 acl_direct_grants
 acl_inherited_grants
 ```
 
 `acl_direct_grants` is the ACL assigned to the current node. `acl_inherited_grants` is the union of all ancestor direct ACLs. Each principal stores only its highest level as `{mask}:{principal}`: `1` means `read`, `3` means `write`, and `7` means `manage`. For example, `3:group:dev` gives `group:dev` `write` and therefore also `read`. Effective permission is the union of the two fields; there is no separate ACL collection.
 
-The request principals are `user:{ctx.user_id}`, `user:*`, and one `group:{group_id}` for each ID in `ctx.group_ids`. For reads, `find/search` matches the `1`, `3`, and `7` tokens for each principal against both native `list<string>` grant fields within the `viking://resources` scope; private resources remain isolated by URI owner. Legacy records without ACL fields are treated as `acl_enabled=false`, so they do not require a full data backfill.
+The request principals are `user:{ctx.user_id}`, `user:*`, and one `group:{group_id}` for each ID in `ctx.group_ids`. For reads, `find/search` matches the `1`, `3`, and `7` tokens for each principal against both native `list<string>` grant fields within the `viking://resources` scope; private resources remain isolated by URI owner. Legacy records without ACL fields are treated as `acl_mode=none`, so they do not require a full data backfill.
 
 A retrieval target URI is only a search scope; the caller does not need to read the target node itself. A user can discover a deeply shared file even when intermediate directories are not readable.
 

--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1470,7 +1470,7 @@ Supports cloud-deployed VikingDB on Volcengine
 
 ##### ACL schema
 
-ACL data exists only in the context collection. In addition to `acl_enabled: bool`, add these scalar-indexed `list<string>` fields:
+ACL data exists only in the context collection. In addition to `acl_mode: string` (`none` or `inherit`), add these scalar-indexed `list<string>` fields:
 
 ```text
 acl_direct_grants
@@ -1479,7 +1479,7 @@ acl_inherited_grants
 
 Each element uses `{mask}:{principal}`: `1` means `read`, `3` means `write`, and `7` means `manage`.
 
-Local backends add the fields to an existing collection and rebuild the scalar index during startup. Existing records are not rewritten; missing ACL fields read as `acl_enabled=false` and empty lists.
+Local backends add the fields to an existing collection and rebuild the scalar index during startup. Existing records are not rewritten; missing ACL fields read as `acl_mode=none` and empty lists.
 
 For existing remote collections, including Volcengine VikingDB, provision these fields and scalar indexes before startup; OpenViking validates but does not alter the remote schema. Volcengine API-key data-plane mode also requires the context collection and configured index to exist. See [Resource Access Control (ACL)](../concepts/15-acl.md) for permission semantics.
 

--- a/docs/zh/api/12-acl.md
+++ b/docs/zh/api/12-acl.md
@@ -45,7 +45,7 @@ ACL API 管理 `viking://resources/...` 共享资源的直接授权，并返回�
 ```json
 {
   "uri": "viking://resources/project-a",
-  "acl_enabled": true,
+  "acl_mode": "inherit",
   "direct_entries": [
     {"principal": "user:bob", "level": "read"}
   ],
@@ -64,7 +64,7 @@ ACL API 管理 `viking://resources/...` 共享资源的直接授权，并返回�
 | `direct_entries` | 只包含当前节点直接设置的条目 |
 | `inherited_entries` | 所有祖先目录直接 ACL 的合并结果 |
 | `effective_entries` | `direct_entries` 与 `inherited_entries` 的合并结果 |
-| `acl_enabled` | 当前节点或任一祖先存在直接 ACL 时为 `true`；只读派生字段 |
+| `acl_mode` | `none` 表示不受 ACL 控制，`inherit` 表示 direct 与 inherited ACL 均生效；只读派生字段 |
 
 account `ADMIN` 的隐式 `manage` 权限不出现在这些列表中。
 
@@ -257,7 +257,7 @@ ov acl rm viking://resources/project-a
 | 修改 ACL 时 URI 尚无 context 记录 | `INVALID_ARGUMENT`，需先完成索引 |
 | `principal` 格式非法，或使用 `group:*` | `INVALID_ARGUMENT` |
 | level 不是 `read/write/manage` | `INVALID_ARGUMENT` |
-| 请求包含 `acl_enabled` 等未知字段 | `INVALID_ARGUMENT` |
+| 请求包含 `acl_mode` 等只读字段 | `INVALID_ARGUMENT` |
 
 ACL 的 direct 和 inherited 字段都保存在 context。更新会在同一子树批处理中修改目标 direct 并重算后代 inherited；写入失败时恢复原 context ACL 字段。
 

--- a/docs/zh/concepts/15-acl.md
+++ b/docs/zh/concepts/15-acl.md
@@ -61,7 +61,7 @@ read user:carol on viking://resources/A/B/C/report.md
 
 删除 `A/B` 上用户组的直接 ACL 不会删除 `A` 或 `report.md` 上的条目。子节点只会失去由该条目提供的权限。
 
-## 默认行为与 `acl_enabled`
+## 默认行为与 `acl_mode`
 
 账号级 `acl.enabled` 默认关闭。关闭时，共享资源继续使用原有 URI namespace
 可见性和写入规则，不解析或校验 ACL，也不为新建内容写入 ACL。
@@ -75,10 +75,10 @@ read user:carol on viking://resources/A/B/C/report.md
 只要节点或任一祖先存在直接 ACL，该节点就进入 ACL 控制域：
 
 ```text
-acl_enabled = true
+acl_mode = "inherit"
 ```
 
-`acl_enabled` 是系统派生字段，不能由 API 调用者设置。删除最后一个相关直接 ACL 后，它会自动恢复为 `false`。
+`acl_mode` 是系统派生字段，不能由 API 调用者设置。当前基础模式只有 `none` 和 `inherit`：`none` 表示节点不受 ACL 控制，`inherit` 表示 direct 与 inherited ACL 均生效。删除最后一个相关直接 ACL 后，它会自动恢复为 `none`。
 
 ## 文件操作
 
@@ -111,14 +111,14 @@ bootstrap，后续 ACL 修改要求有效 `manage` 能力。
 ACL 只保存在 context collection。每条 context 记录维护当前节点和继承权限两组原生标量字段：
 
 ```text
-acl_enabled
+acl_mode
 acl_direct_grants
 acl_inherited_grants
 ```
 
 `acl_direct_grants` 是当前节点直接 ACL，`acl_inherited_grants` 是所有祖先直接 ACL 的并集。每个 principal 只保存最高 level，编码为 `{mask}:{principal}`：`1` 表示 `read`、`3` 表示 `write`、`7` 表示 `manage`。例如 `3:group:dev` 表示 `group:dev` 拥有 `write`，同时也具备 `read`。有效权限是两组列表的并集，不维护独立 ACL collection。
 
-请求的可用 principal 为 `user:{ctx.user_id}`、`user:*`，以及 `ctx.group_ids` 中每个 ID 对应的 `group:{group_id}`。`find/search` 读取时为每个 principal 匹配 `1`、`3`、`7` 三种 token，并在 `viking://resources` scope 内对 direct 和 inherited 两个原生 `list<string>` 字段做过滤；个人资源始终按 URI owner 隔离。旧记录缺少 ACL 字段时按 `acl_enabled=false` 处理，无需全量回填。
+请求的可用 principal 为 `user:{ctx.user_id}`、`user:*`，以及 `ctx.group_ids` 中每个 ID 对应的 `group:{group_id}`。`find/search` 读取时为每个 principal 匹配 `1`、`3`、`7` 三种 token，并在 `viking://resources` scope 内对 direct 和 inherited 两个原生 `list<string>` 字段做过滤；个人资源始终按 URI owner 隔离。旧记录缺少 ACL 字段时按 `acl_mode=none` 处理，无需全量回填。
 
 检索 target URI 只是搜索范围，不要求调用者能够读取 target 节点本身。用户即使不能读取中间目录，也可以检索到深层单独授权给自己的文件。
 

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1445,7 +1445,7 @@ RAGFS 默认使用 Rust binding 模式，通过 Rust 实现直接访问文件系
 
 ##### ACL schema
 
-ACL 只维护在 context collection。除 `acl_enabled: bool` 外，需要以下 `list<string>` 标量索引字段：
+ACL 只维护在 context collection。除 `acl_mode: string`（`none` 或 `inherit`）外，需要以下 `list<string>` 标量索引字段：
 
 ```text
 acl_direct_grants
@@ -1454,7 +1454,7 @@ acl_inherited_grants
 
 每个元素使用 `{mask}:{principal}` 格式，其中 `1` 表示 `read`、`3` 表示 `write`、`7` 表示 `manage`。
 
-本地 backend 会在启动时为存量 collection 增加字段并重建标量索引。旧记录不做全量回填；缺失 ACL 字段按 `acl_enabled=false` 和空列表读取。
+本地 backend 会在启动时为存量 collection 增加字段并重建标量索引。旧记录不做全量回填；缺失 ACL 字段按 `acl_mode=none` 和空列表读取。
 
 火山向量库等远端 backend 的存量 collection 需要由部署方预先添加这些字段和 scalar index，OpenViking 只校验 schema。`volcengine` API key 数据面模式还要求 context collection 和配置的 index 已存在。权限模型详见 [资源访问控制（ACL）](../concepts/15-acl.md)。
 

--- a/openviking/storage/acl.py
+++ b/openviking/storage/acl.py
@@ -28,6 +28,11 @@ class AclAction(str, Enum):
     MANAGE = "manage"
 
 
+class AclMode(str, Enum):
+    NONE = "none"
+    INHERIT = "inherit"
+
+
 class CreatorAclGrant(str, Enum):
     DIRECT = "direct"
     INHERITED = "inherited"
@@ -40,7 +45,8 @@ _LEVEL_MASK = {
 }
 _MASK_LEVEL = {mask: level for level, mask in _LEVEL_MASK.items()}
 ACL_GRANT_FIELDS = ("acl_direct_grants", "acl_inherited_grants")
-ACL_CONTEXT_FIELDS = frozenset(("acl_enabled", *ACL_GRANT_FIELDS))
+ACL_MODE_FIELD = "acl_mode"
+ACL_CONTEXT_FIELDS = frozenset((ACL_MODE_FIELD, *ACL_GRANT_FIELDS))
 ACL_CREATOR_GRANT_FIELD = "_acl_creator_grant"
 _ACL_OUTPUT_FIELDS = ["uri", *sorted(ACL_CONTEXT_FIELDS)]
 
@@ -92,9 +98,18 @@ class DirectAcl:
 
 @dataclass(frozen=True)
 class EffectiveAcl:
-    enabled: bool
+    mode: AclMode
     direct: DirectAcl
     inherited: DirectAcl
+
+    @classmethod
+    def from_permissions(cls, direct: DirectAcl, inherited: DirectAcl) -> "EffectiveAcl":
+        mode = AclMode.NONE if direct.empty and inherited.empty else AclMode.INHERIT
+        return cls(mode, direct, inherited)
+
+    @property
+    def enabled(self) -> bool:
+        return self.mode != AclMode.NONE
 
     @property
     def permissions(self) -> DirectAcl:
@@ -102,7 +117,7 @@ class EffectiveAcl:
 
     def context_fields(self) -> dict[str, Any]:
         return {
-            "acl_enabled": self.enabled,
+            ACL_MODE_FIELD: self.mode.value,
             **self.direct.context_fields("acl_direct"),
             **self.inherited.context_fields("acl_inherited"),
         }
@@ -237,10 +252,13 @@ class AclManager:
     def _effective_from_record(record: Mapping[str, Any]) -> EffectiveAcl:
         direct = DirectAcl.from_context_fields(record, "acl_direct")
         inherited = DirectAcl.from_context_fields(record, "acl_inherited")
+        raw_mode = record.get(ACL_MODE_FIELD, AclMode.NONE.value)
+        try:
+            mode = AclMode(raw_mode)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(f"Invalid ACL mode: {raw_mode!r}") from exc
         return EffectiveAcl(
-            enabled=bool(record.get("acl_enabled", False))
-            or not direct.empty
-            or not inherited.empty,
+            mode=mode,
             direct=direct,
             inherited=inherited,
         )
@@ -248,7 +266,7 @@ class AclManager:
     @classmethod
     def _effective_from_records(cls, records: Sequence[Mapping[str, Any]]) -> EffectiveAcl:
         if not records:
-            return EffectiveAcl(False, DirectAcl(), DirectAcl())
+            return EffectiveAcl(AclMode.NONE, DirectAcl(), DirectAcl())
         values = {cls._effective_from_record(record) for record in records}
         if len(values) != 1:
             uri = records[0].get("uri", "<unknown>")
@@ -341,11 +359,7 @@ class AclManager:
                 for ancestor in paths[uri][:-1]:
                     inherited = inherited.union(direct_map.get(ancestor, DirectAcl()))
                 direct = direct_map.get(uri, DirectAcl())
-                result[uri] = EffectiveAcl(
-                    enabled=not inherited.empty or not direct.empty,
-                    direct=direct,
-                    inherited=inherited,
-                )
+                result[uri] = EffectiveAcl.from_permissions(direct, inherited)
         return result
 
     async def resolve(self, uri: str, ctx: RequestContext) -> EffectiveAcl:
@@ -409,7 +423,7 @@ class AclManager:
                         direct = creator_acl
                     else:
                         inherited = inherited.union(creator_acl)
-                effective = EffectiveAcl(not direct.empty or not inherited.empty, direct, inherited)
+                effective = EffectiveAcl.from_permissions(direct, inherited)
             materialized.append({**record, **effective.context_fields()})
         return materialized
 
@@ -417,7 +431,7 @@ class AclManager:
         self, record: Mapping[str, Any], new_uri: str, ctx: RequestContext
     ) -> dict[str, Any]:
         if not is_acl_uri(new_uri):
-            return EffectiveAcl(False, DirectAcl(), DirectAcl()).context_fields()
+            return EffectiveAcl(AclMode.NONE, DirectAcl(), DirectAcl()).context_fields()
         ancestors = acl_ancestors(new_uri)
         parent = ancestors[-2] if len(ancestors) > 1 else None
         inherited = (await self.resolve(parent, ctx)).permissions if parent else DirectAcl()
@@ -427,11 +441,7 @@ class AclManager:
             if is_acl_uri(source_uri)
             else DirectAcl()
         )
-        return EffectiveAcl(
-            enabled=not direct.empty or not inherited.empty,
-            direct=direct,
-            inherited=inherited,
-        ).context_fields()
+        return EffectiveAcl.from_permissions(direct, inherited).context_fields()
 
     async def _apply_subtree(
         self,
@@ -462,11 +472,7 @@ class AclManager:
             for ancestor in ancestors[root_depth - 1 : -1]:
                 inherited = inherited.union(direct_map.get(ancestor, DirectAcl()))
             direct = direct_map.get(uri, DirectAcl())
-            effective_by_uri[uri] = EffectiveAcl(
-                enabled=not direct.empty or not inherited.empty,
-                direct=direct,
-                inherited=inherited,
-            )
+            effective_by_uri[uri] = EffectiveAcl.from_permissions(direct, inherited)
 
         updated = [
             {**record, **effective_by_uri[str(record["uri"])].context_fields()}
@@ -507,7 +513,7 @@ class AclManager:
     def to_report(uri: str, effective: EffectiveAcl) -> dict[str, Any]:
         return {
             "uri": uri,
-            "acl_enabled": effective.enabled,
+            ACL_MODE_FIELD: effective.mode.value,
             "direct_entries": [entry.to_dict() for entry in effective.direct.entries],
             "inherited_entries": [entry.to_dict() for entry in effective.inherited.entries],
             "effective_entries": [entry.to_dict() for entry in effective.permissions.entries],

--- a/openviking/storage/collection_schemas.py
+++ b/openviking/storage/collection_schemas.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List, Optional
 from openviking.core.context import ContextType, ResourceContentType
 from openviking.models.embedder.base import embed_compat
 from openviking.server.identity import RequestContext, Role
-from openviking.storage.acl import ACL_GRANT_FIELDS
+from openviking.storage.acl import ACL_GRANT_FIELDS, ACL_MODE_FIELD, AclMode
 from openviking.storage.errors import (
     CollectionNotFoundError,
     EmbeddingConfigurationError,
@@ -120,7 +120,11 @@ class CollectionSchemas:
                 {"FieldName": "content", "FieldType": "text"},
                 {"FieldName": "account_id", "FieldType": "string"},
                 {"FieldName": "owner_user_id", "FieldType": "string"},
-                {"FieldName": "acl_enabled", "FieldType": "bool", "DefaultValue": False},
+                {
+                    "FieldName": ACL_MODE_FIELD,
+                    "FieldType": "string",
+                    "DefaultValue": AclMode.NONE.value,
+                },
                 *[
                     {
                         "FieldName": field,
@@ -147,7 +151,7 @@ class CollectionSchemas:
                 "search_tags",
                 "account_id",
                 "owner_user_id",
-                "acl_enabled",
+                ACL_MODE_FIELD,
                 *ACL_GRANT_FIELDS,
             ]
         )

--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -19,8 +19,10 @@ from openviking.core.namespace import (
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.acl import (
     ACL_CONTEXT_FIELDS,
+    ACL_MODE_FIELD,
     AclAction,
     AclManager,
+    AclMode,
     acl_grant_tokens,
     acl_principals,
     is_acl_uri,
@@ -2275,9 +2277,15 @@ class VikingVectorIndexBackend:
                 ]
             )
 
-        legacy_filter = And(
+        uncontrolled_filter = And(
             [
-                RawDSL({"op": "must_not", "field": "acl_enabled", "conds": [True]}),
+                RawDSL(
+                    {
+                        "op": "must_not",
+                        "field": ACL_MODE_FIELD,
+                        "conds": [AclMode.INHERIT.value],
+                    }
+                ),
                 Or([PathScope("uri", root, depth=-1) for root in visible_roots(ctx)]),
             ]
         )
@@ -2294,7 +2302,7 @@ class VikingVectorIndexBackend:
             ]
         )
         access_filters: List[FilterExpr] = [
-            legacy_filter,
+            uncontrolled_filter,
             shared_acl_filter,
             PathScope("uri", f"{canonical_user_root(ctx)}/resources", depth=-1),
         ]

--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -158,7 +158,8 @@ async def test_shared_resource_creation_inherits_acl_and_preserves_plain_append(
         },
         ctx=admin,
     )
-    await service.fs.set_acl(
+    assert (await service.fs.get_acl(parent_uri, ctx=admin))["acl_mode"] == "none"
+    parent_acl = await service.fs.set_acl(
         parent_uri,
         [
             {"principal": "group:readers", "level": "read"},
@@ -166,6 +167,7 @@ async def test_shared_resource_creation_inherits_acl_and_preserves_plain_append(
         ],
         ctx=admin,
     )
+    assert parent_acl["acl_mode"] == "inherit"
 
     await service.fs.write(uri, content="line1\n", ctx=creator, mode="create", wait=True)
     inherited_entries = [

--- a/tests/server/test_http_client_sdk.py
+++ b/tests/server/test_http_client_sdk.py
@@ -66,7 +66,7 @@ async def test_sdk_add_resource(http_client):
         role=Role.ADMIN,
     )
     acl = await service.fs.get_acl(result["root_uri"], ctx=creator)
-    assert acl["acl_enabled"] is False
+    assert acl["acl_mode"] == "none"
     assert acl["direct_entries"] == []
 
 

--- a/tests/storage/test_collection_schemas.py
+++ b/tests/storage/test_collection_schemas.py
@@ -725,11 +725,20 @@ async def test_embedding_handler_settles_request_wait_by_message_id(monkeypatch)
     assert completed == [("request-1", queue_data["id"], {"vector_written": True})]
 
 
-def test_context_collection_excludes_parent_uri():
+def test_context_collection_uses_acl_mode_and_excludes_parent_uri():
     schema = CollectionSchemas.context_collection("ctx", 8)
 
     field_names = [field["FieldName"] for field in schema["Fields"]]
+    acl_mode = next(field for field in schema["Fields"] if field["FieldName"] == "acl_mode")
 
+    assert acl_mode == {
+        "FieldName": "acl_mode",
+        "FieldType": "string",
+        "DefaultValue": "none",
+    }
+    assert "acl_mode" in schema["ScalarIndex"]
+    assert "acl_enabled" not in field_names
+    assert "acl_enabled" not in schema["ScalarIndex"]
     assert "parent_uri" not in field_names
     assert "parent_uri" not in schema["ScalarIndex"]
 

--- a/tests/storage/test_transfer_merge_binding.py
+++ b/tests/storage/test_transfer_merge_binding.py
@@ -94,7 +94,7 @@ async def test_overwrite_preserves_target_acl_with_real_storage(
                 "level": 2,
                 "abstract": "old private",
                 "vector": [0.9, 0.8, 0.7, 0.6],
-                "acl_enabled": True,
+                "acl_mode": "inherit",
                 "acl_direct_grants": [f"3:user:{ctx.user.user_id}"],
                 "acl_inherited_grants": [],
             }
@@ -138,7 +138,7 @@ async def test_chunk_only_copy_preserves_private_target_main_record(indexed_fs):
         "level": 2,
         "abstract": "old",
         "vector": [0.1] * 4,
-        "acl_enabled": True,
+        "acl_mode": "inherit",
         "acl_direct_grants": [f"7:user:{ctx.user.user_id}"],
         "acl_inherited_grants": [],
     }
@@ -220,7 +220,7 @@ async def test_transfer_protects_chunk_shaped_target_file(
                 "level": 2,
                 "abstract": "private sibling",
                 "vector": [0.1] * 4,
-                "acl_enabled": True,
+                "acl_mode": "inherit",
                 "acl_direct_grants": [f"7:user:{ctx.user.user_id}"],
                 "acl_inherited_grants": [],
             }

--- a/tests/storage/test_vector_transfer.py
+++ b/tests/storage/test_vector_transfer.py
@@ -148,7 +148,7 @@ class _TransferAclManager:
         return [
             {
                 **record,
-                "acl_enabled": True,
+                "acl_mode": "inherit",
                 "acl_direct_grants": [],
                 "acl_inherited_grants": ["1:group:target-readers"],
             }
@@ -158,7 +158,7 @@ class _TransferAclManager:
     async def materialize_moved_record(self, record, new_uri, ctx):
         del new_uri, ctx
         return {
-            "acl_enabled": True,
+            "acl_mode": "inherit",
             "acl_direct_grants": list(record.get("acl_direct_grants") or []),
             "acl_inherited_grants": ["1:group:target-readers"],
         }
@@ -660,7 +660,7 @@ async def test_copy_over_private_target_preserves_target_acl_for_new_chunks():
             _record(
                 "target-file",
                 target,
-                acl_enabled=True,
+                acl_mode="inherit",
                 acl_direct_grants=["7:user:bob"],
                 acl_inherited_grants=[],
             ),
@@ -690,14 +690,14 @@ async def test_copy_target_without_direct_acl_keeps_parent_inheritance():
             _record(
                 "parent",
                 parent,
-                acl_enabled=True,
+                acl_mode="inherit",
                 acl_direct_grants=inherited,
                 acl_inherited_grants=[],
             ),
             _record(
                 "target-file",
                 target,
-                acl_enabled=True,
+                acl_mode="inherit",
                 acl_direct_grants=[],
                 acl_inherited_grants=inherited,
             ),
@@ -728,7 +728,7 @@ async def test_unindexed_source_preserves_target_records_and_acl(
                 target,
                 level=level,
                 abstract="old abstract",
-                acl_enabled=private,
+                acl_mode="inherit" if private else "none",
                 acl_direct_grants=["7:user:bob"] if private else [],
                 acl_inherited_grants=[],
             ),
@@ -747,7 +747,7 @@ async def test_unindexed_source_preserves_target_records_and_acl(
     assert backend.acl_manager is not None
     effective = await backend.acl_manager.resolve(target, _ctx())
     assert effective.context_fields() == {
-        "acl_enabled": private,
+        "acl_mode": "inherit" if private else "none",
         "acl_direct_grants": ["7:user:bob"] if private else [],
         "acl_inherited_grants": [],
     }
@@ -790,14 +790,14 @@ async def test_copy_directory_preserves_root_acl_and_inherits_it_to_new_entries(
                 "target-root",
                 target,
                 level=0,
-                acl_enabled=True,
+                acl_mode="inherit",
                 acl_direct_grants=root_acl,
                 acl_inherited_grants=[],
             ),
             _record(
                 "unique-target",
                 unique_target,
-                acl_enabled=True,
+                acl_mode="inherit",
                 acl_direct_grants=["3:user:carol"],
                 acl_inherited_grants=root_acl,
             ),
@@ -964,7 +964,7 @@ async def test_update_uri_mapping_preserves_source_direct_acl_on_target():
             _record(
                 "source",
                 source,
-                acl_enabled=True,
+                acl_mode="inherit",
                 acl_direct_grants=["7:user:alice"],
                 acl_inherited_grants=["1:group:source-readers"],
             )
@@ -1008,14 +1008,14 @@ async def test_update_uri_mapping_rollback_restores_source_direct_acl():
             _record(
                 "source-root",
                 source,
-                acl_enabled=True,
+                acl_mode="inherit",
                 acl_direct_grants=["7:user:alice"],
                 acl_inherited_grants=["1:group:source-readers"],
             ),
             _record(
                 "source-child",
                 f"{source}/child.md",
-                acl_enabled=True,
+                acl_mode="inherit",
                 acl_direct_grants=["3:user:bob"],
                 acl_inherited_grants=["7:user:alice"],
             ),

--- a/tests/storage/test_viking_vector_scope_filter.py
+++ b/tests/storage/test_viking_vector_scope_filter.py
@@ -149,7 +149,7 @@ async def test_tenant_search_enforces_visible_roots_and_shared_acl():
             "uri": "viking://resources/direct.md",
             "account_id": "acct",
             "context_type": "resource",
-            "acl_enabled": True,
+            "acl_mode": "inherit",
             "acl_direct_grants": ["1:user:alice"],
         },
         {
@@ -157,7 +157,7 @@ async def test_tenant_search_enforces_visible_roots_and_shared_acl():
             "uri": "viking://resources/inherited.md",
             "account_id": "acct",
             "context_type": "resource",
-            "acl_enabled": True,
+            "acl_mode": "inherit",
             "acl_inherited_grants": ["3:user:*"],
         },
         {
@@ -165,7 +165,7 @@ async def test_tenant_search_enforces_visible_roots_and_shared_acl():
             "uri": "viking://resources/denied.md",
             "account_id": "acct",
             "context_type": "resource",
-            "acl_enabled": True,
+            "acl_mode": "inherit",
             "acl_direct_grants": ["7:user:bob"],
         },
         {


### PR DESCRIPTION
## Description

将资源级 ACL 的派生状态从 `acl_enabled: bool` 收敛为可扩展的 `acl_mode: string`。本 PR 只提供 `none` 和 `inherit` 两种基础模式，不实现 restricted 行为；账号级配置 `acl.enabled` 仍保持布尔值。

### Before

同一 ACL report 和 context 记录使用布尔字段表示是否进入 ACL 控制域：

```json
{"acl_enabled": false}
{"acl_enabled": true}
```

### After

同一状态改为字符串模式：

```json
{"acl_mode": "none"}
{"acl_mode": "inherit"}
```

`acl_mode` 表示资源 ACL 是否开启，以及开启后使用哪种模式：`none` 表示未开启 ACL；开启 ACL 后，默认模式为 `inherit`。判断资源 ACL 是否开启时，统一检查 `acl_mode != "none"`。这次只把原来的布尔状态改为模式，实际权限计算不变。

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

N/A

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- 用 `AclMode.NONE` 和 `AclMode.INHERIT` 替代资源记录中的 `acl_enabled` 布尔状态
- 将 context schema、ACL report 和向量权限过滤统一到 `acl_mode`
- 更新已有 schema、ACL、检索和复制移动契约测试及中英文文档

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

验证结果：

- `138 passed`：collection schema、向量 ACL 过滤和 vector transfer
- `38 passed`：真实 RAGFS 复制移动 ACL 契约
- `1 passed`：共享资源 ACL 从 `none` 到 `inherit` 的服务契约
- Ruff 和 `git diff --check` 通过

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

N/A

## Additional Notes

<!-- Add any additional notes or context about the PR -->

后续 restricted 模式可在同一字段中增加 `restricted` 枚举值，无需再增加并行布尔状态。
