### PR TITLE
fix(server): allow '/' in X-Request-ID for tunnel trace ids

### DIFF
--- a/openviking/server/request_id.py
+++ b/openviking/server/request_id.py
@@ -17,7 +17,9 @@ from openviking_cli.utils.logger import bind_log_request_id
 
 REQUEST_ID_HEADER = "X-Request-ID"
 _REQUEST_ID_HEADER_BYTES = b"x-request-id"
-_REQUEST_ID_PATTERN = re.compile(r"[A-Za-z0-9._:-]{1,128}")
+# Allow '/' so gateway/tunnel trace ids like OpenAI Secure MCP Tunnel
+# (`<uuid>/<suffix>`) are accepted instead of failing the request (#4830).
+_REQUEST_ID_PATTERN = re.compile(r"[A-Za-z0-9._:/-]{1,128}")
 _IGNORED_COMPLETION_ROUTES = frozenset({"/health", "/ready", "/metrics"})
 
 _completion_logger = logging.getLogger("openviking.observability.http")
@@ -88,7 +90,7 @@ class RequestIdMiddleware:
                                 "code": "INVALID_ARGUMENT",
                                 "message": (
                                     "X-Request-ID must be supplied once and contain 1-128 "
-                                    "characters from [A-Za-z0-9._:-]"
+                                    "characters from [A-Za-z0-9._:/-]"
                                 ),
                             },
                         },

--- a/tests/server/test_request_id.py
+++ b/tests/server/test_request_id.py
@@ -81,6 +81,21 @@ async def test_client_request_id_is_returned_and_reused_by_observability() -> No
     assert response.json()["observability_request_id"] == "resource-import-20260728-001"
 
 
+async def test_slash_separated_tunnel_request_id_is_accepted() -> None:
+    """OpenAI Secure MCP Tunnel forwards X-Request-Id as ``<uuid>/<suffix>`` (#4830)."""
+    app = _make_test_app()
+    tunnel_id = "4257d51f-61c7-49d4-b78d-773e19a2c461/g6hr"
+
+    @app.get("/mcp")
+    async def mcp():
+        return {"ok": True}
+
+    response = await _request(app, "/mcp", headers={REQUEST_ID_HEADER: tunnel_id})
+
+    assert response.status_code == 200
+    assert response.headers[REQUEST_ID_HEADER] == tunnel_id
+
+
 async def test_missing_request_id_generates_uuid_for_health_and_cors_exposes_it() -> None:
     app = _make_test_app()
 


### PR DESCRIPTION
<!-- require-linked-issue -->
Fixes #4830

## Summary
`RequestIdMiddleware` rejected `X-Request-ID` values containing `/`, which breaks OpenAI Secure MCP Tunnel connectors that forward ids as `<uuid>/<suffix>`.

## Changes
- Allow `/` in `_REQUEST_ID_PATTERN` (and the 400 error message charset text).
- Add a regression test with a captured tunnel-style request id.

## Test plan
- [x] `tests/server/test_request_id.py` — slash-separated id accepted; invalid cases still rejected
- [ ] Optional: curl `/mcp` with `X-Request-Id: <uuid>/suffix` returns non-400
