### PR TITLE
fix(index): propagate native search failures

### DIFF
--- a/src/index/index_engine.cpp
+++ b/src/index/index_engine.cpp
@@ -13,7 +13,10 @@ IndexEngine::IndexEngine(const std::string& path_or_json) {
 
 SearchResult IndexEngine::search(const SearchRequest& req) {
   SearchResult result;
-  impl_->search(req, result);
+  const int ret = impl_->search(req, result);
+  if (ret != 0) {
+    throw std::runtime_error("Failed to search native index");
+  }
   result.result_num = result.labels.size();
   return result;
 }

--- a/tests/engine/test_index_engine.cpp
+++ b/tests/engine/test_index_engine.cpp
@@ -35,6 +35,43 @@ void expect_filter_projection(IndexEngine& engine, const std::string& dsl,
   }
 }
 
+void test_search_invalid_dsl_throws() {
+  SPDLOG_INFO("[Running] test_search_invalid_dsl_throws...");
+
+  const std::string config = R"({
+        "CollectionName": "search_invalid_dsl_throws",
+        "IndexName": "default",
+        "VectorIndex": {
+            "IndexType": "flat",
+            "ElementCount": 0,
+            "MaxElementCount": 4,
+            "Dimension": 1,
+            "Distance": "l2",
+            "Quant": "float"
+        }
+    })";
+
+  IndexEngine engine(config);
+  if (!engine.is_valid()) {
+    SPDLOG_ERROR("Search engine initialization failed");
+    exit(1);
+  }
+
+  SearchRequest req;
+  req.query = {0.1f};
+  req.topk = 1;
+  req.dsl = "{";
+
+  try {
+    (void)engine.search(req);
+    SPDLOG_ERROR("Search accepted invalid DSL");
+    exit(1);
+  } catch (const std::runtime_error&) {
+  }
+
+  SPDLOG_INFO("[Passed] test_search_invalid_dsl_throws");
+}
+
 void test_basic_workflow() {
   SPDLOG_INFO("[Running] test_basic_workflow...");
 
@@ -585,6 +622,7 @@ void test_paged_store_scan() {
 
 int main() {
   init_logging("INFO", "stdout", "[%Y-%m-%d %H:%M:%S.%e] [%l] %v");
+  test_search_invalid_dsl_throws();
   test_basic_workflow();
   test_routed_filter_projection_edge_cases();
   test_path_bitmap_lifecycle_and_reload();


### PR DESCRIPTION
## Description

Fix native search error handling so `IndexEngine::search()` no longer swallows failures from the C++ backend. Invalid or failed native search requests now raise an exception instead of returning an empty-looking result.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Changes Made

- Propagate non-zero return values from native `search()` as `runtime_error`.
- Add a native C++ regression test for invalid DSL search failure.
- Keep existing search success behavior unchanged.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Ran:

```bash
cmake --build tests/engine/build --target test_index_engine -j2
./tests/engine/build/test_index_engine