### PR TITLE
fix(web-studio): honor task API status instead of inventing pending

### DIFF
--- a/web-studio/src/routes/tasks/-lib/task-list.test.ts
+++ b/web-studio/src/routes/tasks/-lib/task-list.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { fetchTasks, MAX_TASKS } from './task-list'
+import { fetchTasks, getEffectiveTaskStatus, MAX_TASKS } from './task-list'
 
 const clientMocks = vi.hoisted(() => ({
   getTasks: vi.fn(),
@@ -51,21 +51,37 @@ describe('task list requests', () => {
     })
   })
 
-  it('keeps effective status filtering on the client', async () => {
-    clientMocks.getTasks.mockResolvedValue(
-      Array.from({ length: 9 }, (_, index) => ({
-        created_at: index + 1,
-        status: 'running',
-        task_id: `task-${index + 1}`,
-      })),
-    )
+  it('sends status to the API before the result limit is applied', async () => {
+    clientMocks.getTasks.mockResolvedValue([
+      {
+        created_at: 1,
+        status: 'failed',
+        task_id: 'old-failed',
+      },
+    ])
 
-    await expect(fetchTasks('all', 'pending')).resolves.toEqual([
-      expect.objectContaining({ task_id: 'task-9' }),
+    await expect(fetchTasks('session_commit', 'failed')).resolves.toEqual([
+      expect.objectContaining({ task_id: 'old-failed' }),
     ])
     expect(clientMocks.getTasks).toHaveBeenCalledWith({
-      query: { limit: MAX_TASKS },
+      query: {
+        limit: MAX_TASKS,
+        status: 'failed',
+        task_type: 'session_commit',
+      },
     })
+  })
+
+  it('does not reclassify surplus running tasks as pending', () => {
+    const tasks = Array.from({ length: 12 }, (_, index) => ({
+      created_at: index + 1,
+      status: 'running' as const,
+      task_id: `task-${index + 1}`,
+    }))
+
+    expect(tasks.map((task) => getEffectiveTaskStatus(task, tasks))).toEqual(
+      Array.from({ length: 12 }, () => 'running'),
+    )
   })
 
   it('propagates request failures to the query error state', async () => {

--- a/web-studio/src/routes/tasks/-lib/task-list.ts
+++ b/web-studio/src/routes/tasks/-lib/task-list.ts
@@ -19,26 +19,13 @@ export type TaskTypeFilter =
   | 'all'
 
 export const MAX_TASKS = 200
-const MAX_EFFECTIVE_RUNNING_TASKS = 8
 
+/** Prefer the API status; do not invent pending from a running-slot cap. */
 export function getEffectiveTaskStatus(
   taskItem: TaskRecord,
-  list: TaskRecord[],
+  _list?: TaskRecord[],
 ): TaskStatus {
-  const rawStatus = normalizeTaskStatus(taskItem.status)
-  if (rawStatus !== 'running') {
-    return rawStatus
-  }
-  const runningList = list
-    .filter((task) => normalizeTaskStatus(task.status) === 'running')
-    .sort(
-      (left, right) =>
-        Number(left.created_at || 0) - Number(right.created_at || 0),
-    )
-  const index = runningList.findIndex(
-    (task) => task.task_id === taskItem.task_id,
-  )
-  return index >= MAX_EFFECTIVE_RUNNING_TASKS ? 'pending' : 'running'
+  return normalizeTaskStatus(taskItem.status)
 }
 
 export async function fetchTasks(
@@ -50,17 +37,12 @@ export async function fetchTasks(
       query: {
         limit: MAX_TASKS,
         ...(taskType === 'all' ? {} : { task_type: taskType }),
+        ...(status === 'all' ? {} : { status }),
       },
     }),
   )
-  const fetched = normalizeTasks(result).sort(
+  return normalizeTasks(result).sort(
     (left, right) =>
       Number(right.created_at || 0) - Number(left.created_at || 0),
   )
-  if (status !== 'all') {
-    return fetched.filter(
-      (task) => getEffectiveTaskStatus(task, fetched) === status,
-    )
-  }
-  return fetched
 }

--- a/web-studio/src/routes/tasks/route.tsx
+++ b/web-studio/src/routes/tasks/route.tsx
@@ -52,7 +52,7 @@ import { TaskDetailSheet } from '#/routes/tasks/-components/task-detail-sheet'
 import { normalizeTaskStatus } from '#/routes/tasks/-lib/task-record'
 import type { TaskRecord } from '#/routes/tasks/-lib/task-record'
 import { formatTaskDuration, getTaskDate } from '#/routes/tasks/-lib/task-time'
-import { fetchTasks, getEffectiveTaskStatus, MAX_TASKS } from './-lib/task-list'
+import { fetchTasks, MAX_TASKS } from './-lib/task-list'
 import type { TaskStatusFilter, TaskTypeFilter } from './-lib/task-list'
 import { getTaskPipelineGroups } from './-lib/task-pipeline'
 
@@ -265,9 +265,7 @@ function TasksRoute() {
 
   const renderStatus = (task: TaskRecord) => {
     const taskId = task.task_id
-    // 使用基于 8 并发算力的物理有效状态判定
-    const effStatus = getEffectiveTaskStatus(task, allTasks)
-    const status = normalizeTaskStatus(effStatus)
+    const status = normalizeTaskStatus(task.status)
     const pct = getTaskProgressPct(task)
     const isRetrying = retryMutation.isPending && retryMutation.variables.task_id === taskId
     const Icon =
@@ -487,10 +485,9 @@ function TasksRoute() {
       (item) => normalizeTaskStatus(item.status) === 'failed',
     ).length
 
-    // 物理硬件与底层并发槽位限制：Embedding 槽位上限为 8
-    const MAX_CONCURRENT_CAP = 8
-    const running = Math.min(rawRunning, MAX_CONCURRENT_CAP)
-    const pending = rawPending + Math.max(0, rawRunning - MAX_CONCURRENT_CAP)
+    // Reflect API statuses; do not invent pending from an 8-slot running cap.
+    const running = rawRunning
+    const pending = rawPending
 
     const successRate = total > 0 ? (completed / total) * 100 : 100
 


### PR DESCRIPTION
<!-- require-linked-issue -->
Fixes #4821

## Summary
Web Studio Task Center was disagreeing with the task API in two ways:

1. `getEffectiveTaskStatus` reclassified running records with index ≥ 8 as `pending`, which also skewed KPI Running/Pending counts.
2. `fetchTasks` fetched at most 200 unfiltered rows and filtered status on the client, so older retained failures could be dropped even when `GET /api/v1/tasks?status=failed` would return them.

## Changes
- Pass `status` (and keep `task_type`) through to the generated `getTasks` client so the server filters before applying `limit`.
- Make `getEffectiveTaskStatus` return the normalized API status (no invented pending).
- Use API statuses for row labels and Active/Pending KPI counts.
- Update unit tests accordingly.

## Test plan
- [x] `task-list.test.ts`: status query forwarded; 12 running records stay running
- [ ] Manual: `/studio/tasks` with >8 running tasks shows matching Running count / empty Pending
- [ ] Manual: Failed filter still finds an older retained failure when many newer completed tasks exist
