### PR TITLE
fix(storage): fail resource sync without replaying partial source trees

### DIFF
--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -334,6 +334,7 @@ class SemanticProcessor(DequeueHandlerBase):
         """Process dequeued SemanticMsg, recursively process all subdirectories."""
         msg: Optional[SemanticMsg] = None
         collector = None
+        syncing_source = False
         try:
             import json
 
@@ -445,12 +446,14 @@ class SemanticProcessor(DequeueHandlerBase):
                                         "Syncing semantic source into target before processing: "
                                         f"{msg.uri} -> {msg.target_uri}"
                                     )
+                                    syncing_source = True
                                     diff = await self._sync_topdown_recursive(
                                         msg.uri,
                                         msg.target_uri,
                                         ctx=current_ctx,
                                         lock=semantic_lock.lock,
                                     )
+                                    syncing_source = False
                                     logger.info(
                                         "[SyncDiff] Diff computed: "
                                         f"added_files={len(diff.added_files)}, "
@@ -527,6 +530,15 @@ class SemanticProcessor(DequeueHandlerBase):
                     reset_root_observability_context(root_context_token)
 
         except Exception as e:
+            if syncing_source:
+                assert msg is not None
+                # A move-based sync may already have consumed part of the source.
+                # Replaying that partial tree can delete previously moved content.
+                logger.error("Source sync failed; retaining remaining staging data: %s", e)
+                self._merge_request_stats(msg.telemetry_id, error_count=1)
+                get_request_wait_tracker().mark_semantic_failed(msg.telemetry_id, msg.id, str(e))
+                self.report_error(str(e), data)
+                return None
             if isinstance(e, LockAcquisitionError):
                 logger.warning(
                     "Lock error processing semantic message, re-enqueueing without "

--- a/openviking/storage/viking_fs/_sync.py
+++ b/openviking/storage/viking_fs/_sync.py
@@ -59,6 +59,8 @@ class _SyncMixin:
         Hidden entries (names starting with ``.``) are skipped on both sides.
         Name conflicts (file vs. directory at the same name) are resolved by
         deleting the target-side entry before moving the source in place.
+        Move/remove failures propagate to the caller without deleting the remaining
+        staging tree. Changes already applied before a failure are not rolled back.
 
         Args:
             root_uri: Source (typically a temp/staging tree). Must exist.
@@ -139,38 +141,25 @@ class _SyncMixin:
 
                 if root_file and name in target_dirs:
                     target_conflict_dir = target_dirs[name]
-                    try:
-                        await self.rm(
-                            target_conflict_dir,
-                            recursive=True,
-                            ctx=ctx,
-                            lease_ref=lease_ref,
-                        )
-                        diff.deleted_dirs.append(target_conflict_dir)
-                        target_dirs.pop(name, None)
-                    except Exception as e:
-                        logger.error(
-                            f"[SyncDiff] Failed to delete directory for file conflict: {target_conflict_dir}, error={e}"
-                        )
+                    await self.rm(
+                        target_conflict_dir,
+                        recursive=True,
+                        ctx=ctx,
+                        lease_ref=lease_ref,
+                    )
+                    diff.deleted_dirs.append(target_conflict_dir)
+                    target_dirs.pop(name, None)
                     target_file = None
 
                 if target_file and name in root_dirs and not root_file:
-                    try:
-                        await self.rm(target_file, ctx=ctx, lease_ref=lease_ref)
-                        diff.deleted_files.append(target_file)
-                        target_files.pop(name, None)
-                    except Exception as e:
-                        logger.error(
-                            f"[SyncDiff] Failed to delete file for dir conflict: {target_file}, error={e}"
-                        )
+                    await self.rm(target_file, ctx=ctx, lease_ref=lease_ref)
+                    diff.deleted_files.append(target_file)
+                    target_files.pop(name, None)
                     continue
 
                 if target_file and not root_file:
-                    try:
-                        await self.rm(target_file, ctx=ctx, lease_ref=lease_ref)
-                        diff.deleted_files.append(target_file)
-                    except Exception as e:
-                        logger.error(f"[SyncDiff] Failed to delete file: {target_file}, error={e}")
+                    await self.rm(target_file, ctx=ctx, lease_ref=lease_ref)
+                    diff.deleted_files.append(target_file)
                     continue
 
                 if root_file and target_file:
@@ -186,40 +175,25 @@ class _SyncMixin:
                             )
                             changed = False
                     if changed:
+                        await self.rm(target_file, ctx=ctx, lease_ref=lease_ref)
+                        await self.mv(
+                            root_file,
+                            target_file,
+                            ctx=ctx,
+                            lease_ref=lease_ref,
+                        )
                         diff.updated_files.append(target_file)
-                        try:
-                            await self.rm(target_file, ctx=ctx, lease_ref=lease_ref)
-                        except Exception as e:
-                            logger.error(
-                                f"[SyncDiff] Failed to remove old file before update: {target_file}, error={e}"
-                            )
-                        try:
-                            await self.mv(
-                                root_file,
-                                target_file,
-                                ctx=ctx,
-                                lease_ref=lease_ref,
-                            )
-                        except Exception as e:
-                            logger.error(
-                                f"[SyncDiff] Failed to move updated file: {root_file} -> {target_file}, error={e}"
-                            )
                     continue
 
                 if root_file and not target_file:
                     target_file_uri = VikingURI(target_dir).join(name).uri
+                    await self.mv(
+                        root_file,
+                        target_file_uri,
+                        ctx=ctx,
+                        lease_ref=lease_ref,
+                    )
                     diff.added_files.append(target_file_uri)
-                    try:
-                        await self.mv(
-                            root_file,
-                            target_file_uri,
-                            ctx=ctx,
-                            lease_ref=lease_ref,
-                        )
-                    except Exception as e:
-                        logger.error(
-                            f"[SyncDiff] Failed to move added file: {root_file} -> {target_file_uri}, error={e}"
-                        )
 
             dir_names = set(root_dirs.keys()) | set(target_dirs.keys())
             for name in sorted(dir_names):
@@ -228,49 +202,34 @@ class _SyncMixin:
 
                 if root_subdir and name in target_files:
                     target_conflict_file = target_files[name]
-                    try:
-                        await self.rm(
-                            target_conflict_file,
-                            ctx=ctx,
-                            lease_ref=lease_ref,
-                        )
-                        diff.deleted_files.append(target_conflict_file)
-                        target_files.pop(name, None)
-                    except Exception as e:
-                        logger.error(
-                            f"[SyncDiff] Failed to delete file for dir conflict: {target_conflict_file}, error={e}"
-                        )
+                    await self.rm(
+                        target_conflict_file,
+                        ctx=ctx,
+                        lease_ref=lease_ref,
+                    )
+                    diff.deleted_files.append(target_conflict_file)
+                    target_files.pop(name, None)
                     target_subdir = None
 
                 if target_subdir and not root_subdir:
-                    try:
-                        await self.rm(
-                            target_subdir,
-                            recursive=True,
-                            ctx=ctx,
-                            lease_ref=lease_ref,
-                        )
-                        diff.deleted_dirs.append(target_subdir)
-                    except Exception as e:
-                        logger.error(
-                            f"[SyncDiff] Failed to delete directory: {target_subdir}, error={e}"
-                        )
+                    await self.rm(
+                        target_subdir,
+                        recursive=True,
+                        ctx=ctx,
+                        lease_ref=lease_ref,
+                    )
+                    diff.deleted_dirs.append(target_subdir)
                     continue
 
                 if root_subdir and not target_subdir:
                     target_subdir_uri = VikingURI(target_dir).join(name).uri
+                    await self.mv(
+                        root_subdir,
+                        target_subdir_uri,
+                        ctx=ctx,
+                        lease_ref=lease_ref,
+                    )
                     diff.added_dirs.append(target_subdir_uri)
-                    try:
-                        await self.mv(
-                            root_subdir,
-                            target_subdir_uri,
-                            ctx=ctx,
-                            lease_ref=lease_ref,
-                        )
-                    except Exception as e:
-                        logger.error(
-                            f"[SyncDiff] Failed to move added directory: {root_subdir} -> {target_subdir_uri}, error={e}"
-                        )
                     continue
 
                 if root_subdir and target_subdir:
@@ -286,8 +245,8 @@ class _SyncMixin:
                     ctx=ctx,
                     lease_ref=lease_ref,
                 )
-            diff.added_dirs.append(target_uri)
             await self.mv(root_uri, target_uri, ctx=ctx, lease_ref=lease_ref)
+            diff.added_dirs.append(target_uri)
             return diff
 
         await sync_dir(root_uri, target_uri)

--- a/tests/storage/test_transfer_merge_binding.py
+++ b/tests/storage/test_transfer_merge_binding.py
@@ -4,7 +4,7 @@
 
 import json
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import pytest_asyncio
@@ -538,3 +538,133 @@ async def test_watch_persistence_overwrites_after_backup_removal_failure(binding
     backup = json.loads(await fs.read_file(manager.STORAGE_BAK_URI, ctx=ctx))
     assert backup["tasks"] == []
     assert not await fs.exists(manager.STORAGE_TMP_URI, ctx=ctx)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("semantic", [False, True], ids=["sync-tree", "semantic-sync"])
+@pytest.mark.parametrize(
+    "source_files,target_files,operation",
+    [
+        (["item.md"], [], "mv"),
+        (["item/file.md"], [], "mv"),
+        (["item.md"], ["item.md"], "mv"),
+        (["item.md"], ["item.md"], "rm"),
+        ([], ["item.md"], "rm"),
+        ([], ["item/file.md"], "rm"),
+        (["item"], ["item/file.md"], "rm"),
+        (["item/file.md"], ["item"], "rm"),
+    ],
+    ids=[
+        "add-file",
+        "add-dir",
+        "update-move",
+        "update-remove",
+        "delete-file",
+        "delete-dir",
+        "file-over-dir",
+        "dir-over-file",
+    ],
+)
+async def test_sync_failure_preserves_staged_content(
+    binding_fs, monkeypatch, semantic, source_files, target_files, operation
+):
+    from openviking.storage.queuefs.semantic_processor import SemanticProcessor
+
+    fs, ctx = binding_fs, root_ctx()
+    source, target = "viking://temp/import", "viking://resources/target"
+    await fs.mkdir(source, ctx=ctx)
+    await fs.mkdir(target, ctx=ctx)
+    for name in source_files:
+        await fs.write_file_bytes(f"{source}/{name}", b"new payload", ctx=ctx)
+    for name in target_files:
+        await fs.write_file_bytes(f"{target}/{name}", b"old", ctx=ctx)
+    sidecar = f"{source}/.image_mappings.json"
+    await fs.write_file_bytes(sidecar, b"{}", ctx=ctx)
+    error = OSError("injected storage failure")
+    monkeypatch.setattr(fs, operation, AsyncMock(side_effect=error))
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_processor.get_viking_fs", lambda: fs)
+
+    with pytest.raises(OSError) as caught:
+        if semantic:
+            await SemanticProcessor()._sync_topdown_recursive(source, target, ctx=ctx)
+        else:
+            await fs.sync_tree(source, target, ctx=ctx, delete_temp_after=True)
+
+    assert caught.value is error
+    assert await fs.read_file_bytes(sidecar, ctx=ctx) == b"{}"
+    for name in source_files:
+        assert await fs.read_file_bytes(f"{source}/{name}", ctx=ctx) == b"new payload"
+
+
+@pytest.mark.asyncio
+async def test_successful_sync_reports_applied_changes_and_cleans_temp(binding_fs):
+    fs, ctx = binding_fs, root_ctx()
+    source, target = "viking://temp/import", "viking://resources/target"
+    for name in ("added.md", "updated.md", "newdir/file.md"):
+        await fs.write_file_bytes(f"{source}/{name}", b"new payload", ctx=ctx)
+    for name in ("updated.md", "removed.md", "olddir/file.md"):
+        await fs.write_file_bytes(f"{target}/{name}", b"old", ctx=ctx)
+
+    diff = await fs.sync_tree(source, target, ctx=ctx, delete_temp_after=True)
+
+    assert diff.to_changes() == {
+        "added": [f"{target}/added.md", f"{target}/newdir"],
+        "modified": [f"{target}/updated.md"],
+        "deleted": [f"{target}/removed.md", f"{target}/olddir"],
+    }
+    assert not await fs.exists(source, ctx=ctx)
+    for name in ("added.md", "updated.md", "newdir/file.md"):
+        assert await fs.read_file_bytes(f"{target}/{name}", ctx=ctx) == b"new payload"
+    for name in ("removed.md", "olddir"):
+        assert not await fs.exists(f"{target}/{name}", ctx=ctx)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("lock_error", [False, True], ids=["storage-error", "lock-error"])
+async def test_partial_source_sync_fails_task_without_replaying_moves(
+    binding_fs, monkeypatch, lock_error
+):
+    from openviking.storage.errors import LockAcquisitionError
+    from openviking.storage.queuefs.semantic_msg import SemanticMsg
+    from openviking.storage.queuefs.semantic_processor import SemanticProcessor
+
+    fs, ctx = binding_fs, root_ctx()
+    source, target = "viking://temp/import", "viking://resources/target"
+    await fs.mkdir(target, ctx=ctx)
+    for name in ("a.md", "z.md"):
+        await fs.write_file_bytes(f"{source}/{name}", b"payload", ctx=ctx)
+    real_mv = fs.mv
+    error = (
+        LockAcquisitionError("injected lock failure") if lock_error else OSError("storage failed")
+    )
+
+    async def fail_second_move(src, dst, **kwargs):
+        if src == f"{source}/z.md":
+            raise error
+        return await real_mv(src, dst, **kwargs)
+
+    monkeypatch.setattr(fs, "mv", fail_second_move)
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_processor.get_viking_fs", lambda: fs)
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.SemanticLockScope.resolve",
+        AsyncMock(return_value=SimpleNamespace(lock=None, close=AsyncMock())),
+    )
+    tracker = MagicMock()
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_request_wait_tracker", lambda: tracker
+    )
+    processor = SemanticProcessor()
+    processor._reenqueue_semantic_msg = AsyncMock()
+    processor.report_success = MagicMock()
+    msg = SemanticMsg(
+        uri=source, target_uri=target, context_type="resource", telemetry_id="sync-fail"
+    )
+
+    await processor.on_dequeue(msg.to_dict())
+
+    tracker.mark_semantic_failed.assert_called_once_with(msg.telemetry_id, msg.id, str(error))
+    tracker.mark_semantic_done.assert_not_called()
+    processor._reenqueue_semantic_msg.assert_not_awaited()
+    processor.report_success.assert_not_called()
+    assert await fs.read_file_bytes(f"{target}/a.md", ctx=ctx) == b"payload"
+    assert await fs.read_file_bytes(f"{source}/z.md", ctx=ctx) == b"payload"


### PR DESCRIPTION
## Description

Addresses #4555's false-success path. On current main, `sync_tree` logs and suppresses failed moves/removals, returns a normal diff, and allows its caller to delete staged payloads. Propagate these failures and record diff entries only after successful operations.

There is a necessary queue boundary change: a move-based sync may already have consumed part of its source before failing. Automatically replaying that partial tree can delete previously moved target entries. `SemanticProcessor.on_dequeue` therefore marks failures during source synchronization as failed instead of re-enqueueing them. Lock acquisition before source synchronization and later API retry handling retain their existing behavior.

Remaining staged files survive the failure. Operations already applied are not rolled back; this does not add transactional storage or establish the original backend failure. Re-import from the original complete source after resolving the storage error, rather than replaying an incomplete staging tree.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Type of Change

- [x] Bug fix
- [x] Test update

## Validation

19 new cases pass using a locally built RAGFS native binding and real filesystem I/O, with fault injection at the move/remove boundary. They cover both sync entrypoints, file/directory additions, updates, deletions and type conflicts, successful cleanup, and task failure after a successful first move followed by a storage or lock error.

The 16 propagation cases fail against unmodified main because no error is raised. With only propagation fixed, the two task-boundary cases fail against the original queue handler because it re-enqueues the partial source.

```sh
python -m pytest tests/storage/test_transfer_merge_binding.py -k 'sync_failure or successful_sync or partial_source_sync' -q -o addopts=''
ruff check openviking/storage/viking_fs/_sync.py openviking/storage/queuefs/semantic_processor.py tests/storage/test_transfer_merge_binding.py
ruff format --check openviking/storage/viking_fs/_sync.py openviking/storage/queuefs/semantic_processor.py tests/storage/test_transfer_merge_binding.py
```

The broader run included the transfer binding, semantic target-preexisting, L0/L1, move/vector-store, incremental DAG, and resource-processor move suites: 84 passed, 29 skipped (local vector engine unavailable), 2 failed. Both failures are unchanged main test fakes missing `_ensure_access` in `test_resource_processor_mv.py`, reproduced with baseline implementations. Targeted mypy reports the same 29 existing errors on main and this branch. No live object-storage deployment or full repository suite was tested.

## Scope

Related #4718 and #4774 address transfer locks and vector queries; this change handles failure propagation and unsafe replay in the owning sync/task paths. No new retry mechanism, schema, configuration, or dependency changes.
