### PR TITLE
fix(session): guide skill reads to exact files

### DIFF
--- a/openviking/session/skill/session_skill_context_provider.py
+++ b/openviking/session/skill/session_skill_context_provider.py
@@ -88,8 +88,10 @@ class SessionSkillContextProvider(SessionExtractContextProvider):
 
     def instruction(self) -> str:
         return (
-            "You are an extraction agent. Analyze the archived conversation, use read when "
-            "needed, and output only JSON that matches the schema descriptions."
+            "You are an extraction agent. Analyze the archived conversation and output only JSON "
+            "that matches the schema descriptions. Only call read on an exact .../SKILL.md URI "
+            "from the prefetched skill listing. Never read a directory URI; if the listing is "
+            "empty, proceed without reading an existing skill."
         )
 
     async def prefetch(self) -> List[Dict[str, Any]]:
@@ -117,10 +119,7 @@ class SessionSkillContextProvider(SessionExtractContextProvider):
                 for entry in entries:
                     if not entry.get("isDir", False):
                         continue
-                    skill_root = (
-                        entry.get("uri")
-                        or f"{skill_root_uri.rstrip('/')}/{entry.get('name', '')}"
-                    )
+                    skill_root = entry.get("uri") or f"{skill_root_uri.rstrip('/')}/{entry.get('name', '')}"
                     skill_name = entry.get("name") or skill_root.rstrip("/").split("/")[-1]
                     if skill_name in seen_names:
                         continue
@@ -163,7 +162,14 @@ class SessionSkillContextProvider(SessionExtractContextProvider):
         limit = arguments.get("limit", -1)
 
         if not uri.endswith("/SKILL.md"):
-            return await super().execute_tool(tool_call)
+            return {
+                "error": (
+                    "This extraction agent can only read an exact .../SKILL.md URI from the "
+                    "prefetched skill listing. Directory URIs cannot be read because no list tool "
+                    "is available. If the listing was empty, proceed without reading an existing "
+                    "skill."
+                )
+            }
 
         try:
             raw_content = await self._viking_fs.read_file(uri, ctx=self._ctx)

--- a/openviking/session/skill/session_skill_context_provider.py
+++ b/openviking/session/skill/session_skill_context_provider.py
@@ -119,7 +119,9 @@ class SessionSkillContextProvider(SessionExtractContextProvider):
                 for entry in entries:
                     if not entry.get("isDir", False):
                         continue
-                    skill_root = entry.get("uri") or f"{skill_root_uri.rstrip('/')}/{entry.get('name', '')}"
+                    skill_root = (
+                        entry.get("uri") or f"{skill_root_uri.rstrip('/')}/{entry.get('name', '')}"
+                    )
                     skill_name = entry.get("name") or skill_root.rstrip("/").split("/")[-1]
                     if skill_name in seen_names:
                         continue

--- a/tests/session/test_commit_skill_inference.py
+++ b/tests/session/test_commit_skill_inference.py
@@ -116,6 +116,23 @@ async def test_session_skill_context_provider_prefetch_lists_existing_skills():
 
 
 @pytest.mark.asyncio
+async def test_session_skill_context_provider_rejects_directory_read_with_actionable_guidance():
+    viking_fs = MagicMock()
+    viking_fs.read_file = AsyncMock()
+    provider = object.__new__(SessionSkillContextProvider)
+    provider._viking_fs = viking_fs
+
+    result = await provider.execute_tool(
+        SimpleNamespace(name="read", arguments={"uri": "viking://user/default/skills"})
+    )
+
+    assert result["error"].startswith("This extraction agent can only read")
+    assert "no list tool is available" in result["error"]
+    assert "proceed without reading" in result["error"]
+    viking_fs.read_file.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_agent_trajectory_context_provider_without_session_skills_prefetches_history_only():
     provider = AgentTrajectoryContextProvider(
         messages=[


### PR DESCRIPTION
## Description

Prevent the session skill extraction agent from entering an unfollowable directory-read path.

Before this change, the extraction prompt allowed a generic `read` call and directory URIs fell through to the base provider, which replied with “List it first.” This agent does not expose a list tool, so it could not recover. The skill context provider now tells the model to read only exact `.../SKILL.md` URIs from the prefetched listing and returns actionable guidance if a directory URI is requested.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4831

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Restrict extraction-agent reads to exact prefetched `SKILL.md` URIs in the system instruction.
- Reject directory reads locally with guidance the agent can act on.
- Add regression coverage that verifies no filesystem read is attempted for a directory URI.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Commands run:

- `uv run pytest tests/session/test_commit_skill_inference.py -q -k rejects_directory_read`
- `uv run ruff check openviking/session/skill/session_skill_context_provider.py tests/session/test_commit_skill_inference.py`
- `uv run ruff format --check openviking/session/skill/session_skill_context_provider.py tests/session/test_commit_skill_inference.py`
- `git diff --check`

## Checklist

- [x] My code follows the project coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The targeted regression test passes. Running the entire test file in this sandbox also exercises configuration-dependent cases; four pre-existing cases fail because no OpenViking config file is available at `/root/.openviking/ov.conf` and `OPENVIKING_CONFIG_FILE` is unset.
