### PR TITLE
fix(tasks): 兼容并保留历史任务记录中的扩展字段

### DIFF
--- a/openviking/service/task_store.py
+++ b/openviking/service/task_store.py
@@ -174,6 +174,7 @@ class PersistentTaskStore:
 def _task_to_payload(task: Any) -> Dict[str, Any]:
     status = getattr(task, "status", None)
     return {
+        **deepcopy(getattr(task, "_extra_fields", {})),
         "task_id": task.task_id,
         "task_type": task.task_type,
         "status": status.value if hasattr(status, "value") else status,

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -19,7 +19,7 @@ import re
 import threading
 import time
 from copy import deepcopy
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional
@@ -82,10 +82,14 @@ class TaskRecord:
     result: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
     auth: Dict[str, Any] = field(default_factory=dict, repr=False)
+    _extra_fields: Dict[str, Any] = field(
+        default_factory=dict, init=False, repr=False, compare=False
+    )
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize for JSON response."""
         d = asdict(self)
+        d.pop("_extra_fields", None)
         d["status"] = self.status.value
         d["created_at_iso"] = datetime.fromtimestamp(self.created_at, tz=timezone.utc).isoformat()
         d["updated_at_iso"] = datetime.fromtimestamp(self.updated_at, tz=timezone.utc).isoformat()
@@ -1083,9 +1087,15 @@ class TaskTracker:
 
     @staticmethod
     def _record_from_payload(payload: Dict[str, Any]) -> TaskRecord:
-        data = dict(payload)
+        known_fields = {item.name for item in fields(TaskRecord) if item.init}
+        data = {key: deepcopy(value) for key, value in payload.items() if key in known_fields}
         data["status"] = TaskStatus(data["status"])
-        return TaskRecord(**data)
+        record = TaskRecord(**data)
+        # Keep fields from other writers for the next persistence update.
+        record._extra_fields = {
+            key: deepcopy(value) for key, value in payload.items() if key not in known_fields
+        }
+        return record
 
     async def _load_from_store(
         self,

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -19,7 +19,7 @@ import re
 import threading
 import time
 from copy import deepcopy
-from dataclasses import asdict, dataclass, field, fields
+from dataclasses import dataclass, field, fields
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional
@@ -88,17 +88,20 @@ class TaskRecord:
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize for JSON response."""
-        d = asdict(self)
-        d.pop("_extra_fields", None)
-        d["status"] = self.status.value
-        d["created_at_iso"] = datetime.fromtimestamp(self.created_at, tz=timezone.utc).isoformat()
-        d["updated_at_iso"] = datetime.fromtimestamp(self.updated_at, tz=timezone.utc).isoformat()
-        d["result"] = _sanitize_task_result(d.get("result"))
-        d["meta"] = _sanitize_task_result(d.get("meta"))
-        d.pop("auth", None)
-        d.pop("account_id", None)
-        d.pop("user_id", None)
-        return d
+        return {
+            "task_id": self.task_id,
+            "task_type": self.task_type,
+            "status": self.status.value,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "resource_id": self.resource_id,
+            "meta": _sanitize_task_result(deepcopy(self.meta)),
+            "stage": self.stage,
+            "result": _sanitize_task_result(deepcopy(self.result)),
+            "error": self.error,
+            "created_at_iso": datetime.fromtimestamp(self.created_at, tz=timezone.utc).isoformat(),
+            "updated_at_iso": datetime.fromtimestamp(self.updated_at, tz=timezone.utc).isoformat(),
+        }
 
 
 # ── Singleton ──

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -5,13 +5,14 @@
 
 import json
 import time
+from copy import deepcopy
 
 import pytest
 
 from openviking.pyagfs.exceptions import AGFSAlreadyExistsError
 from openviking.server.identity import RequestContext, Role
 from openviking.service.session_service import SessionService
-from openviking.service.task_store import PersistentTaskStore
+from openviking.service.task_store import PersistentTaskStore, _task_to_payload
 from openviking.service.task_tracker import (
     TaskStatus,
     TaskTracker,
@@ -577,6 +578,78 @@ async def test_persistent_store_cross_tracker_visibility():
     assert loaded is not None
     assert loaded.status == TaskStatus.COMPLETED
     assert loaded.result == {"ok": True}
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {
+            "operation_id": "operation-1",
+            "parent_task_id": "parent-1",
+            "attempt_number": 2,
+            "error_info": {"category": "network", "retryable": True},
+        },
+        {"future_field": {"values": [1, 2]}, "_extra_fields": {"reserved": True}},
+    ],
+)
+async def test_persistent_task_extensions_survive_updates(extra):
+    agfs = _FakeAgfs()
+    store = PersistentTaskStore(agfs)
+    writer = TaskTracker(store=store)
+    task = await writer.create("session_commit", **_owner_kwargs())
+    path = f"/local/acme/_system/tasks/alice/{task.task_id}.json"
+    payload = json.loads(agfs.files[path])
+    payload.update(extra)
+    agfs.files[path] = json.dumps(payload).encode()
+    original = agfs.files[path]
+
+    reader = TaskTracker(store=store)
+    loaded = await reader.get(task.task_id, **_owner_kwargs())
+    assert loaded is not None
+    assert loaded.status == TaskStatus.PENDING
+    assert not (set(extra) & set(loaded.to_dict()))
+    assert len(await reader.list_tasks(**_owner_kwargs())) == 1
+    assert await reader.get(task.task_id, account_id="acme", user_id="bob") is None
+    assert agfs.files[path] == original
+
+    await reader.start(task.task_id, **_owner_kwargs())
+    await reader.complete(task.task_id, {"ok": True}, **_owner_kwargs())
+    saved = json.loads(agfs.files[path])
+    assert saved["status"] == "completed"
+    assert saved["result"] == {"ok": True}
+    assert {key: saved[key] for key in extra} == extra
+    reloaded = await TaskTracker(store=store).get(task.task_id, **_owner_kwargs())
+    assert reloaded is not None
+    assert reloaded.status == TaskStatus.COMPLETED
+    assert {key: _task_to_payload(reloaded)[key] for key in extra} == extra
+
+
+async def test_task_extension_payload_is_defensively_copied():
+    payload = {
+        "task_id": "task-1",
+        "task_type": "session_commit",
+        "status": "pending",
+        "future_field": {"values": [1]},
+        "meta": {"values": [2]},
+    }
+    original = deepcopy(payload)
+    record = TaskTracker._record_from_payload(payload)
+    record._extra_fields["future_field"]["values"].append(3)
+    record.meta["values"].append(4)
+    assert payload == original
+    saved = _task_to_payload(record)
+    saved["future_field"]["values"].append(5)
+    assert record._extra_fields["future_field"]["values"] == [1, 3]
+    record._extra_fields["status"] = "failed"
+    assert _task_to_payload(record)["status"] == "pending"
+
+
+@pytest.mark.parametrize("status", ["unknown", None])
+async def test_task_extensions_do_not_hide_invalid_status(status):
+    with pytest.raises(ValueError):
+        TaskTracker._record_from_payload(
+            {"task_id": "task-1", "task_type": "session_commit", "status": status, "extra": 1}
+        )
 
 
 async def test_persistent_store_writes_task_record_json():

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -456,6 +456,43 @@ async def test_to_dict(tracker: TaskTracker):
     assert (await tracker.list_tasks(**_owner_kwargs()))[0].auth == {}
 
 
+async def test_public_serialization_skips_private_payloads(tracker: TaskTracker):
+    class PrivatePayload(dict):
+        def items(self):
+            raise AssertionError("Private payload was traversed")
+
+        def __deepcopy__(self, memo):
+            raise AssertionError("Private payload was copied")
+
+    task = await tracker.create("session_commit", **_owner_kwargs())
+    task.auth = PrivatePayload()
+    task._extra_fields = PrivatePayload()
+    task.meta = {"nested": [{"user_key": "secret", "values": [1]}]}
+    task.result = {"nested": [{"user_key": "secret", "values": [2]}]}
+
+    public = task.to_dict()
+    assert set(public) == {
+        "task_id",
+        "task_type",
+        "status",
+        "created_at",
+        "updated_at",
+        "resource_id",
+        "meta",
+        "stage",
+        "result",
+        "error",
+        "created_at_iso",
+        "updated_at_iso",
+    }
+    assert public["meta"] == {"nested": [{"values": [1]}]}
+    assert public["result"] == {"nested": [{"values": [2]}]}
+    public["meta"]["nested"][0]["values"].append(3)
+    public["result"]["nested"][0]["values"].append(4)
+    assert task.meta["nested"][0]["values"] == [1]
+    assert task.result["nested"][0]["values"] == [2]
+
+
 # ── Sanitization ──
 
 


### PR DESCRIPTION
## 说明

历史任务记录包含额外的顶层字段时，`GET /api/v1/tasks` 和任务详情接口会返回 HTTP 500。原因是 `TaskTracker._record_from_payload()` 将全部存储字段直接传入 `TaskRecord`，遇到 `operation_id` 等未定义字段时抛出 `TypeError`。

本 PR 在读取时将已知字段用于构造 `TaskRecord`，其余字段保存在内部，供后续更新任务记录时写回。修复后，任务列表和详情可以正常读取这些记录，对外响应结构保持不变。单纯读取不会修改原始 JSON，后续更新也会保留扩展字段，无需迁移数据。

## 人工参与

- [x] 有人工参与本次实现或审查
- [ ] 本 PR 完全由 AI Agent 生成，没有人工参与实现或技术审查

## 关联 Issue

无

## 变更类型

- [x] 缺陷修复（不破坏现有兼容性）
- [ ] 新功能（不破坏现有兼容性）
- [ ] 破坏性变更
- [ ] 文档更新
- [ ] 重构（不改变功能）
- [ ] 性能优化
- [x] 测试更新

## 主要变更

- 直接构造公开字段字典，避免序列化时遍历和复制内部扩展字段；结果与元数据保留脱敏及副本隔离。

- 反序列化时区分已知任务字段和扩展字段，分别保存独立副本。
- 持久化时将扩展字段合并回原记录，以当前已知字段值为准；对外序列化继续排除内部扩展字段。
- 补充回归测试，覆盖历史重试字段、未来扩展字段、只读加载、任务状态更新、归属检查、副本隔离和无效状态。

## 测试

- [x] 已添加能够验证修复或功能的测试
- [x] 新增测试和现有单元测试在本地通过
- [x] 已在以下平台测试：
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

测试在隔离的 Linux 容器中运行，使用官方 v0.4.19 运行环境并挂载修改后的模块。相关模块和测试的基线内容在该版本与本 PR 基线提交之间一致。

- `python -m pytest /tests --noconftest -o asyncio_mode=auto -q`：88 项测试通过，覆盖 `test_task_tracker.py` 和 `test_task_tracker_concurrency.py`。
- `python -m ruff format --check openviking/service/task_tracker.py openviking/service/task_store.py tests/test_task_tracker.py`：通过。
- `python -m ruff check --no-cache openviking/service/task_tracker.py openviking/service/task_store.py tests/test_task_tracker.py`：通过。
- `python -m mypy --cache-dir /tmp/mypy-cache openviking/service/task_tracker.py openviking/service/task_store.py tests/test_task_tracker.py`：基线和修复后均报告 199 个文件中的 1,530 项错误。对诊断信息去除行号后逐项比较，未发现新增或减少的错误。
- 提交 `f874f254` 的运行验证：任务列表和历史任务详情接口恢复 HTTP 200；原始任务文件哈希保持不变，服务诊断和检索检查通过。本次公开序列化优化在隔离容器中验证，并对历史快照的 260 条记录逐条比较，公开响应内容一致；尚未部署此次优化。

## 检查清单

- [x] 代码符合项目风格
- [x] 已完成自查
- [x] 已为较难理解的代码补充必要注释
- [ ] 已同步更新相关文档
- [ ] 本次修改没有产生新的警告
- [x] 依赖变更已经合并并发布（本 PR 无依赖 PR）

## 补充说明

公共 API 和配置文档保持不变。
