### PR TITLE
fix(web-studio): scope evolution settings to selected account

### DIFF
--- a/web-studio/src/i18n/locales/en/workspace.ts
+++ b/web-studio/src/i18n/locales/en/workspace.ts
@@ -251,8 +251,6 @@ const workspace = {
       title: 'Experience settings',
       description:
         'Agent Evolution switch for the target account. When off, new session commits in that account stop extracting experiences and trajectories.',
-      targetAccount: 'Target account: {{account}}',
-      unknownAccount: 'Unconfirmed',
       scopeMismatch:
         'The API target account differs from the current account or cannot be confirmed. Changes are disabled. Use an administrator credential for the current account.',
       loading: 'Reading switch status...',

--- a/web-studio/src/i18n/locales/zh-CN/workspace.ts
+++ b/web-studio/src/i18n/locales/zh-CN/workspace.ts
@@ -248,8 +248,6 @@ const workspace = {
       title: '经验设置',
       description:
         '作用账号的 Agent Evolution 开关。关闭后，该账号的新会话提交将停止提取经验与轨迹。',
-      targetAccount: '作用账号：{{account}}',
-      unknownAccount: '无法确认',
       scopeMismatch:
         '接口返回的作用账号与当前账号不一致或无法确认，已禁止修改。请使用当前账号的管理凭证。',
       loading: '正在读取开关状态...',

--- a/web-studio/src/routes/agent-experience/-components/evolution-settings-popover.tsx
+++ b/web-studio/src/routes/agent-experience/-components/evolution-settings-popover.tsx
@@ -121,11 +121,6 @@ export function EvolutionSettingsPopover() {
           ) : statusQuery.data ? (
             <div className="flex items-center justify-between gap-3 rounded-lg border px-3 py-2.5">
               <div className="grid gap-0.5">
-                <span className="break-all text-xs text-muted-foreground">
-                  {t('settings.targetAccount', {
-                    account: targetAccountId || t('settings.unknownAccount'),
-                  })}
-                </span>
                 <span className="text-sm font-medium">
                   {statusQuery.data.enabled
                     ? t('settings.statusEnabled')

--- a/web-studio/src/routes/agent-experience/-components/evolution-settings-popover.tsx
+++ b/web-studio/src/routes/agent-experience/-components/evolution-settings-popover.tsx
@@ -22,8 +22,8 @@ import {
 } from '../-lib/api'
 
 /**
- * Admin/root-only settings popover that toggles the deployment Agent
- * Evolution switch (`GET/PUT /api/v1/admin/agent-evolution`).
+ * Admin/root-only settings popover that toggles the selected account Agent
+ * Evolution switch (`GET/PATCH /api/v1/admin/accounts/{account_id}/settings`).
  *
  * When disabled, new session commits stop extracting experiences and
  * trajectories, which is the most common reason the impact panel stays empty.
@@ -43,8 +43,9 @@ export function EvolutionSettingsPopover() {
     (connectionRole === 'admin' || connectionRole === 'root')
 
   const statusQuery = useQuery({
-    enabled: canManage,
-    queryFn: ({ signal }) => fetchAgentEvolutionStatus(signal),
+    enabled: canManage && Boolean(connection.accountId),
+    queryFn: ({ signal }) =>
+      fetchAgentEvolutionStatus(connection.accountId, signal),
     queryKey: ['agent-evolution-status', identityScopeKey],
     staleTime: 30_000,
   })
@@ -58,7 +59,7 @@ export function EvolutionSettingsPopover() {
       if (!matchesCurrentAccount) {
         throw new Error(t('settings.scopeMismatch'))
       }
-      return setAgentEvolutionEnabled(enabled)
+      return setAgentEvolutionEnabled(connection.accountId, enabled)
     },
     onSuccess: (status) => {
       queryClient.setQueryData(

--- a/web-studio/src/routes/agent-experience/-lib/api.test.ts
+++ b/web-studio/src/routes/agent-experience/-lib/api.test.ts
@@ -1,10 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { fetchExperiences } from './api'
+import {
+  fetchAgentEvolutionStatus,
+  fetchExperiences,
+  setAgentEvolutionEnabled,
+} from './api'
 
-const { get } = vi.hoisted(() => ({ get: vi.fn() }))
+const { get, patch } = vi.hoisted(() => ({ get: vi.fn(), patch: vi.fn() }))
 vi.mock('#/lib/ov-client', () => ({
-  ovClient: { client: { get } },
+  ovClient: { client: { get, patch } },
   getOvResult: (result: unknown) => result,
   isOvClientError: () => false,
 }))
@@ -74,5 +78,59 @@ describe('experience listing server pagination', () => {
       pageSize: 50,
     })
     expect(result).toEqual({ items: [], hasMore: false, page: 3, pageSize: 50 })
+  })
+})
+
+describe('account-scoped evolution settings', () => {
+  beforeEach(() => {
+    get.mockReset()
+    patch.mockReset()
+  })
+
+  it('reads the selected account effective value instead of its override', async () => {
+    get.mockResolvedValue({
+      account_id: 'acme',
+      settings: { agent_evolution: { enabled: true } },
+      overrides: {},
+    })
+    const signal = new AbortController().signal
+    expect(await fetchAgentEvolutionStatus('acme', signal)).toEqual({
+      accountId: 'acme',
+      enabled: true,
+    })
+    expect(get).toHaveBeenCalledWith({
+      url: '/api/v1/admin/accounts/acme/settings',
+      signal,
+    })
+    await fetchAgentEvolutionStatus('other')
+    expect(get).toHaveBeenLastCalledWith({
+      url: '/api/v1/admin/accounts/other/settings',
+      signal: undefined,
+    })
+  })
+
+  it('patches only evolution for the selected account and reads the effective response', async () => {
+    patch.mockResolvedValue({
+      account_id: 'acme',
+      settings: { agent_evolution: { enabled: false }, acl: { enabled: true } },
+    })
+    expect(await setAgentEvolutionEnabled('acme', false)).toEqual({
+      accountId: 'acme',
+      enabled: false,
+    })
+    expect(patch).toHaveBeenCalledWith({
+      url: '/api/v1/admin/accounts/acme/settings',
+      body: { agent_evolution: { enabled: false } },
+    })
+  })
+
+  it('preserves the returned account so the UI can reject a scope mismatch', async () => {
+    get.mockResolvedValue({
+      account_id: 'default',
+      settings: { agent_evolution: { enabled: true } },
+    })
+    expect((await fetchAgentEvolutionStatus('acme')).accountId).toBe('default')
+    get.mockResolvedValue({ settings: { agent_evolution: { enabled: true } } })
+    expect((await fetchAgentEvolutionStatus('acme')).accountId).toBeUndefined()
   })
 })

--- a/web-studio/src/routes/agent-experience/-lib/api.ts
+++ b/web-studio/src/routes/agent-experience/-lib/api.ts
@@ -147,41 +147,45 @@ export async function fetchSourceTrajectories(
   return normalizeSourceTrajectoryLinks(result)
 }
 
-export async function fetchAgentEvolutionStatus(
-  signal?: AbortSignal,
-): Promise<AgentEvolutionStatus> {
-  const result = await getOvResult<unknown>(
-    ovClient.client.get({ signal, url: '/api/v1/admin/agent-evolution' }),
-  )
-  const record =
-    result && typeof result === 'object'
-      ? (result as Record<string, unknown>)
-      : {}
+type AccountSettingsResult = {
+  account_id?: string
+  settings?: { agent_evolution?: { enabled?: boolean } }
+}
+
+function normalizeAgentEvolutionStatus(
+  result: AccountSettingsResult,
+): AgentEvolutionStatus {
   return {
-    enabled: record.enabled === true,
+    enabled: result.settings?.agent_evolution?.enabled === true,
     accountId:
-      typeof record.account_id === 'string' ? record.account_id : undefined,
+      typeof result.account_id === 'string' ? result.account_id : undefined,
   }
 }
 
-export async function setAgentEvolutionEnabled(
-  enabled: boolean,
+export async function fetchAgentEvolutionStatus(
+  accountId: string,
+  signal?: AbortSignal,
 ): Promise<AgentEvolutionStatus> {
-  const result = await getOvResult<unknown>(
-    ovClient.client.put({
-      body: { enabled },
-      url: '/api/v1/admin/agent-evolution',
+  const result = await getOvResult<AccountSettingsResult>(
+    ovClient.client.get({
+      signal,
+      url: `/api/v1/admin/accounts/${encodeURIComponent(accountId)}/settings`,
     }),
   )
-  const record =
-    result && typeof result === 'object'
-      ? (result as Record<string, unknown>)
-      : {}
-  return {
-    enabled: record.enabled === true,
-    accountId:
-      typeof record.account_id === 'string' ? record.account_id : undefined,
-  }
+  return normalizeAgentEvolutionStatus(result)
+}
+
+export async function setAgentEvolutionEnabled(
+  accountId: string,
+  enabled: boolean,
+): Promise<AgentEvolutionStatus> {
+  const result = await getOvResult<AccountSettingsResult>(
+    ovClient.client.patch({
+      body: { agent_evolution: { enabled } },
+      url: `/api/v1/admin/accounts/${encodeURIComponent(accountId)}/settings`,
+    }),
+  )
+  return normalizeAgentEvolutionStatus(result)
 }
 
 export const fetchTrajectoryContent = fetchContent


### PR DESCRIPTION
## Description

Root 用户在 Web Studio 切换到非默认账号后，经验设置仍调用仅作用于默认账号的旧接口，导致显示默认账号状态并禁用开关。改用已有的账号 settings 接口，使查询和修改跟随当前选中的账号。仅修改 Web Studio。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4834

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- 将经验设置 GET/PUT 替换为 `/api/v1/admin/accounts/{account_id}/settings` 的 GET/PATCH，从响应的 `settings.agent_evolution.enabled` 读取生效值。
- PATCH 只提交 `agent_evolution.enabled`，保留账号匹配检查和现有身份缓存隔离；账号为空时不发起查询。
- 增加账号请求目标、切换后的查询、生效值读取、最小 PATCH 请求及返回账号保留的回归测试。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (targeted API suite: 7 tests)
- [x] I have tested this on the following platforms:
  - [x] macOS

验证命令（在 web-studio 目录直接使用已安装工具）：

```sh
./node_modules/.bin/vitest run src/routes/agent-experience/-lib/api.test.ts
./node_modules/.bin/eslint src/routes/agent-experience/-lib/api.ts src/routes/agent-experience/-lib/api.test.ts src/routes/agent-experience/-components/evolution-settings-popover.tsx
```

以上检查及 `git diff --check` 均通过。未进行登录后的浏览器实测或全量测试。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] Any dependent changes have been merged and published (uses existing server endpoints)
