### PR TITLE
docs: embedding head-truncation semantics, query cache behavior, debug/vector endpoints, FindResult bucket caveats

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -231,7 +231,8 @@ const apiReferenceSidebar = {
           ['07-system.md', 'System Status'],
           ['17-tasks.md', 'Background Tasks'],
           ['18-observer.md', 'Runtime Observability'],
-          ['09-metrics.md', 'Metrics']
+          ['09-metrics.md', 'Metrics'],
+          ['21-debug.md', 'Debug']
         ]
       },
       {

--- a/docs/en/api/06-retrieval.md
+++ b/docs/en/api/06-retrieval.md
@@ -94,6 +94,10 @@ class FindResult:
     total: int                       # Total count (auto-calculated)
 ```
 
+**Result Buckets**
+
+`FindResult` partitions hits into three independent buckets — `memories`, `resources`, and `skills`. A hit appears in exactly one bucket, so reading only a single bucket (for example, only `result["memories"]`) silently misses every hit in the other buckets, including knowledge-layer hits in `resources` and `skills`. Observed on v0.4.17.dev7: consumers that iterate only one bucket reported "no results" while matching content sat in another bucket. Iterate all three buckets, or use `context_type` / `target_uri` to scope the query intentionally, and do not infer "no results" from one empty bucket.
+
 **MatchedContext Structure**
 
 ```python
@@ -1126,6 +1130,27 @@ curl -X GET "http://localhost:1933/api/v1/content/overview?uri=viking://resource
 curl -X GET "http://localhost:1933/api/v1/content/read?uri=viking://resources/docs/auth.md" \
     -H "X-API-Key: your-key"
 ```
+
+## Behavioral Notes
+
+The behaviors in this section were observed on v0.4.17.dev7 and are deliberately worded as observations rather than contractual guarantees.
+
+### Tag Filtering and `set_tags` Propagation
+
+The `tags` parameter of `find()` and `search()` (strict `k=v` form, AND-combined) is applied as a filter against the tags stored on vector records, not against live filesystem metadata: `openviking/utils/tags.py:build_search_tags_filter()` builds the vector-store filter consumed by `openviking/server/routers/search.py:search()`.
+
+**Observed behavior**:
+
+- Tags written after ingest via the filesystem `set_tags` operation did not show up on existing vector records immediately; tag-filtered searches did not return the affected URIs until the content was re-indexed (re-ingest or reindex).
+- The most reliable path to tag-filterable content is to pass tags at ingest time, e.g. `add_resource(..., tags=["project=demo", "type=runbook"])`, so the tags are present on the vector records from the start.
+- After calling `set_tags`, verify propagation with the debug endpoints (see [Debug](21-debug.md)) before relying on tag-filtered retrieval.
+
+### Same-Query Cache
+
+Identical retrieval queries (same query text and scope) may be served from a cache instead of running the full retrieval pipeline.
+
+- **Observed behavior**: repeating an unchanged query returned in sub-millisecond time, while the first execution of the same query took the usual pipeline time.
+- **Practical impact**: benchmarks and evaluations must vary the query text between runs; otherwise the measured latency reflects cache replay rather than retrieval cost.
 
 ## Best Practices
 

--- a/docs/en/api/06-retrieval.md
+++ b/docs/en/api/06-retrieval.md
@@ -96,7 +96,7 @@ class FindResult:
 
 **Result Buckets**
 
-`FindResult` partitions hits into three independent buckets — `memories`, `resources`, and `skills`. A hit appears in exactly one bucket, so reading only a single bucket (for example, only `result["memories"]`) silently misses every hit in the other buckets, including knowledge-layer hits in `resources` and `skills`. Observed on v0.4.17.dev7: consumers that iterate only one bucket reported "no results" while matching content sat in another bucket. Iterate all three buckets, or use `context_type` / `target_uri` to scope the query intentionally, and do not infer "no results" from one empty bucket.
+`FindResult` partitions hits into three independent buckets — `memories`, `resources`, and `skills`. A hit appears in exactly one bucket, so reading only a single bucket (for example, only `result["memories"]`) silently misses every hit in the other buckets, including knowledge-layer hits in `resources` and `skills`. Observed on a self-hosted v0.4.17.dev7 deployment with Qwen3-Embedding-8B: consumers that iterate only one bucket reported "no results" while matching content sat in another bucket. Iterate all three buckets, or use `context_type` / `target_uri` to scope the query intentionally, and do not infer "no results" from one empty bucket.
 
 **MatchedContext Structure**
 
@@ -1133,7 +1133,7 @@ curl -X GET "http://localhost:1933/api/v1/content/read?uri=viking://resources/do
 
 ## Behavioral Notes
 
-The behaviors in this section were observed on v0.4.17.dev7 and are deliberately worded as observations rather than contractual guarantees.
+The behaviors in this section were observed on a self-hosted v0.4.17.dev7 deployment with Qwen3-Embedding-8B and are deliberately worded as observations rather than contractual guarantees.
 
 ### Tag Filtering and `set_tags` Propagation
 

--- a/docs/en/api/21-debug.md
+++ b/docs/en/api/21-debug.md
@@ -1,6 +1,6 @@
 # Debug
 
-Diagnostic endpoints for inspecting the vector index maintained by OpenViking. They are intended for troubleshooting and operational verification — for example, confirming that a URI actually has vector records, or what metadata (such as tags) is attached to them. They are not part of the stable retrieval surface and the record shape may vary by vector backend.
+Diagnostic endpoints for inspecting the vector index maintained by OpenViking. They are intended for troubleshooting and operational verification — for example, confirming that a URI actually has vector records, or what metadata (such as tags) is attached to them. On the reference self-hosted deployment (v0.4.17.dev7 with Qwen3-Embedding-8B) these endpoints were used to verify tag propagation and record state after ingestion and reindexing. They are not part of the stable retrieval surface and the record shape may vary by vector backend.
 
 All endpoints are read-only and apply the same tenant isolation as regular requests: records are filtered to the account/user (and peer, when `X-OpenViking-Actor-Peer` is set) of the calling context.
 

--- a/docs/en/api/21-debug.md
+++ b/docs/en/api/21-debug.md
@@ -1,0 +1,125 @@
+# Debug
+
+Diagnostic endpoints for inspecting the vector index maintained by OpenViking. They are intended for troubleshooting and operational verification — for example, confirming that a URI actually has vector records, or what metadata (such as tags) is attached to them. They are not part of the stable retrieval surface and the record shape may vary by vector backend.
+
+All endpoints are read-only and apply the same tenant isolation as regular requests: records are filtered to the account/user (and peer, when `X-OpenViking-Actor-Peer` is set) of the calling context.
+
+## API Reference
+
+### debug/vector/scroll
+
+#### 1. API Implementation Introduction
+
+Returns vector records paginated, optionally restricted to one URI. Useful for checking what is actually stored in the vector database after ingestion or reindexing.
+
+**Code Entry**:
+- `openviking/server/routers/debug.py:debug_vector_scroll()` - HTTP router
+- `openviking/storage/vikingdb_manager.py:VikingDBManagerProxy.scroll()` - Tenant-isolated vector store access
+
+#### 2. Interface and Parameter Description
+
+**Parameters**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| limit | int | No | `100` | Page size, `1`–`1000` |
+| cursor | str | No | None | Opaque cursor taken from a previous response's `next_cursor` |
+| uri | str | No | None | Restrict records to this Viking URI (path variables such as `~` are resolved against the request identity) |
+
+#### 3. Usage Examples
+
+**HTTP API**
+
+```
+GET /api/v1/debug/vector/scroll
+```
+
+```bash
+curl "http://localhost:1933/api/v1/debug/vector/scroll?limit=10&uri=viking://resources/docs/auth" \
+    -H "X-API-Key: your-key"
+```
+
+#### 4. Response Contract
+
+Successful responses use the standard response envelope. `result.records` is a list of raw vector records (shape depends on the configured vector backend), and `result.next_cursor` is the cursor to pass as `cursor` for the next page; it is empty or absent when there are no more pages.
+
+**Response Example**
+
+```json
+{
+  "status": "ok",
+  "result": {
+    "records": [
+      {
+        "uri": "viking://resources/docs/auth/login.md",
+        "tags": ["project=demo"],
+        "...": "backend-specific fields"
+      }
+    ],
+    "next_cursor": ""
+  },
+  "time": 0.012
+}
+```
+
+---
+
+### debug/vector/count
+
+#### 1. API Implementation Introduction
+
+Returns the number of vector records matching an optional filter, without transferring the records themselves. Useful for verifying ingestion completeness or the effect of a reindex.
+
+**Code Entry**:
+- `openviking/server/routers/debug.py:debug_vector_count()` - HTTP router
+- `openviking/storage/vikingdb_manager.py:VikingDBManagerProxy.count()` - Tenant-isolated vector store access
+
+#### 2. Interface and Parameter Description
+
+**Parameters**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| uri | str | No | None | Count only records under this Viking URI |
+| filter | str | No | None | JSON-encoded vector-store filter expression, e.g. `{"op":"must","field":"uri","conds":["viking://resources/docs"]}`. Combined with `uri` when both are given |
+
+#### 3. Usage Examples
+
+**HTTP API**
+
+```
+GET /api/v1/debug/vector/count
+```
+
+```bash
+curl "http://localhost:1933/api/v1/debug/vector/count?uri=viking://resources/docs/auth" \
+    -H "X-API-Key: your-key"
+```
+
+#### 4. Response Contract and Error Handling
+
+`result.count` is the number of matching vector records after tenant isolation and filtering.
+
+**Response Example**
+
+```json
+{
+  "status": "ok",
+  "result": {
+    "count": 42
+  },
+  "time": 0.008
+}
+```
+
+**Error Handling**
+
+- `INVALID_FILTER`: `filter` is not valid JSON.
+- `NO_VECTOR_DB`: the vector database is not initialized.
+
+---
+
+## Related Documentation
+
+- [System Status](07-system.md) - health/ready/status and consistency endpoints
+- [Retrieval](06-retrieval.md) - behavioral notes on tag filtering and the same-query cache

--- a/docs/en/configuration/01-server.md
+++ b/docs/en/configuration/01-server.md
@@ -144,7 +144,7 @@ Changing the model or `dimension` can make existing vector collections incompati
 |---|---|---|---|
 | `max_input_tokens` | integer; `0` disables | `4096` | Maximum estimated raw-text tokens per embedding input; oversized inputs are truncated before the request is sent |
 
-**Truncation semantics (observed on v0.4.17.dev7)**
+**Truncation semantics (observed on a self-hosted v0.4.17.dev7 deployment with Qwen3-Embedding-8B)**
 
 - The token estimate is character-based: CJK characters count as one token each and other characters as roughly four characters per token (`openviking/utils/embedding_input.py:estimate_embedding_input_tokens()`).
 - When the estimate exceeds the limit, the input is truncated from the head — the beginning of the text is kept — and a `\n...(truncated for embedding)` suffix is appended (`openviking/utils/embedding_input.py:truncate_embedding_input()`).

--- a/docs/en/configuration/01-server.md
+++ b/docs/en/configuration/01-server.md
@@ -136,6 +136,21 @@ API-based `embedding`, `vlm`, `query_planner`, and `rerank` configurations reuse
 
 Changing the model or `dimension` can make existing vector collections incompatible and may require migration or reindexing.
 
+#### `embedding.max_input_tokens`
+
+`max_input_tokens` sits on the `embedding` object itself, next to `dense` / `sparse` / `hybrid` (not inside them).
+
+| Field | Type / values | Default | Purpose |
+|---|---|---|---|
+| `max_input_tokens` | integer; `0` disables | `4096` | Maximum estimated raw-text tokens per embedding input; oversized inputs are truncated before the request is sent |
+
+**Truncation semantics (observed on v0.4.17.dev7)**
+
+- The token estimate is character-based: CJK characters count as one token each and other characters as roughly four characters per token (`openviking/utils/embedding_input.py:estimate_embedding_input_tokens()`).
+- When the estimate exceeds the limit, the input is truncated from the head — the beginning of the text is kept — and a `\n...(truncated for embedding)` suffix is appended (`openviking/utils/embedding_input.py:truncate_embedding_input()`).
+- The limit interacts with the embedding slot capacity: in-flight token volume per embedder scales with `embedding.max_concurrent` (default `10`) × `max_input_tokens`, so raising the limit for long-document workloads also raises per-request token volume against the embedding provider.
+- Boundary to keep in mind: because only the head of an oversized document is embedded, content in the middle of a long document beyond the truncation point is, in practice, not represented in its vector and cannot be recalled by vector search. Keep the default, split long documents at ingest, or set `embedding.text_source` to a summary-based mode when mid-document recall matters.
+
 ### `rerank`
 
 | Field | Type / values | Default | Purpose |


### PR DESCRIPTION
## Summary

Backfills four undocumented retrieval-adjacent behaviors that cost real debugging time on a self-hosted deployment, written as observations (with code entry points) rather than contractual guarantees:

1. **`embedding.max_input_tokens` head-truncation semantics** (`docs/en/configuration/01-server.md`): where the field lives, the character-based estimator behind it (CJK = 1 token/char, others ~4 chars/token), head-keeping truncation with the `\n...(truncated for embedding)` suffix, and the estimator's CJK-inflation limitation — mid-document content beyond the truncation point is effectively not represented in its vector.
2. **Same-query cache** (`docs/en/api/06-retrieval.md`): identical queries can be served from cache in sub-millisecond time; benchmarks/evals must vary query text or they measure cache replay, not retrieval.
3. **`debug/vector/scroll` and `debug/vector/count` endpoints** (new `docs/en/api/21-debug.md`): parameters, curl examples, response contracts, tenant isolation, and code entry points — plus a sidebar entry.
4. **`FindResult` three-bucket caveat** (`docs/en/api/06-retrieval.md`): hits are partitioned into exactly one of `memories` / `resources` / `skills`, so reading a single bucket silently misses the rest; also covers `tags` filtering against vector records and `set_tags` propagation timing.

## Evidence

All behaviors were observed on a self-hosted v0.4.17.dev7 deployment with Qwen3-Embedding-8B; each doc section states its observation basis inline.

## Changes

- `docs/en/configuration/01-server.md`: new `embedding.max_input_tokens` section (config, truncation semantics, estimator limits, capacity interaction with `max_concurrent`, mid-document recall boundary).
- `docs/en/api/06-retrieval.md`: new "Result Buckets" note on `FindResult`, and a "Behavioral Notes" section covering tag filtering / `set_tags` propagation and the same-query cache.
- `docs/en/api/21-debug.md` (new): `debug/vector/scroll` and `debug/vector/count` reference.
- `docs/.vitepress/config.ts`: sidebar entry for the Debug page.

## Checklist

- [x] Each behavior documented as phenomenon -> semantics -> configuration/parameter -> observed case
- [x] Observation environment stated inline (self-hosted v0.4.17.dev7 + Qwen3-Embedding-8B)
- [x] Docs-only change; no code, no API behavior change
- [x] Companion code change for the estimator limitation: #4784
