### PR TITLE
fix(store): guard truncated fixed-width rows

### DIFF
--- a/src/store/bytes_row.cpp
+++ b/src/store/bytes_row.cpp
@@ -342,13 +342,35 @@ Value BytesRow::deserialize_field(const std::string& serialized_data,
   const FieldMeta& meta = *meta_ptr;
   const char* ptr = serialized_data.data();
 
+  const size_t field_offset = static_cast<size_t>(meta.offset);
+
   // Check if data is large enough for this field's offset
-  if (serialized_data.size() <= static_cast<size_t>(meta.offset)) {
+  if (serialized_data.size() <= field_offset) {
     return meta.default_value;
   }
 
   uint8_t field_count = static_cast<uint8_t>(ptr[0]);
   if (meta.id >= field_count) {
+    return meta.default_value;
+  }
+
+  size_t fixed_field_size = 0;
+  switch (meta.data_type) {
+    case FieldType::INT64:
+    case FieldType::UINT64:
+      fixed_field_size = sizeof(uint64_t);
+      break;
+    case FieldType::FLOAT32:
+      fixed_field_size = sizeof(float);
+      break;
+    case FieldType::BOOLEAN:
+      fixed_field_size = sizeof(uint8_t);
+      break;
+    default:
+      break;
+  }
+  if (fixed_field_size > 0 &&
+      serialized_data.size() - field_offset < fixed_field_size) {
     return meta.default_value;
   }
 

--- a/tests/vectordb/test_bytes_row.py
+++ b/tests/vectordb/test_bytes_row.py
@@ -207,6 +207,31 @@ class TestBytesRow(unittest.TestCase):
         self.assertEqual(row.deserialize_field(serialized, "tags"), ["a", "b"])
         self.assertAlmostEqual(row.deserialize_field(serialized, "score"), 0.0, places=5)
 
+    def test_truncated_fixed_width_fields_use_defaults(self):
+        cases = [
+            ("int64", engine.FieldType.int64, 0x1122334455667788, -1),
+            ("uint64", engine.FieldType.uint64, 0x8877665544332211, 123),
+            ("float32", engine.FieldType.float32, 1.25, 2.5),
+        ]
+
+        for field_name, field_type, value, default_value in cases:
+            with self.subTest(field_type=field_type):
+                schema = engine.Schema(
+                    [{
+                        "name": field_name,
+                        "data_type": field_type,
+                        "id": 0,
+                        "default_value": default_value,
+                    }]
+                )
+                row = engine.BytesRow(schema)
+                serialized = row.serialize({field_name: value})
+
+                self.assertEqual(
+                    row.deserialize_field(serialized[:-1], field_name),
+                    default_value,
+                )
+
 
 class TestBytesRowConsistency(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Description

Prevent truncated serialized rows from causing out-of-bounds reads when deserializing fixed-width fields.

`BytesRow::deserialize_field()` previously checked only that the field offset existed. A payload could contain the first byte of an `INT64`, `UINT64`, or `FLOAT32` field while being shorter than the complete field, and the subsequent `memcpy` would read past the end of the input buffer.

The deserializer now validates the remaining payload length before reading fixed-width fields and returns the existing schema default value for truncated data.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add fixed-width payload bounds checks for `INT64`, `UINT64`, `FLOAT32`, and `BOOLEAN`.
- Preserve the existing default-value behavior for incomplete fields.
- Add regression coverage for truncated multi-byte fixed-width fields.

## Testing

- [x] Added a regression test for truncated fixed-width fields.
- [x] Existing BytesRow tests pass locally.
- [x] C++ engine tests pass locally.
- [x] Tested on Linux.

Commands:

```bash
.venv/bin/python setup.py build_ext --inplace --force
.venv/bin/pytest tests/vectordb/test_bytes_row.py -q
cmake --build tests/engine/build --target test_index_engine -j2
./tests/engine/build/test_index_engine
git diff --check
```

## Additional Notes

This is a cross-repository pull request from `zhanglistar/OpenViking` to `volcengine/OpenViking:main`.