### PR TITLE
fix(store): reject truncated list string payloads

### DIFF
--- a/src/store/bytes_row.cpp
+++ b/src/store/bytes_row.cpp
@@ -489,18 +489,24 @@ Value BytesRow::deserialize_field(const std::string& serialized_data,
       uint32_t offset;
       if (sizeof(offset) >
           serialized_data.size() -
-              static_cast<size_t>(field_ptr - serialized_data.data()))
-        return std::vector<std::string>{};
+              static_cast<size_t>(field_ptr - serialized_data.data())) {
+        throw std::runtime_error("LIST_STRING field '" + meta.name +
+                                 "' truncated while reading offset");
+      }
       std::memcpy(&offset, field_ptr, sizeof(offset));
-      if (offset >= serialized_data.size())
-        return std::vector<std::string>{};
+      if (offset >= serialized_data.size()) {
+        throw std::runtime_error("LIST_STRING field '" + meta.name +
+                                 "' offset out of range");
+      }
 
       const char* var_ptr = ptr + offset;
       uint16_t list_len;
 
       if (static_cast<size_t>(offset) + sizeof(list_len) >
-          serialized_data.size())
-        return std::vector<std::string>{};
+          serialized_data.size()) {
+        throw std::runtime_error("LIST_STRING field '" + meta.name +
+                                 "' truncated while reading list length");
+      }
       std::memcpy(&list_len, var_ptr, sizeof(list_len));
       var_ptr += sizeof(list_len);
 
@@ -509,13 +515,17 @@ Value BytesRow::deserialize_field(const std::string& serialized_data,
       for (int i = 0; i < list_len; ++i) {
         uint16_t s_len;
         if (static_cast<size_t>(var_ptr - ptr) + sizeof(s_len) >
-            serialized_data.size())
-          break;
+            serialized_data.size()) {
+          throw std::runtime_error("LIST_STRING field '" + meta.name +
+                                   "' truncated while reading element length");
+        }
         std::memcpy(&s_len, var_ptr, sizeof(s_len));
         var_ptr += sizeof(s_len);
 
-        if (static_cast<size_t>(var_ptr - ptr) + s_len > serialized_data.size())
-          break;
+        if (static_cast<size_t>(var_ptr - ptr) + s_len > serialized_data.size()) {
+          throw std::runtime_error("LIST_STRING field '" + meta.name +
+                                   "' truncated while reading element data");
+        }
         vec.emplace_back(var_ptr, s_len);
         var_ptr += s_len;
       }

--- a/tests/engine/test_index_engine.cpp
+++ b/tests/engine/test_index_engine.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 // SPDX-License-Identifier: AGPL-3.0
 #include "index/index_engine.h"
+#include "store/bytes_row.h"
 #include "store/persist_store.h"
 #include "store/volatile_store.h"
 #include <iostream>
@@ -33,6 +34,27 @@ void expect_filter_projection(IndexEngine& engine, const std::string& dsl,
         first_word, expected_first_word);
     exit(1);
   }
+}
+
+void test_list_string_deserialize_rejects_truncated_payload() {
+  SPDLOG_INFO("[Running] test_list_string_deserialize_rejects_truncated_payload...");
+
+  auto schema = std::make_shared<Schema>(std::vector<FieldDef>{{"tags", FieldType::LIST_STRING, 0, std::vector<std::string>{}}});
+  BytesRow row(schema);
+
+  std::vector<Value> data;
+  data.emplace_back(std::vector<std::string>{"alpha", "beta"});
+  const std::string serialized = row.serialize(data);
+  const std::string truncated = serialized.substr(0, serialized.size() - 1);
+
+  try {
+    (void)row.deserialize(truncated);
+    SPDLOG_ERROR("Truncated LIST_STRING payload was accepted");
+    exit(1);
+  } catch (const std::exception&) {
+  }
+
+  SPDLOG_INFO("[Passed] test_list_string_deserialize_rejects_truncated_payload");
 }
 
 void test_basic_workflow() {
@@ -585,6 +607,7 @@ void test_paged_store_scan() {
 
 int main() {
   init_logging("INFO", "stdout", "[%Y-%m-%d %H:%M:%S.%e] [%l] %v");
+  test_list_string_deserialize_rejects_truncated_payload();
   test_basic_workflow();
   test_routed_filter_projection_edge_cases();
   test_path_bitmap_lifecycle_and_reload();


### PR DESCRIPTION
## Description

Reject truncated `LIST_STRING` payloads during native deserialization instead of returning a partially decoded prefix.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Changes Made

- Make native `BytesRow::deserialize_field()` fail fast on truncated `LIST_STRING` payloads.
- Replace silent prefix վերադարձ with explicit `runtime_error` messages.
- Add a native C++ regression test covering truncated `LIST_STRING` data.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Ran:

```bash
cmake --build tests/engine/build --target test_index_engine -j2
./tests/engine/build/test_index_engine
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
