### PR TITLE
fix(index): reject invalid scalar filters

### DIFF
--- a/src/index/detail/index_manager_impl.cpp
+++ b/src/index/detail/index_manager_impl.cpp
@@ -158,6 +158,12 @@ int parse_dsl_query(const std::string& dsl_filter_query_str,
   }
   if (has_filter) {
     ctx.filter_op = parse_filter_json_doc_outter(dsl_filter_query);
+    if (!ctx.filter_op) {
+      SPDLOG_ERROR(
+          "IndexManagerImpl::parse_dsl_query filter parse failed: {}",
+          dsl_filter_query_str);
+      return -1;
+    }
   }
   if (has_sorter) {
     ctx.sorter_op = parse_sorter_json_doc_outter(dsl_filter_query);

--- a/tests/engine/test_index_engine.cpp
+++ b/tests/engine/test_index_engine.cpp
@@ -35,6 +35,42 @@ void expect_filter_projection(IndexEngine& engine, const std::string& dsl,
   }
 }
 
+void test_invalid_filter_is_rejected() {
+  SPDLOG_INFO("[Running] test_invalid_filter_is_rejected...");
+
+  const std::string config = R"({
+        "CollectionName": "invalid_filter_is_rejected",
+        "IndexName": "default",
+        "VectorIndex": {
+            "IndexType": "flat",
+            "ElementCount": 0,
+            "MaxElementCount": 4,
+            "Dimension": 1,
+            "Distance": "l2",
+            "Quant": "float"
+        },
+        "ScalarIndex": [
+            {"FieldName": "score", "FieldType": "float32"}
+        ]
+    })";
+
+  IndexEngine engine(config);
+  if (!engine.is_valid()) {
+    SPDLOG_ERROR("Invalid-filter test engine initialization failed");
+    exit(1);
+  }
+
+  try {
+    (void)engine.evaluate_filter(
+        R"({"filter":{"op":"not-a-real-op","field":"score","conds":[1]}})");
+    SPDLOG_ERROR("Invalid filter was accepted");
+    exit(1);
+  } catch (const std::runtime_error&) {
+  }
+
+  SPDLOG_INFO("[Passed] test_invalid_filter_is_rejected");
+}
+
 void test_basic_workflow() {
   SPDLOG_INFO("[Running] test_basic_workflow...");
 
@@ -585,6 +621,7 @@ void test_paged_store_scan() {
 
 int main() {
   init_logging("INFO", "stdout", "[%Y-%m-%d %H:%M:%S.%e] [%l] %v");
+  test_invalid_filter_is_rejected();
   test_basic_workflow();
   test_routed_filter_projection_edge_cases();
   test_path_bitmap_lifecycle_and_reload();


### PR DESCRIPTION
## Description

Reject invalid scalar filter DSL instead of silently treating it as an unfiltered query.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Not applicable.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Propagate filter parser failures from `parse_dsl_query`.
- Return an error before search or filter evaluation can fall back to an unfiltered path.
- Add a native regression test for unsupported filter operations.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing native engine tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Verification:

```bash
cmake --build tests/engine/build --target test_index_engine -j2
./tests/engine/build/test_index_engine
git diff --check -- src/index/detail/index_manager_impl.cpp tests/engine/test_index_engine.cpp
```

## Checklist

- [x] My code follows the project coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

This PR is based directly on `volcengine/OpenViking:main`. Unrelated local changes in the contributor workspace were excluded.