### PR TITLE
fix(windows): probe PID liveness without sending Ctrl+C

### DIFF
--- a/openviking/utils/process_lock.py
+++ b/openviking/utils/process_lock.py
@@ -44,10 +44,41 @@ def _read_pid_file(lock_path: str) -> int:
         return 0
 
 
+def _windows_is_pid_alive(pid: int) -> bool:
+    """Side-effect-free Windows PID liveness check.
+
+    ``os.kill(pid, 0)`` maps to ``CTRL_C_EVENT`` on Windows and can interrupt a
+    shared console. Use a ``SYNCHRONIZE`` process handle instead (see #4764).
+    """
+    import _winapi
+
+    handle = None
+    try:
+        try:
+            handle = _winapi.OpenProcess(_winapi.SYNCHRONIZE, False, pid)
+        except OSError as exc:
+            # Access denied: process may still be alive; keep the lock.
+            if getattr(exc, "winerror", None) == 5:
+                return True
+            # Missing / invalid PID (e.g. WinError 87) → treat as stale.
+            return False
+        # WAIT_TIMEOUT means the process has not exited yet.
+        return _winapi.WaitForSingleObject(handle, 0) == _winapi.WAIT_TIMEOUT
+    finally:
+        if handle is not None:
+            try:
+                _winapi.CloseHandle(handle)
+            except OSError:
+                pass
+
+
 def _is_pid_alive(pid: int) -> bool:
     """Check whether a process with the given PID is still running."""
     if pid <= 0:
         return False
+    if sys.platform == "win32":
+        return _windows_is_pid_alive(pid)
+
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -55,9 +86,7 @@ def _is_pid_alive(pid: int) -> bool:
     except PermissionError:
         # Process exists but we can't signal it.
         pass
-    except (OSError, SystemError):
-        if sys.platform == "win32":
-            return False
+    except SystemError:
         raise
 
     # PID exists, but on Linux PIDs are recycled. Verify this is actually

--- a/tests/unit/test_process_lock.py
+++ b/tests/unit/test_process_lock.py
@@ -96,16 +96,90 @@ class TestIsPidAlive:
         """Test that negative PID is not alive."""
         assert _is_pid_alive(-1) is False
 
-    def test_windows_system_error_treated_as_stale(self, monkeypatch):
-        """Windows SystemError from os.kill(pid, 0) should be treated as stale."""
+    def test_windows_liveness_never_calls_os_kill(self, monkeypatch):
+        """Windows liveness must not use os.kill (signal 0 == CTRL_C_EVENT)."""
 
-        def _raise_system_error(_pid: int, _sig: int) -> None:
-            raise SystemError("win32 wrapper failure")
+        def _boom(_pid: int, _sig: int) -> None:
+            raise AssertionError("os.kill must not be used for Windows PID checks")
+
+        class _FakeWinApi:
+            SYNCHRONIZE = 0x00100000
+            WAIT_TIMEOUT = 0x00000102
+            WAIT_OBJECT_0 = 0
+
+            @staticmethod
+            def OpenProcess(_access: int, _inherit: bool, _pid: int) -> int:
+                return 1
+
+            @staticmethod
+            def WaitForSingleObject(_handle: int, _timeout: int) -> int:
+                return _FakeWinApi.WAIT_TIMEOUT
+
+            @staticmethod
+            def CloseHandle(_handle: int) -> None:
+                return None
 
         monkeypatch.setattr(process_lock_module.sys, "platform", "win32")
-        monkeypatch.setattr(process_lock_module.os, "kill", _raise_system_error)
+        monkeypatch.setattr(process_lock_module.os, "kill", _boom)
+        monkeypatch.setitem(__import__("sys").modules, "_winapi", _FakeWinApi)
+
+        assert _is_pid_alive(os.getpid()) is True
+
+    def test_windows_missing_pid_treated_as_stale(self, monkeypatch):
+        """OpenProcess failure (e.g. WinError 87) means the PID is gone."""
+
+        err = OSError(87, "The parameter is incorrect")
+        err.winerror = 87
+
+        class _FakeWinApi:
+            SYNCHRONIZE = 0x00100000
+            WAIT_TIMEOUT = 0x00000102
+            WAIT_OBJECT_0 = 0
+
+            @staticmethod
+            def OpenProcess(_access: int, _inherit: bool, _pid: int) -> int:
+                raise err
+
+            @staticmethod
+            def WaitForSingleObject(_handle: int, _timeout: int) -> int:
+                raise AssertionError("should not wait without a handle")
+
+            @staticmethod
+            def CloseHandle(_handle: int) -> None:
+                raise AssertionError("should not close without a handle")
+
+        monkeypatch.setattr(process_lock_module.sys, "platform", "win32")
+        monkeypatch.setitem(__import__("sys").modules, "_winapi", _FakeWinApi)
 
         assert _is_pid_alive(12345) is False
+
+    def test_windows_access_denied_keeps_lock(self, monkeypatch):
+        """Access denied must not reclaim the lock; process may still be alive."""
+
+        err = OSError(5, "Access is denied")
+        err.winerror = 5
+
+        class _FakeWinApi:
+            SYNCHRONIZE = 0x00100000
+            WAIT_TIMEOUT = 0x00000102
+            WAIT_OBJECT_0 = 0
+
+            @staticmethod
+            def OpenProcess(_access: int, _inherit: bool, _pid: int) -> int:
+                raise err
+
+            @staticmethod
+            def WaitForSingleObject(_handle: int, _timeout: int) -> int:
+                raise AssertionError("unreachable")
+
+            @staticmethod
+            def CloseHandle(_handle: int) -> None:
+                raise AssertionError("unreachable")
+
+        monkeypatch.setattr(process_lock_module.sys, "platform", "win32")
+        monkeypatch.setitem(__import__("sys").modules, "_winapi", _FakeWinApi)
+
+        assert _is_pid_alive(12345) is True
 
     def test_non_windows_system_error_bubbles_up(self, monkeypatch):
         """Non-Windows should not downgrade unexpected SystemError values."""
@@ -219,17 +293,34 @@ class TestAcquireDataDirLock:
         error_msg = str(exc_info.value)
         assert str(tmp_path) in error_msg
 
-    def test_acquire_overwrites_windows_stale_lock_on_system_error(
+    def test_acquire_overwrites_windows_stale_lock_when_pid_missing(
         self, tmp_path: Path, monkeypatch
     ):
-        """Windows stale lock should be reclaimed when os.kill raises SystemError."""
+        """Windows stale lock should be reclaimed when OpenProcess says PID is gone."""
 
-        def _raise_system_error(_pid: int, _sig: int) -> None:
-            raise SystemError("win32 wrapper failure")
+        err = OSError(87, "The parameter is incorrect")
+        err.winerror = 87
+
+        class _FakeWinApi:
+            SYNCHRONIZE = 0x00100000
+            WAIT_TIMEOUT = 0x00000102
+            WAIT_OBJECT_0 = 0
+
+            @staticmethod
+            def OpenProcess(_access: int, _inherit: bool, _pid: int) -> int:
+                raise err
+
+            @staticmethod
+            def WaitForSingleObject(_handle: int, _timeout: int) -> int:
+                raise AssertionError("unreachable")
+
+            @staticmethod
+            def CloseHandle(_handle: int) -> None:
+                raise AssertionError("unreachable")
 
         (tmp_path / LOCK_FILENAME).write_text("12345")
         monkeypatch.setattr(process_lock_module.sys, "platform", "win32")
-        monkeypatch.setattr(process_lock_module.os, "kill", _raise_system_error)
+        monkeypatch.setitem(__import__("sys").modules, "_winapi", _FakeWinApi)
 
         acquire_data_dir_lock(str(tmp_path))
 


### PR DESCRIPTION
<!-- require-linked-issue -->
Fixes #4764

## Summary
On Windows, `_is_pid_alive()` used `os.kill(pid, 0)`. Signal value `0` maps to `CTRL_C_EVENT`, so probing `.openviking.pid` can interrupt OpenViking or its parent console when they share a process group.

## Changes
- Windows path: open the PID with `_winapi.OpenProcess(SYNCHRONIZE)`, query with `WaitForSingleObject(handle, 0)`, always `CloseHandle`.
- Access denied (`WinError 5`) keeps the lock (process may still be alive); missing/invalid PID reclaim as stale.
- Non-Windows path unchanged (`os.kill` + Linux `/proc` cmdline check).
- Unit tests: assert `os.kill` is never used under a Windows platform stub; cover missing PID / access-denied / lock reclaim.

## Test plan
- [x] Unit tests with fake `_winapi` (Linux CI can exercise the Windows branch)
- [ ] On a real Windows console: second OpenViking against the same data dir must not deliver Ctrl+C to the first process
