### PR TITLE
fix(localfs): 修正文件目录扫描的错误类型

### DIFF
--- a/crates/ragfs/src/plugins/localfs/mod.rs
+++ b/crates/ragfs/src/plugins/localfs/mod.rs
@@ -1084,7 +1084,7 @@ impl FileSystem for LocalFileSystem {
             }
 
             if !local_path.is_dir() {
-                return Err(Error::plugin(format!("not a directory: {}", path)));
+                return Err(Error::NotADirectory(path));
             }
 
             // Read directory
@@ -1473,11 +1473,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_localfs_mount_rejects_absolute_remainder() {
+    async fn test_localfs_mount_preserves_path_errors() {
         let dir = TempDir::new().unwrap();
         let mount = dir.path().join("mount");
         std::fs::create_dir(&mount).unwrap();
         write_file(dir.path(), "secret.txt", "secret");
+        write_file(&mount, "note.md", "note");
 
         let fs = MountableFS::new();
         fs.register_plugin(LocalFSPlugin::new()).await;
@@ -1492,6 +1493,9 @@ mod tests {
         let escape_path = format!("/local/{}", dir.path().join("secret.txt").display());
         let err = fs.read(&escape_path, 0, 0).await.unwrap_err();
         assert!(matches!(err, Error::InvalidPath(_)));
+
+        let err = fs.read_internal_dir("/local/note.md").await.unwrap_err();
+        assert!(matches!(err, Error::NotADirectory(_)));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

修复本地存储下，直接修改文件 ACL 会返回 500 的问题。

例如，对已存在的 `viking://resources/note.md` 调用 `PUT /api/v1/acl`，为 `user:reader` 添加读取权限：

- 修改前：锁逻辑扫描到文件时，LocalFS 返回通用插件错误，请求失败并返回 500，权限未更新。
- 修改后：LocalFS 返回明确的“不是目录”错误，锁逻辑按已有规则结束子目录扫描，请求返回 200，权限正常更新，`reader` 可以读取文件。

修复放在 LocalFS 的错误分类处，不修改 ACL 规则，也不改变树锁的加锁、冲突检查或释放逻辑。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

无。本地验证文件 ACL 时发现，独立于 restricted 功能修复。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- LocalFS `read_dir` 在目标是文件时返回 `Error::NotADirectory`，与文件系统接口及锁层已有判断保持一致。
- 在现有挂载路径测试中补充文件扫描断言，保留原有路径越界检查；未新增测试文件或测试函数。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

上述覆盖通过修改现有测试补充。验证范围：

- 回归断言：修复前失败，修复后通过。
- `cargo test -p ragfs --lib plugins::localfs::tests`：23 个通过。
- `cargo test -p ragfs --lib lock::`：32 个通过。
- 重编译 Rust 绑定，使用 `ov.conf` 启动真实服务，创建账号和用户并开启 ACL。直接对 `note.md` 执行 ACL 设置、授权、撤销和删除，全部返回 200；读取权限随授权变为 200、随撤销变为 403，文件内容保持不变。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

从 main 单独分支，只包含一行生产代码修复及现有测试调整，不包含 restricted 功能。无需新增配置或数据迁移。
