### PR TITLE
fix(store): reject oversized bytes row lists

### DIFF
--- a/src/store/bytes_row.cpp
+++ b/src/store/bytes_row.cpp
@@ -163,7 +163,7 @@ std::string BytesRow::serialize(const std::vector<Value>& row_data) const {
       case FieldType::LIST_INT64: {
         if (std::holds_alternative<std::vector<int64_t>>(val)) {
           const auto& vec = std::get<std::vector<int64_t>>(val);
-          int len = vec.size();
+          int len = checked_uint16_length(vec.size(), meta.name, "list");
           var_infos[i] = {variable_region_offset, len};
           variable_region_offset += UINT16_SIZE + len * INT64_SIZE;
         } else {
@@ -175,7 +175,7 @@ std::string BytesRow::serialize(const std::vector<Value>& row_data) const {
       case FieldType::LIST_FLOAT32: {
         if (std::holds_alternative<std::vector<float>>(val)) {
           const auto& vec = std::get<std::vector<float>>(val);
-          int len = vec.size();
+          int len = checked_uint16_length(vec.size(), meta.name, "list");
           var_infos[i] = {variable_region_offset, len};
           variable_region_offset += UINT16_SIZE + len * FLOAT32_SIZE;
         } else {
@@ -187,7 +187,8 @@ std::string BytesRow::serialize(const std::vector<Value>& row_data) const {
       case FieldType::LIST_STRING: {
         if (std::holds_alternative<std::vector<std::string>>(val)) {
           const auto& vec = std::get<std::vector<std::string>>(val);
-          int len = vec.size();
+          int len = checked_uint16_length(vec.size(), meta.name, "list");
+          check_list_string_lengths(vec, meta.name);
           var_infos[i] = {variable_region_offset, len};
           variable_region_offset += UINT16_SIZE;  // List length
           for (const auto& s : vec) {

--- a/src/store/bytes_row.h
+++ b/src/store/bytes_row.h
@@ -13,6 +13,30 @@ namespace vectordb {
 
 constexpr uint32_t STRING_MAX_UINT16_LENGTH = 0xFFFF;
 
+inline uint16_t checked_uint16_length(size_t len, const std::string& field_name,
+                                      const std::string& kind) {
+  if (len > STRING_MAX_UINT16_LENGTH) {
+    if (kind == "string") {
+      throw std::invalid_argument("string field " + field_name +
+                                  " exceeds 65535 bytes");
+    }
+    throw std::invalid_argument("list field " + field_name +
+                                " exceeds 65535 entries");
+  }
+  return static_cast<uint16_t>(len);
+}
+
+inline void check_list_string_lengths(const std::vector<std::string>& vec,
+                                      const std::string& field_name) {
+  for (const auto& s : vec) {
+    if (s.length() > STRING_MAX_UINT16_LENGTH) {
+      throw std::invalid_argument(
+          "string element in list field " + field_name +
+          " exceeds 65535 bytes");
+    }
+  }
+}
+
 enum class FieldType {
   INT64 = 0,
   UINT64 = 1,
@@ -232,6 +256,7 @@ class BytesRow {
                          get_default_list_int64(meta.default_value)) {
             len = static_cast<int>(def->size());
           }
+          len = checked_uint16_length(len, meta.name, "list");
           var_infos[i] = {variable_region_offset, len};
           variable_region_offset += 2 + len * 8;  // UINT16 + INT64_SIZE
           break;
@@ -244,6 +269,7 @@ class BytesRow {
                          get_default_list_float32(meta.default_value)) {
             len = static_cast<int>(def->size());
           }
+          len = checked_uint16_length(len, meta.name, "list");
           var_infos[i] = {variable_region_offset, len};
           variable_region_offset += 2 + len * 4;  // UINT16 + FLOAT32_SIZE
           break;
@@ -257,8 +283,10 @@ class BytesRow {
           } else if (const auto* def =
                          get_default_list_string(meta.default_value)) {
             list_len = static_cast<int>(def->size());
+            check_list_string_lengths(*def, meta.name);
             content_len = get_list_string_content_len(*def);
           }
+          list_len = checked_uint16_length(list_len, meta.name, "list");
           var_infos[i] = {variable_region_offset, list_len};
           // list_len(2) + (elem_len(2) + content) * N
           // Actually content_len should include the 2 bytes for each string

--- a/tests/engine/test_index_engine.cpp
+++ b/tests/engine/test_index_engine.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 // SPDX-License-Identifier: AGPL-3.0
 #include "index/index_engine.h"
+#include "store/bytes_row.h"
 #include "store/persist_store.h"
 #include "store/volatile_store.h"
 #include <iostream>
@@ -33,6 +34,51 @@ void expect_filter_projection(IndexEngine& engine, const std::string& dsl,
         first_word, expected_first_word);
     exit(1);
   }
+}
+
+void test_bytes_row_oversized_lists_rejected() {
+  SPDLOG_INFO("[Running] test_bytes_row_oversized_lists_rejected...");
+
+  {
+    auto schema = std::make_shared<Schema>(std::vector<FieldDef>{{"tags", FieldType::LIST_INT64, 0, std::vector<int64_t>{}}});
+    BytesRow row(schema);
+    std::vector<Value> data;
+    data.emplace_back(std::vector<int64_t>(65536, 7));
+    try {
+      (void)row.serialize(data);
+      SPDLOG_ERROR("LIST_INT64 accepted an oversized list");
+      exit(1);
+    } catch (const std::invalid_argument&) {
+    }
+  }
+
+  {
+    auto schema = std::make_shared<Schema>(std::vector<FieldDef>{{"scores", FieldType::LIST_FLOAT32, 0, std::vector<float>{}}});
+    BytesRow row(schema);
+    std::vector<Value> data;
+    data.emplace_back(std::vector<float>(65536, 1.0f));
+    try {
+      (void)row.serialize(data);
+      SPDLOG_ERROR("LIST_FLOAT32 accepted an oversized list");
+      exit(1);
+    } catch (const std::invalid_argument&) {
+    }
+  }
+
+  {
+    auto schema = std::make_shared<Schema>(std::vector<FieldDef>{{"tags", FieldType::LIST_STRING, 0, std::vector<std::string>{}}});
+    BytesRow row(schema);
+    std::vector<Value> data;
+    data.emplace_back(std::vector<std::string>{std::string(65536, 120)});
+    try {
+      (void)row.serialize(data);
+      SPDLOG_ERROR("LIST_STRING accepted an oversized string element");
+      exit(1);
+    } catch (const std::invalid_argument&) {
+    }
+  }
+
+  SPDLOG_INFO("[Passed] test_bytes_row_oversized_lists_rejected");
 }
 
 void test_basic_workflow() {
@@ -585,6 +631,7 @@ void test_paged_store_scan() {
 
 int main() {
   init_logging("INFO", "stdout", "[%Y-%m-%d %H:%M:%S.%e] [%l] %v");
+  test_bytes_row_oversized_lists_rejected();
   test_basic_workflow();
   test_routed_filter_projection_edge_cases();
   test_path_bitmap_lifecycle_and_reload();


### PR DESCRIPTION
## Description

Reject oversized native `BytesRow` list fields before serialization so 16-bit length prefixes do not silently truncate data.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Changes Made

- Add length validation for `LIST_INT64` and `LIST_FLOAT32` serialization.
- Add per-element length validation for `LIST_STRING`.
- Add a native C++ regression test covering oversized list inputs.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Ran:

```bash
cmake --build tests/engine/build --target test_index_engine -j2
./tests/engine/build/test_index_engine
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
