### PR TITLE
fix(server): accept slash in X-Request-ID and regenerate invalid ids instead of 400

### DIFF
--- a/openviking/server/request_id.py
+++ b/openviking/server/request_id.py
@@ -10,25 +10,20 @@ import re
 import time
 import uuid
 
-from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from openviking_cli.utils.logger import bind_log_request_id
 
 REQUEST_ID_HEADER = "X-Request-ID"
 _REQUEST_ID_HEADER_BYTES = b"x-request-id"
-_REQUEST_ID_PATTERN = re.compile(r"[A-Za-z0-9._:-]{1,128}")
+_REQUEST_ID_PATTERN = re.compile(r"[A-Za-z0-9._:/-]{1,128}")
 _IGNORED_COMPLETION_ROUTES = frozenset({"/health", "/ready", "/metrics"})
 
 _completion_logger = logging.getLogger("openviking.observability.http")
 
 
 def _resolve_request_id(scope: Scope) -> tuple[str, bool]:
-    values = [
-        value
-        for name, value in scope["headers"]
-        if name.lower() == _REQUEST_ID_HEADER_BYTES
-    ]
+    values = [value for name, value in scope["headers"] if name.lower() == _REQUEST_ID_HEADER_BYTES]
     invalid = bool(values)
     if len(values) == 1:
         try:
@@ -80,22 +75,15 @@ class RequestIdMiddleware:
         with bind_log_request_id(request_id):
             try:
                 if invalid:
-                    response = JSONResponse(
-                        status_code=400,
-                        content={
-                            "status": "error",
-                            "error": {
-                                "code": "INVALID_ARGUMENT",
-                                "message": (
-                                    "X-Request-ID must be supplied once and contain 1-128 "
-                                    "characters from [A-Za-z0-9._:-]"
-                                ),
-                            },
-                        },
+                    # Regenerated ids from _resolve_request_id are used as-is;
+                    # reject-by-HTTP-400 broke legitimate gateways (e.g. OpenAI
+                    # Secure MCP Tunnel) that forward trace ids like
+                    # "<uuid>/<suffix>". Never log the raw invalid value.
+                    _completion_logger.warning(
+                        "HTTP request arrived with missing or invalid "
+                        "X-Request-ID header; generated replacement"
                     )
-                    await response(scope, receive, send_with_request_id)
-                else:
-                    await self.app(scope, receive, send_with_request_id)
+                await self.app(scope, receive, send_with_request_id)
             finally:
                 if scope["path"] not in _IGNORED_COMPLETION_ROUTES:
                     duration_ms = (time.perf_counter() - started_at) * 1000

--- a/tests/server/test_request_id.py
+++ b/tests/server/test_request_id.py
@@ -99,7 +99,7 @@ async def test_missing_request_id_generates_uuid_for_health_and_cors_exposes_it(
     assert REQUEST_ID_HEADER.lower() in response.headers["Access-Control-Expose-Headers"].lower()
 
 
-async def test_invalid_request_ids_are_rejected_without_logging_raw_values() -> None:
+async def test_invalid_request_ids_are_replaced_without_logging_raw_values() -> None:
     app = _make_test_app()
     records: list[logging.LogRecord] = []
     server_logger = logging.getLogger("openviking")
@@ -117,16 +117,32 @@ async def test_invalid_request_ids_are_rejected_without_logging_raw_values() -> 
     finally:
         server_logger.removeHandler(handler)
 
-    assert all(response.status_code == 400 for response in responses)
-    assert all(response.json()["error"]["code"] == "INVALID_ARGUMENT" for response in responses)
+    assert all(response.status_code == 404 for response in responses)
     for response in responses:
         _assert_generated_request_id(response.headers[REQUEST_ID_HEADER])
     completion_records = [
         record for record in records if record.name == "openviking.observability.http"
     ]
     assert all(record.request_id for record in completion_records)
-    rendered = "\n".join(record.getMessage() for record in completion_records)
+    rendered = "\n".join(record.getMessage() for record in records)
     assert all(raw not in rendered for raw in ("contains spaces", "x" * 129, "first", "second"))
+
+
+async def test_request_id_with_slash_suffix_is_accepted_verbatim() -> None:
+    app = _make_test_app()
+
+    @app.get("/items/{item_id}")
+    async def item(item_id: str):
+        return {"item_id": item_id}
+
+    response = await _request(
+        app,
+        "/items/42",
+        headers={REQUEST_ID_HEADER: "4257d51f-61c7-49d4-b78d-773e19a2c461/g6hr"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers[REQUEST_ID_HEADER] == "4257d51f-61c7-49d4-b78d-773e19a2c461/g6hr"
 
 
 async def test_unhandled_500_keeps_request_id_for_log_and_response(monkeypatch) -> None:


### PR DESCRIPTION
## Description

`RequestIdMiddleware` (`openviking/server/request_id.py`) rejects any `X-Request-Id` containing `/` with HTTP 400 `INVALID_ARGUMENT`. OpenAI Secure MCP Tunnel forwards ids formatted `<uuid>/<suffix>`, so every MCP request through the tunnel fails and ChatGPT/Codex connectors cannot be created against OpenViking. Full capture and repro in #4830.

Before: request with `X-Request-Id: <uuid>/<suffix>` → 400 `INVALID_ARGUMENT`.
After: the id is accepted verbatim; genuinely invalid ids (empty, whitespace, >128 chars, duplicate headers) are replaced by a generated uuid4 with a warning log — consistent with the missing-header path. Invalid raw values are still never logged.

## Human Involvement

- [x] A human participated in the implementation or review loop

## Related Issue

Fixes #4830

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `_REQUEST_ID_PATTERN`: allow `/` → `[A-Za-z0-9._:/-]{1,128}` (still capped at 128 chars)
- Middleware: replace the 400 rejection with a warning log; the regenerated id from `_resolve_request_id` is used as-is (no new mechanism — reuses the existing regeneration path)
- Removed the now-unused `JSONResponse` import
- Updated `tests/server/test_request_id.py`: invalid ids are replaced (generated id returned, no raw values logged) and a slash-suffixed id is echoed verbatim

## Testing

Root cause captured from live traffic between tunnel-client v0.0.14 and OpenViking v0.4.17.1 (tcpdump); reproduction in #4830.

Validation run against the patched files mounted into the official `ghcr.io/volcengine/openviking:latest` image:

```
/app/.venv/bin/python -m pytest tests/server/test_request_id.py -q -o addopts="" -o asyncio_mode=auto
# 7 passed
ruff format --check openviking/server/request_id.py tests/server/test_request_id.py  # pass
ruff check openviking/server/request_id.py tests/server/test_request_id.py           # pass
```

Skipped: `mypy` and the full `uv run pytest` suite — they require a complete `uv sync --all-extras` environment with native builds that was not available in the validation container; the focused middleware tests above pass against the official image.