### PR TITLE
fix(index): reject negative label_in values

### DIFF
--- a/src/index/detail/index_manager_impl.cpp
+++ b/src/index/detail/index_manager_impl.cpp
@@ -158,9 +158,15 @@ int parse_dsl_query(const std::string& dsl_filter_query_str,
   }
   if (has_filter) {
     ctx.filter_op = parse_filter_json_doc_outter(dsl_filter_query);
+    if (!ctx.filter_op) {
+      return -1;
+    }
   }
   if (has_sorter) {
     ctx.sorter_op = parse_sorter_json_doc_outter(dsl_filter_query);
+    if (!ctx.sorter_op) {
+      return -1;
+    }
   }
   return 0;
 }

--- a/src/index/detail/scalar/filter/filter_ops.cpp
+++ b/src/index/detail/scalar/filter/filter_ops.cpp
@@ -894,16 +894,16 @@ int LabelInOp::load_json_doc(const JsonValue& json_doc) {
   if (!conds_arr.IsArray() || conds_arr.Size() <= 0) {
     return -4;
   }
-  bool is_uint64 = false;
   for (rapidjson::SizeType i = 0; i < conds_arr.Size(); i++) {
     if (conds_arr[i].IsUint64()) {
       uint64_t temp_id = conds_arr[i].GetUint64();
       label_u64_.emplace_back(temp_id);
-      is_uint64 = true;
     } else if (conds_arr[i].IsInt64()) {
       int64_t temp_id = conds_arr[i].GetInt64();
+      if (temp_id < 0) {
+        return -8;
+      }
       label_u64_.emplace_back(static_cast<uint64_t>(temp_id));
-      is_uint64 = true;
     } else {
       return -8;
     }

--- a/tests/engine/test_index_engine.cpp
+++ b/tests/engine/test_index_engine.cpp
@@ -8,6 +8,7 @@
 #include <cassert>
 #include <filesystem>
 #include <cmath>
+#include <limits>
 #include "spdlog/spdlog.h"
 #include "common/log_utils.h"
 
@@ -33,6 +34,53 @@ void expect_filter_projection(IndexEngine& engine, const std::string& dsl,
         first_word, expected_first_word);
     exit(1);
   }
+}
+
+void test_label_in_negative_label_rejected() {
+  SPDLOG_INFO("[Running] test_label_in_negative_label_rejected...");
+
+  const std::string config = R"({
+        "CollectionName": "label_in_negative_label_rejected",
+        "IndexName": "default",
+        "VectorIndex": {
+            "IndexType": "flat",
+            "ElementCount": 0,
+            "MaxElementCount": 4,
+            "Dimension": 1,
+            "Distance": "l2",
+            "Quant": "float"
+        },
+        "ScalarIndex": [
+            {"FieldName": "tag", "FieldType": "int64"}
+        ]
+    })";
+
+  IndexEngine engine(config);
+  if (!engine.is_valid()) {
+    SPDLOG_ERROR("LabelIn engine initialization failed");
+    exit(1);
+  }
+
+  AddDataRequest req;
+  req.label = std::numeric_limits<uint64_t>::max();
+  req.vector = {0.1f};
+  if (engine.add_data({req}) != 0) {
+    SPDLOG_ERROR("LabelIn test data add failed");
+    exit(1);
+  }
+  if (engine.set_filter_layout({req.label}) != 0) {
+    SPDLOG_ERROR("LabelIn filter layout registration failed");
+    exit(1);
+  }
+
+  try {
+    (void)engine.evaluate_filter(R"({"op":"label_in","labels":[-1]})");
+    SPDLOG_ERROR("LabelIn accepted a negative label");
+    exit(1);
+  } catch (const std::runtime_error&) {
+  }
+
+  SPDLOG_INFO("[Passed] test_label_in_negative_label_rejected");
 }
 
 void test_basic_workflow() {
@@ -585,6 +633,7 @@ void test_paged_store_scan() {
 
 int main() {
   init_logging("INFO", "stdout", "[%Y-%m-%d %H:%M:%S.%e] [%l] %v");
+  test_label_in_negative_label_rejected();
   test_basic_workflow();
   test_routed_filter_projection_edge_cases();
   test_path_bitmap_lifecycle_and_reload();


### PR DESCRIPTION
## Description

Reject negative values in native `label_in` filters instead of allowing them to be silently cast to large `uint64_t` labels.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Reject negative `label_in` labels during DSL parsing.
- Propagate filter/sorter parse failures from `parse_dsl_query()`.
- Add a native C++ regression test covering `label_in` negative input.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Ran:

```bash
cmake --build tests/engine/build --target test_index_engine -j2
./tests/engine/build/test_index_engine

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
