### PR TITLE
fix(storage): 统一 cp/mv 向量路径查询，避免后端算子不兼容

### DIFF
--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -27,7 +27,7 @@ from openviking.storage.acl import (
     acl_principals,
     is_acl_uri,
 )
-from openviking.storage.expr import And, Contains, Eq, FilterExpr, In, Or, PathScope, RawDSL
+from openviking.storage.expr import And, Eq, FilterExpr, In, Or, PathScope, RawDSL
 from openviking.storage.vector_migration import (
     rewrite_transfer_uri,
     rewrite_vector_record,
@@ -1714,13 +1714,11 @@ class VikingVectorIndexBackend:
         scopes: List[FilterExpr] = [Eq("uri", uri)]
         if recursive:
             scopes.append(PathScope("uri", uri, depth=-1))
-        # Both VikingDB deployments require path-index queries for URI chunks.
-        if self.mode in {"volcengine", "vikingdb"}:
-            parent = VikingURI(uri).parent
-            if parent is not None and parent.uri != "viking://":
-                scopes.append(PathScope("uri", parent.uri, depth=1))
-        else:
-            scopes.append(Contains("uri", uri + "#"))
+        # Chunk URIs are siblings in the path index. Scan one parent level and
+        # filter exact transfer entries below, without backend-specific operators.
+        parent = VikingURI(uri).parent
+        if parent is not None and parent.uri != "viking://":
+            scopes.append(PathScope("uri", parent.uri, depth=1))
         return And([Eq("account_id", ctx.account_id), Or(scopes)])
 
     async def _scan_uri_transfer_scope(
@@ -1738,27 +1736,10 @@ class VikingVectorIndexBackend:
         if selected_entries is not None:
             if not selected_entries:
                 return [], 0
-            filters: List[FilterExpr] = []
-            for entry in sorted(selected_entries):
-                if self.mode in {"volcengine", "vikingdb"}:
-                    filters.append(self._uri_transfer_filter(ctx, entry, recursive=False))
-                else:
-                    # Raw prefix filters encode URI values to the stored path format.
-                    filters.append(
-                        And(
-                            [
-                                Eq("account_id", ctx.account_id),
-                                Or(
-                                    [
-                                        Eq("uri", entry),
-                                        RawDSL(
-                                            {"op": "prefix", "field": "uri", "prefix": entry + "#"}
-                                        ),
-                                    ]
-                                ),
-                            ]
-                        )
-                    )
+            filters = [
+                self._uri_transfer_filter(ctx, entry, recursive=False)
+                for entry in sorted(selected_entries)
+            ]
             transfer_filter = filters[0] if len(filters) == 1 else Or(filters)
         else:
             transfer_filter = self._uri_transfer_filter(ctx, uri, recursive=recursive)

--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -1714,7 +1714,8 @@ class VikingVectorIndexBackend:
         scopes: List[FilterExpr] = [Eq("uri", uri)]
         if recursive:
             scopes.append(PathScope("uri", uri, depth=-1))
-        if self.mode == "volcengine":
+        # Both VikingDB deployments require path-index queries for URI chunks.
+        if self.mode in {"volcengine", "vikingdb"}:
             parent = VikingURI(uri).parent
             if parent is not None and parent.uri != "viking://":
                 scopes.append(PathScope("uri", parent.uri, depth=1))
@@ -1739,7 +1740,7 @@ class VikingVectorIndexBackend:
                 return [], 0
             filters: List[FilterExpr] = []
             for entry in sorted(selected_entries):
-                if self.mode == "volcengine":
+                if self.mode in {"volcengine", "vikingdb"}:
                     filters.append(self._uri_transfer_filter(ctx, entry, recursive=False))
                 else:
                     # Raw prefix filters encode URI values to the stored path format.

--- a/tests/storage/test_transfer_merge_binding.py
+++ b/tests/storage/test_transfer_merge_binding.py
@@ -74,6 +74,66 @@ async def seed_vector(backend, uri, content):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["copy_uri_mapping", "update_uri_mapping"])
+@pytest.mark.parametrize("directory", [False, True])
+async def test_path_transfer_scans_native_chunks_without_unrelated_subtrees(
+    indexed_fs, monkeypatch, operation, directory
+):
+    _, backend = indexed_fs
+    ctx = root_ctx()
+    source_file = "viking://resources/source/file.md"
+    target_file = "viking://resources/target/file.md"
+    source = "viking://resources/source" if directory else source_file
+    target = "viking://resources/target" if directory else target_file
+    source_uris = [source_file] + [f"{source_file}#chunk_{i:04d}" for i in range(205)]
+    old_targets = [target_file] + [f"{target_file}#chunk_{i:04d}" for i in range(206)]
+    untouched = [
+        "viking://resources/target/keep.md",
+        "viking://resources/target/unrelated/deep.md",
+    ]
+    records = [
+        {
+            "id": uri,
+            "uri": uri,
+            "level": 2,
+            "vector": [0.1, 0.2, 0.3, 0.4],
+            "account_id": ctx.account_id,
+        }
+        for uri in source_uris + old_targets + untouched
+    ]
+    await backend._upsert_many_raw(records, ctx=ctx)
+    read_ids = set()
+    original_page = backend._strict_transfer_page
+
+    async def tracked_page(*args, **kwargs):
+        page, cursor = await original_page(*args, **kwargs)
+        read_ids.update(record["id"] for record in page)
+        return page, cursor
+
+    monkeypatch.setattr(backend, "_strict_transfer_page", tracked_page)
+    result = await getattr(backend, operation)(
+        ctx,
+        source,
+        target,
+        recursive=directory,
+        **({"source_uris": [source, source_file]} if directory else {}),
+    )
+
+    assert result.scanned == result.written == 206
+    assert result.batches >= 3
+    assert set(source_uris + old_targets).issubset(read_ids)
+    assert untouched[1] not in read_ids
+    expected_targets = [target_file] + [f"{target_file}#chunk_{i:04d}" for i in range(205)]
+    target_ids = [vector_record_id(ctx.account_id, uri, 2) for uri in expected_targets]
+    copied = await backend.get(target_ids, ctx=ctx)
+    assert {record["uri"] for record in copied} == set(expected_targets)
+    assert not await backend.get(old_targets, ctx=ctx)
+    assert {record["uri"] for record in await backend.get(untouched, ctx=ctx)} == set(untouched)
+    remaining_source = await backend.get(source_uris, ctx=ctx)
+    assert len(remaining_source) == (206 if operation == "copy_uri_mapping" else 0)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("operation,indexed_source", [("cp", False), ("cp", True), ("mv", False)])
 async def test_overwrite_preserves_target_acl_with_real_storage(
     indexed_fs, operation, indexed_source
@@ -279,20 +339,21 @@ async def test_directory_merge_replaces_only_affected_file_vectors(
     await seed_vector(backend, f"{target}/tasks/indexed.txt", "old task")
     await seed_vector(backend, f"{target}/only.txt", "keep")
 
-    scanned_uris: list[str] = []
-    original_page = backend._strict_transfer_page
+    fetched_ids: list[str] = []
+    original_get = backend._strict_transfer_get
 
-    async def counted_page(*args, **kwargs):
-        page, cursor = await original_page(*args, **kwargs)
-        scanned_uris.extend(record["uri"] for record in page)
-        return page, cursor
+    async def counted_get(ctx, ids):
+        fetched_ids.extend(ids)
+        return await original_get(ctx, ids)
 
-    monkeypatch.setattr(backend, "_strict_transfer_page", counted_page)
+    monkeypatch.setattr(backend, "_strict_transfer_get", counted_get)
     kwargs = {"recursive": True} if operation == "cp" else {}
     await getattr(fs, operation)(source, target, ctx=ctx, **kwargs)
 
-    assert f"{target}/only.txt" not in scanned_uris
-    assert f"{target}/unindexed.txt" not in scanned_uris
+    # Path queries may scan sibling IDs/URIs, but discard unrelated entries
+    # before loading their full vector records.
+    assert f"{target}/only.txt" not in fetched_ids
+    assert f"{target}/unindexed.txt" not in fetched_ids
     copied = await backend.get_context_by_uri(f"{target}/indexed.txt", ctx=ctx)
     copied = await backend.get([record["id"] for record in copied], ctx=ctx)
     assert [record["abstract"] for record in copied] == ["new"]

--- a/tests/storage/test_vector_transfer.py
+++ b/tests/storage/test_vector_transfer.py
@@ -15,6 +15,8 @@ from openviking.storage.acl import AclManager
 from openviking.storage.collection_schemas import CollectionSchemas
 from openviking.storage.expr import And, Contains, Eq, In, Or, PathScope, RawDSL
 from openviking.storage.vectordb import engine as vectordb_engine
+from openviking.storage.vectordb.collection.collection import Collection
+from openviking.storage.vectordb.collection.vikingdb_collection import VikingDBCollection
 from openviking.storage.vectordb_adapters.vikingdb_private_adapter import (
     VikingDBPrivateCollectionAdapter,
 )
@@ -437,7 +439,7 @@ async def test_copy_uri_mapping_preserves_dense_sparse_and_chunk_payloads():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("mode", ["volcengine", "vikingdb"])
+@pytest.mark.parametrize("mode", ["local", "volcengine", "vikingdb", "bytedviking", "custom"])
 async def test_remote_transfer_scope_avoids_unsupported_contains_filter(mode):
     source = "viking://resources/src.md"
     backend = _MemoryTransferBackend([_record("source", source)])
@@ -458,8 +460,9 @@ async def test_remote_transfer_scope_avoids_unsupported_contains_filter(mode):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("selected_entries", [False, True], ids=["source", "target"])
 @pytest.mark.parametrize("recursive", [False, True], ids=["file", "directory"])
-async def test_vikingdb_transfer_scan_emits_supported_aggregate_dsl(
-    monkeypatch, selected_entries, recursive
+@pytest.mark.parametrize("mode", ["vikingdb", "bytedviking", "custom"])
+async def test_transfer_scan_emits_supported_aggregate_request(
+    monkeypatch, selected_entries, recursive, mode
 ):
     root = "viking://resources/docs"
     entry = f"{root}/file.md"
@@ -470,7 +473,7 @@ async def test_vikingdb_transfer_scan_emits_supported_aggregate_dsl(
         _record("sibling", "viking://resources/other.md"),
     ]
     backend = _RealAclMemoryTransferBackend(records)
-    backend.backend_mode = "vikingdb"
+    backend.backend_mode = mode
     adapter = VikingDBPrivateCollectionAdapter(
         host="unused.invalid",
         headers=None,
@@ -478,6 +481,11 @@ async def test_vikingdb_transfer_scan_emits_supported_aggregate_dsl(
         collection_name="context",
         index_name="default",
     )
+    collection = VikingDBCollection(
+        host="unused.invalid",
+        meta_data={"ProjectName": "test", "CollectionName": "context"},
+    )
+    adapter._collection = Collection(collection)
     requests = []
 
     def validate_dsl(node):
@@ -492,16 +500,17 @@ async def test_vikingdb_transfer_scan_emits_supported_aggregate_dsl(
             assert node["para"] in {"-d=0", "-d=1", "-d=-1"}
 
     async def count(ctx, filter):
-        def aggregate_data(**kwargs):
-            validate_dsl(kwargs["filters"])
-            requests.append(kwargs)
-            return SimpleNamespace(
-                agg={"_total": sum(_matches_filter(filter, record) for record in records)}
-            )
+        def data_post(path, data):
+            assert path == "/api/vikingdb/data/agg"
+            assert data["project"] == "test"
+            assert data["collection_name"] == "context"
+            assert data["index_name"] == "default"
+            assert data["op"] == "count"
+            validate_dsl(data["filter"])
+            requests.append(data)
+            return {"agg": {"_total": sum(_matches_filter(filter, record) for record in records)}}
 
-        monkeypatch.setattr(
-            adapter, "get_collection", lambda: SimpleNamespace(aggregate_data=aggregate_data)
-        )
+        monkeypatch.setattr(collection, "_data_post", data_post)
         return adapter.count(filter)
 
     monkeypatch.setattr(backend, "_strict_transfer_count", count)

--- a/tests/storage/test_vector_transfer.py
+++ b/tests/storage/test_vector_transfer.py
@@ -15,6 +15,9 @@ from openviking.storage.acl import AclManager
 from openviking.storage.collection_schemas import CollectionSchemas
 from openviking.storage.expr import And, Contains, Eq, In, Or, PathScope, RawDSL
 from openviking.storage.vectordb import engine as vectordb_engine
+from openviking.storage.vectordb_adapters.vikingdb_private_adapter import (
+    VikingDBPrivateCollectionAdapter,
+)
 from openviking.storage.viking_vector_index_backend import (
     VectorTransferRollbackError,
     VikingVectorIndexBackend,
@@ -434,10 +437,11 @@ async def test_copy_uri_mapping_preserves_dense_sparse_and_chunk_payloads():
 
 
 @pytest.mark.asyncio
-async def test_volcengine_transfer_scope_avoids_unsupported_contains_filter():
+@pytest.mark.parametrize("mode", ["volcengine", "vikingdb"])
+async def test_remote_transfer_scope_avoids_unsupported_contains_filter(mode):
     source = "viking://resources/src.md"
     backend = _MemoryTransferBackend([_record("source", source)])
-    backend.backend_mode = "volcengine"
+    backend.backend_mode = mode
 
     await backend.copy_uri_mapping(_ctx(), source, "viking://resources/dst.md", recursive=False)
 
@@ -449,6 +453,67 @@ async def test_volcengine_transfer_scope_avoids_unsupported_contains_filter():
         assert any(
             isinstance(scope, PathScope) and scope.path == "viking://resources" for scope in scopes
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("selected_entries", [False, True], ids=["source", "target"])
+@pytest.mark.parametrize("recursive", [False, True], ids=["file", "directory"])
+async def test_vikingdb_transfer_scan_emits_supported_aggregate_dsl(
+    monkeypatch, selected_entries, recursive
+):
+    root = "viking://resources/docs"
+    entry = f"{root}/file.md"
+    uri = root if recursive else entry
+    records = [
+        _record("file", entry),
+        _record("chunk", entry + "#chunk_0001"),
+        _record("sibling", "viking://resources/other.md"),
+    ]
+    backend = _RealAclMemoryTransferBackend(records)
+    backend.backend_mode = "vikingdb"
+    adapter = VikingDBPrivateCollectionAdapter(
+        host="unused.invalid",
+        headers=None,
+        project_name="test",
+        collection_name="context",
+        index_name="default",
+    )
+    requests = []
+
+    def validate_dsl(node):
+        # The deployed recall service accepts path-index must queries, not
+        # contains/prefix. Validate the actual adapter output at the I/O boundary.
+        assert node["op"] in {"and", "or", "must"}, node
+        if node["op"] in {"and", "or"}:
+            for child in node["conds"]:
+                validate_dsl(child)
+        elif node["field"] == "uri":
+            assert all(value.startswith("/") for value in node["conds"])
+            assert node["para"] in {"-d=0", "-d=1", "-d=-1"}
+
+    async def count(ctx, filter):
+        def aggregate_data(**kwargs):
+            validate_dsl(kwargs["filters"])
+            requests.append(kwargs)
+            return SimpleNamespace(
+                agg={"_total": sum(_matches_filter(filter, record) for record in records)}
+            )
+
+        monkeypatch.setattr(
+            adapter, "get_collection", lambda: SimpleNamespace(aggregate_data=aggregate_data)
+        )
+        return adapter.count(filter)
+
+    monkeypatch.setattr(backend, "_strict_transfer_count", count)
+    found, _ = await backend._scan_uri_transfer_scope(
+        _ctx(),
+        uri,
+        recursive=recursive,
+        include_full_records=True,
+        entry_uris=[entry] if selected_entries else None,
+    )
+    assert requests
+    assert {record["id"] for record in found} == {"file", "chunk"}
 
 
 @pytest.mark.asyncio
@@ -510,7 +575,7 @@ async def test_uri_mapping_preserves_target_records_for_unaffected_entries(trans
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transfer_method", ["copy_uri_mapping", "update_uri_mapping"])
-@pytest.mark.parametrize("backend_mode", ["local", "volcengine"])
+@pytest.mark.parametrize("backend_mode", ["local", "volcengine", "vikingdb"])
 async def test_merge_target_scan_excludes_unrelated_subtrees(
     transfer_method, backend_mode, monkeypatch
 ):
@@ -1053,7 +1118,7 @@ async def test_update_uri_mapping_returns_empty_result_when_source_has_no_vector
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("operation", ["copy_uri_mapping", "update_uri_mapping"])
-@pytest.mark.parametrize("mode", ["local", "volcengine"])
+@pytest.mark.parametrize("mode", ["local", "volcengine", "vikingdb"])
 @pytest.mark.parametrize("incoming_chunk", [False, True])
 async def test_target_chunk_candidate_respects_filesystem_entry(operation, mode, incoming_chunk):
     source, target = "viking://resources/source.md", "viking://resources/target.md"


### PR DESCRIPTION
## 问题与修复

#4185 的向量迁移扫描新增了 `contains` 查询，部分远端后端的 Aggregate/recall DSL 不支持该算子，导致 `DslFilterBuildFailed`。`add-resource` 同步临时文件时也会调用 `mv`，因此会导致资源导入失败。#4718 保留了源端查询，并为部分目标扫描使用 `prefix`。

本 PR 统一源、目标向量扫描的路径查询，不再根据 `mode` 列举后端名称，也不再发送 `contains/prefix`。使用精确 URI、递归路径范围（目录源）和父目录单层路径查询获取候选，再按实际传输条目筛选，保留 chunk、分页和覆盖清理逻辑。这样自定义后端无需使用特定的 `vikingdb` 名称才能进入兼容路径。

## 人工参与

- [x] 有人工参与实现方案讨论和审查
- [ ] 完全由 AI 生成，无人工参与

## 关联变更

#4185、#4718。

## 变更类型与范围

- [x] Bug 修复
- [x] 测试更新

统一 `_uri_transfer_filter()` 和目标条目扫描，删除后端名称分支。保持覆盖合并、锁范围、账户隔离和回滚策略不变。

查询取舍：本地后端也会扫描受影响条目父目录下的同层兄弟 ID/URI；目标查询不递归遍历无关子树，无关候选在读取完整向量前被过滤，不参与覆盖或删除。父目录范围仅用于向量查询，不扩大文件系统锁范围。

## 验证

- [x] 后端名称独立性测试覆盖 `local`、`volcengine`、`vikingdb`、`bytedviking` 和自定义名称；改动前可复现遗漏分支。
- [x] 文件/目录、源/目标计数测试经过真实适配器 `count()` 和 `VikingDBCollection.aggregate_data()`，仅替换 HTTP 发送边界，检查 `/api/vikingdb/data/agg` 请求体、DSL 算子与 URI 编码。
- [x] 原生本地向量库验证 cp/mv 跨页迁移 205 条 chunk、清理多余旧 chunk、保留同层无关记录，并避免扫描目标无关子树。
- [x] 覆盖目标独有记录保留、无索引源、chunk 形状文件名冲突等回归。
- [x] macOS 联合回归：181 passed，4 个已有 Pydantic 弃用告警。
- [x] Ruff lint、格式检查及 `git diff --check` 通过，已完成代码自查。

回归范围：`test_vector_transfer.py`、`test_vector_migration.py`、`test_viking_fs_cp.py`、`test_transfer_merge_binding.py`、`test_semantic_processor_mv_vector_store.py`。

尚未连接站内服务实测；需使用原报错资源复验 `add-resource`。测试中的后端名称模拟用于验证查询分支不依赖名称，不代表加载了站内私有适配器。
