### PR TITLE
docs: add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ The official Docker image bundles VikingBot and starts it by default alongside t
 
 For production, run OpenViking as a standalone HTTP service — see [Server deployment](https://docs.openviking.ai/en/getting-started/03-quickstart-server) and the [Deployment guide](https://docs.openviking.ai/en/guides/03-deployment).
 
+## ☁️ One-Click Deploy
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/openviking/)
+
 ## Commercial editions
 
 **The open-source edition is not crippled.** OpenViking in this repo is fully open source under AGPLv3: no feature gates, no account required, no activation key. Follow [Deploy in production](#deploy-in-production) above and run it in production yourself — and that will stay true.


### PR DESCRIPTION
Adds a RepoCloud one-click deploy button to the README, placed in a new "One-Click Deploy" section between "Deploy in production" and "Commercial editions."

 - New `## ☁️ One-Click Deploy` section with deploy button
 - Button links to https://repocloud.io/details/openviking/