### PR TITLE
feat: add limit/offset to read mcp

### DIFF
--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -498,8 +498,12 @@ def _mcp_media_download_hint(uri: str) -> str:
 
 
 @mcp.tool(structured_output=False)
-async def read(uris: str | list[str]) -> str | list[ContentBlock]:
-    """Read one or more viking:// file URIs. Raster images and supported audio return native MCP content blocks. For directory listing, use the list tool instead."""
+async def read(
+    uris: str | list[str],
+    offset: int = 0,
+    limit: int = -1,
+) -> str | list[ContentBlock]:
+    """Read one or more viking:// file URIs. Text reads accept line-based offset/limit. Raster images and supported audio return native MCP content blocks. For directory listing, use the list tool instead."""
     import asyncio
 
     service = get_service()
@@ -596,7 +600,12 @@ async def read(uris: str | list[str]) -> str | list[ContentBlock]:
                     if is_image:
                         return _mcp_image_content(data, mime_type)
                     return _mcp_audio_content(data, mime_type)
-                content = await service.fs.read_visible(resolved_uri, ctx=ctx)
+                content = await service.fs.read_visible(
+                    resolved_uri,
+                    ctx=ctx,
+                    offset=offset,
+                    limit=limit,
+                )
                 return content
             except OpenVikingError as exc:
                 return str(exc)

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -622,6 +622,38 @@ async def test_read_delegates_to_visible_read(monkeypatch):
     read_visible.assert_awaited_once_with(
         "viking://user/test_user/project/private.md",
         ctx=DEFAULT_CTX,
+        offset=0,
+        limit=-1,
+    )
+
+
+async def test_read_passes_offset_limit_to_visible_read(monkeypatch):
+    read_visible = AsyncMock(return_value="line 3\nline 4\n")
+    monkeypatch.setattr(
+        mcp_endpoint,
+        "get_service",
+        lambda: SimpleNamespace(fs=SimpleNamespace(read_visible=read_visible)),
+    )
+    uri = "viking://resources/notes.md"
+
+    result = await mcp_endpoint.mcp.call_tool(
+        "read",
+        {
+            "uris": uri,
+            "offset": 2,
+            "limit": 2,
+        },
+    )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert isinstance(result[0], TextContent)
+    assert result[0].text == "line 3\nline 4\n"
+    read_visible.assert_awaited_once_with(
+        uri,
+        ctx=DEFAULT_CTX,
+        offset=2,
+        limit=2,
     )
 
 
@@ -892,7 +924,7 @@ async def test_read_svg_remains_text(monkeypatch):
     uri = "viking://resources/diagram.svg"
 
     assert await read(uri) == "<svg></svg>"
-    read_visible.assert_awaited_once_with(uri, ctx=DEFAULT_CTX)
+    read_visible.assert_awaited_once_with(uri, ctx=DEFAULT_CTX, offset=0, limit=-1)
     read_file_bytes.assert_not_awaited()
 
 


### PR DESCRIPTION
## Description

support read mcp limit/offset

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## Changes Made

- Added optional `offset` and `limit` parameters to the MCP `read` tool.
- Passed `offset` and `limit` through to `fs.read_visible()` so MCP reads can use the existing line-based pagination behavior.
- Preserved existing behavior by defaulting to `offset=0` and `limit=-1`.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Default MCP `read` behavior is unchanged for existing clients that do not pass `offset` or `limit`.