### PR TITLE
build: allow skipping optional native artifacts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import sys
 import sysconfig
 from pathlib import Path
 
-from setuptools import Extension, setup
+from setuptools import Distribution, Extension, setup
 from setuptools.command.build_ext import build_ext
 from setuptools.command.build_py import build_py
 
@@ -33,6 +33,7 @@ C_COMPILER_PATH = os.environ.get("CC") or shutil.which("gcc") or "gcc"
 CXX_COMPILER_PATH = os.environ.get("CXX") or shutil.which("g++") or "g++"
 ENGINE_SOURCE_DIR = "src/"
 ENGINE_BUILD_CONFIG = get_host_engine_build_config(platform.machine())
+SKIP_CPP_BUILD = os.environ.get("OV_SKIP_CPP_BUILD") == "1"
 
 
 def _sanitize_native_build_env(env):
@@ -111,8 +112,11 @@ class OpenVikingBuildExt(build_ext):
         self.build_ragfs_python_artifact()
         self.cmake_executable = CMAKE_PATH
 
-        for ext in self.extensions:
-            self.build_extension(ext)
+        if SKIP_CPP_BUILD:
+            print("[SKIP] C++ vector engine build disabled by OV_SKIP_CPP_BUILD=1")
+        else:
+            for ext in self.extensions:
+                self.build_extension(ext)
 
     def _copy_artifact(self, src, dst):
         """Copy a build artifact into the package tree and preserve executability."""
@@ -175,6 +179,10 @@ class OpenVikingBuildExt(build_ext):
 
     def build_ov_cli_artifact(self):
         """Build or reuse the ov Rust CLI binary."""
+        if os.environ.get("OV_SKIP_OV_BUILD") == "1":
+            print("[SKIP] ov CLI build disabled by OV_SKIP_OV_BUILD=1")
+            return
+
         binary_name = "ov.exe" if sys.platform == "win32" else "ov"
         ov_cli_dir = Path("crates/ov_cli").resolve()
         ov_target_binary = Path("openviking/bin").resolve() / binary_name
@@ -195,12 +203,6 @@ class OpenVikingBuildExt(build_ext):
             if src_bin.exists():
                 self._copy_artifact(src_bin, ov_target_binary)
                 return
-
-        if os.environ.get("OV_SKIP_OV_BUILD") == "1":
-            if ov_target_binary.exists():
-                print("[OK] Skipping ov CLI build, using existing binary")
-                return
-            print("[Warning] OV_SKIP_OV_BUILD=1 but binary is missing. Will try to build.")
 
         if ov_cli_dir.exists() and shutil.which("cargo"):
             print("Building ov CLI from source...")
@@ -541,6 +543,13 @@ else:
     OpenVikingBdistWheel = None
 
 
+class OpenVikingDistribution(Distribution):
+    """Keep wheels platform-specific because ragfs-python is a native artifact."""
+
+    def has_ext_modules(self):
+        return True
+
+
 cmdclass = {
     "build_ext": OpenVikingBuildExt,
     "build_py": OpenVikingBuildPy,
@@ -550,13 +559,18 @@ if OpenVikingBdistWheel is not None:
 
 
 setup(
-    ext_modules=[
-        Extension(
-            name=ENGINE_BUILD_CONFIG.primary_extension,
-            sources=[],
-            py_limited_api=True,
-        )
-    ],
+    distclass=OpenVikingDistribution,
+    ext_modules=(
+        []
+        if SKIP_CPP_BUILD
+        else [
+            Extension(
+                name=ENGINE_BUILD_CONFIG.primary_extension,
+                sources=[],
+                py_limited_api=True,
+            )
+        ]
+    ),
     cmdclass=cmdclass,
     package_data={
         "openviking": [

--- a/tests/misc/test_root_docker_image_packaging.py
+++ b/tests/misc/test_root_docker_image_packaging.py
@@ -97,6 +97,17 @@ def test_root_build_system_honors_ci_compiler_overrides_and_requires_ragfs_for_w
     assert 'echo "OV_REQUIRE_RAGFS_BUILD=1" >> "$GITHUB_ENV"' in build_workflow
 
 
+def test_root_build_system_can_skip_cli_and_cpp_without_skipping_ragfs():
+    setup_py = _read_text("setup.py")
+
+    assert 'os.environ.get("OV_SKIP_OV_BUILD") == "1"' in setup_py
+    assert 'os.environ.get("OV_SKIP_CPP_BUILD") == "1"' in setup_py
+    assert "if SKIP_CPP_BUILD" in setup_py
+    assert "class OpenVikingDistribution(Distribution)" in setup_py
+    assert "self.build_ov_cli_artifact()" in setup_py
+    assert "self.build_ragfs_python_artifact()" in setup_py
+
+
 def test_rust_crates_declare_the_repo_minimum_rust_version():
     makefile = _read_text("Makefile")
     min_rust_version = _extract_rust_version(


### PR DESCRIPTION
## 背景

  部分部署场景只需要 OpenViking 的 Python 服务端代码和 `ragfs-python`，不需要 Rust `ov` CLI 与本地 C++ VectorDB
  engine。

  当前 `OV_SKIP_OV_BUILD=1` 在找不到已有 `ov` 二进制时仍会回退到源码编译；`OV_SKIP_CPP_BUILD` 则尚未在构建流程中
  生效。

  ## 改动内容

  支持通过现有环境变量独立跳过可选的 native 产物：

  - `OV_SKIP_OV_BUILD=1`
    - 直接跳过 Rust `ov` CLI 构建；
    - 不再因为缺少预构建 binary 而回退到 Cargo 编译。

  - `OV_SKIP_CPP_BUILD=1`
    - 跳过本地 C++ VectorDB engine 构建；
    - 不再向 setuptools 注册对应的 C++ extension。

  - `ragfs-python`
    - 不受上述两个开关影响；
    - 继续通过 maturin 构建并打包进 wheel。

  即使跳过 C++ engine，wheel 中仍包含 `ragfs-python` native extension，因此构建产物仍保持 platform-specific 和
  ABI3 标签。

  ## 兼容性

  未设置上述环境变量时，默认构建行为保持不变：

  - 构建 Rust `ov` CLI；
  - 构建 `ragfs-python`；
  - 构建本地 C++ VectorDB engine。

  两个环境变量可以独立使用，也可以同时启用。

  ## 验证

  使用以下命令进行了真实 wheel 构建：

  ```bash
  OV_SKIP_OV_BUILD=1 \
  OV_SKIP_CPP_BUILD=1 \
  python setup.py bdist_wheel

  验证结果：

  - wheel 构建成功；
  - 产物标签为 cp310-abi3-linux_x86_64；
  - ragfs_python.abi3.so 正常打包并可加载；
  - Rust ov CLI 未构建；
  - C++ VectorDB engine 未构建；
  - 新增的针对性构建测试通过。