### PR TITLE
fix(vectordb): 降低本地 schema 自动升级的内存占用

### DIFF
--- a/openviking/storage/vectordb/collection/local_collection.py
+++ b/openviking/storage/vectordb/collection/local_collection.py
@@ -485,9 +485,7 @@ class LocalCollection(ICollection):
             if scalar_index is not None:
                 if not self.store_mgr:
                     raise RuntimeError("Store manager is not initialized")
-                index.rebuild_scalar_index(
-                    scalar_index, self.store_mgr.get_all_cands_data()
-                )
+                index.rebuild_scalar_index(scalar_index, self.store_mgr.iter_all_cands_fields())
             if description is not None:
                 index.update(None, description)
 

--- a/openviking/storage/vectordb/engine/_python_api.py
+++ b/openviking/storage/vectordb/engine/_python_api.py
@@ -475,13 +475,13 @@ def build_abi3_exports(backend: Any) -> dict[str, Any]:
             )
 
         def rebuild_scalar_index(
-            self, scalar_index_json: str, data_list: list[AddDataRequest]
+            self, scalar_index_json: str, data_list: Iterable[AddDataRequest]
         ) -> int:
             return int(
                 self._backend._index_engine_rebuild_scalar_index(
                     self._handle,
                     scalar_index_json,
-                    _request_list_to_backend(data_list),
+                    data_list,
                 )
             )
 

--- a/openviking/storage/vectordb/index/index.py
+++ b/openviking/storage/vectordb/index/index.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
-from openviking.storage.vectordb.store.data import CandidateData, DeltaRecord
+from openviking.storage.vectordb.store.data import DeltaRecord
 
 
 class IIndex(ABC):
@@ -191,7 +191,7 @@ class IIndex(ABC):
 
     @abstractmethod
     def rebuild_scalar_index(
-        self, scalar_index: List[str], cands_list: List[CandidateData]
+        self, scalar_index: List[str], cands_fields: Iterable[Tuple[int, str]]
     ) -> None:
         """Replace the scalar index from a Store snapshot without rebuilding vectors."""
         raise NotImplementedError

--- a/openviking/storage/vectordb/index/local_index.py
+++ b/openviking/storage/vectordb/index/local_index.py
@@ -201,18 +201,12 @@ class IndexEngineProxy:
         self.index_engine.add_data(add_req_list)
 
     def rebuild_scalar_index(
-        self, scalar_index_meta: List[Dict[str, str]], cands_list: List[CandidateData]
+        self, scalar_index_meta: List[Dict[str, str]], requests: Iterable[engine.AddDataRequest]
     ) -> None:
         if not self.index_engine:
             raise RuntimeError("Index engine not initialized")
 
-        requests = [engine.AddDataRequest() for _ in range(len(cands_list))]
-        for request, data in zip(requests, cands_list, strict=False):
-            request.label = data.label
-            request.fields_str = data.fields
-        result = self.index_engine.rebuild_scalar_index(
-            json.dumps(scalar_index_meta), requests
-        )
+        result = self.index_engine.rebuild_scalar_index(json.dumps(scalar_index_meta), requests)
         if result != 0:
             raise RuntimeError("Failed to rebuild native scalar index")
 
@@ -483,32 +477,31 @@ class LocalIndex(IIndex):
         self.meta.update(meta_data)
 
     def rebuild_scalar_index(
-        self, scalar_index: List[str], cands_list: List[CandidateData]
+        self, scalar_index: List[str], cands_fields: Iterable[Tuple[int, str]]
     ) -> None:
         if not self.engine_proxy:
             raise RuntimeError("Index engine not initialized")
 
         self.field_type_converter = DataProcessor(self.meta.collection_meta.fields_dict)
-        converted_candidates: List[CandidateData] = []
-        vector_key = self.meta.collection_meta.vector_key
-        sparse_vector_key = self.meta.collection_meta.sparse_vector_key
-        for candidate in cands_list:
-            fields = fix_fields_data(
-                json.loads(candidate.fields), self.meta.collection_meta.fields_dict
-            )
-            fields.pop(vector_key, None)
-            if sparse_vector_key:
-                fields.pop(sparse_vector_key, None)
-            converted = CandidateData()
-            converted.label = candidate.label
-            converted.fields = safe_json_dumps(fields, ensure_ascii=False)
-            converted_candidates.append(converted)
+        indexed_fields = {
+            name: self.meta.collection_meta.fields_dict[name] for name in scalar_index
+        }
+
+        def requests() -> Iterator[engine.AddDataRequest]:
+            for label, fields_json in cands_fields:
+                fields = json.loads(fields_json)
+                fields = {name: fields[name] for name in indexed_fields if name in fields}
+                fix_fields_data(fields, indexed_fields)
+                request = engine.AddDataRequest()
+                request.label = label
+                request.fields_str = safe_json_dumps(
+                    self.field_type_converter.convert_fields_dict_for_index(fields),
+                    ensure_ascii=False,
+                )
+                yield request
 
         engine_scalar_meta = self.field_type_converter.build_scalar_index_meta(scalar_index)
-        self.engine_proxy.rebuild_scalar_index(
-            engine_scalar_meta,
-            self._convert_candidate_list_for_index(converted_candidates),
-        )
+        self.engine_proxy.rebuild_scalar_index(engine_scalar_meta, requests())
         if isinstance(self, PersistentIndex) and self.persist() <= 0:
             raise RuntimeError("Failed to persist rebuilt scalar index")
         if not self.meta.update({"ScalarIndex": scalar_index}):

--- a/openviking/storage/vectordb/store/store_manager.py
+++ b/openviking/storage/vectordb/store/store_manager.py
@@ -227,6 +227,14 @@ class StoreManager:
         """
         return list(self.iter_all_cands_data())
 
+    def iter_all_cands_fields(self) -> Iterator[Tuple[int, str]]:
+        """Scan labels and scalar fields without decoding stored vectors."""
+        for _, bytes_data in self.storage.iter_all(StoreManager.CandsTable):
+            yield (
+                CandidateData.bytes_row.deserialize_field(bytes_data, "label"),
+                CandidateData.bytes_row.deserialize_field(bytes_data, "fields"),
+            )
+
     def iter_all_cands_data(self) -> Iterator[CandidateData]:
         """Iterate candidates without retaining deserialized full tables.
 

--- a/src/abi3_engine_backend.cpp
+++ b/src/abi3_engine_backend.cpp
@@ -1390,18 +1390,53 @@ PyObject* py_index_engine_rebuild_scalar_index(PyObject*, PyObject* args) {
     return nullptr;
   }
 
-  std::vector<vdb::AddDataRequest> requests;
-  if (!parse_request_list(items, parse_add_request, &requests)) {
+  std::unique_ptr<PyObject, decltype(&Py_DecRef)> iterator(PyObject_GetIter(items),
+                                                        Py_DecRef);
+  if (!iterator) {
     return nullptr;
   }
 
   try {
+    // Bound the native input independently of the Store's encoded page size.
+    // A single oversized row is allowed so every nonempty batch makes progress.
+    auto read_batch = [&](std::vector<vdb::AddDataRequest>& batch) {
+      constexpr size_t kMaxRows = 1024;
+      constexpr size_t kMaxBytes = 1024 * 1024;
+      const auto gil = PyGILState_Ensure();
+      try {
+        batch.clear();
+        size_t bytes = 0;
+        while (batch.size() < kMaxRows && bytes < kMaxBytes) {
+          std::unique_ptr<PyObject, decltype(&Py_DecRef)> item(
+              PyIter_Next(iterator.get()), Py_DecRef);
+          if (!item) {
+            if (PyErr_Occurred()) {
+              throw std::runtime_error("Failed to read scalar index rows");
+            }
+            break;
+          }
+          vdb::AddDataRequest request;
+          if (!parse_add_request(item.get(), &request)) {
+            throw std::runtime_error("Invalid scalar index row");
+          }
+          bytes += request.fields_str.size();
+          batch.push_back(std::move(request));
+        }
+      } catch (...) {
+        PyGILState_Release(gil);
+        throw;
+      }
+      PyGILState_Release(gil);
+      return !batch.empty();
+    };
     const int result = call_without_gil([&]() {
-      return engine->rebuild_scalar_index(scalar_index_json, requests);
+      return engine->rebuild_scalar_index(scalar_index_json, read_batch);
     });
     return PyLong_FromLong(result);
   } catch (const std::exception& exc) {
-    raise_runtime_error(exc.what());
+    if (!PyErr_Occurred()) {
+      raise_runtime_error(exc.what());
+    }
     return nullptr;
   }
 }

--- a/src/index/detail/index_manager_impl.cpp
+++ b/src/index/detail/index_manager_impl.cpp
@@ -625,7 +625,7 @@ int IndexManagerImpl::delete_data(
 
 int IndexManagerImpl::rebuild_scalar_index(
     const std::string& scalar_index_json,
-    const std::vector<AddDataRequest>& data_list) {
+    const std::function<bool(std::vector<AddDataRequest>&)>& read_batch) {
   JsonDoc scalar_index_doc;
   scalar_index_doc.Parse(scalar_index_json.c_str());
   if (scalar_index_doc.HasParseError() || !scalar_index_doc.IsArray()) {
@@ -637,30 +637,30 @@ int IndexManagerImpl::rebuild_scalar_index(
     throw std::invalid_argument("Invalid scalar index metadata");
   }
 
-  std::vector<FieldsDict> parsed_fields(data_list.size());
-  for (size_t i = 0; i < data_list.size(); ++i) {
-    if (parsed_fields[i].parse_from_json(data_list[i].fields_str) != 0) {
-      throw std::runtime_error(
-          "Failed to parse scalar fields for label=" +
-          std::to_string(data_list[i].label));
-    }
-  }
-
   auto next_scalar_index = std::make_shared<ScalarIndex>(next_meta);
   std::unique_lock<std::shared_mutex> lock(rw_mutex_);
-  for (size_t i = 0; i < data_list.size(); ++i) {
-    const int offset = vector_index_->get_offset_by_label(data_list[i].label);
-    if (offset < 0) {
-      SPDLOG_WARN("IndexManagerImpl::rebuild_scalar_index label={} not found",
-                  data_list[i].label);
-      continue;
+  std::vector<AddDataRequest> batch;
+  while (read_batch(batch)) {
+    for (const auto& data : batch) {
+      FieldsDict fields;
+      if (fields.parse_from_json(data.fields_str) != 0) {
+        throw std::runtime_error(
+            "Failed to parse scalar fields for label=" +
+            std::to_string(data.label));
+      }
+      const int offset = vector_index_->get_offset_by_label(data.label);
+      if (offset < 0) {
+        SPDLOG_WARN("IndexManagerImpl::rebuild_scalar_index label={} not found",
+                    data.label);
+        continue;
+      }
+      if (next_scalar_index->add_row_data(offset, fields, FieldsDict{}) != 0) {
+        throw std::runtime_error(
+            "Failed to rebuild scalar fields for label=" +
+            std::to_string(data.label));
+      }
     }
-    if (next_scalar_index->add_row_data(offset, parsed_fields[i],
-                                        FieldsDict{}) != 0) {
-      throw std::runtime_error(
-          "Failed to rebuild scalar fields for label=" +
-          std::to_string(data_list[i].label));
-    }
+    batch.clear();
   }
 
   scalar_index_ = std::move(next_scalar_index);

--- a/src/index/detail/index_manager_impl.h
+++ b/src/index/detail/index_manager_impl.h
@@ -54,7 +54,7 @@ class IndexManagerImpl : public IndexManager {
 
   int rebuild_scalar_index(
       const std::string& scalar_index_json,
-      const std::vector<AddDataRequest>& data_list) override;
+      const std::function<bool(std::vector<AddDataRequest>&)>& read_batch) override;
 
   int64_t dump(const std::string& dir) override;
 

--- a/src/index/index_engine.cpp
+++ b/src/index/index_engine.cpp
@@ -72,8 +72,8 @@ int IndexEngine::delete_data(const std::vector<DeleteDataRequest>& data_list) {
 
 int IndexEngine::rebuild_scalar_index(
     const std::string& scalar_index_json,
-    const std::vector<AddDataRequest>& data_list) {
-  return impl_->rebuild_scalar_index(scalar_index_json, data_list);
+    const std::function<bool(std::vector<AddDataRequest>&)>& read_batch) {
+  return impl_->rebuild_scalar_index(scalar_index_json, read_batch);
 }
 
 int64_t IndexEngine::dump(const std::string& dir) {

--- a/src/index/index_engine.h
+++ b/src/index/index_engine.h
@@ -25,7 +25,7 @@ class IndexEngine {
 
   int rebuild_scalar_index(
       const std::string& scalar_index_json,
-      const std::vector<AddDataRequest>& data_list);
+      const std::function<bool(std::vector<AddDataRequest>&)>& read_batch);
 
   SearchResult search(const SearchRequest& req);
 

--- a/src/index/index_manager.h
+++ b/src/index/index_manager.h
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 // SPDX-License-Identifier: AGPL-3.0
 #pragma once
+#include <functional>
 #include <string>
 #include <vector>
 #include "index/common_structs.h"
@@ -38,7 +39,7 @@ class IndexManager {
 
   virtual int rebuild_scalar_index(
       const std::string& scalar_index_json,
-      const std::vector<AddDataRequest>& data_list) = 0;
+      const std::function<bool(std::vector<AddDataRequest>&)>& read_batch) = 0;
 
   virtual int64_t dump(const std::string& dir) = 0;
 

--- a/tests/vectordb/test_engine_filter_packed_native_abi.py
+++ b/tests/vectordb/test_engine_filter_packed_native_abi.py
@@ -87,7 +87,21 @@ def test_native_packed_filter_abi_has_exact_little_endian_layout_and_shapes():
         {"FieldName": "uri", "FieldType": "path"},
         {"FieldName": "schema_flag", "FieldType": "bool"},
     ]
-    assert index.rebuild_scalar_index(json.dumps(scalar_meta), requests) == 0
+
+    def interrupted_rows():
+        for row in range(1100):
+            request = engine.AddDataRequest()
+            request.label = labels[row % len(labels)]
+            request.fields_str = '{"uri":"/replacement","schema_flag":true}'
+            yield request
+        raise ValueError("Store scan interrupted")
+
+    # Even after a batch has been built, a failed scan must keep the old index.
+    with pytest.raises(ValueError, match="Store scan interrupted"):
+        index.rebuild_scalar_index(json.dumps(scalar_meta), interrupted_rows())
+    assert index.evaluate_filter(keep_filter).bitset_words == expected_words
+
+    assert index.rebuild_scalar_index(json.dumps(scalar_meta), iter(requests)) == 0
     assert index.set_filter_layout(labels) == 0
     rebuilt = index.evaluate_filter(
         json.dumps({"op": "must", "field": "schema_flag", "conds": [True]})


### PR DESCRIPTION
## Description

本地已有 collection 在启动时补齐 ACL 字段和标量索引，会扫描存量记录并重建标量索引。原实现把全库向量展开成 Python 对象，又同时保留多份字段数据和 Native 解析结果，导致升级时内存明显上涨。

**Before：** Store 全量候选记录 → Python 全量字段转换与请求列表 → Native 全量请求和字段解析结果 → 构建新标量索引。

**After：** Store 分页读取，只解码 label 和 fields → Python 逐条保留需要建立索引的字段 → Native 分批消费、逐条解析 → 完整构建成功后替换标量索引。

同一份由 v0.4.17 写入的旧数据，额外增加 20,000 条 1024 维压力记录后：不执行自动更新的进程峰值为 413.1 MiB，原自动更新为 1946.7 MiB，本 PR 为 588.9 MiB。以不更新为基线，自动更新的额外峰值从 1533.6 MiB 降至 175.8 MiB，减少 **88.5%**；总峰值减少 **69.8%**。完整测量条件和原始值见 Testing。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

无单独 issue；优化 #4700 引入的本地 schema 自动补齐路径。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made

- 复用现有 Store 分页扫描和字段解码能力，不再为标量索引重建反序列化向量；Python 只转换目标索引字段。
- Python 到 Native 的重建入口接受迭代输入，Native 每批最多 1024 行、约 1 MiB 字段载荷；最后一条允许超过字节预算。消除全库请求列表及全库解析字段同时驻留。
- 保留 collection 的排他写入屏障、完整标量索引重建和持久化顺序。扫描或解析失败时不替换旧标量索引；不重建向量索引，不引入后台迁移、双写或新配置。
- 扩展一个现有 Native ABI 契约测试：消费超过一批后迭代器抛错，旧过滤结果仍正确，之后可以成功重建。未新增测试文件。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

### 内存和耗时对比

- **代码和环境：** 未优化侧为 main `2eb36eabbd6b589bc14e89f462d852b887dc62bf`，优化侧为同一提交加本 PR 改动；并非直接比较 v0.4.17 和 v0.4.18 两个发布包。macOS arm64、Python 3.14.6、local VectorDB，使用同一个 `ov.conf`。两侧 Native 均以相同 Release 参数构建，RAGFS 动态库一致。
- **数据：** 先启动精确标签 v0.4.17，通过 HTTP 写入 4 份合成文档并等待处理完成，使用配置中的真实 embedding/VLM；再通过旧版 LocalCollection 写入 20,000 条合成压力记录，每条 1024 维、正文 4264 字节，压力记录不调用模型。
- **不更新基线：** 最新未优化代码正常加载同一份旧 collection 和索引，仅在外部测量启动器中跳过 `update_collection_schema`。实际保持 18 个字段、12 个标量索引。没有在产品代码中增加禁用迁移的开关。
- **对照过程：** 每轮恢复完全相同的旧数据快照。三组各两轮，顺序为不更新、优化前、优化后、优化后、优化前、不更新；更新组均补齐到 21 个字段、15 个实际标量索引。
- **统计口径：** 峰值为服务进程正常退出后读取的 macOS `ru_maxrss`，覆盖启动、health 就绪后 3 秒和正常退出；此间不发送业务请求。就绪后 RSS 为 health 成功 3 秒后的 `ps` 采样。schema 耗时包围实际 `LocalCollection.update_index`，包含读取、转换、Native 重建及持久化，不含整进程导入时间。

以下为两轮平均值：

| 方案 | 进程峰值 RSS（MiB） | 比不更新增加（MiB） | 就绪后 RSS（MiB） | 比不更新增加（MiB） | schema 更新（秒） |
|---|---:|---:|---:|---:|---:|
| 不执行自动更新 | 413.1 | +0.0 | 384.5 | +0.0 | — |
| 优化前自动更新 | 1946.7 | +1533.6 | 1304.6 | +920.1 | 2.048 |
| 优化后自动更新 | 588.9 | +175.8 | 563.0 | +178.5 | 1.030 |

<details>
<summary>六轮原始数据</summary>

| 顺序 | 方案 | 进程峰值 RSS（MiB） | 就绪后 RSS（MiB） | schema 更新（秒） |
|---|---|---:|---:|---:|
| 1 | 不执行自动更新 | 412.1 | 383.5 | — |
| 2 | 优化前自动更新 | 1949.8 | 1307.1 | 2.242 |
| 3 | 优化后自动更新 | 587.8 | 562.8 | 0.992 |
| 4 | 优化后自动更新 | 589.9 | 563.2 | 1.068 |
| 5 | 优化前自动更新 | 1943.6 | 1302.1 | 1.854 |
| 6 | 不执行自动更新 | 414.1 | 385.6 | — |

</details>

### 空闲和重启观察

另外恢复同一份旧压力数据，补测优化版升级完成后的空闲 RSS；不发送业务请求，也不主动执行 GC 或释放内存。随后正常关闭服务，再加载这份已经升级的数据，确认没有重复执行 schema 更新。

| 状态 | RSS（MiB） |
|---|---:|
| 升级完成，就绪后 3 秒 | 570.0 |
| 空闲 1 分钟 | 240.5 |
| 空闲 3 分钟 | 241.1 |
| 空闲 5 分钟 | 196.1 |
| 已升级数据重启，就绪后 3 秒 | 379.1 |
| 重启后空闲 1 分钟 | 379.2 |

空闲下降包含系统压缩/换出的影响：约就绪后 105 秒，`vmmap` 显示 279.3 MiB 的 SWAPPED。原升级进程的文件映射驻留约 144.9 MiB，同一份已升级数据重启后为约 368 KiB。重启后的 RSS 接近不更新的 384.5 MiB 基线，说明本数据集升级后的额外 RSS 有很大部分来自扫描后的文件映射驻留，不能全部当作 ACL 索引的固定常驻成本。

上述空闲观察仅针对优化版，不能把 macOS 的压缩/换出效果外推为 Linux 上同样的回落，也不代表已经复现或解决特定生产机器上的 OOM。

### v0.4.17 → 最新代码的 ACL 验证

在 v0.4.17 通过 HTTP 写入数据，正常关闭后切换到最新代码加本 PR，以同一配置和旧数据启动，实际验证：

- 旧文档内容和向量检索保持正确；开启 ACL 后，未设置权限的旧内容仍公开。
- 直接授权、父目录继承、`restricted` 阻断继承和新文件继承均正确；未授权读取返回 403，向量检索排除不可见内容。
- read/write/manage 的权限边界、撤销授权、ACL 关闭后重新开启，以及重启后的读取和向量过滤均正确。

### 现有测试与构建

Native VectorDB 和 RAGFS 均完成本地 Release 编译。以下现有测试 **82 passed**；Ruff 检查、格式检查及 `git diff --check` 通过。

```bash
python -m pytest \
  tests/vectordb/test_engine_filter_packed_native_abi.py \
  tests/vectordb/test_openviking_vectordb.py \
  tests/vectordb/test_store_streaming.py \
  tests/storage/test_collection_schemas.py \
  --no-cov -q
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

无公开 HTTP/SDK API、配置或存储格式变更，不需要用户文档调整。Python 与 Native 重建入口一并修改，需要使用匹配构建的 Native 动态库。

本 PR 仍然完整重建标量索引，构建期间需要保留旧索引与新索引；有界的是扫描和转换的临时输入，不承诺总内存与数据量无关。上述结果来自该合成数据集，不能代表所有线上集合与 ACL 授权分布。
