### PR TITLE
fix: avoid signaling Windows processes during PID checks

### DIFF
--- a/openviking/utils/process_lock.py
+++ b/openviking/utils/process_lock.py
@@ -48,6 +48,23 @@ def _is_pid_alive(pid: int) -> bool:
     """Check whether a process with the given PID is still running."""
     if pid <= 0:
         return False
+    if sys.platform == "win32":
+        import _winapi
+
+        # Unlike POSIX, os.kill(pid, 0) sends CTRL_C_EVENT on Windows.
+        try:
+            handle = _winapi.OpenProcess(_winapi.SYNCHRONIZE, False, pid)
+        except OSError as exc:
+            # ERROR_INVALID_PARAMETER confirms there is no such PID. Access
+            # denied and other query failures must not discard a live lock.
+            return exc.winerror != 87
+        try:
+            return _winapi.WaitForSingleObject(handle, 0) != _winapi.WAIT_OBJECT_0
+        except OSError:
+            return True
+        finally:
+            _winapi.CloseHandle(handle)
+
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -55,10 +72,6 @@ def _is_pid_alive(pid: int) -> bool:
     except PermissionError:
         # Process exists but we can't signal it.
         pass
-    except (OSError, SystemError):
-        if sys.platform == "win32":
-            return False
-        raise
 
     # PID exists, but on Linux PIDs are recycled. Verify this is actually
     # an OpenViking process by checking /proc/{pid}/cmdline to avoid false

--- a/tests/unit/test_process_lock.py
+++ b/tests/unit/test_process_lock.py
@@ -4,7 +4,10 @@
 """Tests for PID-based process lock utility."""
 
 import os
+import sys
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
@@ -96,16 +99,48 @@ class TestIsPidAlive:
         """Test that negative PID is not alive."""
         assert _is_pid_alive(-1) is False
 
-    def test_windows_system_error_treated_as_stale(self, monkeypatch):
-        """Windows SystemError from os.kill(pid, 0) should be treated as stale."""
+    @pytest.mark.parametrize(
+        "open_error, wait_result, wait_error, expected",
+        [
+            (None, 258, None, True),  # WAIT_TIMEOUT: still running
+            (None, 0, None, False),  # WAIT_OBJECT_0: exited
+            (87, None, None, False),  # no such PID
+            (5, None, None, True),  # access denied
+            (6, None, None, True),  # unknown query failure
+            (None, None, OSError("wait failed"), True),
+        ],
+    )
+    def test_windows_probe_never_signals(
+        self, monkeypatch, open_error, wait_result, wait_error, expected
+    ):
+        api = SimpleNamespace(
+            SYNCHRONIZE=0x100000,
+            WAIT_OBJECT_0=0,
+            OpenProcess=Mock(return_value=123),
+            WaitForSingleObject=Mock(return_value=wait_result, side_effect=wait_error),
+            CloseHandle=Mock(),
+        )
+        if open_error is not None:
+            error = OSError("open failed")
+            error.winerror = open_error
+            api.OpenProcess.side_effect = error
+        with monkeypatch.context() as patch:
+            patch.setattr(process_lock_module.sys, "platform", "win32")
+            patch.setitem(sys.modules, "_winapi", api)
+            patch.setattr(os, "kill", Mock(side_effect=AssertionError("must not signal")))
+            assert _is_pid_alive(os.getpid()) is expected
+        api.OpenProcess.assert_called_once_with(api.SYNCHRONIZE, False, os.getpid())
+        if open_error is None:
+            api.WaitForSingleObject.assert_called_once_with(123, 0)
+            api.CloseHandle.assert_called_once_with(123)
+        else:
+            api.WaitForSingleObject.assert_not_called()
+            api.CloseHandle.assert_not_called()
 
-        def _raise_system_error(_pid: int, _sig: int) -> None:
-            raise SystemError("win32 wrapper failure")
-
-        monkeypatch.setattr(process_lock_module.sys, "platform", "win32")
-        monkeypatch.setattr(process_lock_module.os, "kill", _raise_system_error)
-
-        assert _is_pid_alive(12345) is False
+    @pytest.mark.skipif(sys.platform != "win32", reason="requires native Windows APIs")
+    def test_windows_native_current_pid_never_signals(self, monkeypatch):
+        monkeypatch.setattr(os, "kill", Mock(side_effect=AssertionError("must not signal")))
+        assert _is_pid_alive(os.getpid()) is True
 
     def test_non_windows_system_error_bubbles_up(self, monkeypatch):
         """Non-Windows should not downgrade unexpected SystemError values."""
@@ -219,22 +254,24 @@ class TestAcquireDataDirLock:
         error_msg = str(exc_info.value)
         assert str(tmp_path) in error_msg
 
-    def test_acquire_overwrites_windows_stale_lock_on_system_error(
-        self, tmp_path: Path, monkeypatch
-    ):
-        """Windows stale lock should be reclaimed when os.kill raises SystemError."""
-
-        def _raise_system_error(_pid: int, _sig: int) -> None:
-            raise SystemError("win32 wrapper failure")
-
-        (tmp_path / LOCK_FILENAME).write_text("12345")
-        monkeypatch.setattr(process_lock_module.sys, "platform", "win32")
-        monkeypatch.setattr(process_lock_module.os, "kill", _raise_system_error)
-
-        acquire_data_dir_lock(str(tmp_path))
-
-        stored_pid = int((tmp_path / LOCK_FILENAME).read_text().strip())
-        assert stored_pid == os.getpid()
+    @pytest.mark.parametrize("winerror", [87, 5])
+    def test_windows_lock_reclaimed_only_for_missing_pid(self, tmp_path, monkeypatch, winerror):
+        lock_file = tmp_path / LOCK_FILENAME
+        lock_file.write_text("12345")
+        error = OSError("process query failed")
+        error.winerror = winerror
+        api = SimpleNamespace(SYNCHRONIZE=0x100000, OpenProcess=Mock(side_effect=error))
+        with monkeypatch.context() as patch:
+            patch.setattr(process_lock_module.sys, "platform", "win32")
+            patch.setitem(sys.modules, "_winapi", api)
+            patch.setattr(os, "kill", Mock(side_effect=AssertionError("must not signal")))
+            if winerror == 87:
+                acquire_data_dir_lock(str(tmp_path))
+                assert int(lock_file.read_text()) == os.getpid()
+            else:
+                with pytest.raises(DataDirectoryLocked):
+                    acquire_data_dir_lock(str(tmp_path))
+                assert lock_file.read_text() == "12345"
 
 
 class TestAcquireDataDirLockEdgeCases:


### PR DESCRIPTION
## Description

Use a non-signaling Windows process-handle query for PID lock liveness. `os.kill(pid, 0)` can send CTRL_C_EVENT on Windows; catching errors afterwards does not prevent that side effect.

Windows now opens the process with SYNCHRONIZE, polls with WaitForSingleObject(handle, 0), and always closes the acquired handle. A signaled handle or OpenProcess ERROR_INVALID_PARAMETER means the process is gone. Access denied and other OSError query failures conservatively preserve the lock. Non-Windows probing is unchanged.

## Human Involvement
- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue
Fixes #4764

Independent of #4789 / #4766: based on upstream main, with only process_lock.py and its existing unit tests changed. No semantic retry changes are included.

## Type of Change
- [x] Bug fix
- [x] Test update

## Testing
- `python -m pytest -o addopts='' -q tests/unit/test_process_lock.py tests/misc/test_process_lock.py`: 48 passed, 1 skipped on macOS.
- Ruff check and formatting on both changed files: passed.
- Mocked Windows API coverage: running/exited/missing PID, access denied, unexpected open/wait failures, handle cleanup, and lock preservation. os.kill raises AssertionError in these cases to detect any accidental signaling.
- Added a native Windows current-PID test that forbids os.kill. This test is skipped on macOS; native Windows execution is still required and is not claimed as passed.

## Checklist
- [x] Self-reviewed the complete diff
- [x] Added regression tests
- [x] No dependencies or configuration changes
