### PR TITLE
fix(opencode): automatically version and publish npm releases

### DIFF
--- a/.github/scripts/opencode-release-version.mjs
+++ b/.github/scripts/opencode-release-version.mjs
@@ -1,0 +1,56 @@
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+export function resolveRelease(metadata, sourceCommit, date) {
+  if (!metadata || typeof metadata.versions !== 'object' || !metadata.versions) {
+    throw new Error('Registry response is missing versions');
+  }
+  const existing = Object.values(metadata.versions).find(pkg => pkg.openvikingSourceCommit === sourceCommit);
+  if (existing) return { version: existing.version, published: true };
+  let max = -1;
+  for (const version of Object.keys(metadata.versions)) {
+    if (version === date) max = Math.max(max, 0);
+    else if (version.startsWith(`${date}-`)) {
+      const suffix = version.slice(date.length + 1);
+      if (/^\d+$/.test(suffix)) max = Math.max(max, Number(suffix));
+    }
+  }
+  return { version: max < 0 ? date : `${date}-${max + 1}`, published: false };
+}
+
+async function main() {
+  const sourceCommit = process.env.SOURCE_COMMIT;
+  if (!/^[a-f0-9]{40}$/.test(sourceCommit || '')) throw new Error('Missing source commit');
+  const packagePath = 'examples/opencode-plugin/package.json';
+  const pkg = JSON.parse(readFileSync(packagePath, 'utf8'));
+  if (pkg.name !== '@openviking/opencode-plugin') throw new Error('Unexpected package');
+  let metadata;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const response = await fetch(`https://registry.npmjs.org/${encodeURIComponent(pkg.name)}`, {
+        signal: AbortSignal.timeout(30000),
+      });
+      if (!response.ok) throw new Error(`Registry HTTP ${response.status}`);
+      metadata = await response.json();
+      break;
+    } catch (error) {
+      if (attempt === 2) throw error;
+      await new Promise(resolve => setTimeout(resolve, 2000 * (attempt + 1)));
+    }
+  }
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Asia/Shanghai', year: 'numeric', month: 'numeric', day: 'numeric',
+  }).formatToParts(new Date());
+  const part = type => parts.find(p => p.type === type).value;
+  const date = `${part('year')}.${part('month')}.${part('day')}`;
+  const release = resolveRelease(metadata, sourceCommit, date);
+  if (!release.published) {
+    pkg.version = release.version;
+    pkg.openvikingSourceCommit = sourceCommit;
+    writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
+  }
+  appendFileSync(process.env.GITHUB_OUTPUT, `version=${release.version}\npublished=${release.published}\n`);
+  console.log(`${pkg.name}@${release.version}: ${release.published ? 'already published from this commit' : 'ready to publish'}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) await main();

--- a/.github/scripts/opencode-release-version.test.mjs
+++ b/.github/scripts/opencode-release-version.test.mjs
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveRelease } from './opencode-release-version.mjs';
+const date = '2026.9.9';
+test('first date release ignores old source version', () => {
+  assert.deepEqual(resolveRelease({ versions: { '0.2.4': {} } }, 'new', date), { version: date, published: false });
+});
+test('same day chooses unused suffix, ignoring dev releases', () => {
+  assert.equal(resolveRelease({ versions: { [date]: {}, [`${date}-2`]: {}, [`${date}-dev.99`]: {} } }, 'new', date).version, `${date}-3`);
+});
+test('retry after successful publish reuses source commit even on another day', () => {
+  assert.deepEqual(resolveRelease({ versions: { old: { version: '2026.9.8', openvikingSourceCommit: 'same' } } }, 'same', date), { version: '2026.9.8', published: true });
+});
+test('malformed registry data cannot allocate a version', () => {
+  assert.throws(() => resolveRelease({}, 'new', date));
+});

--- a/.github/workflows/opencode-plugin-release.yml
+++ b/.github/workflows/opencode-plugin-release.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "examples/opencode-plugin/**"
       - ".github/workflows/opencode-plugin-release.yml"
+      - ".github/scripts/opencode-release-version*.mjs"
   workflow_dispatch:
 
 permissions:
@@ -18,6 +19,8 @@ concurrency:
 
 jobs:
   publish:
+    # Forks must not publish the official package.
+    if: github.repository == 'volcengine/OpenViking' && github.ref == 'refs/heads/main'
     name: Publish @openviking/opencode-plugin
     runs-on: ubuntu-24.04
     defaults:
@@ -26,6 +29,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          # Queued runs package current main, never an older event snapshot.
+          ref: main
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -42,33 +48,20 @@ jobs:
           npm test
           npm pack --dry-run
 
-      - name: Resolve package version
+      - name: Resolve release version
         id: package
+        working-directory: .
         run: |
-          node -e "
-            const pkg = require('./package.json')
-            if (pkg.name !== '@openviking/opencode-plugin') {
-              throw new Error('Unexpected package name: ' + pkg.name)
-            }
-            console.log('name=' + pkg.name)
-            console.log('version=' + pkg.version)
-          " >> "$GITHUB_OUTPUT"
+          node --test .github/scripts/opencode-release-version.test.mjs
+          export SOURCE_COMMIT="$(git rev-parse HEAD)"
+          node .github/scripts/opencode-release-version.mjs
 
-      - name: Check whether version already exists
-        id: published
-        env:
-          PACKAGE_NAME: ${{ steps.package.outputs.name }}
-          PACKAGE_VERSION: ${{ steps.package.outputs.version }}
-        run: |
-          if npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::$PACKAGE_NAME@$PACKAGE_VERSION is already published; skipping."
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Validate versioned artifact
+        if: steps.package.outputs.published == 'false'
+        run: npm pack --dry-run
 
       - name: Publish package
-        if: steps.published.outputs.exists == 'false'
+        if: steps.package.outputs.published == 'false'
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
@@ -77,4 +70,4 @@ jobs:
           else
             echo "::notice::NPM_TOKEN is not set; npm publish will use Trusted Publishing/OIDC. For first-time packages, publish once with an npm token or configure npm trusted publishing after the package exists."
           fi
-          npm publish --access public --provenance
+          npm publish --access public --provenance --tag latest

--- a/examples/opencode-plugin/README.md
+++ b/examples/opencode-plugin/README.md
@@ -212,3 +212,20 @@ The plugin writes runtime files to `~/.config/opencode/openviking/` by default:
 - `openviking-session-state.json`
 
 Set `runtime.dataDir` in config to override this directory.
+
+## Automated npm releases
+
+Changes merged into upstream `main` under `examples/opencode-plugin/` trigger
+`.github/workflows/opencode-plugin-release.yml`. Releases use the same calendar
+version convention as the OpenClaw plugin: `YYYY.M.D`, then `YYYY.M.D-N` for
+subsequent releases on that date (Asia/Shanghai). No manual source version bump
+is required. The workflow changes the version only in the package being published;
+it does not commit generated version changes back to the repository.
+
+Releases are serialized. A queued run checks out current `main`, so several quick
+merges may be included in one package. The npm manifest records
+`openvikingSourceCommit`; rerunning a successfully published commit skips publication.
+Registry failures stop the workflow instead of treating an unavailable registry as
+an unused version. Only upstream `main` can publish the official npm `latest` tag.
+Manual dispatch on `main` retries a failed release using the existing npm credentials
+or Trusted Publishing configuration.


### PR DESCRIPTION
## Description

OpenCode plugin merges can pass the release workflow without shipping because `package.json` remains at an already-published version. Allocate a calendar version at publication time, following the OpenClaw convention, so relevant merges to upstream main publish `@openviking/opencode-plugin` automatically.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

The maintainer requested matching OpenClaw's automatic versioning and publishing after merge; implementation and local validation were done by an agent.

## Related Issue

Maintainer request; no linked issue.

## Type of Change

- [x] Bug fix
- [x] Documentation update
- [x] Test update

## Changes Made

- Generate `YYYY.M.D`, then `YYYY.M.D-N`, using Asia/Shanghai and existing npm versions. The source manifest does not need manual bumps or generated commits.
- Serialize releases, package current main when queued jobs start, and restrict publication to upstream main. Multiple quick merges may be included in one release.
- Record `openvikingSourceCommit` in the published manifest and skip already-published commits on retry. Registry failures stop version allocation.
- Keep existing npm token/OIDC publishing and explicitly publish the latest tag. The workflow/script paths trigger release, so merging this PR itself triggers the first automatic release.

## Testing

- [x] Added allocation, same-day collision, retry, and malformed-registry tests: 4 pass.
- [x] Existing OpenCode package tests: 30 pass; syntax checks pass.
- [x] Linux: real npm registry read and manifest generation in a temporary directory; npm pack dry-run; workflow YAML parsing; git diff --check.

## Checklist

- [x] Self-reviewed changes and updated documentation.
- [x] No dependency changes.

## Additional Notes

No npm package was published locally. Actual publishing and provenance must be verified in the main-branch workflow after merge. This intentionally adopts OpenClaw's calendar version convention rather than incrementing 0.2.x.
