### PR TITLE
fix(watches): scope non-ROOT watch access to the owning user

### DIFF
--- a/openviking/resource/watch_manager.py
+++ b/openviking/resource/watch_manager.py
@@ -362,9 +362,10 @@ class WatchManager:
             True if has permission, False otherwise
 
         Notes:
-            - ROOT can access all tasks.
-            - ADMIN can access tasks within the same account.
-            - USER can only access tasks they created within the same account.
+            - ROOT can access all tasks (system/scheduler bypass).
+            - Every other role (including ADMIN) is scoped to tasks they own
+              within the same account, so callers sharing an account but using
+              different user_ids never see each other's tasks.
         """
         role_value = (role or "").lower()
         if role_value == "root":
@@ -372,9 +373,6 @@ class WatchManager:
 
         if task.account_id != account_id:
             return False
-
-        if role_value == "admin":
-            return True
 
         return task.user_id == user_id
 

--- a/tests/resource/test_watch_manager.py
+++ b/tests/resource/test_watch_manager.py
@@ -604,6 +604,41 @@ class TestWatchManager:
         assert tasks[0].is_active is True
 
     @pytest.mark.asyncio
+    async def test_get_all_tasks_admin_scoped_to_own_tasks(
+        self, watch_manager: WatchManager
+    ):
+        """ADMIN is scoped to its own tasks; ROOT still sees the whole account."""
+        await watch_manager.create_task(path="/test/alice1", user_id="alice")
+        await watch_manager.create_task(path="/test/bob1", user_id="bob")
+        await watch_manager.create_task(path="/test/alice2", user_id="alice")
+
+        # ROOT keeps the system-wide view.
+        all_tasks = await watch_manager.get_all_tasks(
+            account_id=TEST_ACCOUNT_ID, user_id="root", role="root"
+        )
+        assert len(all_tasks) == 3
+
+        # ADMIN no longer sees the whole account — only its own tasks.
+        alice_tasks = await watch_manager.get_all_tasks(
+            account_id=TEST_ACCOUNT_ID, user_id="alice", role="admin"
+        )
+        assert {task.user_id for task in alice_tasks} == {"alice"}
+        assert len(alice_tasks) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_all_tasks_isolates_same_account_users(
+        self, watch_manager: WatchManager
+    ):
+        """Same account, different user_id → each caller sees only its own tasks."""
+        await watch_manager.create_task(path="/test/alice1", user_id="alice")
+        await watch_manager.create_task(path="/test/bob1", user_id="bob")
+
+        bob_tasks = await watch_manager.get_all_tasks(
+            account_id=TEST_ACCOUNT_ID, user_id="bob", role="user"
+        )
+        assert {task.user_id for task in bob_tasks} == {"bob"}
+
+    @pytest.mark.asyncio
     async def test_get_task_by_uri(self, watch_manager: WatchManager):
         """Test getting a task by URI."""
         task = await watch_manager.create_task(
@@ -933,7 +968,7 @@ class TestSharedConnectorTargets:
             ("carol", "user", ()),
             ("bob", "user", (2,)),
             ("alice", "user", (0, 1)),
-            ("bob", "admin", (0, 1, 2)),
+            ("bob", "admin", (2,)),
             ("bob", "root", (0, 1, 2)),
         ],
     )


### PR DESCRIPTION
GET /api/v1/watches (and every WatchManager read/mutate primitive) filtered visibility by role, so an ADMIN caller saw every task in the account. Cloud libraries register their per-user keys as ADMIN, so ListOpenVikingWatches called with the same account but different user_id returned identical tasks.

Drop the ADMIN blanket-visibility branch in _check_permission: ROOT keeps the system/scheduler bypass (WatchScheduler.schedule_task reads tasks as ROOT), but ADMIN now falls through to the same owner check as USER (task.user_id == user_id). This isolates watch tasks per user within a shared account without any cloud-side change; the scheduler's own execution path already passes each task's stored user_id/original_role, so background runs are unaffected.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Human Involvement

<!-- Select exactly one option -->

- [ ] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
