### PR TITLE
docs(server): add persistent local service setup

### DIFF
--- a/docs/en/getting-started/03-quickstart-server.md
+++ b/docs/en/getting-started/03-quickstart-server.md
@@ -53,6 +53,8 @@ curl http://localhost:1933/health
 
 Web Studio is also served at `http://localhost:1933/studio` (bundled with pip/pipx installs since v0.3.21 — no Docker required).
 
+For a local server that survives terminal closure and restarts automatically, follow the [systemd (Linux) or launchd (macOS) service instructions](../guides/03-deployment.md#persistent-local-services).
+
 ## Connect with Python SDK
 
 ```python
@@ -332,7 +334,7 @@ nohup openviking-server > /data/log/openviking.log 2>&1 &
 
 ```
 
-*Note: For production environments requiring auto-restart on failure, we recommend using `systemctl` (not covered here).*
+*Note: `nohup` does not provide startup-on-login or reliable crash recovery. For a persistent service, use the [systemd or launchd setup](../guides/03-deployment.md#persistent-local-services).*
 
 #### Verify Service Status
 

--- a/docs/en/guides/03-deployment.md
+++ b/docs/en/guides/03-deployment.md
@@ -87,11 +87,13 @@ Server manages local RAGFS and VectorDB. Configure the storage path in `ov.conf`
 openviking-server
 ```
 
-## Deploying with Systemd (Recommended)
+## Persistent Local Services
 
-For Linux systems, you can use Systemd to manage OpenViking as a service, enabling automatic restart and startup on boot. Firstly, you should tried to install and configure openviking on your own.
+### Linux: systemd (Recommended)
 
-### Create Systemd Service File
+On Linux, systemd keeps OpenViking running after logout, restarts it after failures, and starts it at boot. First install and configure OpenViking, then confirm that `openviking-server` starts successfully in the foreground. Run `command -v openviking-server` and use the returned absolute path for `ExecStart` below.
+
+#### Create a systemd service file
 
 Create `/etc/systemd/system/openviking.service` file:
 
@@ -104,7 +106,7 @@ After=network.target
 Type=simple
 # Replace with your working directory
 WorkingDirectory=/var/lib/openviking
-# Choose one of the following start methods
+# Replace with the output of command -v openviking-server
 ExecStart=/usr/bin/openviking-server
 Restart=always
 RestartSec=5
@@ -115,7 +117,7 @@ Environment="OPENVIKING_CONFIG_FILE=/etc/openviking/ov.conf"
 WantedBy=multi-user.target
 ```
 
-### Manage the Service
+#### Manage the service
 
 After creating the service file, use the following commands to manage the OpenViking service:
 
@@ -135,6 +137,67 @@ sudo systemctl status openviking.service
 # View service logs
 sudo journalctl -u openviking.service -f
 ```
+
+### macOS: launchd
+
+A user LaunchAgent keeps OpenViking running after its terminal closes, restarts it after failures, and loads it whenever that user logs in. It does not run before login. First confirm that the server works in the foreground, then run `command -v openviking-server` to find its absolute executable path.
+
+#### Create a LaunchAgent
+
+Create `~/Library/LaunchAgents/ai.openviking.server.plist` with the following content. Replace every `/Users/your-name` path, including the executable path, with absolute paths on your machine; launchd does not expand `~`.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ai.openviking.server</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/your-name/.local/bin/openviking-server</string>
+    <string>--config</string>
+    <string>/Users/your-name/.openviking/ov.conf</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>/Users/your-name/.openviking</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/Users/your-name/Library/Logs/OpenViking.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/your-name/Library/Logs/OpenViking.error.log</string>
+</dict>
+</plist>
+```
+
+Validate and load it:
+
+```bash
+plutil -lint ~/Library/LaunchAgents/ai.openviking.server.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.openviking.server.plist
+```
+
+#### Manage the LaunchAgent
+
+```bash
+# Check status
+launchctl print gui/$(id -u)/ai.openviking.server
+
+# Restart after changing the config
+launchctl kickstart -k gui/$(id -u)/ai.openviking.server
+
+# Follow logs
+tail -f ~/Library/Logs/OpenViking.log ~/Library/Logs/OpenViking.error.log
+
+# Stop and unload
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/ai.openviking.server.plist
+```
+
+After editing the plist itself, run `bootout` and then `bootstrap` again so launchd reloads the definition.
 
 ## Connecting Clients
 

--- a/docs/zh/getting-started/03-quickstart-server.md
+++ b/docs/zh/getting-started/03-quickstart-server.md
@@ -53,6 +53,8 @@ curl http://localhost:1933/health
 
 Web Studio 也会在 `http://localhost:1933/studio` 提供（自 v0.3.21 起 pip/pipx 安装即自带，无需 Docker）。
 
+如果希望本地服务在关闭终端后继续运行并自动恢复，请参考[使用 systemd（Linux）或 launchd（macOS）管理服务](../guides/03-deployment.md#本地服务常驻运行)。
+
 ## 使用 Python SDK 连接
 
 ```python
@@ -319,7 +321,7 @@ nohup openviking-server > /data/log/openviking.log 2>&1 &
 # 默认会以执行命令的路径下创建 ./data 存放数据
 # 如果后续希望杀死服务进程记得要清理两个后台服务：pkill openviking; pkill agfs
 ```
-可以看到服务在后台常驻运行。当然如果希望重启自动恢复，建议采用 systemctl 启动，此处不赘述。
+`nohup` 不提供登录时自动启动或可靠的异常恢复。如果需要常驻服务，请使用 [systemd 或 launchd 方案](../guides/03-deployment.md#本地服务常驻运行)。
 服务启动后，可以在 /data 下看到数据文件、日志文件等。
 
 **验证服务状态：**

--- a/docs/zh/guides/03-deployment.md
+++ b/docs/zh/guides/03-deployment.md
@@ -87,11 +87,13 @@ openviking-server --config /path/to/ov.conf --host 127.0.0.1 --port 8000
 openviking-server
 ```
 
-## 使用 Systemd 部署服务（推荐）
+## 本地服务常驻运行
 
-对于 Linux 系统，可以使用 Systemd 服务来管理 OpenViking，实现自动重启、开机自启等功能。首先，你应该已经成功安装并配置了 OpenViking 服务器，确保它可以正常运行，再进行服务化部署。
+### Linux：systemd（推荐）
 
-### 创建 Systemd 服务文件
+在 Linux 上，systemd 可以让 OpenViking 在退出终端后继续运行、异常退出后自动重启，并随系统启动。请先完成 OpenViking 的安装和配置，确认 `openviking-server` 能在前台正常启动。运行 `command -v openviking-server`，并将下面 `ExecStart` 替换为返回的绝对路径。
+
+#### 创建 systemd 服务文件
 
 创建 `/etc/systemd/system/openviking.service` 文件：
 
@@ -108,7 +110,7 @@ User=your-username
 Group=your-group
 # 替换为工作目录
 WorkingDirectory=/var/lib/openviking
-# 以下两种启动方式二选一
+# 替换为 command -v openviking-server 的输出
 ExecStart=/path/to/your/python/bin/openviking-server
 Restart=always
 RestartSec=5
@@ -119,7 +121,7 @@ Environment="OPENVIKING_CONFIG_FILE=/etc/openviking/ov.conf"
 WantedBy=multi-user.target
 ```
 
-### 管理服务
+#### 管理服务
 
 创建好服务文件后，使用以下命令管理 OpenViking 服务：
 
@@ -139,6 +141,67 @@ sudo systemctl status openviking.service
 # 查看服务日志
 sudo journalctl -u openviking.service -f
 ```
+
+### macOS：launchd
+
+用户级 LaunchAgent 可以让 OpenViking 在关闭终端后继续运行、异常退出后自动重启，并在该用户登录时自动加载；它不会在用户登录前运行。请先确认服务能在前台正常启动，再运行 `command -v openviking-server` 获取可执行文件的绝对路径。
+
+#### 创建 LaunchAgent
+
+创建 `~/Library/LaunchAgents/ai.openviking.server.plist`，内容如下。请将所有 `/Users/your-name` 路径（包括可执行文件路径）替换为本机绝对路径；launchd 不会展开 `~`。
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ai.openviking.server</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/your-name/.local/bin/openviking-server</string>
+    <string>--config</string>
+    <string>/Users/your-name/.openviking/ov.conf</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>/Users/your-name/.openviking</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/Users/your-name/Library/Logs/OpenViking.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/your-name/Library/Logs/OpenViking.error.log</string>
+</dict>
+</plist>
+```
+
+校验并加载配置：
+
+```bash
+plutil -lint ~/Library/LaunchAgents/ai.openviking.server.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.openviking.server.plist
+```
+
+#### 管理 LaunchAgent
+
+```bash
+# 查看状态
+launchctl print gui/$(id -u)/ai.openviking.server
+
+# 修改 OpenViking 配置后重启
+launchctl kickstart -k gui/$(id -u)/ai.openviking.server
+
+# 持续查看日志
+tail -f ~/Library/Logs/OpenViking.log ~/Library/Logs/OpenViking.error.log
+
+# 停止并卸载
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/ai.openviking.server.plist
+```
+
+如果修改了 plist 文件本身，请先执行 `bootout`，再执行 `bootstrap`，让 launchd 重新加载服务定义。
 
 ## 连接客户端
 


### PR DESCRIPTION
## Description

Add practical persistent local-service instructions for Linux and macOS, and link them from both server quickstart guides.

Before this change, the docs only provided a partial systemd example and recommended `nohup` for background execution without covering login startup or reliable crash recovery. The deployment guide now documents systemd and a user-level launchd LaunchAgent, including executable-path discovery, lifecycle commands, logs, and reload behavior.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4836

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Expand the Linux systemd section with persistence behavior and absolute-path guidance.
- Add a complete macOS user LaunchAgent example and management commands.
- Explain the limitations of `nohup` and link quickstart readers to the persistent-service guide.
- Keep English and Chinese documentation synchronized.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Documentation validation:

- Parsed both embedded launchd plist examples with Python `plistlib.loads`.
- Ran `git diff --check`.

## Checklist

- [x] My code follows the project coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The launchd example is intentionally a user-level LaunchAgent: it starts after user login, not before login as a system daemon.
