### PR TITLE
fix(train): preserve Skill description from merge_memory_fields

### DIFF
--- a/openviking/session/train/components/skill_policy_updater.py
+++ b/openviking/session/train/components/skill_policy_updater.py
@@ -132,8 +132,7 @@ def _coerce_request_context(context: Any) -> RequestContext | None:
         value = getattr(context, attr, None)
         if value is not None:
             return value
-    # If it quacks like a RequestContext…
-    if hasattr(context, "user_id") or hasattr(context, "account_id"):
+    # If it quacks like a RequestContext鈥?    if hasattr(context, "user_id") or hasattr(context, "account_id"):
         return context  # type: ignore[return-value]
     return None
 
@@ -165,7 +164,17 @@ def _apply_items_to_snapshot(items: list[PolicyPlanItem], policy_set: PolicySet)
             policy_set, uri=None, name=item.target_name
         )
         metadata = dict(existing.metadata) if existing is not None else {}
-        metadata.update(item.metadata.get("patch_metadata", {}))
+        # PatchMergePolicyOptimizer stores extracted skill fields under
+        # merge_memory_fields (including description). Prefer those, then allow
+        # explicit patch_metadata to override. Reading only patch_metadata left
+        # new Skills with an empty description and SkillOperationUpdater rejected
+        # them (#4801).
+        merge_fields = item.metadata.get("merge_memory_fields") or {}
+        if isinstance(merge_fields, dict):
+            for key in ("description", "allowed_tools", "tags"):
+                if key in merge_fields and merge_fields[key] is not None:
+                    metadata[key] = merge_fields[key]
+        metadata.update(item.metadata.get("patch_metadata", {}) or {})
         metadata.setdefault("memory_type", item.memory_type or "skills")
         version = (existing.version + 1) if existing is not None else 1
         updated = Policy(
@@ -302,7 +311,7 @@ def _policy_to_memory_file(policy: Policy | None) -> MemoryFile | None:
 def _safe_skill_dirname(name: str) -> str:
     import re
 
-    cleaned = re.sub(r"[^a-zA-Z0-9_\-一-鿿]+", "_", name.strip()).strip("._-")
+    cleaned = re.sub(r"[^a-zA-Z0-9_\-涓€-榭縘+", "_", name.strip()).strip("._-")
     return cleaned or "new_skill"
 
 

--- a/tests/session/train/test_skill_merge_memory_fields.py
+++ b/tests/session/train/test_skill_merge_memory_fields.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for SkillPolicyUpdater merge_memory_fields (#4801)."""
+
+from openviking.session.train.components.skill_policy_updater import (
+    _apply_items_to_snapshot,
+    _plan_to_resolved_operations,
+)
+from openviking.session.train.domain import PolicyPlanItem, PolicySet, PolicyUpdatePlan
+
+
+def _upsert_item(*, description: str, content: str = "do the thing") -> PolicyPlanItem:
+    return PolicyPlanItem(
+        kind="upsert",
+        memory_type="skills",
+        target_name="markdown-release-check",
+        target_uri="",
+        before_content=None,
+        after_content=content,
+        confidence=1.0,
+        metadata={
+            "merge_memory_fields": {
+                "skill_name": "markdown-release-check",
+                "description": description,
+                "content": content,
+            }
+        },
+    )
+
+
+def test_apply_items_preserves_description_from_merge_memory_fields():
+    """New Skills must keep optimizer-extracted description (#4801)."""
+    policy_set = PolicySet(root_uri="viking://agent/skills", policies=[])
+    updated = _apply_items_to_snapshot([_upsert_item(description="Validate Markdown frontmatter")], policy_set)
+
+    assert len(updated.policies) == 1
+    assert updated.policies[0].metadata.get("description") == "Validate Markdown frontmatter"
+
+
+def test_plan_to_resolved_operations_forwards_merge_description():
+    policy_set = PolicySet(root_uri="viking://agent/skills", policies=[])
+    plan = PolicyUpdatePlan(items=[_upsert_item(description="中文描述也要保留")])
+    updated = _apply_items_to_snapshot(plan.items, policy_set)
+    ops = _plan_to_resolved_operations(
+        plan=plan,
+        policy_set=policy_set,
+        updated_policy_set=updated,
+    )
+
+    assert len(ops.upsert_operations) == 1
+    assert ops.upsert_operations[0].memory_fields.get("description") == "中文描述也要保留"
+
+
+def test_patch_metadata_still_overrides_merge_memory_fields():
+    item = _upsert_item(description="from-merge")
+    item.metadata["patch_metadata"] = {"description": "from-patch"}
+    policy_set = PolicySet(root_uri="viking://agent/skills", policies=[])
+    updated = _apply_items_to_snapshot([item], policy_set)
+    assert updated.policies[0].metadata.get("description") == "from-patch"


### PR DESCRIPTION
## Summary
- `SkillPolicyUpdater` now applies `merge_memory_fields` (description / allowed_tools / tags) when building the policy snapshot.
- Explicit `patch_metadata` still overrides.
- Adds regression tests so new Skills keep the optimizer-extracted description through `_plan_to_resolved_operations`.

Closes #4801.

## Why
`PatchMergePolicyOptimizer` stores extracted fields under `merge_memory_fields`, but the Skill updater only read `patch_metadata`. New Skills therefore got an empty description and were rejected by `SkillOperationUpdater` before any write.

## Test plan
- [x] Unit: description preserved from `merge_memory_fields`
- [x] Unit: Chinese description forwarded to resolved operations
- [x] Unit: `patch_metadata` still wins
- [ ] CI