### PR TITLE
feat(bot): add Keenable web search backend

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -411,6 +411,8 @@ For the complete loading order, file responsibilities, and customization boundar
 
 `readonly` mode does not register `openviking_add_resource`. When a channel sets `ov_tools_enable: false`, it does not expose OpenViking tools or inject Profiles, Memories, and Experiences.
 
+`web_search` picks its backend automatically: Tavily, Exa, or Brave when the matching key is configured (`bot.tools.web.search.tavily_api_key`, `EXA_API_KEY`, `bot.tools.web.search.api_key`), otherwise Keenable, which needs no key, and finally DuckDuckGo. `bot.tools.web.search.keenable_api_key` (or `KEENABLE_API_KEY`) is optional and only lifts Keenable's rate limits.
+
 ### MCP Tools
 
 Configure third-party MCP Servers under `bot.tools.mcp_servers`:

--- a/bot/README_CN.md
+++ b/bot/README_CN.md
@@ -408,6 +408,8 @@ Agent 实际使用的活动目录还取决于 `bot.sandbox.mode`：
 
 `readonly` 模式不会注册 `openviking_add_resource`。渠道设置 `ov_tools_enable: false` 时，该渠道不显示 OpenViking 工具，也不注入 Profile、Memory 和 Experience。
 
+`web_search` 自动选择后端：配置了对应密钥时依次使用 Tavily、Exa、Brave（`bot.tools.web.search.tavily_api_key`、`EXA_API_KEY`、`bot.tools.web.search.api_key`），否则使用无需密钥的 Keenable，最后回退到 DuckDuckGo。`bot.tools.web.search.keenable_api_key`（或 `KEENABLE_API_KEY`）为可选项，仅用于提升 Keenable 的速率限制。
+
 ### MCP 工具
 
 第三方 MCP Server 配置在 `bot.tools.mcp_servers`：

--- a/bot/tests/test_websearch_registry.py
+++ b/bot/tests/test_websearch_registry.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Web search backend selection and the keyless Keenable backend."""
+
+import httpx
+import pytest
+from vikingbot.agent.tools.websearch import registry
+from vikingbot.agent.tools.websearch.keenable import KeenableBackend
+
+KEY_ENV_VARS = ("BRAVE_API_KEY", "EXA_API_KEY", "TAVILY_API_KEY", "KEENABLE_API_KEY")
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_keys(monkeypatch):
+    for var in KEY_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_auto_prefers_keenable_over_ddgs_when_no_key_is_configured():
+    assert registry.select_auto().name == "keenable"
+
+
+def test_auto_prefers_a_configured_key_over_keenable():
+    assert registry.select_auto(brave_api_key="brave-key").name == "brave"
+
+
+class _Transport(httpx.AsyncBaseTransport):
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self.payload = payload or {}
+        self.request = None
+
+    async def handle_async_request(self, request):
+        self.request = request
+        return httpx.Response(self.status_code, json=self.payload)
+
+
+@pytest.fixture
+def transport(monkeypatch):
+    holder = {}
+    real_client = httpx.AsyncClient
+
+    def fake_client(**kwargs):
+        return real_client(transport=holder["transport"], **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", fake_client)
+
+    def install(**kwargs):
+        holder["transport"] = _Transport(**kwargs)
+        return holder["transport"]
+
+    return install
+
+
+async def test_keyless_search_uses_public_endpoint_and_reads_snippet(transport):
+    t = transport(
+        payload={
+            "results": [
+                {
+                    "title": "OpenViking",
+                    "url": "https://example.com/ov",
+                    "description": "",
+                    "snippet": "context\ndatabase  for agents",
+                }
+            ]
+        }
+    )
+
+    result = await KeenableBackend().search("openviking", count=3)
+
+    assert t.request.url == "https://api.keenable.ai/v1/search/public"
+    assert t.request.headers["X-Keenable-Title"] == "openviking"
+    assert "X-API-Key" not in t.request.headers
+    assert result == (
+        "Results for: openviking\n\n"
+        "1. OpenViking\n   https://example.com/ov\n   context database for agents"
+    )
+
+
+async def test_keyed_search_uses_keyed_endpoint(transport):
+    t = transport(payload={"results": []})
+
+    result = await KeenableBackend(api_key="secret").search("openviking", count=3)
+
+    assert t.request.url == "https://api.keenable.ai/v1/search"
+    assert t.request.headers["X-API-Key"] == "secret"
+    assert result == "No results for: openviking"
+
+
+async def test_rate_limit_is_reported_as_a_backend_error(transport):
+    transport(status_code=429, payload={"error": "Rate limit exceeded"})
+
+    result = await KeenableBackend().search("openviking", count=3)
+
+    assert result.startswith("Error: ")
+    assert "429" in result

--- a/bot/vikingbot/agent/tools/factory.py
+++ b/bot/vikingbot/agent/tools/factory.py
@@ -61,6 +61,7 @@ def register_default_tools(
     brave_api_key = config.tools.web.search.api_key if config.tools.web.search else None
     exa_api_key = None  # TODO: Add to config if needed
     tavily_api_key = config.tools.web.search.tavily_api_key if config.tools.web.search else None
+    keenable_api_key = config.tools.web.search.keenable_api_key if config.tools.web.search else None
 
     # Get provider API key and base from config
 
@@ -88,6 +89,7 @@ def register_default_tools(
             brave_api_key=brave_api_key,
             exa_api_key=exa_api_key,
             tavily_api_key=tavily_api_key,
+            keenable_api_key=keenable_api_key,
         )
     )
     registry.register(WebFetchTool())

--- a/bot/vikingbot/agent/tools/websearch/__init__.py
+++ b/bot/vikingbot/agent/tools/websearch/__init__.py
@@ -1,5 +1,5 @@
 """
-Web search tool with multiple backends (brave, ddgs, exa, tavily).
+Web search tool with multiple backends (brave, ddgs, exa, keenable, tavily).
 
 To add a new backend:
     1. Create new file: websearch/mybackend.py
@@ -18,7 +18,7 @@ from .base import WebSearchBackend
 from .registry import registry
 
 # Import backends to register them
-from . import brave, ddgs, exa, tavily
+from . import brave, ddgs, exa, keenable, tavily
 
 
 class WebSearchTool(Tool):
@@ -67,30 +67,37 @@ class WebSearchTool(Tool):
         brave_api_key: Optional[str] = None,
         exa_api_key: Optional[str] = None,
         tavily_api_key: Optional[str] = None,
+        keenable_api_key: Optional[str] = None,
         max_results: int = 5,
     ):
         """
         Initialize WebSearchTool.
 
         Args:
-            backend: Backend name ("auto", "brave", "ddgs", "exa", "tavily") or WebSearchBackend instance
+            backend: Backend name ("auto", "brave", "ddgs", "exa", "keenable", "tavily") or WebSearchBackend instance
             brave_api_key: Brave Search API key
             exa_api_key: Exa AI API key
             tavily_api_key: Tavily Search API key
+            keenable_api_key: Keenable API key (optional, lifts rate limits)
             max_results: Default max results
         """
         self.max_results = max_results
         self._brave_api_key = brave_api_key
         self._exa_api_key = exa_api_key
         self._tavily_api_key = tavily_api_key
+        self._keenable_api_key = keenable_api_key
 
         # Select backend
         if isinstance(backend, WebSearchBackend):
             self._backend = backend
         elif backend == "auto":
-            self._backend = registry.select_auto(brave_api_key, exa_api_key, tavily_api_key)
+            self._backend = registry.select_auto(
+                brave_api_key, exa_api_key, tavily_api_key, keenable_api_key
+            )
         else:
-            self._backend = registry.create(backend, brave_api_key, exa_api_key, tavily_api_key)
+            self._backend = registry.create(
+                backend, brave_api_key, exa_api_key, tavily_api_key, keenable_api_key
+            )
             if not self._backend:
                 raise ValueError(f"Unknown backend: {backend}")
 

--- a/bot/vikingbot/agent/tools/websearch/keenable.py
+++ b/bot/vikingbot/agent/tools/websearch/keenable.py
@@ -1,0 +1,63 @@
+"""Keenable Search backend - works without an API key."""
+
+import os
+from typing import Any
+
+import httpx
+
+from .base import WebSearchBackend
+from .registry import register_backend
+
+
+@register_backend
+class KeenableBackend(WebSearchBackend):
+    """Keenable Search API backend.
+
+    Uses the public endpoint when no key is configured (10 requests/s and
+    1000 requests/hour per client IP). Setting KEENABLE_API_KEY lifts those
+    limits; it is never required.
+    """
+
+    name = "keenable"
+
+    def __init__(self, api_key: str | None = None):
+        self.api_key = api_key or os.environ.get("KEENABLE_API_KEY", "")
+
+    @property
+    def is_available(self) -> bool:
+        return True
+
+    async def search(self, query: str, count: int, **kwargs: Any) -> str:
+        try:
+            n = min(max(count, 1), 20)
+            headers = {"Content-Type": "application/json", "X-Keenable-Title": "openviking"}
+            if self.api_key:
+                url = "https://api.keenable.ai/v1/search"
+                headers["X-API-Key"] = self.api_key
+            else:
+                url = "https://api.keenable.ai/v1/search/public"
+
+            async with httpx.AsyncClient() as client:
+                r = await client.post(
+                    url,
+                    headers=headers,
+                    json={"query": query, "max_results": n, "snippet_max_length": 500},
+                    timeout=15.0,
+                )
+                r.raise_for_status()
+
+            results = r.json().get("results", [])
+            if not results:
+                return f"No results for: {query}"
+
+            lines = [f"Results for: {query}\n"]
+            for i, item in enumerate(results[:n], 1):
+                lines.append(f"{i}. {item.get('title', '')}\n   {item.get('url', '')}")
+                if text := (item.get("snippet") or item.get("description")):
+                    text = " ".join(text.split())
+                    snippet = text[:500]
+                    suffix = "..." if len(text) > 500 else ""
+                    lines.append(f"   {snippet}{suffix}")
+            return "\n".join(lines)
+        except Exception as e:
+            return f"Error: {e}"

--- a/bot/vikingbot/agent/tools/websearch/registry.py
+++ b/bot/vikingbot/agent/tools/websearch/registry.py
@@ -42,6 +42,7 @@ class WebSearchBackendRegistry:
         brave_api_key: Optional[str] = None,
         exa_api_key: Optional[str] = None,
         tavily_api_key: Optional[str] = None,
+        keenable_api_key: Optional[str] = None,
     ) -> Optional[WebSearchBackend]:
         """
         Create a backend instance.
@@ -51,6 +52,7 @@ class WebSearchBackendRegistry:
             brave_api_key: Brave API key (for brave backend)
             exa_api_key: Exa API key (for exa backend)
             tavily_api_key: Tavily API key (for tavily backend)
+            keenable_api_key: Keenable API key (for keenable backend, optional)
 
         Returns:
             Backend instance or None
@@ -66,6 +68,8 @@ class WebSearchBackendRegistry:
             return backend_class(api_key=exa_api_key)
         elif name == "tavily":
             return backend_class(api_key=tavily_api_key)
+        elif name == "keenable":
+            return backend_class(api_key=keenable_api_key)
         else:
             return backend_class()
 
@@ -74,16 +78,22 @@ class WebSearchBackendRegistry:
         brave_api_key: Optional[str] = None,
         exa_api_key: Optional[str] = None,
         tavily_api_key: Optional[str] = None,
+        keenable_api_key: Optional[str] = None,
     ) -> WebSearchBackend:
         """
         Auto-select the best available backend.
 
-        Priority: tavily → exa → brave → ddgs
+        Priority: tavily → exa → brave → keenable → ddgs
+
+        Keyed backends come first so a configured key is always used.
+        Keenable needs no key, so it sits between them and the DuckDuckGo scraper.
         """
-        priority = ["tavily", "exa", "brave", "ddgs"]
+        priority = ["tavily", "exa", "brave", "keenable", "ddgs"]
 
         for name in priority:
-            backend = self.create(name, brave_api_key, exa_api_key, tavily_api_key)
+            backend = self.create(
+                name, brave_api_key, exa_api_key, tavily_api_key, keenable_api_key
+            )
             if backend and backend.is_available:
                 return backend
 

--- a/bot/vikingbot/config/schema.py
+++ b/bot/vikingbot/config/schema.py
@@ -575,6 +575,7 @@ class WebSearchConfig(BaseModel):
 
     api_key: str = ""  # Brave Search API key
     tavily_api_key: str = ""  # Tavily Search API key
+    keenable_api_key: str = ""  # Keenable API key (optional, lifts rate limits)
     max_results: int = 5
 
 


### PR DESCRIPTION
## Description

Adds Keenable as a `web_search` backend for VikingBot. Keenable works without an API key, so in `auto` mode it now sits between the keyed vendors and the DuckDuckGo scraper: a configured Tavily, Exa or Brave key is still used first; with no key at all, `web_search` uses Keenable's public endpoint instead of `ddgs`. An optional `bot.tools.web.search.keenable_api_key` (or `KEENABLE_API_KEY`) only lifts the public rate limits. I work at Keenable.

Before: no key configured → `ddgs`.
After: no key configured → `keenable`, then `ddgs` if that fails to construct. Keyed behaviour is unchanged.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

None.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `websearch/keenable.py`: new backend in the shape of `tavily.py`/`brave.py` (httpx, `Error: ...` strings, 500-char snippets). Keyless requests go to `/v1/search/public`, keyed ones to `/v1/search` with `X-API-Key`.
- `websearch/registry.py`, `websearch/__init__.py`: `keenable_api_key` passthrough; `select_auto` priority is now `tavily → exa → brave → keenable → ddgs`.
- `config/schema.py`, `tools/factory.py`: `WebSearchConfig.keenable_api_key`, wired like `tavily_api_key`.
- `bot/tests/test_websearch_registry.py`: auto-selection order with and without keys, keyless/keyed endpoint and headers, snippet mapping, 429 reported as a backend error. Fake httpx transport, no network.
- `bot/README.md`, `bot/README_CN.md`: one paragraph on the `web_search` backend order and the optional key.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

```
uv run ruff format <changed paths>     # clean
uv run ruff check  <changed paths>     # only the pre-existing I001/F821 in __init__.py and registry.py, identical on main
uv run mypy vikingbot/agent/tools/websearch/keenable.py   # clean
uv run pytest bot/tests/test_websearch_registry.py -o addopts=''   # 5 passed
```

Also ran one live keyless search through `registry.select_auto().search(...)` with no `*_API_KEY` set: backend `keenable`, 5 results, all with non-empty snippets.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

`bot/tests` is not part of the CI matrix, so the new tests are run locally. mypy still reports the pre-existing `Unexpected keyword argument "api_key"` for every keyed branch in `registry.create`, including the new one; left as-is to keep the diff focused.
