### PR TITLE
fix(queue): 修复 wait=true 漏等下游索引任务

### DIFF
--- a/openviking/storage/queuefs/embedding_msg_converter.py
+++ b/openviking/storage/queuefs/embedding_msg_converter.py
@@ -22,10 +22,16 @@ class EmbeddingMsgConverter:
 
     @staticmethod
     def from_context(
-        context: Context, creator_acl_grant: CreatorAclGrant | None = None
+        context: Context,
+        creator_acl_grant: CreatorAclGrant | None = None,
+        *,
+        telemetry_id: str | None = None,
     ) -> EmbeddingMsg | None:
         """
         Convert a Context object to EmbeddingMsg.
+
+        Queued producers pass their message's request ID, including an empty ID
+        for detached work. Direct producers use the current request when omitted.
         """
         vectorization_text = context.get_vectorization_text()
         vectorization_images = context.get_vectorization_images()
@@ -85,6 +91,8 @@ class EmbeddingMsgConverter:
         embedding_msg = EmbeddingMsg(
             message=message,
             context_data=context_data,
-            telemetry_id=get_current_telemetry().telemetry_id,
+            telemetry_id=(
+                get_current_telemetry().telemetry_id if telemetry_id is None else telemetry_id
+            ),
         )
         return embedding_msg

--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -179,6 +179,7 @@ class SemanticDagExecutor:
         generation_trigger: str = "semantic_refresh",
         aggregate_directory: bool = True,
         copy_source_uri: str = "",
+        telemetry_id: str = "",
     ):
         self._processor = processor
         self._context_type = context_type
@@ -200,6 +201,8 @@ class SemanticDagExecutor:
         self._copy_source_uri = copy_source_uri
         self._task_context = get_task_context()
         self._telemetry = get_current_telemetry()
+        # Queue work retains its request ID even when no telemetry collector is registered.
+        self._telemetry_id = telemetry_id
         self._stale = False
         self._changed_paths = {
             path for key in ("added", "modified", "deleted") for path in self._changes.get(key, [])
@@ -823,6 +826,7 @@ class SemanticDagExecutor:
                     use_summary=use_summary,
                     ingest_options=self._ingest_options_for_file(file_path),
                     creator_acl_grant=self._creator_acl_grant(file_path),
+                    telemetry_id=self._telemetry_id,
                 )
             except Exception as e:
                 logger.error(
@@ -1101,6 +1105,7 @@ class SemanticDagExecutor:
                         ctx=self._ctx,
                         ingest_options=self._ingest_options_for_directory(),
                         creator_acl_grant=self._creator_acl_grant(dir_uri),
+                        telemetry_id=self._telemetry_id,
                     )
                 except Exception as e:
                     logger.error(

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -495,6 +495,7 @@ class SemanticProcessor(DequeueHandlerBase):
                                 generation_trigger=msg.generation_trigger,
                                 aggregate_directory=msg.aggregate_directory,
                                 copy_source_uri=msg.copy_source_uri,
+                                telemetry_id=msg.telemetry_id,
                             )
                             await executor.run(run_uri)
                             self._cache_dag_stats(
@@ -728,6 +729,7 @@ class SemanticProcessor(DequeueHandlerBase):
                         summary_dict=summary_dict,
                         ctx=ctx,
                         preserve_existing_created_at=True,
+                        telemetry_id=msg.telemetry_id,
                     )
                 file_summaries[idx] = {
                     "name": str(summary_dict.get("name") or file_name),
@@ -793,6 +795,7 @@ class SemanticProcessor(DequeueHandlerBase):
             abstract=abstract,
             overview=overview,
             ctx=ctx,
+            telemetry_id=msg.telemetry_id,
         )
         logger.info(f"Vectorized abstract.md and overview.md for {dir_uri}")
 
@@ -1556,6 +1559,7 @@ class SemanticProcessor(DequeueHandlerBase):
         ctx: Optional[RequestContext] = None,
         ingest_options: IngestOptions | None = None,
         creator_acl_grant: CreatorAclGrant | None = None,
+        telemetry_id: str = "",
     ) -> None:
         """Create directory Context and enqueue to EmbeddingQueue."""
 
@@ -1570,6 +1574,7 @@ class SemanticProcessor(DequeueHandlerBase):
             ctx=active_ctx,
             ingest_options=ingest_options,
             creator_acl_grant=creator_acl_grant,
+            telemetry_id=telemetry_id,
         )
 
     async def _load_transfer_file_summaries(
@@ -1598,6 +1603,7 @@ class SemanticProcessor(DequeueHandlerBase):
         preserve_existing_created_at: bool = False,
         ingest_options: IngestOptions | None = None,
         creator_acl_grant: CreatorAclGrant | None = None,
+        telemetry_id: str = "",
     ) -> None:
         """Vectorize a single file using its content or summary."""
         from openviking.utils.embedding_utils import vectorize_file
@@ -1613,4 +1619,5 @@ class SemanticProcessor(DequeueHandlerBase):
             preserve_existing_created_at=preserve_existing_created_at,
             ingest_options=ingest_options,
             creator_acl_grant=creator_acl_grant,
+            telemetry_id=telemetry_id,
         )

--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -365,6 +365,7 @@ async def vectorize_directory_meta(
     ingest_options: IngestOptions | None = None,
     creator_acl_grant: CreatorAclGrant | None = None,
     include_abstract: bool = True,
+    telemetry_id: str | None = None,
 ) -> None:
     """
     Vectorize directory metadata (.abstract.md and .overview.md).
@@ -414,7 +415,7 @@ async def vectorize_directory_meta(
                 Vectorize(text=embedding_text_for_body(ContextLevel.ABSTRACT, uri, abstract))
             )
             msg_abstract = EmbeddingMsgConverter.from_context(
-                context_abstract, creator_acl_grant
+                context_abstract, creator_acl_grant, telemetry_id=telemetry_id
             )
             _apply_scalar_overrides(
                 msg_abstract,
@@ -461,7 +462,7 @@ async def vectorize_directory_meta(
                 Vectorize(text=embedding_text_for_body(ContextLevel.OVERVIEW, uri, overview))
             )
             msg_overview = EmbeddingMsgConverter.from_context(
-                context_overview, creator_acl_grant
+                context_overview, creator_acl_grant, telemetry_id=telemetry_id
             )
             _apply_scalar_overrides(
                 msg_overview,
@@ -508,6 +509,7 @@ async def vectorize_file(
     scalar_override: Optional[Dict[str, Any]] = None,
     ingest_options: IngestOptions | None = None,
     creator_acl_grant: CreatorAclGrant | None = None,
+    telemetry_id: str | None = None,
 ) -> bool:
     """
     Vectorize a single file.
@@ -623,7 +625,9 @@ async def vectorize_file(
             logger.debug(f"Skipping file {file_path} (no text content or summary)")
             return False
 
-        embedding_msg = EmbeddingMsgConverter.from_context(context, creator_acl_grant)
+        embedding_msg = EmbeddingMsgConverter.from_context(
+            context, creator_acl_grant, telemetry_id=telemetry_id
+        )
         if not embedding_msg:
             return False
 

--- a/tests/server/test_request_wait_tracking.py
+++ b/tests/server/test_request_wait_tracking.py
@@ -3,15 +3,14 @@
 
 """Tests for request-scoped wait behavior on write APIs."""
 
-from types import SimpleNamespace
+import asyncio
 
 import pytest
 
 from openviking.server.identity import RequestContext, Role
-from openviking.storage.content_write import ContentWriteCoordinator
 from openviking.telemetry.context import bind_telemetry
 from openviking.telemetry.operation import OperationTelemetry
-from openviking_cli.session.user_id import UserIdentifier
+from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 
 
 class _FakeRequestWaitTracker:
@@ -40,45 +39,6 @@ class _FakeRequestWaitTracker:
 class _ExplodingQueueManager:
     async def wait_complete(self, *args, **kwargs):
         raise AssertionError("global queue wait should not be used")
-
-
-class _FakeVikingFS:
-    def __init__(self, file_uri: str, root_uri: str):
-        self._file_uri = file_uri
-        self._root_uri = root_uri
-        self.content = {file_uri: "original"}
-        self._async_agfs = SimpleNamespace(
-            pathlock_acquire_exact=lambda lock_path: SimpleNamespace(id="lock-1"),
-            pathlock_release=lambda lease: None,
-        )
-
-    async def stat(self, uri: str, ctx=None):
-        del ctx
-        if uri == self._file_uri:
-            return {"isDir": False}
-        if uri == self._root_uri:
-            return {"isDir": True}
-        raise AssertionError(f"unexpected stat uri: {uri}")
-
-    def _uri_to_path(self, uri: str, ctx=None):
-        del ctx
-        return f"/fake/{uri.replace('://', '/').strip('/')}"
-
-    async def delete_temp(self, temp_uri: str, ctx=None):
-        del temp_uri, ctx
-        return None
-
-    async def read_file(self, uri: str, ctx=None):
-        del ctx
-        return self.content[uri]
-
-    async def write_file(self, uri: str, content: str, ctx=None, lease_ref=None):
-        del ctx, lease_ref
-        self.content[uri] = content
-
-    async def rm(self, uri: str, ctx=None, lock_handle=None, lease_ref=None):
-        del ctx, lock_handle, lease_ref
-        self.content.pop(uri, None)
 
 
 @pytest.mark.asyncio
@@ -165,112 +125,68 @@ async def test_add_skill_wait_uses_request_tracker_when_telemetry_disabled(servi
 
 
 @pytest.mark.asyncio
-async def test_content_write_wait_uses_request_tracker(monkeypatch):
+@pytest.mark.parametrize("telemetry_enabled", [False, True])
+@pytest.mark.parametrize("embedding_fails", [False, True])
+async def test_content_write_wait_uses_request_tracker(
+    service, monkeypatch, telemetry_enabled, embedding_fails
+):
+    """wait=True includes downstream indexing even without a registered collector."""
     file_uri = "viking://resources/demo/doc.md"
     root_uri = "viking://resources/demo"
-    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
-    telemetry = OperationTelemetry(operation="content.write", enabled=True)
-    tracker = _FakeRequestWaitTracker(
-        {
-            "Semantic": {"processed": 1, "error_count": 0, "errors": []},
-            "Embedding": {"processed": 0, "error_count": 0, "errors": []},
-        }
-    )
-    coordinator = ContentWriteCoordinator(
-        viking_fs=_FakeVikingFS(file_uri=file_uri, root_uri=root_uri)
-    )
+    ctx = RequestContext(user=service.user, role=Role.USER)
+    await service.viking_fs.mkdir(root_uri, ctx=ctx)
+    telemetry = OperationTelemetry(operation="content.write", enabled=telemetry_enabled)
+    tracker = get_request_wait_tracker()
+    embedding_started = asyncio.Event()
+    release_embedding = asyncio.Event()
+    semantic_finished = asyncio.Event()
+    materialize = service.viking_fs.acl_manager.materialize_context_records
+    mark_semantic_done = tracker.mark_semantic_done
+
+    async def delayed_materialize(records, ctx):
+        if any(record.get("uri") == file_uri for record in records):
+            embedding_started.set()
+            await release_embedding.wait()
+            if embedding_fails:
+                raise RuntimeError("test index write failed")
+        return await materialize(records, ctx)
+
+    def record_semantic_done(telemetry_id, root_id, processed_delta=1):
+        mark_semantic_done(telemetry_id, root_id, processed_delta)
+        if telemetry_id == telemetry.telemetry_id:
+            semantic_finished.set()
 
     monkeypatch.setattr(
-        "openviking.storage.content_write.get_request_wait_tracker",
-        lambda: tracker,
-        raising=False,
+        service.viking_fs.acl_manager, "materialize_context_records", delayed_materialize
     )
-
-    async def _fake_enqueue_semantic_refresh(**kwargs):
-        del kwargs
-        return None
-
-    async def _explode_wait_for_queues(*, timeout):
-        del timeout
-        raise AssertionError("global queue wait should not be used")
-
-    monkeypatch.setattr(coordinator, "_enqueue_semantic_refresh", _fake_enqueue_semantic_refresh)
-    monkeypatch.setattr(coordinator, "_wait_for_queues", _explode_wait_for_queues)
+    monkeypatch.setattr(tracker, "mark_semantic_done", record_semantic_done)
 
     with bind_telemetry(telemetry):
-        result = await coordinator.write(
-            uri=file_uri,
-            content="updated",
-            ctx=ctx,
-            wait=True,
-            timeout=5.0,
+        write_task = asyncio.create_task(
+            service.fs.write(
+                uri=file_uri,
+                content="Request-scoped indexing wait",
+                mode="create",
+                ctx=ctx,
+                wait=True,
+                timeout=10.0,
+            )
         )
 
-    assert result["queue_status"] == tracker.queue_status
-    assert tracker.registered_requests == [telemetry.telemetry_id]
-    assert tracker.wait_calls == [(telemetry.telemetry_id, 5.0)]
-    assert tracker.build_calls == [telemetry.telemetry_id]
-    assert tracker.cleaned == [telemetry.telemetry_id]
-    assert result["semantic_status"] == "complete"
-    assert result["vector_status"] == "complete"
-
-
-@pytest.mark.asyncio
-async def test_content_write_wait_uses_request_tracker_when_telemetry_disabled(monkeypatch):
-    file_uri = "viking://resources/demo/doc.md"
-    root_uri = "viking://resources/demo"
-    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
-    telemetry = OperationTelemetry(operation="content.write", enabled=False)
-    tracker = _FakeRequestWaitTracker(
-        {
-            "Semantic": {"processed": 1, "error_count": 0, "errors": []},
-            "Embedding": {"processed": 0, "error_count": 0, "errors": []},
-        }
-    )
-    coordinator = ContentWriteCoordinator(
-        viking_fs=_FakeVikingFS(file_uri=file_uri, root_uri=root_uri)
-    )
-
-    monkeypatch.setattr(
-        "openviking.storage.content_write.get_request_wait_tracker",
-        lambda: tracker,
-        raising=False,
-    )
-
-    async def _fake_enqueue_semantic_refresh(**kwargs):
-        del kwargs
-        return None
-
-    async def _explode_wait_for_queues(*, timeout):
-        del timeout
-        raise AssertionError("global queue wait should not be used")
-
-    monkeypatch.setattr(coordinator, "_enqueue_semantic_refresh", _fake_enqueue_semantic_refresh)
-    monkeypatch.setattr(coordinator, "_wait_for_queues", _explode_wait_for_queues)
-
-    with bind_telemetry(telemetry):
-        result = await coordinator.write(
-            uri=file_uri,
-            content="updated",
-            ctx=ctx,
-            wait=True,
-            timeout=5.0,
+    try:
+        await asyncio.wait_for(
+            asyncio.gather(embedding_started.wait(), semantic_finished.wait()), timeout=10.0
         )
+        assert not tracker.is_complete(telemetry.telemetry_id)
+        assert not write_task.done()
+        release_embedding.set()
+        result = await asyncio.wait_for(write_task, timeout=10.0)
+    finally:
+        release_embedding.set()
+        if not write_task.done():
+            await asyncio.wait_for(write_task, timeout=10.0)
 
-    assert result["queue_status"] == tracker.queue_status
-    assert tracker.registered_requests == [telemetry.telemetry_id]
-    assert tracker.wait_calls == [(telemetry.telemetry_id, 5.0)]
-    assert tracker.build_calls == [telemetry.telemetry_id]
-    assert tracker.cleaned == [telemetry.telemetry_id]
     assert result["semantic_status"] == "complete"
-    assert result["vector_status"] == "complete"
-
-
-async def _return_true(handle, path):
-    del handle, path
-    return True
-
-
-async def _return_none(handle):
-    del handle
-    return None
+    assert result["vector_status"] == ("failed" if embedding_fails else "complete")
+    assert result["queue_status"]["Embedding"]["error_count"] == int(embedding_fails)
+    assert result["queue_status"]["Embedding"]["processed"] >= (2 if embedding_fails else 3)

--- a/tests/storage/test_semantic_dag_incremental.py
+++ b/tests/storage/test_semantic_dag_incremental.py
@@ -125,6 +125,7 @@ class _FakeProcessor:
         use_summary=False,
         ingest_options=None,
         creator_acl_grant=None,
+        telemetry_id="",
     ):
         del creator_acl_grant
         self.vectorized_files.append(file_path)
@@ -139,6 +140,7 @@ class _FakeProcessor:
         ctx=None,
         ingest_options=None,
         creator_acl_grant=None,
+        telemetry_id="",
     ):
         del creator_acl_grant
         self.directory_ingest_options[uri] = ingest_options

--- a/tests/storage/test_semantic_dag_skip_files.py
+++ b/tests/storage/test_semantic_dag_skip_files.py
@@ -73,6 +73,7 @@ class _FakeProcessor:
         ctx=None,
         ingest_options=None,
         creator_acl_grant=None,
+        telemetry_id="",
     ):
         pass
 
@@ -89,6 +90,7 @@ class _FakeProcessor:
         use_summary=False,
         ingest_options=None,
         creator_acl_grant=None,
+        telemetry_id="",
     ):
         self.vectorized_files.append(file_path)
 

--- a/tests/storage/test_semantic_dag_stats.py
+++ b/tests/storage/test_semantic_dag_stats.py
@@ -93,6 +93,7 @@ class _FakeProcessor:
         ctx=None,
         ingest_options=None,
         creator_acl_grant=None,
+        telemetry_id="",
     ):
         self.vectorized_dirs.append(uri)
 
@@ -106,6 +107,7 @@ class _FakeProcessor:
         use_summary=False,
         ingest_options=None,
         creator_acl_grant=None,
+        telemetry_id="",
     ):
         if self.verify_streaming:
             assert summary_dict["content"]
@@ -114,6 +116,7 @@ class _FakeProcessor:
         self.vectorized_contexts[file_path] = (
             task_context.task_id if task_context is not None else None,
             get_current_telemetry().telemetry_id,
+            telemetry_id,
         )
 
     async def _vectorize_directory_simple(self, uri, context_type, abstract, overview, ctx=None):
@@ -379,6 +382,7 @@ async def test_semantic_dag_shares_node_scheduler_across_roots(monkeypatch):
             context_type="resource",
             max_concurrent_llm=1,
             ctx=ctx,
+            telemetry_id="request-a",
         )
     with (
         bind_task_context("task-b", "acc1", "user1"),
@@ -389,6 +393,7 @@ async def test_semantic_dag_shares_node_scheduler_across_roots(monkeypatch):
             context_type="resource",
             max_concurrent_llm=1,
             ctx=ctx,
+            telemetry_id="request-b",
         )
 
     await asyncio.gather(executor_a.run(root_a), executor_b.run(root_b))
@@ -397,10 +402,10 @@ async def test_semantic_dag_shares_node_scheduler_across_roots(monkeypatch):
     assert executor_a.get_stats().done_nodes == 21
     assert executor_b.get_stats().done_nodes == 21
     assert {processor.vectorized_contexts[f"{root_a}/a-{idx}.txt"] for idx in range(20)} == {
-        ("task-a", telemetry_a.telemetry_id)
+        ("task-a", telemetry_a.telemetry_id, "request-a")
     }
     assert {processor.vectorized_contexts[f"{root_b}/b-{idx}.txt"] for idx in range(20)} == {
-        ("task-b", telemetry_b.telemetry_id)
+        ("task-b", telemetry_b.telemetry_id, "request-b")
     }
 
 

--- a/tests/storage/test_semantic_queue_memory_dedupe.py
+++ b/tests/storage/test_semantic_queue_memory_dedupe.py
@@ -267,8 +267,10 @@ async def test_memory_directory_vectorizes_changed_files_with_generated_summary(
         name = file_path.rsplit("/", 1)[-1]
         return {"name": name, "summary": f"summary:{name}", "content": "raw content"}
 
-    async def generate_overview(dir_uri, file_summaries, children_abstracts, llm_sem=None):
-        del dir_uri, children_abstracts, llm_sem
+    async def generate_overview(
+        dir_uri, file_summaries, children_abstracts, llm_sem=None, total_files=None
+    ):
+        del dir_uri, children_abstracts, llm_sem, total_files
         assert len(captured_file_vectorize) == 1
         assert all("content" not in summary for summary in file_summaries)
         return "overview"
@@ -306,6 +308,7 @@ async def test_memory_directory_vectorizes_changed_files_with_generated_summary(
             uri=dir_uri,
             context_type="memory",
             changes={"modified": [changed_uri]},
+            telemetry_id="memory-request",
         )
     )
 
@@ -319,8 +322,10 @@ async def test_memory_directory_vectorizes_changed_files_with_generated_summary(
         "content": "raw content",
     }
     assert captured_file_vectorize[0]["preserve_existing_created_at"] is True
+    assert captured_file_vectorize[0]["telemetry_id"] == "memory-request"
     assert len(captured_directory_vectorize) == 1
     assert captured_directory_vectorize[0]["uri"] == dir_uri
+    assert captured_directory_vectorize[0]["telemetry_id"] == "memory-request"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

修复文件写入 `wait=true` 提前报告索引完成的问题。

例如创建一个文件：

```http
POST /api/v1/content/write
```

```json
{"uri":"viking://resources/docs/note.md","content":"hello","mode":"create","wait":true}
```

- 修改前：文件摘要生成完后，接口可能就返回 `vector_status: "complete"`，但这个文件的索引还没写完。开启 ACL 时，创建者紧接着查询文件权限，可能短暂收到 403。
- 修改后：在等待未超时的情况下，只有本次请求的摘要和索引都处理成功，才返回 `semantic_status: "complete"`、`vector_status: "complete"`；索引处理失败则返回 `vector_status: "failed"`。

原因是等待方使用原请求编号，但下游索引消息从后台监控上下文取编号。原请求的监控对象未注册时，两边编号不一致，等待方就漏掉了索引任务。本次让索引消息沿用上游语义消息已有的 `telemetry_id`，不再依赖监控对象是否注册。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

无独立 Issue。此等待回归在 [#3636](https://github.com/volcengine/OpenViking/pull/3636) 改为流式提交索引任务后暴露。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 从语义消息到文件、目录的索引消息，显式传递同一个请求编号；同时覆盖目录 DAG 和 memory 目录处理路径。
- 保留流式并行处理及按请求等待，不恢复全局队列等待。直接提交索引的调用方仍使用当前请求编号；上游显式传入空编号时保持为空。
- 合并并改写已有等待测试，通过暂停实际索引写入，验证接口不会提前返回；覆盖监控开关、索引失败和并发请求隔离。

## Testing

仅改写现有测试，没有新增测试文件或测试函数。

- 同一份延迟索引回归测试：修复前 main 的 4 个场景全部复现漏等；修复后全部通过。
- 基于已合入 restricted 模式的 main，153 项相关测试通过，包括文件创建后立即查询 ACL、restricted/inherit 切换、HTTP 写入和 `wait=false`。
- 测试使用真实本地队列与存储、模拟模型输出；不是在线模型服务联调。
- Ruff lint、`git diff --check` 通过。

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

不修改 ACL 授权规则、公开 API 或消息 Schema，无需数据迁移。
