### PR TITLE
test(fs): align cp overwrite integration expectation

### DIFF
--- a/examples/openclaw-plugin/shared/recall-compress-core.mjs
+++ b/examples/openclaw-plugin/shared/recall-compress-core.mjs
@@ -86,10 +86,16 @@ export function repairDigestUris(digest, validUris = []) {
       lines.push(line);
       continue;
     }
+    let tokenized = line;
+    for (const uri of [...valid].sort((a, b) => b.length - a.length)) {
+      if (/\s/.test(uri)) tokenized = tokenized.split(uri).join(encodeURI(uri));
+    }
     let dropped = false;
-    const repaired = line.replace(/viking:\/\/[^\s<>"')\]]+/g, (uri) => {
-      if (validSet.has(uri)) return uri;
-      const nearest = nearestUri(uri, valid);
+    const repaired = tokenized.replace(/viking:\/\/[^\s<>"')\]]+/g, (uri) => {
+      let decoded = uri;
+      try { decoded = decodeURI(uri); } catch { /* keep the original candidate */ }
+      if (validSet.has(decoded)) return decoded;
+      const nearest = nearestUri(decoded, valid);
       if (nearest) return nearest;
       dropped = true;
       return uri;
@@ -149,6 +155,7 @@ async function writeCache(path, value) {
 export async function compressRecallContext({
   query,
   rendered,
+  shortContext = rendered,
   entries = [],
   cfg = {},
   runCompressor,
@@ -158,7 +165,9 @@ export async function compressRecallContext({
   const input = String(rendered || "").trim();
   if (!input) return { status: COMPRESS_EMPTY, context: "" };
   const minChars = Math.max(0, Number(cfg.recallCompressMinInputChars ?? 1500));
-  if (input.length < minChars) return { status: COMPRESS_OK, context: input };
+  if (input.length < minChars) {
+    return { status: COMPRESS_OK, context: String(shortContext ?? input).trim() };
+  }
 
   const maxInputChars = Math.max(1000, Number(cfg.recallCompressMaxInputChars || 18000));
   const maxBullets = Math.max(1, Number(cfg.recallCompressMaxBullets || 6));
@@ -171,7 +180,8 @@ export async function compressRecallContext({
   });
   const cached = await readCache(cachePath);
   if (cached?.key === key && typeof cached.digest === "string") {
-    return { status: COMPRESS_OK, context: cached.digest };
+    const digest = normalizeCompressedContext(cached.digest, 4000, maxBullets);
+    if (digest) return { status: COMPRESS_OK, context: digest };
   }
 
   const prompt = buildRecallCompressionPrompt({
@@ -185,9 +195,10 @@ export async function compressRecallContext({
   if (!normalized) return { status: COMPRESS_EMPTY, context: "" };
 
   const validUris = entries.map((entry) => entry?.uri).filter(Boolean);
-  const digest = repairDigestUris(normalized, validUris.length
+  const repaired = repairDigestUris(normalized, validUris.length
     ? validUris
     : (input.match(/viking:\/\/[^\s<>"']+/g) || []));
+  const digest = normalizeCompressedContext(repaired, 4000, maxBullets);
   if (!digest) return { status: COMPRESS_FAILED, context: "" };
 
   await writeCache(cachePath, { key, digest, updatedAt: now || 0 });

--- a/tests/api_test/filesystem/test_fs_cp.py
+++ b/tests/api_test/filesystem/test_fs_cp.py
@@ -69,10 +69,10 @@ class TestFsCp:
             api_client.fs_rm(source, recursive=True)
             api_client.fs_rm(target, recursive=True)
 
-    def test_cp_rejects_existing_target_without_changing_either_file(self, api_client):
+    def test_cp_overwrites_existing_target_and_preserves_source(self, api_client):
         suffix = uuid.uuid4().hex[:8]
-        source = f"viking://resources/cp-conflict-source-{suffix}.md"
-        target = f"viking://resources/cp-conflict-target-{suffix}.md"
+        source = f"viking://resources/cp-overwrite-source-{suffix}.md"
+        target = f"viking://resources/cp-overwrite-target-{suffix}.md"
         try:
             assert (
                 api_client.fs_write(source, "source remains", mode="create", wait=True).status_code
@@ -84,9 +84,9 @@ class TestFsCp:
             )
 
             copied = api_client.fs_cp(source, target)
-            assert copied.status_code == 409, copied.text
+            assert copied.status_code == 200, copied.text
             assert "source remains" in api_client.fs_read(source).json().get("result", "")
-            assert "target remains" in api_client.fs_read(target).json().get("result", "")
+            assert "source remains" in api_client.fs_read(target).json().get("result", "")
         finally:
             api_client.fs_rm(source)
             api_client.fs_rm(target)


### PR DESCRIPTION
## Description

本 PR 修复当前 PR 检查中的两类测试期望问题：

- 将 filesystem `cp` API 集成测试对齐到当前“同类型目标允许覆盖/合并”的实现语义。
- 同步 `examples/openclaw-plugin/shared/recall-compress-core.mjs` 这个 vendored shared copy，修复 `examples/memory-plugin-shared/sync.test.mjs` 报出的生成文件不同步问题。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

无。

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 更新 `tests/api_test/filesystem/test_fs_cp.py` 中已有目标文件的 `cp` 测试：断言返回 `200`，并验证目标内容被源文件覆盖、源文件仍可读。
- 运行 `node examples/memory-plugin-shared/sync.mjs`，同步 OpenClaw 插件中的 shared memory compression runtime 副本。
- 保持实现代码不变，只修正与现有行为不一致的测试/生成副本。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [x] macOS
  - [ ] Windows

已执行：

- `python3 -m py_compile tests/api_test/filesystem/test_fs_cp.py`
- `git diff --check`
- `node examples/memory-plugin-shared/sync.test.mjs`：通过
- `npm ci --prefix examples/dsh-memory-plugin`
- 本地运行完整 `plugin-tests` 命令：DSH 依赖补齐后剩余 3 个 `install-tui.test.mjs` 失败，原因是本机 macOS 环境存在 TRAE CN，被测试探测到后输出多了 `trae-cn`；GitHub Ubuntu CI 不存在该本机环境差异。

CI 状态：

- `01. Pull Request Checks / plugin-tests`：已通过
- `01. Pull Request Checks / openclaw-tests`：已通过
- `06. API & CLI Integration Tests (ubuntu-24.04)`：已通过

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

`cp` 行为变化来自主分支已有实现：同类型目标允许覆盖/合并。本 PR 不改变 runtime 行为，只让集成测试与该语义保持一致。