### PR TITLE
docs(parser): clarify smart splitting thresholds

### DIFF
--- a/docs/en/concepts/06-extraction.md
+++ b/docs/en/concepts/06-extraction.md
@@ -43,14 +43,13 @@ parse_result.temp_dir_path  # viking://temp/abc123
 
 ### Smart Splitting
 
-```
-If document_tokens <= 1024:
-    → Save as single file
-Else:
-    → Split by headers
-    → Section < 512 tokens → Merge
-    → Section > 1024 tokens → Create subdirectory
-```
+Smart splitting is threshold-based, not one-file-per-heading. In the default parse mode:
+
+- Markdown stays in one file while it is at most `2048` estimated tokens **and** `6000` characters, even when it contains multiple headings.
+- Once either limit is exceeded, headings become section boundaries. Sections below `512` tokens are merged with adjacent content when possible to avoid low-value fragments.
+- Oversized leaf sections, or documents without headings, are split by paragraph while targeting both limits. A single Markdown table row may exceed a target so its structure is preserved.
+
+The values above are the `ParserConfig.max_section_size` and `ParserConfig.max_section_chars` defaults. Set `args.parse_mode` to `no_split` to keep each converted Markdown body intact. This changes the stored file layout only; semantic processing, vectorization, and internal embedding chunking still run normally.
 
 ### Return Result
 

--- a/docs/zh/concepts/06-extraction.md
+++ b/docs/zh/concepts/06-extraction.md
@@ -42,14 +42,13 @@ parse_result.temp_dir_path  # viking://temp/abc123
 
 ### 智能分割
 
-```
-如果 document_tokens <= 1024:
-    → 保存为单文件
-否则:
-    → 按标题分割
-    → 小节 < 512 tokens → 合并
-    → 大节 > 1024 tokens → 创建子目录
-```
+智能分割由阈值触发，并不是每个标题都生成一个文件。在默认解析模式下：
+
+- Markdown 不超过约 `2048` 个估算 token 且不超过 `6000` 个字符时，即使包含多个标题，也会保存为单文件。
+- 任一限制被超过后，标题才会成为章节边界。小于 `512` 个 token 的小节会尽可能与相邻内容合并，避免产生低价值碎片。
+- 超大的叶子章节或没有标题的文档会按段落切分，并同时以 token 和字符限制为目标。为保持 Markdown 表格结构，单行表格内容可能超过目标限制。
+
+以上数值分别是 `ParserConfig.max_section_size` 和 `ParserConfig.max_section_chars` 的默认值。若希望转换后的每篇 Markdown 正文保持完整，可将 `args.parse_mode` 设为 `no_split`。该选项只改变存储布局；语义处理、向量化和内部 embedding 分块仍会正常执行。
 
 ### 返回结果
 


### PR DESCRIPTION
## Description

Clarify that smart splitting is threshold-based, document the current 2048-token and 6000-character defaults, and explain the storage-only effect of `parse_mode=no_split` in both English and Chinese guides.

Before this change, the extraction guide showed stale 1024-token pseudocode that implied every heading could become a separate file. The parser actually preserves smaller documents as one file and only uses headings after a size threshold is exceeded.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4783

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Document the dual token and character thresholds used by the default parser configuration.
- Explain heading, paragraph, small-section, and Markdown-table splitting behavior.
- Clarify that `no_split` changes storage layout without disabling semantic processing or embedding chunking.
- Keep the English and Chinese documentation synchronized.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

Documentation validation:

- `git diff --check`

## Checklist

- [x] My code follows the project coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Documentation-only change; no runtime behavior is modified.
