### PR TITLE
fix(index): guard center1d maximum boundary

### DIFF
--- a/src/index/detail/scalar/bitmap_holder/ranged_map.cpp
+++ b/src/index/detail/scalar/bitmap_holder/ranged_map.cpp
@@ -323,9 +323,13 @@ RecallResultPtr RangedMap::get_topk_result_with_slot_data_center1d(
       }
     }
     slot_r++;
-    offset_r = std::upper_bound(slots_[slot_r].value_vec.begin(),
-                                slots_[slot_r].value_vec.end(), center1d) -
-               slots_[slot_r].value_vec.begin();
+    if (slot_r == (int)slots_.size()) {
+      offset_r = 0;
+    } else {
+      offset_r = std::upper_bound(slots_[slot_r].value_vec.begin(),
+                                  slots_[slot_r].value_vec.end(), center1d) -
+                 slots_[slot_r].value_vec.begin();
+    }
   }
   // add values between lower bound and upper bound
   if (slot_l != -1) {

--- a/tests/engine/test_index_engine.cpp
+++ b/tests/engine/test_index_engine.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 // SPDX-License-Identifier: AGPL-3.0
 #include "index/index_engine.h"
+#include "index/detail/scalar/bitmap_holder/ranged_map.h"
 #include "store/persist_store.h"
 #include "store/volatile_store.h"
 #include <iostream>
@@ -33,6 +34,27 @@ void expect_filter_projection(IndexEngine& engine, const std::string& dsl,
         first_word, expected_first_word);
     exit(1);
   }
+}
+
+void test_ranged_map_center1d_at_maximum() {
+  SPDLOG_INFO("[Running] test_ranged_map_center1d_at_maximum...");
+
+  RangedMap ranged_map;
+  if (ranged_map.add_offset_and_score(0, 1.0) != 0 ||
+      ranged_map.add_offset_and_score(1, 2.0) != 0) {
+    SPDLOG_ERROR("Failed to add center1d regression data");
+    exit(1);
+  }
+
+  const RecallResultPtr result =
+      ranged_map.get_topk_result_center1d(2, true, 2.0, nullptr);
+  if (result == nullptr || result->offsets != std::vector<uint32_t>{1, 0} ||
+      result->scores != std::vector<float>{2.0f, 1.0f}) {
+    SPDLOG_ERROR("center1d maximum-boundary result was incorrect");
+    exit(1);
+  }
+
+  SPDLOG_INFO("[Passed] test_ranged_map_center1d_at_maximum");
 }
 
 void test_basic_workflow() {
@@ -585,6 +607,7 @@ void test_paged_store_scan() {
 
 int main() {
   init_logging("INFO", "stdout", "[%Y-%m-%d %H:%M:%S.%e] [%l] %v");
+  test_ranged_map_center1d_at_maximum();
   test_basic_workflow();
   test_routed_filter_projection_edge_cases();
   test_path_bitmap_lifecycle_and_reload();


### PR DESCRIPTION
## Description

Fix an out-of-bounds access in the `center1d` top-k path when the query center equals the largest indexed value. The upper-bound slot can be the end sentinel (`slots_.size()`), so the implementation now avoids indexing that sentinel.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Not applicable.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Guard the `slot_r == slots_.size()` sentinel before calculating `offset_r`.
- Add a regression test for top-k search centered on the maximum indexed value.
- Keep the existing nearest-value ordering unchanged for normal and boundary cases.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The regression test failed with exit code 139 before the fix and passes after the fix. The branch is based on the latest `upstream/main`.