### PR TITLE
test(codex): 补充 MCP 代理工作区身份回归测试

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           node --test \
             examples/codex-memory-plugin/servers/mcp-proxy.test.mjs \
+            examples/codex-memory-plugin/servers/mcp-peer.test.mjs \
             examples/codex-memory-plugin/scripts/auto-capture.test.mjs \
             examples/codex-memory-plugin/scripts/capture-utils.test.mjs \
             examples/codex-memory-plugin/scripts/marketplace.test.mjs \

--- a/examples/codex-memory-plugin/README.md
+++ b/examples/codex-memory-plugin/README.md
@@ -138,7 +138,7 @@ Upgrading from the path-derived peer needs no action: memories written under the
 
 Recall defaults to broad mode: global memory, the current workspace, and other workspace memories can all be recalled, with other workspaces ranked lower and rendered later. In this mode, the MCP proxy omits `X-OpenViking-Actor-Peer` so it can read any URI returned by broad recall for the authenticated user.
 
-Set `OPENVIKING_RECALL_PEER_SCOPE=actor` or `codex.recallPeerScope="actor"` for isolation mode, which only sees global memory plus the configured peer. The MCP proxy requires `actor_peer_id` or `OPENVIKING_PEER_ID` in this mode and exits with a configuration error if neither is set. In deployments where one bot serves multiple people, such as zouk, vikingbot, or AstrBot, use isolation mode with an explicit actor peer so sessions cannot read another person's memories.
+Set `OPENVIKING_RECALL_PEER_SCOPE=actor` or `codex.recallPeerScope="actor"` to scope recall to global memory plus the configured peer. The MCP proxy uses an explicit `actor_peer_id` or `OPENVIKING_PEER_ID` in this mode. If neither is set, it warns on stderr and falls back to broad recall across the authenticated user's peers; it does not derive a peer from the plugin's launch directory. In deployments where one bot serves multiple people, such as zouk, vikingbot, or AstrBot, configure an explicit actor peer for each connection before relying on actor scope. Restart the MCP connection after changing its peer configuration.
 
 The checked-in `.mcp.json` contains only a stdio command. It never stores server URLs, bearer-token env mappings, or identity headers, so switching `ovcli.conf` changes the MCP target on the next Codex launch without cache rendering.
 

--- a/examples/codex-memory-plugin/servers/mcp-peer.test.mjs
+++ b/examples/codex-memory-plugin/servers/mcp-peer.test.mjs
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const pluginRoot = fileURLToPath(new URL("../", import.meta.url));
+
+async function runProxy(t, { scope, peer = "", cliPeer } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "ov-mcp-peer-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const configPath = join(dir, "ov.conf");
+  writeFileSync(configPath, "{}");
+  const requests = [];
+  const server = createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const message = JSON.parse(Buffer.concat(chunks).toString());
+    requests.push({ headers: req.headers, message });
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ jsonrpc: "2.0", id: message.id, result: { tools: [] } }));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+  const env = Object.fromEntries(Object.entries(process.env).filter(([k]) => !k.startsWith("OPENVIKING_")));
+  Object.assign(env, {
+    OPENVIKING_CREDENTIAL_SOURCE: "env",
+    OPENVIKING_CONFIG_FILE: configPath,
+    OPENVIKING_CLI_CONFIG_FILE: join(dir, "missing.conf"),
+    OPENVIKING_URL: `http://127.0.0.1:${server.address().port}`,
+    OPENVIKING_API_KEY: "test-key",
+    OPENVIKING_ACCOUNT: "test-account",
+    OPENVIKING_USER: "test-user",
+    OPENVIKING_PEER_ID: peer,
+  });
+  if (scope !== undefined) env.OPENVIKING_RECALL_PEER_SCOPE = scope;
+  if (cliPeer !== undefined) {
+    const cliPath = join(dir, "ovcli.conf");
+    writeFileSync(cliPath, JSON.stringify({
+      url: env.OPENVIKING_URL,
+      api_key: "cli-key",
+      account_id: "cli-account",
+      user_id: "cli-user",
+      actor_peer_id: cliPeer,
+    }));
+    env.OPENVIKING_CLI_CONFIG_FILE = cliPath;
+    env.OPENVIKING_CREDENTIAL_SOURCE = "cli";
+  }
+  const child = spawn(process.execPath, [join(pluginRoot, "servers/mcp-proxy.mjs")], {
+    cwd: pluginRoot, env, stdio: ["pipe", "pipe", "pipe"],
+  });
+  t.after(() => child.kill());
+  let stderr = "";
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  const lines = createInterface({ input: child.stdout });
+  t.after(() => lines.close());
+  const closed = once(child, "close").then(([code]) => ({ code, stderr, requests }));
+  const response = once(lines, "line").then(([line]) => ({ response: JSON.parse(line) }));
+  child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" })}\n`);
+  const outcome = await Promise.race([closed, response]);
+  if (!outcome.response) return outcome;
+  // Drain both output streams before checking warnings: stdout and stderr
+  // are independent pipes and may deliver their data in either order.
+  child.stdin.end();
+  return { ...await closed, ...outcome };
+}
+
+test("broad recall never uses the plugin launch directory as an actor peer", { timeout: 5000 }, async (t) => {
+  const result = await runProxy(t);
+  assert.ok(result.response, result.stderr);
+  assert.equal(result.requests[0].headers["x-openviking-actor-peer"], undefined);
+  assert.equal(result.requests[0].headers.authorization, "Bearer test-key");
+  assert.equal(result.requests[0].headers["x-openviking-user"], "test-user");
+});
+
+test("broad recall remains broad when hooks have an explicit workspace peer", { timeout: 5000 }, async (t) => {
+  const result = await runProxy(t, { scope: "all", peer: "workspace-a" });
+  assert.ok(result.response, result.stderr);
+  assert.equal(result.requests[0].headers["x-openviking-actor-peer"], undefined);
+});
+
+test("concurrent actor-scoped proxies keep distinct explicit workspace peers", { timeout: 5000 }, async (t) => {
+  const results = await Promise.all([
+    runProxy(t, { scope: "actor", peer: "workspace-a" }),
+    runProxy(t, { scope: "actor", peer: "workspace-b" }),
+  ]);
+  for (const result of results) assert.ok(result.response, result.stderr);
+  assert.deepEqual(results.map((r) => r.requests[0].headers["x-openviking-actor-peer"]), ["workspace-a", "workspace-b"]);
+});
+
+test("actor scope uses the selected ovcli identity instead of competing environment values", { timeout: 5000 }, async (t) => {
+  const result = await runProxy(t, { scope: "actor", peer: "env-workspace", cliPeer: "cli-workspace" });
+  assert.ok(result.response, result.stderr);
+  const headers = result.requests[0].headers;
+  assert.equal(headers["x-openviking-actor-peer"], "cli-workspace");
+  assert.equal(headers.authorization, "Bearer cli-key");
+  assert.equal(headers["x-openviking-account"], "cli-account");
+  assert.equal(headers["x-openviking-user"], "cli-user");
+});
+
+test("actor scope without explicit identity warns on stderr and falls back to broad recall", { timeout: 5000 }, async (t) => {
+  const result = await runProxy(t, { scope: "actor" });
+  assert.deepEqual(result.response, { jsonrpc: "2.0", id: 1, result: { tools: [] } });
+  assert.match(result.stderr, /explicit peer id/);
+  assert.match(result.stderr, /Falling back to broad recall/);
+  assert.equal(result.requests[0].headers["x-openviking-actor-peer"], undefined);
+});


### PR DESCRIPTION
## Description

旧版 Codex 插件从插件安装目录启动 MCP 代理时，会把该目录错误地映射为 actor peer。用户能够在召回结果中看到自己工作区的记忆，但随后读取正文返回 `Access denied for viking://...`；HTTP 请求日志仍可能显示 `POST /mcp` 返回 200，因为错误出现在工具返回内容中。

#4400 已修复该问题。本 PR 补充真实代理进程的回归测试，覆盖配置加载到 HTTP 身份头的完整路径，并修正文档中“缺少显式 peer 会退出”的过时描述。不改动生产逻辑。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

补充 #4400 的回归验证。

## Type of Change

- [x] Documentation update
- [x] Test update

## Changes Made

- 从插件目录启动真实 stdio 代理，验证默认 broad scope 不发送 actor peer，显式 peer 也不会意外收窄 broad scope。
- 验证两个并行代理各自携带配置的 actor peer，以及选定 `ovcli.conf` 时身份字段优先于环境变量。
- 验证 actor scope 缺少显式 peer 时，当前实现将警告写入 stderr 并回退到 broad scope，stdout 保持 JSON-RPC；同步 README 并接入现有插件 CI。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] macOS

```bash
node --test examples/codex-memory-plugin/servers/*.test.mjs examples/memory-plugin-shared/mcp-proxy-config.test.mjs
```

29 项相关测试通过。临时恢复从 `process.cwd()` 派生 actor peer 的旧行为后，新增回归用例按预期失败；恢复代码后重新验证通过。未运行全仓测试。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published
