### PR TITLE
fix(tasks): add 24h success summary independent of list window

### DIFF
--- a/openviking/server/routers/tasks.py
+++ b/openviking/server/routers/tasks.py
@@ -25,6 +25,33 @@ from openviking_cli.exceptions import (
 router = APIRouter(prefix="/api/v1", tags=["tasks"])
 
 
+@router.get("/tasks/summary")
+async def summarize_tasks(
+    include_internal: bool = Query(False, description="Include internal Connector child tasks"),
+    window_seconds: Optional[int] = Query(
+        None,
+        ge=1,
+        description="Trailing window in seconds (default: 24h completed retention)",
+    ),
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Summarize terminal task outcomes in a trailing window for Studio KPIs."""
+    tracker = get_task_tracker()
+    if _ctx.role == Role.ROOT:
+        summary = await tracker.summarize_tasks(
+            include_internal=include_internal,
+            window_seconds=window_seconds,
+        )
+    else:
+        summary = await tracker.summarize_tasks(
+            account_id=_ctx.account_id,
+            user_id=_ctx.user.user_id,
+            include_internal=include_internal,
+            window_seconds=window_seconds,
+        )
+    return Response(status="ok", result=summary)
+
+
 @router.get("/tasks/{task_id}")
 async def get_task(
     task_id: str,

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -1040,6 +1040,63 @@ class TaskTracker:
         tasks.sort(key=lambda t: t.created_at, reverse=True)
         return tasks[:limit]
 
+    async def summarize_tasks(
+        self,
+        *,
+        account_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        include_internal: bool = False,
+        window_seconds: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Summarize terminal tasks in a trailing window for Studio KPIs.
+
+        Counts completed and failed attempts by ``updated_at`` within
+        ``window_seconds`` (default: TTL_COMPLETED / 24h), using the same owner
+        and internal-task visibility rules as :meth:`list_tasks`, but without
+        list limits or resource folding.
+        """
+        window = self.TTL_COMPLETED if window_seconds is None else int(window_seconds)
+        return await self._dispatcher.run(
+            lambda: self._summarize_tasks_on_owner(
+                account_id,
+                user_id,
+                include_internal,
+                window,
+            )
+        )
+
+    async def _summarize_tasks_on_owner(
+        self,
+        account_id: Optional[str],
+        user_id: Optional[str],
+        include_internal: bool,
+        window_seconds: int,
+    ) -> Dict[str, Any]:
+        if account_id is not None:
+            self._merge_loaded_tasks(await self._load_all_from_store(account_id, user_id))
+        now = time.time()
+        cutoff = now - max(window_seconds, 0)
+        completed = 0
+        failed = 0
+        for task in self._cache_snapshot():
+            if not self._matches_owner(task, account_id, user_id):
+                continue
+            if not include_internal and task.meta.get("internal") is True:
+                continue
+            if task.updated_at < cutoff:
+                continue
+            if task.status == TaskStatus.COMPLETED:
+                completed += 1
+            elif task.status == TaskStatus.FAILED:
+                failed += 1
+        eligible = completed + failed
+        return {
+            "window_seconds": window_seconds,
+            "completed": completed,
+            "failed": failed,
+            "success_rate": (completed / eligible * 100.0) if eligible else None,
+        }
+
     async def has_running(
         self,
         task_type: str,

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -827,3 +827,35 @@ async def test_feishu_response_checkpoint_survives_reload(tracker):
     restored = TaskTracker(store=tracker._store)
     record = await restored.get(task.task_id, **_owner_kwargs())
     assert record.meta["feishu_responses"] == {"nested/doc": "response-1"}
+
+
+async def test_summarize_tasks_uses_trailing_window_not_list_mix(tracker: TaskTracker):
+    """24h success rate ignores older retained failures and unfinished work (#4777)."""
+    recent_ok = await tracker.create("session_commit", resource_id="a", **_owner_kwargs())
+    recent_fail = await tracker.create("session_commit", resource_id="b", **_owner_kwargs())
+    old_fail = await tracker.create("session_commit", resource_id="c", **_owner_kwargs())
+    pending = await tracker.create("session_commit", resource_id="d", **_owner_kwargs())
+
+    await tracker.complete(recent_ok.task_id, {}, **_owner_kwargs())
+    await tracker.fail(recent_fail.task_id, "boom", **_owner_kwargs())
+    await tracker.fail(old_fail.task_id, "old", **_owner_kwargs())
+    # pending stays unfinished and must not affect the rate
+
+    tracker._tasks[old_fail.task_id].updated_at = time.time() - tracker.TTL_COMPLETED - 60
+
+    summary = await tracker.summarize_tasks(**_owner_kwargs())
+    assert summary["completed"] == 1
+    assert summary["failed"] == 1
+    assert summary["success_rate"] == 50.0
+    assert summary["window_seconds"] == tracker.TTL_COMPLETED
+    assert pending.status == TaskStatus.PENDING
+
+
+async def test_summarize_tasks_returns_no_rate_without_terminal_attempts(
+    tracker: TaskTracker,
+):
+    await tracker.create("session_commit", **_owner_kwargs())
+    summary = await tracker.summarize_tasks(**_owner_kwargs())
+    assert summary["completed"] == 0
+    assert summary["failed"] == 0
+    assert summary["success_rate"] is None

--- a/web-studio/src/routes/tasks/-lib/task-list.test.ts
+++ b/web-studio/src/routes/tasks/-lib/task-list.test.ts
@@ -1,14 +1,26 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { fetchTasks, getEffectiveTaskStatus, MAX_TASKS } from './task-list'
+import {
+  fetchTaskSummary,
+  fetchTasks,
+  getEffectiveTaskStatus,
+  MAX_TASKS,
+} from './task-list'
 
 const clientMocks = vi.hoisted(() => ({
   getTasks: vi.fn(),
+  clientGet: vi.fn(),
 }))
 
 vi.mock('#/lib/ov-client', () => ({
   getOvResult: async (value: unknown) => value,
   getTasks: clientMocks.getTasks,
+}))
+
+vi.mock('#/gen/ov-client/client.gen', () => ({
+  client: {
+    get: (...args: unknown[]) => clientMocks.clientGet(...args),
+  },
 }))
 
 beforeEach(() => {
@@ -88,5 +100,24 @@ describe('task list requests', () => {
     clientMocks.getTasks.mockRejectedValue(new Error('request failed'))
 
     await expect(fetchTasks('all', 'all')).rejects.toThrow('request failed')
+  })
+
+  it('loads the trailing-window success summary independently of the list', async () => {
+    clientMocks.clientGet.mockResolvedValue({
+      completed: 8,
+      failed: 2,
+      success_rate: 80,
+      window_seconds: 86_400,
+    })
+
+    await expect(fetchTaskSummary()).resolves.toEqual({
+      completed: 8,
+      failed: 2,
+      success_rate: 80,
+      window_seconds: 86_400,
+    })
+    expect(clientMocks.clientGet).toHaveBeenCalledWith({
+      url: '/api/v1/tasks/summary',
+    })
   })
 })

--- a/web-studio/src/routes/tasks/-lib/task-list.ts
+++ b/web-studio/src/routes/tasks/-lib/task-list.ts
@@ -1,3 +1,4 @@
+import { client } from '#/gen/ov-client/client.gen'
 import { getOvResult, getTasks } from '#/lib/ov-client'
 import {
   normalizeTasks,
@@ -19,6 +20,13 @@ export type TaskTypeFilter =
   | 'all'
 
 export const MAX_TASKS = 200
+
+export type TaskSummary = {
+  window_seconds: number
+  completed: number
+  failed: number
+  success_rate: number | null
+}
 
 /** Prefer the API status; do not invent pending from a running-slot cap. */
 export function getEffectiveTaskStatus(
@@ -45,4 +53,21 @@ export async function fetchTasks(
     (left, right) =>
       Number(right.created_at || 0) - Number(left.created_at || 0),
   )
+}
+
+export async function fetchTaskSummary(): Promise<TaskSummary> {
+  const result = await getOvResult<TaskSummary>(
+    client.get({
+      url: '/api/v1/tasks/summary',
+    }),
+  )
+  return {
+    window_seconds: Number(result.window_seconds) || 86_400,
+    completed: Number(result.completed) || 0,
+    failed: Number(result.failed) || 0,
+    success_rate:
+      result.success_rate === null || result.success_rate === undefined
+        ? null
+        : Number(result.success_rate),
+  }
 }

--- a/web-studio/src/routes/tasks/route.tsx
+++ b/web-studio/src/routes/tasks/route.tsx
@@ -52,7 +52,7 @@ import { TaskDetailSheet } from '#/routes/tasks/-components/task-detail-sheet'
 import { normalizeTaskStatus } from '#/routes/tasks/-lib/task-record'
 import type { TaskRecord } from '#/routes/tasks/-lib/task-record'
 import { formatTaskDuration, getTaskDate } from '#/routes/tasks/-lib/task-time'
-import { fetchTasks, MAX_TASKS } from './-lib/task-list'
+import { fetchTaskSummary, fetchTasks, MAX_TASKS } from './-lib/task-list'
 import type { TaskStatusFilter, TaskTypeFilter } from './-lib/task-list'
 import { getTaskPipelineGroups } from './-lib/task-pipeline'
 
@@ -97,6 +97,11 @@ function TasksRoute() {
   const tasksQuery = useQuery({
     queryFn: () => fetchTasks(taskType, statusFilter),
     queryKey: ['tasks', identityScopeKey, taskType, statusFilter],
+    refetchInterval: 10_000,
+  })
+  const summaryQuery = useQuery({
+    queryFn: () => fetchTaskSummary(),
+    queryKey: ['tasks-summary', identityScopeKey],
     refetchInterval: 10_000,
   })
   const rawTasks = tasksQuery.data ?? []
@@ -489,7 +494,13 @@ function TasksRoute() {
     const running = rawRunning
     const pending = rawPending
 
-    const successRate = total > 0 ? (completed / total) * 100 : 100
+    const summary = summaryQuery.data
+    const successRate =
+      summary && summary.success_rate !== null && summary.success_rate !== undefined
+        ? summary.success_rate
+        : null
+    const summaryCompleted = summary?.completed ?? 0
+    const summaryFailed = summary?.failed ?? 0
 
     const durations = allTasks
       .map((item) => {
@@ -578,12 +589,14 @@ function TasksRoute() {
       pending,
       failed,
       successRate,
+      summaryCompleted,
+      summaryFailed,
       avgDurationSec,
       topType,
       topCount,
       typeRows,
     }
-  }, [allTasks, t])
+  }, [allTasks, summaryQuery.data, t])
 
   return (
     <div className="flex w-full min-w-0 flex-col gap-4">
@@ -617,18 +630,24 @@ function TasksRoute() {
         <Card className="flex flex-col gap-1 p-3 shadow-none transition-colors hover:border-primary/40">
           <div className="flex items-center justify-between text-xs text-muted-foreground">
             <span className="font-medium">
-              {i18n.language.startsWith('zh') ? '任务成功率' : 'Success Rate'}
+              {i18n.language.startsWith('zh') ? '24小时成功率' : '24h Success Rate'}
             </span>
           </div>
           <div className="flex items-baseline gap-1">
             <span className="font-mono text-xl font-bold tabular-nums text-foreground">
-              {kpiData.successRate.toFixed(1)}%
+              {kpiData.successRate === null
+                ? '—'
+                : `${kpiData.successRate.toFixed(1)}%`}
             </span>
           </div>
           <p className="text-[11px] text-muted-foreground truncate">
             {i18n.language.startsWith('zh')
-              ? `共 ${kpiData.total} 条任务 (${kpiData.failed} 异常)`
-              : `Total ${kpiData.total} (${kpiData.failed} Failed)`}
+              ? kpiData.successRate === null
+                ? '近 24 小时暂无已结束任务'
+                : `近 24 小时 ${kpiData.summaryCompleted} 成功 / ${kpiData.summaryFailed} 失败`
+              : kpiData.successRate === null
+                ? 'No terminal attempts in 24h'
+                : `24h ${kpiData.summaryCompleted} ok / ${kpiData.summaryFailed} failed`}
           </p>
         </Card>
 
@@ -655,7 +674,7 @@ function TasksRoute() {
         <Card className="flex flex-col gap-1 p-3 shadow-none transition-colors hover:border-primary/40">
           <div className="flex items-center justify-between text-xs text-muted-foreground">
             <span className="font-medium">
-              {i18n.language.startsWith('zh') ? '任务总数' : 'Total Tasks'}
+              {i18n.language.startsWith('zh') ? '列表条目' : 'List Entries'}
             </span>
           </div>
           <div className="flex items-baseline gap-1">


### PR DESCRIPTION
<!-- require-linked-issue -->
Fixes #4777

## Summary
Follow-up to #4825. The Task Center success-rate card was still derived from the displayed (≤200, optionally folded) list, mixing 24h completions with 7-day retained failures and treating an empty list as 100%.

## Changes
- Add `TaskTracker.summarize_tasks`: count completed/failed by `updated_at` in the trailing 24h window (same owner / internal visibility as list, no limit/folding).
- Add `GET /api/v1/tasks/summary` (registered before `/tasks/{task_id}`).
- Studio: fetch the summary for the KPI card; show `—` when there are no terminal attempts; relabel the third card as list entries.

## Test plan
- [x] Unit: `test_summarize_tasks_uses_trailing_window_not_list_mix`
- [x] Unit: empty window returns `success_rate: null`
- [x] Studio: `fetchTaskSummary` hits `/api/v1/tasks/summary`
- [ ] Manual: `/studio/tasks` success card matches 24h completed/(completed+failed) independent of Failed filter / resource folding
