### PR TITLE
fix(bot): preserve OpenViking credentials with --with-bot

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -64,7 +64,7 @@ ov chat → OpenViking Server → VikingBot Gateway → Agent
 
 Follow the [OpenViking quickstart](../docs/en/getting-started/03-quickstart-server.md) to configure the models and storage required by OpenViking. By default, the Bot inherits the root-level `vlm` configuration as its Agent model. Configure `bot.agents` only if the Bot should use a separate model.
 
-In this combined mode, the Bot always uses the OpenViking Server started by the same command and ignores `bot.ov_server` settings that point to another service. OpenViking Server injects an authenticated request-scoped identity into every Chat request sent to the Bot.
+In this combined mode, the Bot always uses the OpenViking Server started by the same command. `bot.ov_server.server_url` is ignored, while an explicit `bot.ov_server.api_key` and other Bot OpenViking settings are preserved. In `api_key` mode, that key must be a User/Admin key. OpenViking Server injects an authenticated request-scoped identity into every Chat request sent to the Bot.
 
 #### 2. Start both services
 

--- a/bot/README_CN.md
+++ b/bot/README_CN.md
@@ -61,7 +61,7 @@ ov chat → OpenViking Server → VikingBot Gateway → Agent
 
 先按照 [OpenViking 快速开始](../docs/zh/getting-started/03-quickstart-server.md)配置好 OpenViking 所需的模型和存储。Bot 默认继承根级 `vlm` 作为 Agent 模型；如需使用独立模型，再配置 `bot.agents`。
 
-一体启动时，Bot 固定使用当前启动的 OpenViking Server，忽略 `bot.ov_server` 中指向其他服务的配置。OpenViking Server 会为每个 Chat 请求向 Bot 注入已经认证的 request-scoped 身份。
+一体启动时，Bot 固定使用当前启动的 OpenViking Server；`bot.ov_server.server_url` 会被忽略，但显式配置的 `bot.ov_server.api_key` 和其他 Bot 侧 OpenViking 设置会保留。`api_key` 模式下，该 key 必须是 User/Admin key。OpenViking Server 会为每个 Chat 请求向 Bot 注入已经认证的 request-scoped 身份。
 
 #### 2. 一体启动
 

--- a/bot/tests/test_openviking_api_key_type.py
+++ b/bot/tests/test_openviking_api_key_type.py
@@ -430,7 +430,7 @@ def test_ov_server_without_root_server_section_stays_standalone():
     assert bot_data["api_key_type"] == "user"
 
 
-def test_server_managed_load_config_ignores_bot_ov_server(monkeypatch, tmp_path):
+def test_server_managed_load_config_preserves_bot_ov_server_credentials(monkeypatch, tmp_path):
     config_path = tmp_path / "ov.conf"
     config_path.write_text(
         json.dumps(
@@ -444,6 +444,7 @@ def test_server_managed_load_config_ignores_bot_ov_server(monkeypatch, tmp_path)
                 "bot": {
                     "ov_server": {
                         "server_url": "https://remote.example",
+                        "api_key_type": "user",
                         "api_key": "bot-key",
                     }
                 },
@@ -455,9 +456,10 @@ def test_server_managed_load_config_ignores_bot_ov_server(monkeypatch, tmp_path)
     config = config_loader_module.load_config()
 
     assert config.ov_server.server_url == "http://127.0.0.1:1935"
-    assert config.ov_server.api_key == ""
+    assert config.ov_server.api_key == "bot-key"
     assert config.ov_server.get_config_source() == "inherited"
-    assert config.ov_server.get_api_key_source() == "none"
+    assert config.ov_server.get_api_key_source() == "bot.ov_server.api_key"
+    assert config.ov_server.api_key_type == "user"
     assert config.ov_server.is_server_managed() is True
 
 
@@ -485,6 +487,9 @@ def test_server_managed_load_config_uses_runtime_server_url(monkeypatch, tmp_pat
     config = config_loader_module.load_config()
 
     assert config.ov_server.server_url == "http://127.0.0.1:1940"
+    assert config.ov_server.api_key == ""
+    assert config.ov_server.get_config_source() == "inherited"
+    assert config.ov_server.get_api_key_source() == "none"
     assert config.ov_server.is_server_managed() is True
 
 

--- a/bot/vikingbot/config/loader.py
+++ b/bot/vikingbot/config/loader.py
@@ -159,7 +159,15 @@ def load_config() -> Config:
                 )
 
             server_managed = _is_truthy_env(VIKINGBOT_WITH_OPENVIKING_SERVER_ENV)
-            bot_server_data = {} if server_managed else bot_data.get("ov_server", {})
+            configured_bot_server = bot_data.get("ov_server", {})
+            # --with-bot owns the server lifecycle and endpoint, but Bot-level
+            # OpenViking credentials and settings still belong to the Bot.
+            # Ignore only an explicitly configured alternate server URL.
+            bot_server_data = (
+                _server_managed_bot_server_data(configured_bot_server)
+                if server_managed
+                else configured_bot_server
+            )
             server_section_present = "server" in full_data and isinstance(
                 full_data.get("server"), dict
             )
@@ -230,6 +238,13 @@ def _merge_vlm_model_config(
             agents["temperature"] = vlm_data["temperature"]
         if "extra_headers" in vlm_data and vlm_data["extra_headers"] is not None:
             agents["extra_headers"] = vlm_data["extra_headers"]
+
+
+def _server_managed_bot_server_data(value: Any) -> dict:
+    """Keep Bot OpenViking settings while ignoring an alternate server URL."""
+    if not isinstance(value, dict):
+        return {}
+    return {key: item for key, item in value.items() if key != "server_url"}
 
 
 def _merge_ov_server_config(


### PR DESCRIPTION
## Description

When `openviking-server --with-bot` runs with the current Server in `auth_mode=api_key`, the Bot may have a valid User API key under `bot.ov_server.api_key`. The current loader replaces `bot.ov_server` with an empty mapping whenever the server-managed flag is set, so the Bot default VikingClient loses its tenant credential and memory/file tools fail.

This PR keeps the current Server endpoint under `--with-bot`, preserves Bot-side OpenViking credentials and settings, and ignores only an alternate `bot.ov_server.server_url`.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4846

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Preserve `bot.ov_server` credentials and Bot-side settings in server-managed mode.
- Keep `--with-bot` on the active Server URL and ignore an alternate configured `server_url`.
- Update English and Chinese Bot integration documentation and the existing configuration regression test.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Targeted validation:

- The server-managed configuration tests and the existing `ovcli.conf` isolation test passed: 3 passed.
- `ruff check` and `ruff format --check` for changed Python files passed.
- `git diff --check` passed.

The complete `bot/tests/test_openviking_api_key_type.py` run collected 97 tests and reported 93 passed and 4 failures. All 4 failures are in unchanged compact-hook fake clients whose `commit_session()` signatures do not accept the existing `retention_mode` keyword; this PR does not modify that hook path.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

No storage, API, or tenant schema changes are included. The change is limited to VikingBot configuration loading and its documentation/tests. No dependent changes are required.
