### PR TITLE
fix(studio): respect backend task status in lists and filters

### DIFF
--- a/web-studio/src/routes/tasks/-lib/task-list.test.ts
+++ b/web-studio/src/routes/tasks/-lib/task-list.test.ts
@@ -51,20 +51,40 @@ describe('task list requests', () => {
     })
   })
 
-  it('keeps effective status filtering on the client', async () => {
-    clientMocks.getTasks.mockResolvedValue(
-      Array.from({ length: 9 }, (_, index) => ({
-        created_at: index + 1,
-        status: 'running',
-        task_id: `task-${index + 1}`,
+  it('finds matching tasks before the server applies its result limit', async () => {
+    const failedTask = {
+      task_id: 'old-failure',
+      task_type: 'session_commit',
+      status: 'failed',
+      created_at: 1,
+    }
+    const records = [
+      ...Array.from({ length: MAX_TASKS }, (_, index) => ({
+        task_id: `completed-${index}`,
+        task_type: 'session_commit',
+        status: 'completed',
+        created_at: MAX_TASKS + 1 - index,
       })),
+      failedTask,
+    ]
+    clientMocks.getTasks.mockImplementation(({ query }) =>
+      records
+        .filter((task) => !query.status || task.status === query.status)
+        .filter(
+          (task) => !query.task_type || task.task_type === query.task_type,
+        )
+        .slice(0, query.limit),
     )
 
-    await expect(fetchTasks('all', 'pending')).resolves.toEqual([
-      expect.objectContaining({ task_id: 'task-9' }),
+    await expect(fetchTasks('session_commit', 'failed')).resolves.toEqual([
+      failedTask,
     ])
     expect(clientMocks.getTasks).toHaveBeenCalledWith({
-      query: { limit: MAX_TASKS },
+      query: {
+        limit: MAX_TASKS,
+        task_type: 'session_commit',
+        status: 'failed',
+      },
     })
   })
 

--- a/web-studio/src/routes/tasks/-lib/task-list.ts
+++ b/web-studio/src/routes/tasks/-lib/task-list.ts
@@ -1,8 +1,5 @@
 import { getOvResult, getTasks } from '#/lib/ov-client'
-import {
-  normalizeTasks,
-  normalizeTaskStatus,
-} from '#/routes/tasks/-lib/task-record'
+import { normalizeTasks } from '#/routes/tasks/-lib/task-record'
 import type { TaskRecord, TaskStatus } from '#/routes/tasks/-lib/task-record'
 
 export type TaskStatusFilter = Exclude<TaskStatus, 'unknown'> | 'all'
@@ -19,27 +16,6 @@ export type TaskTypeFilter =
   | 'all'
 
 export const MAX_TASKS = 200
-const MAX_EFFECTIVE_RUNNING_TASKS = 8
-
-export function getEffectiveTaskStatus(
-  taskItem: TaskRecord,
-  list: TaskRecord[],
-): TaskStatus {
-  const rawStatus = normalizeTaskStatus(taskItem.status)
-  if (rawStatus !== 'running') {
-    return rawStatus
-  }
-  const runningList = list
-    .filter((task) => normalizeTaskStatus(task.status) === 'running')
-    .sort(
-      (left, right) =>
-        Number(left.created_at || 0) - Number(right.created_at || 0),
-    )
-  const index = runningList.findIndex(
-    (task) => task.task_id === taskItem.task_id,
-  )
-  return index >= MAX_EFFECTIVE_RUNNING_TASKS ? 'pending' : 'running'
-}
 
 export async function fetchTasks(
   taskType: TaskTypeFilter,
@@ -50,17 +26,12 @@ export async function fetchTasks(
       query: {
         limit: MAX_TASKS,
         ...(taskType === 'all' ? {} : { task_type: taskType }),
+        ...(status === 'all' ? {} : { status }),
       },
     }),
   )
-  const fetched = normalizeTasks(result).sort(
+  return normalizeTasks(result).sort(
     (left, right) =>
       Number(right.created_at || 0) - Number(left.created_at || 0),
   )
-  if (status !== 'all') {
-    return fetched.filter(
-      (task) => getEffectiveTaskStatus(task, fetched) === status,
-    )
-  }
-  return fetched
 }

--- a/web-studio/src/routes/tasks/route.test.tsx
+++ b/web-studio/src/routes/tasks/route.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+
+import * as React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { TasksRoute } from './route'
+import type { TaskRecord } from './-lib/task-record'
+
+const clientMocks = vi.hoisted(() => ({ getTasks: vi.fn() }))
+
+vi.mock('#/lib/ov-client', () => ({
+  getOvResult: async (value: unknown) => value,
+  getTasks: clientMocks.getTasks,
+  ovClient: { instance: { post: vi.fn() } },
+}))
+
+vi.mock('#/gen/ov-client', () => ({ postResources: vi.fn() }))
+vi.mock('#/lib/sessions/api', () => ({ commitSession: vi.fn() }))
+vi.mock('#/hooks/use-app-connection', () => ({
+  useAppConnection: () => ({ identityScopeKey: 'test/test' }),
+}))
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    i18n: { language: 'en' },
+    t: (key: string, options?: { taskId?: string }) =>
+      key === 'detail.openLabel' ? `Task ${options?.taskId}` : key,
+  }),
+}))
+vi.mock('#/routes/monitoring/-components/queue-status-card', () => ({
+  QueueStatusCard: () => null,
+}))
+vi.mock('#/routes/tasks/-components/task-detail-sheet', () => ({
+  TaskDetailSheet: () => null,
+}))
+
+let records: TaskRecord[]
+const queryClients: QueryClient[] = []
+
+function runningTasks(count: number): TaskRecord[] {
+  return Array.from({ length: count }, (_, index) => ({
+    task_id: `task-${index + 1}`,
+    task_type: index < 8 ? 'session_commit' : 'add_resource',
+    resource_id: `resource-${index + 1}`,
+    status: 'running',
+    created_at: 100 + index,
+  }))
+}
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  queryClients.push(queryClient)
+  render(
+    <QueryClientProvider client={queryClient}>
+      <TasksRoute />
+    </QueryClientProvider>,
+  )
+  return userEvent.setup()
+}
+
+function taskRows() {
+  return screen.queryAllByRole('row', { name: /^Task / })
+}
+
+function expectRunningRows(count: number) {
+  expect(taskRows()).toHaveLength(count)
+  for (const row of taskRows()) {
+    expect(within(row).getByText('status.running')).toBeDefined()
+  }
+}
+
+beforeEach(() => {
+  records = runningTasks(12)
+  clientMocks.getTasks.mockReset()
+  // Model the API contract: filtering precedes ordering and the result limit.
+  clientMocks.getTasks.mockImplementation(({ query }) =>
+    records
+      .filter((task) => !query.status || task.status === query.status)
+      .filter((task) => !query.task_type || task.task_type === query.task_type)
+      .sort((left, right) => Number(right.created_at) - Number(left.created_at))
+      .slice(0, query.limit),
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  for (const client of queryClients.splice(0)) client.clear()
+})
+
+describe('task status presentation', () => {
+  it('keeps all twelve running tasks running in both rows and the count', async () => {
+    renderPage()
+    await screen.findByRole('row', { name: 'Task task-12' })
+
+    expectRunningRows(12)
+    expect(screen.getByText('12 / 0')).toBeDefined()
+  })
+
+  it('shows no pending tasks when all tasks are running, including after type filtering', async () => {
+    const user = renderPage()
+    await screen.findByRole('row', { name: 'Task task-12' })
+
+    await user.click(screen.getByRole('combobox', { name: 'filters.status' }))
+    await user.click(
+      await screen.findByRole('option', { name: 'status.pending' }),
+    )
+    await screen.findByText('emptyFiltered')
+    expect(taskRows()).toHaveLength(0)
+    expect(screen.getByText('0 / 0')).toBeDefined()
+
+    await user.click(screen.getByRole('button', { name: 'filters.clear' }))
+    await screen.findByRole('row', { name: 'Task task-12' })
+    await user.click(screen.getByRole('combobox', { name: 'filters.type' }))
+    await user.click(
+      await screen.findByRole('option', { name: 'types.add_resource' }),
+    )
+    await screen.findByText('4 / 0')
+    expectRunningRows(4)
+  })
+
+  it('counts and filters actual pending tasks without moving running tasks into pending', async () => {
+    records.push(
+      ...[1, 2].map((index) => ({
+        task_id: `pending-${index}`,
+        task_type: 'add_resource',
+        resource_id: `pending-resource-${index}`,
+        status: 'pending',
+        created_at: 200 + index,
+      })),
+    )
+    const user = renderPage()
+    await screen.findByRole('row', { name: 'Task pending-2' })
+    expect(screen.getByText('12 / 2')).toBeDefined()
+
+    await user.click(screen.getByRole('combobox', { name: 'filters.status' }))
+    await user.click(
+      await screen.findByRole('option', { name: 'status.pending' }),
+    )
+    await screen.findByText('0 / 2')
+    expect(taskRows()).toHaveLength(2)
+    for (const row of taskRows()) {
+      expect(within(row).getByText('status.pending')).toBeDefined()
+    }
+  })
+
+  it('preserves task statuses when grouping and pagination change the visible rows', async () => {
+    records = runningTasks(26)
+    records[25].resource_id = records[0].resource_id
+    const user = renderPage()
+    await screen.findByRole('row', { name: 'Task task-26' })
+    expectRunningRows(20)
+    expect(screen.getByText('25 / 0')).toBeDefined()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Latest per Resource' }),
+    )
+    expect(screen.getByText('26 / 0')).toBeDefined()
+    expectRunningRows(20)
+
+    await user.click(screen.getByRole('button', { name: 'Go to next page' }))
+    expectRunningRows(6)
+    expect(screen.getByText('26 / 0')).toBeDefined()
+  })
+})

--- a/web-studio/src/routes/tasks/route.tsx
+++ b/web-studio/src/routes/tasks/route.tsx
@@ -52,7 +52,7 @@ import { TaskDetailSheet } from '#/routes/tasks/-components/task-detail-sheet'
 import { normalizeTaskStatus } from '#/routes/tasks/-lib/task-record'
 import type { TaskRecord } from '#/routes/tasks/-lib/task-record'
 import { formatTaskDuration, getTaskDate } from '#/routes/tasks/-lib/task-time'
-import { fetchTasks, getEffectiveTaskStatus, MAX_TASKS } from './-lib/task-list'
+import { fetchTasks, MAX_TASKS } from './-lib/task-list'
 import type { TaskStatusFilter, TaskTypeFilter } from './-lib/task-list'
 import { getTaskPipelineGroups } from './-lib/task-pipeline'
 
@@ -81,7 +81,7 @@ const TASK_STATUS_OPTIONS: Exclude<TaskStatusFilter, 'all'>[] = [
   'cancelled',
 ]
 
-function TasksRoute() {
+export function TasksRoute() {
   const { i18n, t } = useTranslation('tasksPage')
   const { identityScopeKey } = useAppConnection()
   const queryClient = useQueryClient()
@@ -265,9 +265,7 @@ function TasksRoute() {
 
   const renderStatus = (task: TaskRecord) => {
     const taskId = task.task_id
-    // 使用基于 8 并发算力的物理有效状态判定
-    const effStatus = getEffectiveTaskStatus(task, allTasks)
-    const status = normalizeTaskStatus(effStatus)
+    const status = normalizeTaskStatus(task.status)
     const pct = getTaskProgressPct(task)
     const isRetrying = retryMutation.isPending && retryMutation.variables.task_id === taskId
     const Icon =
@@ -297,11 +295,7 @@ function TasksRoute() {
               : 'size-3.5'
           }
         />
-        <span>
-          {status === 'pending'
-            ? (i18n.language.startsWith('zh') ? '队首等待中' : 'Queued')
-            : t(`status.${status}`)}
-        </span>
+        <span>{t(`status.${status}`)}</span>
         {status === 'running' && (
           <span className="font-mono font-semibold ml-0.5">
             {pct}%
@@ -477,20 +471,15 @@ function TasksRoute() {
     const completed = allTasks.filter(
       (item) => normalizeTaskStatus(item.status) === 'completed',
     ).length
-    const rawRunning = allTasks.filter(
+    const running = allTasks.filter(
       (item) => normalizeTaskStatus(item.status) === 'running',
     ).length
-    const rawPending = allTasks.filter(
+    const pending = allTasks.filter(
       (item) => normalizeTaskStatus(item.status) === 'pending',
     ).length
     const failed = allTasks.filter(
       (item) => normalizeTaskStatus(item.status) === 'failed',
     ).length
-
-    // 物理硬件与底层并发槽位限制：Embedding 槽位上限为 8
-    const MAX_CONCURRENT_CAP = 8
-    const running = Math.min(rawRunning, MAX_CONCURRENT_CAP)
-    const pending = rawPending + Math.max(0, rawRunning - MAX_CONCURRENT_CAP)
 
     const successRate = total > 0 ? (completed / total) * 100 : 100
 


### PR DESCRIPTION
## Description / 变更说明

**中文**

API 返回 12 条 `running` 记录时，Studio 显示 8 条运行中、4 条等待中；选择等待中后，这 4 条记录又显示为运行中。选择失败状态时，也可能漏掉排在 200 条较新已完成记录之后、仍被后端保留的失败任务。

本次修复使 `/studio/tasks` 的行标签、运行中 / 等待中计数和状态筛选请求统一使用后端任务状态。`fetchTasks` 传递 API 已有的 `status` 参数，由后端先筛选、再应用 200 条结果限制；删除前端基于列表位置推算状态的逻辑，以及独立的 8 条任务计数上限。

**English**

With 12 API records marked `running`, Studio displayed 8 running and 4 pending; filtering Pending then displayed those four records as Running. Selecting Failed could also miss a retained failure behind 200 newer completed records.

This fixes `/studio/tasks` to use backend task statuses consistently for row labels, Running / Pending counts, and status-filtered queries. `fetchTasks` sends the existing `status` query parameter so the server filters before applying its 200-record limit. The frontend's list-position heuristic and separate eight-task count cap are removed.

## Human Involvement / 人工参与

- [x] A human participated in the implementation or review loop / 有人参与实现或评审过程
- [ ] This PR was generated entirely by AI agents without human participation in the loop / 此 PR 完全由 AI 生成，无人参与实现或评审过程

## Related Issue / 关联问题

Fixes #4821

## Type of Change / 变更类型

- [x] Bug fix (non-breaking change that fixes an issue) / Bug 修复（不破坏兼容性）
- [ ] New feature (non-breaking change that adds functionality) / 新功能（不破坏兼容性）
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) / 破坏性变更
- [ ] Documentation update / 文档更新
- [ ] Refactoring (no functional changes) / 重构（不改变功能）
- [ ] Performance improvement / 性能改进
- [x] Test update / 测试更新

## Changes Made / 主要改动

**中文**

- 将选中的任务类型和状态传给现有任务列表 API；对响应进行规范化和排序，不再在本地重新推算或筛选任务状态。
- 根据规范化后的任务状态渲染行标签并统计运行中 / 等待中数量，等待中标签复用现有翻译。
- 用“200 条已完成记录之后的旧失败任务”回归用例替换原先要求第 9 条运行中记录变为等待中的测试；新增页面级回归，覆盖超过 8 条运行中记录、真实等待中记录、状态与类型筛选、资源分组和分页。

**English**

- Pass selected task type and status to the existing task-list API; normalize and sort the response without reclassifying or filtering its statuses locally.
- Render row labels and count Running / Pending from normalized task statuses, using the existing localized pending label.
- Replace the test that expected the ninth running record to become pending with coverage for a retained failure behind 200 completed records. Add page-level regressions covering more than eight running records, genuine pending records, status/type filters, resource grouping, and pagination.

## Testing / 验证结果

**中文**

在 macOS 上使用 Node **24.19.0**，于 `web-studio` 目录执行下方命令：

- 专项测试 **8 项通过**；完整 Studio 测试 **63 个文件、308 项全部通过**；生产构建通过。
- 改动文件 ESLint **0 个错误**；`route.tsx` 保留 34 条既有警告，基线为 36 条。任务列表文件和新增页面测试通过 Prettier；路由文件保留原有格式。构建仍有既有的大文件分块警告。
- 使用本地已部署 Studio 构建和受控 GET 任务接口响应验证：12 条运行中记录显示 `12 / 0`，等待中筛选为空；加入 2 条真实等待中记录后显示 `12 / 2`，等待中筛选恰好返回 2 行。验证后已移除临时响应替换。
- 200 条限制场景通过实际前端任务列表函数和遵循后端“先筛选、再限制数量”规则的 Mock 验证，并核对了后端实现中的执行顺序。本次前端修改未验证模型工作进程的实际并发，也未运行完整 Python 测试。

**English**

- [x] I have added tests that prove my fix is effective or that my feature works / 已添加验证修复有效性的测试
- [x] New and existing unit tests pass locally with my changes / 新增和既有单元测试均在本地通过
- [x] I have tested this on the following platforms: / 已在以下平台测试：
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Run from `web-studio` with Node **24.19.0**:

```sh
npm test -- src/routes/tasks/-lib/task-list.test.ts src/routes/tasks/route.test.tsx
npm test
npm run build -- --base=/studio/
./node_modules/.bin/eslint src/routes/tasks/-lib/task-list.ts src/routes/tasks/-lib/task-list.test.ts src/routes/tasks/route.tsx src/routes/tasks/route.test.tsx --format json
./node_modules/.bin/prettier --check src/routes/tasks/-lib/task-list.ts src/routes/tasks/-lib/task-list.test.ts src/routes/tasks/route.test.tsx
git diff --check
```

- Focused tests: **8 passed**. Full Studio suite: **63 files, 308 tests passed**. Production build passed.
- Changed-file ESLint: **0 errors**; `route.tsx` has 34 existing warnings, down from 36 on the base. Prettier passed for the task-list files and new page test; the route retains its existing formatting. The build retains the existing large-chunk warning.
- Browser validation used the locally deployed Studio build with controlled GET task-response fixtures: 12 running records produce `12 / 0`; Pending is empty; adding two genuine pending records produces `12 / 2` and exactly two Pending rows. The temporary response override was removed afterward.
- The 200-record case is covered through the real frontend task-list function with a mock implementing the server's filter-before-limit contract. The server implementation was inspected to confirm that ordering. Model-worker concurrency and the full Python suite were not exercised for this frontend change.

## Checklist / 检查清单

- [x] My code follows the project's coding style / 代码遵循项目风格
- [x] I have performed a self-review of my code / 已完成代码自审
- [x] I have commented my code, particularly in hard-to-understand areas / 已为需要解释的代码添加注释
- [ ] I have made corresponding changes to the documentation / 已更新对应文档
- [x] My changes generate no new warnings / 改动未引入新警告
- [x] Any dependent changes have been merged and published / 依赖的改动均已合并并发布

## Screenshots (if applicable) / 截图（如适用）

**中文**

以上浏览器验证说明了实际观察到的修复前后行为，未附加截图。

**English**

The browser checks above describe the observed before/after behavior; no screenshots are attached.

## Additional Notes / 补充说明

**中文**

任务 API 已支持 `status`；响应结构和 200 条结果限制保持不变。计数范围仍为当前筛选并按资源分组后的任务列表。本次修复不需要迁移或新增依赖；作为现有状态行为的纠正，无需修改使用文档。

**English**

The task API already accepts `status`; the response shape and 200-record limit are unchanged. Counts retain their existing scope: the current filtered and resource-grouped task list. No migration or additional dependency is required. Documentation changes are not needed for this correction to existing status behavior.
