### PR TITLE
fix(fs): preserve committed delete result on parent refresh failure

### DIFF
--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -396,6 +396,7 @@ class FSService:
         await self._sync_watch_after_rm(uri, account_id=ctx.account_id, context_type=context_type)
         queue_status = None
         refresh_action: Optional[FreshnessAction] = None
+        refresh_error: Optional[str] = None
         request_registered = False
         telemetry_id = get_current_telemetry().telemetry_id
         try:
@@ -403,13 +404,21 @@ class FSService:
                 if wait and telemetry_id:
                     get_request_wait_tracker().register_request(telemetry_id)
                     request_registered = True
-                refresh_action = await self._enqueue_delete_refresh(
-                    root_uri=refresh_parent_uri,
-                    deleted_uri=uri,
-                    context_type=context_type,
-                    ctx=ctx,
-                    force_refresh=wait,
-                )
+                try:
+                    refresh_action = await self._enqueue_delete_refresh(
+                        root_uri=refresh_parent_uri,
+                        deleted_uri=uri,
+                        context_type=context_type,
+                        ctx=ctx,
+                        force_refresh=wait,
+                    )
+                except Exception as exc:
+                    refresh_error = str(exc)
+                    logger.warning(
+                        "Delete committed but parent semantic refresh failed for %s: %s",
+                        uri,
+                        exc,
+                    )
             if self._resource_memory_link_service and context_type == "resource":
                 cleanup_result = await self._resource_memory_link_service.before_resource_delete(
                     ctx=ctx,
@@ -430,7 +439,12 @@ class FSService:
                     directory_uri=cleanup_overview_uri,
                     ctx=ctx,
                 )
-            if refresh_parent_uri and wait and refresh_action is not FreshnessAction.MARK_PENDING:
+            if (
+                refresh_parent_uri
+                and wait
+                and refresh_error is None
+                and refresh_action is not FreshnessAction.MARK_PENDING
+            ):
                 queue_status = await self._wait_for_refresh(timeout=timeout)
         finally:
             if request_registered:
@@ -446,6 +460,9 @@ class FSService:
             )
             if queue_status is not None:
                 result["queue_status"] = queue_status
+            if refresh_error is not None:
+                result["semantic_status"] = "failed"
+                result["semantic_error"] = refresh_error
         return result
 
     @staticmethod

--- a/tests/storage/test_transfer_merge_binding.py
+++ b/tests/storage/test_transfer_merge_binding.py
@@ -12,8 +12,11 @@ import pytest_asyncio
 from openviking.pyagfs import get_binding_client
 from openviking.resource.watch_manager import WatchManager
 from openviking.server.identity import RequestContext, Role
+from openviking.service.fs_service import FSService
+from openviking.storage.abstract_overview import freshness_metadata, write_abstract_overview
 from openviking.storage.acl import AclAction, AclManager
 from openviking.storage.collection_schemas import CollectionSchemas
+from openviking.storage.errors import ResourceBusyError
 from openviking.storage.vector_ids import vector_record_id
 from openviking.storage.vectordb import engine as vectordb_engine
 from openviking.storage.viking_fs import VikingFS
@@ -538,3 +541,75 @@ async def test_watch_persistence_overwrites_after_backup_removal_failure(binding
     backup = json.loads(await fs.read_file(manager.STORAGE_BAK_URI, ctx=ctx))
     assert backup["tasks"] == []
     assert not await fs.exists(manager.STORAGE_TMP_URI, ctx=ctx)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("wait", [False, True])
+async def test_rm_preserves_committed_result_when_parent_refresh_is_locked(
+    binding_fs, monkeypatch, wait
+):
+    ctx = root_ctx()
+    parent = "viking://resources/delete-refresh"
+    source = f"{parent}/source.md"
+    await binding_fs.mkdir(parent, ctx=ctx)
+    await binding_fs.write_file(source, "delete me", ctx=ctx)
+    await write_abstract_overview(
+        viking_fs=binding_fs,
+        dir_uri=parent,
+        overview="overview",
+        abstract="abstract",
+        ctx=ctx,
+        is_stale=lambda: False,
+        metadata={"freshness": freshness_metadata(1, 1)},
+    )
+    monkeypatch.setattr(
+        "openviking.service.fs_service.get_openviking_config",
+        lambda: SimpleNamespace(semantic=SimpleNamespace()),
+    )
+    cleanup = AsyncMock()
+    cleanup.before_resource_delete.return_value = None
+    service = FSService(viking_fs=binding_fs, resource_memory_link_service=cleanup)
+    wait_for_refresh = AsyncMock()
+    monkeypatch.setattr(service, "_wait_for_refresh", wait_for_refresh)
+    lease = await binding_fs._async_agfs.pathlock_acquire_exact_batch(
+        [
+            binding_fs._uri_to_path(f"{parent}/{name}", ctx=ctx)
+            for name in (".overview.md", ".abstract.md")
+        ]
+    )
+    try:
+        result = await service.rm(source, ctx=ctx, wait=wait)
+    finally:
+        await binding_fs._async_agfs.pathlock_release(lease)
+
+    assert isinstance(result, dict)
+    assert result["estimated_deleted_count"] == 0
+    assert result["semantic_status"] == "failed"
+    assert result["semantic_root_uri"] == parent
+    assert "lock acquire timed out" in result["semantic_error"]
+    assert "queue_status" not in result
+    assert not await binding_fs.exists(source, ctx=ctx)
+    wait_for_refresh.assert_not_awaited()
+    cleanup.before_resource_delete.assert_awaited_once_with(
+        ctx=ctx, resource_uri=source, recursive=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_rm_still_rejects_a_locked_source(binding_fs, monkeypatch):
+    ctx = root_ctx()
+    source = "viking://resources/locked-source.md"
+    await binding_fs.write_file(source, "keep me", ctx=ctx)
+    service = FSService(viking_fs=binding_fs)
+    enqueue_delete_refresh = AsyncMock()
+    monkeypatch.setattr(service, "_enqueue_delete_refresh", enqueue_delete_refresh)
+    lease = await binding_fs._async_agfs.pathlock_acquire_exact(
+        binding_fs._uri_to_path(source, ctx=ctx)
+    )
+    try:
+        with pytest.raises(ResourceBusyError):
+            await service.rm(source, ctx=ctx)
+        assert await binding_fs.read_file(source, ctx=ctx) == "keep me"
+        enqueue_delete_refresh.assert_not_awaited()
+    finally:
+        await binding_fs._async_agfs.pathlock_release(lease)


### PR DESCRIPTION
## Description

Preserve the committed delete result when scheduling the parent semantic refresh fails. Currently, a parent abstract/overview lock conflict can escape from `FSService.rm()` after the resource has already been removed, misleading callers into treating the delete as uncommitted.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4814

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Catch only failures from the parent-refresh scheduling step after `viking_fs.rm()` has returned; preserve the delete result and report `semantic_status=failed` plus `semantic_error`, following the existing copy-result pattern.
- Do not wait for a refresh that could not be scheduled. Continue existing resource-memory cleanup and request-tracker cleanup.
- Keep primary delete errors and cancellation propagation unchanged. No locking, retry, queue-policy, or unrelated test changes.
- Extend the existing real-storage binding suite with deterministic parent-sidecar lock cases for `wait=False` and `wait=True`, plus a source-lock control that must still reject deletion and retain the source.

## Testing

- [x] Regression verified red/green: both parent-lock cases fail before the fix with `LockAcquisitionError`, then pass after it.
- [x] `pytest tests/service/test_fs_service.py tests/storage/test_transfer_merge_binding.py -q -o addopts=''`: **89 passed**.
- [x] `ruff check` on both changed paths and `git diff --check`: pass.
- [x] `ruff format --check` on the changed test file: pass.
- [x] Tested on Linux using real local RAGFS/path locks and the released 0.4.18 native library; no model calls are needed.

Static-check baseline comparison against `2eb36eab`: the service file's format check flags only the same pre-existing `set_acl` formatting outside this diff. Mypy reports the same 1,510 errors in 199 files on the base and this patch, with no added diagnostics after normalizing shifted line numbers. These checks are not claimed as globally passing, and unrelated baseline cleanup is intentionally excluded.

## Additional Notes

This is independent of the Skill metadata fix in #4807. It addresses a deterministically reproduced deletion-result defect, not a claim to have reconstructed a historical CI request whose failure body was unavailable. Maintainer confirmation of the post-delete result boundary is requested in #4814. Remote CI remains pending.
