### PR TITLE
fix(studio): calculate task success rate over a consistent 24h window

### DIFF
--- a/docs/en/api/17-tasks.md
+++ b/docs/en/api/17-tasks.md
@@ -351,3 +351,11 @@ ov task list --task-type session_commit --status running
 - [Sessions](05-sessions.md) - session commit tasks
 - [Resources](02-resources.md) - resource ingestion tasks
 - [Content](12-content.md) - asynchronous reindex tasks
+
+### Task summary
+
+`GET /api/v1/tasks/summary` returns statistics for visible, non-internal task attempts in the trailing 24 hours. The optional `task_type` query parameter selects a task type. Authentication and task visibility follow the task list endpoint.
+
+The response `result` contains `window_seconds` (86400), `since` and `until` (Unix seconds), `completed`, `failed`, `total` (completed + failed), and `success_rate` (percentage, or `null` when total is zero). An attempt is counted when its terminal `updated_at` lies within `[since, until]`. Pending, running, cancelling, and cancelled tasks are excluded.
+
+Studio uses this summary independently of list pagination, status filters, and resource folding. List entries still represent at most 200 recently created tasks before filtering/folding. Completed records are retained for 24 hours and failures for 7 days; summary statistics use the same 24-hour window for both. They describe retained records under the existing visibility and storage limits, not lifetime analytics.

--- a/docs/zh/api/17-tasks.md
+++ b/docs/zh/api/17-tasks.md
@@ -349,3 +349,11 @@ ov task list --task-type session_commit --status running
 - [会话](05-sessions.md) - 会话提交任务
 - [资源](02-resources.md) - 资源导入任务
 - [内容](12-content.md) - 异步 reindex 任务
+
+### 任务统计
+
+`GET /api/v1/tasks/summary` 返回最近 24 小时内可见的非内部任务执行统计。可选查询参数 `task_type` 用于选择任务类型。鉴权和任务可见范围与任务列表接口一致。
+
+响应的 `result` 包含 `window_seconds`（86400）、`since` 和 `until`（Unix 秒）、`completed`、`failed`、`total`（成功与失败之和），以及 `success_rate`（百分比；总数为零时为 `null`）。终态的 `updated_at` 位于 `[since, until]` 内的每次执行分别计数；等待中、运行中、取消中和已取消任务不计入。
+
+Studio 的成功率独立于列表分页、状态筛选和资源折叠。列表仍然最多获取最近创建的 200 条任务，再进行筛选和折叠。成功记录保留 24 小时，失败记录保留 7 天；统计对两者统一使用 24 小时窗口。结果受现有任务可见范围和存储限制影响，并非历史累计统计。

--- a/openviking/server/routers/tasks.py
+++ b/openviking/server/routers/tasks.py
@@ -7,7 +7,8 @@ with ``wait=false``).  Callers receive a ``task_id`` and can poll these
 endpoints to check completion, results, or errors.
 """
 
-from typing import Optional
+import time
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
 
@@ -15,7 +16,7 @@ from openviking.server.auth import get_request_context
 from openviking.server.identity import RequestContext, Role
 from openviking.server.models import Response
 from openviking.service.task_store import SYSTEM_TASK_ACCOUNT_ID, SYSTEM_TASK_USER_ID
-from openviking.service.task_tracker import get_task_tracker
+from openviking.service.task_tracker import TaskRecord, TaskStatus, TaskTracker, get_task_tracker
 from openviking_cli.exceptions import (
     FailedPreconditionError,
     OpenVikingError,
@@ -23,6 +24,39 @@ from openviking_cli.exceptions import (
 )
 
 router = APIRouter(prefix="/api/v1", tags=["tasks"])
+
+
+@router.get("/tasks/summary")
+async def summarize_tasks(
+    task_type: Optional[str] = Query(None, description="Filter by task type"),
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Summarize completed and failed attempts in the trailing 24 hours.
+
+    Uses the completed-task retention window, independently of list limits,
+    resource folding and status filters. Internal tasks are excluded.
+    """
+    tasks = await _list_visible_tasks(_ctx, task_type=task_type)
+    until = time.time()
+    since = until - TaskTracker.TTL_COMPLETED
+    completed = failed = 0
+    for task in tasks:
+        if since <= task.updated_at <= until:
+            completed += task.status == TaskStatus.COMPLETED
+            failed += task.status == TaskStatus.FAILED
+    total = completed + failed
+    return Response(
+        status="ok",
+        result={
+            "window_seconds": TaskTracker.TTL_COMPLETED,
+            "since": since,
+            "until": until,
+            "completed": completed,
+            "failed": failed,
+            "total": total,
+            "success_rate": completed / total * 100 if total else None,
+        },
+    )
 
 
 @router.get("/tasks/{task_id}")
@@ -94,6 +128,18 @@ async def list_tasks(
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """List background tasks with optional filters."""
+    tasks = await _list_visible_tasks(_ctx, task_type, status, resource_id, include_internal, limit)
+    return Response(status="ok", result=[t.to_dict() for t in tasks])
+
+
+async def _list_visible_tasks(
+    _ctx: RequestContext,
+    task_type: Optional[str] = None,
+    status: Optional[str] = None,
+    resource_id: Optional[str] = None,
+    include_internal: bool = False,
+    limit: Optional[int] = None,
+) -> List[TaskRecord]:
     tracker = get_task_tracker()
     if _ctx.role == Role.ROOT:
         system_tasks = await tracker.list_tasks(
@@ -125,4 +171,4 @@ async def list_tasks(
             user_id=_ctx.user.user_id,
             include_internal=include_internal,
         )
-    return Response(status="ok", result=[t.to_dict() for t in tasks])
+    return tasks

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -902,12 +902,12 @@ class TaskTracker:
         task_type: Optional[str] = None,
         status: Optional[str] = None,
         resource_id: Optional[str] = None,
-        limit: int = 50,
+        limit: Optional[int] = 50,
         account_id: Optional[str] = None,
         user_id: Optional[str] = None,
         include_internal: bool = True,
     ) -> List[TaskRecord]:
-        """List tasks with optional filters. Most-recent first. Returns snapshot copies."""
+        """List snapshot copies, most-recent first. ``limit=None`` returns all matches."""
         return await self._dispatcher.run(
             lambda: self._list_tasks_on_owner(
                 task_type,
@@ -925,7 +925,7 @@ class TaskTracker:
         task_type: Optional[str],
         status: Optional[str],
         resource_id: Optional[str],
-        limit: int,
+        limit: Optional[int],
         account_id: Optional[str],
         user_id: Optional[str],
         include_internal: bool,

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -7,12 +7,20 @@ import json
 import time
 
 import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
 
 from openviking.pyagfs.exceptions import AGFSAlreadyExistsError
 from openviking.server.identity import RequestContext, Role
+from openviking.server.routers import tasks as task_routes
 from openviking.service.session_service import SessionService
-from openviking.service.task_store import PersistentTaskStore
+from openviking.service.task_store import (
+    SYSTEM_TASK_ACCOUNT_ID,
+    SYSTEM_TASK_USER_ID,
+    PersistentTaskStore,
+)
 from openviking.service.task_tracker import (
+    TaskRecord,
     TaskStatus,
     TaskTracker,
     _sanitize_error,
@@ -351,10 +359,9 @@ async def test_list_can_hide_internal_tasks_before_limit(tracker: TaskTracker):
     internal = await tracker.create("add_resource", meta={"internal": True}, **_owner_kwargs())
 
     assert [task.task_id for task in await tracker.list_tasks(limit=1)] == [internal.task_id]
-    assert [
-        task.task_id
-        for task in await tracker.list_tasks(limit=1, include_internal=False)
-    ] == [visible.task_id]
+    assert [task.task_id for task in await tracker.list_tasks(limit=1, include_internal=False)] == [
+        visible.task_id
+    ]
 
 
 async def test_list_order_most_recent_first(tracker: TaskTracker):
@@ -698,3 +705,83 @@ async def test_session_service_get_commit_task_also_filters_account():
     )
 
     assert other_account_result is None
+
+
+@pytest.mark.parametrize("role", [Role.USER, Role.ADMIN, Role.ROOT])
+async def test_task_summary_counts_retained_attempts_in_one_window(monkeypatch, role):
+    now = time.time()
+    monkeypatch.setattr(task_routes.time, "time", lambda: now)
+    store = PersistentTaskStore(_FakeAgfs())
+    tracker = TaskTracker(store=store)
+    set_task_tracker(tracker)
+    ctx = RequestContext(user=UserIdentifier("acme", "alice"), role=role)
+    owner = (
+        _owner_kwargs(SYSTEM_TASK_ACCOUNT_ID, SYSTEM_TASK_USER_ID)
+        if role == Role.ROOT
+        else _owner_kwargs()
+    )
+    for index, (status, age) in enumerate(
+        [(TaskStatus.COMPLETED, 60)] * 250
+        + [(TaskStatus.FAILED, 60), (TaskStatus.FAILED, 86400)]
+        + [(TaskStatus.FAILED, 86401), (TaskStatus.COMPLETED, 86401)]
+        + [(TaskStatus.FAILED, -1)]
+        + [
+            (status, 60)
+            for status in TaskStatus
+            if status not in (TaskStatus.COMPLETED, TaskStatus.FAILED)
+        ]
+    ):
+        await store.create(
+            TaskRecord(
+                task_id=f"attempt-{index}",
+                task_type="session_commit",
+                status=status,
+                created_at=now - 172800,
+                updated_at=now - age,
+                resource_id="same-session",
+                **owner,
+            )
+        )
+    for task_id, extra in [
+        ("internal", {"meta": {"internal": True}}),
+        ("different-type", {"task_type": "add_resource"}),
+        ("different-user", _owner_kwargs("acme", "bob")),
+        ("different-account", _owner_kwargs("other", "alice")),
+    ]:
+        await store.create(
+            TaskRecord(
+                **{
+                    "task_id": task_id,
+                    "task_type": "session_commit",
+                    "status": TaskStatus.FAILED,
+                    "updated_at": now - 60,
+                    **owner,
+                    **extra,
+                }
+            )
+        )
+    app = FastAPI()
+    app.include_router(task_routes.router)
+    app.dependency_overrides[task_routes.get_request_context] = lambda: ctx
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # The summary loads persisted records even with an initially empty cache.
+        for _ in range(2):
+            response = await client.get("/api/v1/tasks/summary?task_type=session_commit")
+            assert response.status_code == 200
+            assert response.json()["result"] == {
+                "window_seconds": 86400,
+                "since": now - 86400,
+                "until": now,
+                "completed": 250,
+                "failed": 2,
+                "total": 252,
+                "success_rate": pytest.approx(250 / 252 * 100),
+            }
+        # The existing list limit and status filter remain independent.
+        listing = await client.get("/api/v1/tasks?limit=200&status=completed")
+        assert len(listing.json()["result"]) == 200
+        unfiltered = await client.get("/api/v1/tasks/summary")
+        assert unfiltered.json()["result"]["failed"] == 3
+        empty = await client.get("/api/v1/tasks/summary?task_type=add_skill")
+        assert empty.json()["result"]["total"] == 0
+        assert empty.json()["result"]["success_rate"] is None

--- a/web-studio/src/i18n/locales/en/workspace.ts
+++ b/web-studio/src/i18n/locales/en/workspace.ts
@@ -372,6 +372,14 @@ const workspace = {
     },
   },
   tasksPage: {
+    summary: {
+      successRate: 'Success rate (last 24h)',
+      loading: 'Loading summary...',
+      loadFailed: 'Could not load summary',
+      counts: '{{completed}} completed / {{failed}} failed attempts',
+      listEntries: 'List entries',
+      listHint: 'After filters and resource folding; up to 200 recent tasks',
+    },
     title: 'Task Center',
     description:
       'Track background work such as resource processing, session commits, and reindexing.',

--- a/web-studio/src/i18n/locales/zh-CN/workspace.ts
+++ b/web-studio/src/i18n/locales/zh-CN/workspace.ts
@@ -362,6 +362,14 @@ const workspace = {
     },
   },
   tasksPage: {
+    summary: {
+      successRate: '近 24 小时任务成功率',
+      loading: '正在加载统计...',
+      loadFailed: '任务统计加载失败',
+      counts: '成功 {{completed}} 次 / 失败 {{failed}} 次',
+      listEntries: '列表条目数',
+      listHint: '筛选、折叠后的条目；最多取最近 200 条任务',
+    },
     title: '任务中心',
     description: '集中查看资源处理、会话提交和重建索引等后台任务。',
     refresh: '刷新',

--- a/web-studio/src/routes/tasks/-lib/task-list.ts
+++ b/web-studio/src/routes/tasks/-lib/task-list.ts
@@ -1,4 +1,6 @@
-import { getOvResult, getTasks } from '#/lib/ov-client'
+import type { TaskSummary } from '@ov-server/api/v1/tasks'
+
+import { getOvResult, getTasks, ovClient } from '#/lib/ov-client'
 import {
   normalizeTasks,
   normalizeTaskStatus,
@@ -63,4 +65,15 @@ export async function fetchTasks(
     )
   }
   return fetched
+}
+
+export async function fetchTaskSummary(
+  taskType: TaskTypeFilter,
+): Promise<TaskSummary> {
+  return getOvResult<TaskSummary>(
+    ovClient.client.get({
+      url: '/api/v1/tasks/summary',
+      query: taskType === 'all' ? {} : { task_type: taskType },
+    }),
+  )
 }

--- a/web-studio/src/routes/tasks/route.tsx
+++ b/web-studio/src/routes/tasks/route.tsx
@@ -52,7 +52,12 @@ import { TaskDetailSheet } from '#/routes/tasks/-components/task-detail-sheet'
 import { normalizeTaskStatus } from '#/routes/tasks/-lib/task-record'
 import type { TaskRecord } from '#/routes/tasks/-lib/task-record'
 import { formatTaskDuration, getTaskDate } from '#/routes/tasks/-lib/task-time'
-import { fetchTasks, getEffectiveTaskStatus, MAX_TASKS } from './-lib/task-list'
+import {
+  fetchTasks,
+  fetchTaskSummary,
+  getEffectiveTaskStatus,
+  MAX_TASKS,
+} from './-lib/task-list'
 import type { TaskStatusFilter, TaskTypeFilter } from './-lib/task-list'
 import { getTaskPipelineGroups } from './-lib/task-pipeline'
 
@@ -99,6 +104,12 @@ function TasksRoute() {
     queryKey: ['tasks', identityScopeKey, taskType, statusFilter],
     refetchInterval: 10_000,
   })
+  const summaryQuery = useQuery({
+    queryFn: () => fetchTaskSummary(taskType),
+    queryKey: ['task-summary', identityScopeKey, taskType],
+    refetchInterval: 10_000,
+  })
+  const summary = summaryQuery.data
   const rawTasks = tasksQuery.data ?? []
   const allTasks = React.useMemo(() => {
     if (!dedupByResource) return rawTasks
@@ -492,8 +503,6 @@ function TasksRoute() {
     const running = Math.min(rawRunning, MAX_CONCURRENT_CAP)
     const pending = rawPending + Math.max(0, rawRunning - MAX_CONCURRENT_CAP)
 
-    const successRate = total > 0 ? (completed / total) * 100 : 100
-
     const durations = allTasks
       .map((item) => {
         const start = Number(item.created_at || 0)
@@ -580,7 +589,6 @@ function TasksRoute() {
       running,
       pending,
       failed,
-      successRate,
       avgDurationSec,
       topType,
       topCount,
@@ -604,8 +612,11 @@ function TasksRoute() {
             type="button"
             variant="outline"
             size="sm"
-            disabled={tasksQuery.isFetching}
-            onClick={() => void tasksQuery.refetch()}
+            disabled={tasksQuery.isFetching || summaryQuery.isFetching}
+            onClick={() => {
+              void tasksQuery.refetch()
+              void summaryQuery.refetch()
+            }}
           >
             <RefreshCwIcon
               className={tasksQuery.isFetching ? 'animate-spin' : undefined}
@@ -619,19 +630,21 @@ function TasksRoute() {
       <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
         <Card className="flex flex-col gap-1 p-3 shadow-none transition-colors hover:border-primary/40">
           <div className="flex items-center justify-between text-xs text-muted-foreground">
-            <span className="font-medium">
-              {i18n.language.startsWith('zh') ? '任务成功率' : 'Success Rate'}
-            </span>
+            <span className="font-medium">{t('summary.successRate')}</span>
           </div>
           <div className="flex items-baseline gap-1">
             <span className="font-mono text-xl font-bold tabular-nums text-foreground">
-              {kpiData.successRate.toFixed(1)}%
+              {summaryQuery.isError || summary?.success_rate == null
+                ? '—'
+                : `${summary.success_rate.toFixed(1)}%`}
             </span>
           </div>
           <p className="text-[11px] text-muted-foreground truncate">
-            {i18n.language.startsWith('zh')
-              ? `共 ${kpiData.total} 条任务 (${kpiData.failed} 异常)`
-              : `Total ${kpiData.total} (${kpiData.failed} Failed)`}
+            {summaryQuery.isError
+              ? t('summary.loadFailed')
+              : summaryQuery.isPending
+                ? t('summary.loading')
+                : t('summary.counts', summary)}
           </p>
         </Card>
 
@@ -657,19 +670,15 @@ function TasksRoute() {
 
         <Card className="flex flex-col gap-1 p-3 shadow-none transition-colors hover:border-primary/40">
           <div className="flex items-center justify-between text-xs text-muted-foreground">
-            <span className="font-medium">
-              {i18n.language.startsWith('zh') ? '任务总数' : 'Total Tasks'}
-            </span>
+            <span className="font-medium">{t('summary.listEntries')}</span>
           </div>
           <div className="flex items-baseline gap-1">
             <span className="font-mono text-xl font-bold tabular-nums text-foreground">
-              {kpiData.total} 条
+              {kpiData.total}
             </span>
           </div>
           <p className="text-[11px] text-muted-foreground truncate">
-            {i18n.language.startsWith('zh')
-              ? `已完成 ${kpiData.completed} 条`
-              : `Completed ${kpiData.completed} Tasks`}
+            {t('summary.listHint')}
           </p>
         </Card>
 

--- a/web-studio/types/ov-server/api/v1/tasks.ts
+++ b/web-studio/types/ov-server/api/v1/tasks.ts
@@ -19,3 +19,13 @@ export type TaskRecord = {
 }
 
 export type TaskListResult = TaskRecord[]
+
+export type TaskSummary = {
+  window_seconds: number
+  since: number
+  until: number
+  completed: number
+  failed: number
+  total: number
+  success_rate: number | null
+}


### PR DESCRIPTION
## Description

Studio calculates task success from the displayed rows, although successful attempts are retained for 24 hours and failures for 7 days. The 200-task cap, status filter, and default resource folding further change the headline rate without any work completing. For example, 8 successes and 2 failures today plus 10 older failures currently appear as 40% instead of 80%.

Add a fixed trailing-24-hour summary of completed and failed attempts and use it for the success card. Count terminal `updated_at`, return `null` for an empty denominator, and label the existing row count as list entries. Reproduced through the live task API and Studio on v0.4.17.1; the same calculation is present on main.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

A human reported the behavior and requested the PR. Implementation, code review, and validation were performed by an AI agent.

## Related Issue

Fixes #4777

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Add `GET /api/v1/tasks/summary?task_type=...` using the task list's existing visibility rules and excluding internal tasks. Reuse the list implementation; allow an unbounded internal tracker read while preserving the public list limit.
- Count every completed/failed attempt within the completed-task retention window. Retention, task ownership, persistence, and other dashboard metrics are unchanged.
- Fetch the summary separately by identity and task type, refresh it with the list, and render loading/error/empty states. Add English/Chinese strings and API documentation. No generated bundle is included.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

本轮（2026-09-17）在 Linux 上验证合并提交 `e88de017`，上游基线为 `95564021`：

- 保留主分支新增的游标分页、任务取消／事件详情和会话重试提示。修正自动合并把游标分页分支放入统计 helper 的问题：分页仍属于列表端点，统计读取完整可见任务集合。
- `python -m pytest tests/test_task_tracker.py -q -o addopts= --maxfail=1`：**64 passed**。隔离容器运行当前源码，禁用网络；补充上游要求的 RapidFuzz 依赖，并使用镜像中的原生库。三种角色均验证 250 条记录分为 200／50 两页、无重复、正确结束，且统计不受分页和列表筛选影响。保留 4 条依赖弃用警告。
- `npm test -- src/routes/tasks src/lib/ov-client/client.test.ts`：**42 passed / 7 files**。
- `npm run build`：通过，仍有包体积提示。Node 22.23.1。
- 改动涉及的 Python 文件通过 Ruff format/check。前端相关文件 ESLint **0 errors / 26 warnings**；警告来自任务页面原有硬编码文案。测试、helper、类型和语言文件通过 Prettier；保留大型任务页面原有排版。
- `npx tsc --noEmit` 有 **31** 条报错；对当前主分支在同一依赖环境运行相同命令，按文件、错误编号和内容比较，诊断完全一致。
- 针对两个 Python 源文件执行 `mypy --follow-imports=skip --ignore-missing-imports`，PR 和主分支均只有 `task_tracker.py` 中 `records` 缺少类型标注的 **1** 条既有报错。本次不是完整 Python 类型检查。

本轮未重跑浏览器视觉验收；此前的 macOS/Chrome 验证属于合并前版本。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Both locales were opened and checked in Chrome. Screenshots are retained with the local validation artifacts.

## Additional Notes

This is a summary of retained records under the existing visibility/cache/storage limits, not lifetime analytics. In particular, this PR does not broaden ROOT's persisted-task discovery across tenant namespaces. There are no schema migrations or configuration changes.

