### PR TITLE
fix(studio): align pending labels and cover task page status / 统一等待文案并补齐任务页回归

### DIFF
--- a/web-studio/src/routes/tasks/-lib/task-list.test.ts
+++ b/web-studio/src/routes/tasks/-lib/task-list.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { fetchTasks, getEffectiveTaskStatus, MAX_TASKS } from './task-list'
+import { fetchTasks, MAX_TASKS } from './task-list'
 
 const clientMocks = vi.hoisted(() => ({
   getTasks: vi.fn(),
@@ -51,37 +51,41 @@ describe('task list requests', () => {
     })
   })
 
-  it('sends status to the API before the result limit is applied', async () => {
-    clientMocks.getTasks.mockResolvedValue([
-      {
-        created_at: 1,
-        status: 'failed',
-        task_id: 'old-failed',
-      },
-    ])
+  it('finds matching tasks before the server applies its result limit', async () => {
+    const failedTask = {
+      task_id: 'old-failure',
+      task_type: 'session_commit',
+      status: 'failed',
+      created_at: 1,
+    }
+    const records = [
+      ...Array.from({ length: MAX_TASKS }, (_, index) => ({
+        task_id: `completed-${index}`,
+        task_type: 'session_commit',
+        status: 'completed',
+        created_at: MAX_TASKS + 1 - index,
+      })),
+      failedTask,
+    ]
+    clientMocks.getTasks.mockImplementation(({ query }) =>
+      records
+        .filter((task) => !query.status || task.status === query.status)
+        .filter(
+          (task) => !query.task_type || task.task_type === query.task_type,
+        )
+        .slice(0, query.limit),
+    )
 
     await expect(fetchTasks('session_commit', 'failed')).resolves.toEqual([
-      expect.objectContaining({ task_id: 'old-failed' }),
+      failedTask,
     ])
     expect(clientMocks.getTasks).toHaveBeenCalledWith({
       query: {
         limit: MAX_TASKS,
-        status: 'failed',
         task_type: 'session_commit',
+        status: 'failed',
       },
     })
-  })
-
-  it('does not reclassify surplus running tasks as pending', () => {
-    const tasks = Array.from({ length: 12 }, (_, index) => ({
-      created_at: index + 1,
-      status: 'running' as const,
-      task_id: `task-${index + 1}`,
-    }))
-
-    expect(tasks.map((task) => getEffectiveTaskStatus(task, tasks))).toEqual(
-      Array.from({ length: 12 }, () => 'running'),
-    )
   })
 
   it('propagates request failures to the query error state', async () => {

--- a/web-studio/src/routes/tasks/-lib/task-list.ts
+++ b/web-studio/src/routes/tasks/-lib/task-list.ts
@@ -1,8 +1,5 @@
 import { getOvResult, getTasks } from '#/lib/ov-client'
-import {
-  normalizeTasks,
-  normalizeTaskStatus,
-} from '#/routes/tasks/-lib/task-record'
+import { normalizeTasks } from '#/routes/tasks/-lib/task-record'
 import type { TaskRecord, TaskStatus } from '#/routes/tasks/-lib/task-record'
 
 export type TaskStatusFilter = Exclude<TaskStatus, 'unknown'> | 'all'
@@ -19,14 +16,6 @@ export type TaskTypeFilter =
   | 'all'
 
 export const MAX_TASKS = 200
-
-/** Prefer the API status; do not invent pending from a running-slot cap. */
-export function getEffectiveTaskStatus(
-  taskItem: TaskRecord,
-  _list?: TaskRecord[],
-): TaskStatus {
-  return normalizeTaskStatus(taskItem.status)
-}
 
 export async function fetchTasks(
   taskType: TaskTypeFilter,

--- a/web-studio/src/routes/tasks/route.test.tsx
+++ b/web-studio/src/routes/tasks/route.test.tsx
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+
+import * as React from 'react'
+import { createInstance } from 'i18next'
+import { I18nextProvider } from 'react-i18next'
+import type { ComponentType } from 'react'
+import en from '#/i18n/locales/en/workspace'
+import zh from '#/i18n/locales/zh-CN/workspace'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import { Route } from './route'
+import type { TaskRecord } from './-lib/task-record'
+
+const clientMocks = vi.hoisted(() => ({ getTasks: vi.fn() }))
+
+vi.mock('#/lib/ov-client', () => ({
+  getOvResult: async (value: unknown) => value,
+  getTasks: clientMocks.getTasks,
+  ovClient: { instance: { post: vi.fn() } },
+}))
+
+vi.mock('#/gen/ov-client', () => ({ postResources: vi.fn() }))
+vi.mock('#/lib/sessions/api', () => ({ commitSession: vi.fn() }))
+vi.mock('#/hooks/use-app-connection', () => ({
+  useAppConnection: () => ({ identityScopeKey: 'test/test' }),
+}))
+vi.mock('#/routes/monitoring/-components/queue-status-card', () => ({
+  QueueStatusCard: () => null,
+}))
+vi.mock('#/routes/tasks/-components/task-detail-sheet', () => ({
+  TaskDetailSheet: () => null,
+}))
+
+const TaskPage = Route.options.component as ComponentType & {
+  preload?: () => Promise<void>
+}
+beforeAll(async () => {
+  await TaskPage.preload?.()
+})
+
+let records: TaskRecord[]
+const queryClients: QueryClient[] = []
+
+function runningTasks(count: number): TaskRecord[] {
+  return Array.from({ length: count }, (_, index) => ({
+    task_id: `task-${index + 1}`,
+    task_type: index < 8 ? 'session_commit' : 'add_resource',
+    resource_id: `resource-${index + 1}`,
+    status: 'running',
+    created_at: 100 + index,
+  }))
+}
+
+async function renderPage(lng = 'en') {
+  const i18n = createInstance()
+  await i18n.init({
+    lng,
+    resources: { en, 'zh-CN': zh },
+    interpolation: { escapeValue: false },
+  })
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  queryClients.push(queryClient)
+  render(
+    <QueryClientProvider client={queryClient}>
+      <I18nextProvider i18n={i18n}>
+        <TaskPage />
+      </I18nextProvider>
+    </QueryClientProvider>,
+  )
+  return userEvent.setup()
+}
+
+function taskRows() {
+  return screen.queryAllByRole('row', {
+    name: /^(View details for task |查看任务 )/,
+  })
+}
+
+function expectRunningRows(count: number) {
+  expect(taskRows()).toHaveLength(count)
+  for (const row of taskRows()) {
+    expect(within(row).getByText('Running')).toBeDefined()
+  }
+}
+
+beforeEach(() => {
+  records = runningTasks(12)
+  clientMocks.getTasks.mockReset()
+  // Model the API contract: filtering precedes ordering and the result limit.
+  clientMocks.getTasks.mockImplementation(({ query }) =>
+    records
+      .filter((task) => !query.status || task.status === query.status)
+      .filter((task) => !query.task_type || task.task_type === query.task_type)
+      .sort((left, right) => Number(right.created_at) - Number(left.created_at))
+      .slice(0, query.limit),
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  for (const client of queryClients.splice(0)) client.clear()
+})
+
+describe('task status presentation', () => {
+  it('keeps all twelve running tasks running in both rows and the count', async () => {
+    await renderPage()
+    await screen.findByRole('row', { name: 'View details for task task-12' })
+
+    expectRunningRows(12)
+    expect(screen.getByText('12 / 0')).toBeDefined()
+  })
+
+  it('shows no pending tasks when all tasks are running, including after type filtering', async () => {
+    const user = await renderPage()
+    await screen.findByRole('row', { name: 'View details for task task-12' })
+
+    await user.click(screen.getByRole('combobox', { name: 'Task status' }))
+    await user.click(await screen.findByRole('option', { name: 'Pending' }))
+    await screen.findByText('No matching tasks')
+    expect(taskRows()).toHaveLength(0)
+    expect(screen.getByText('0 / 0')).toBeDefined()
+
+    await user.click(screen.getByRole('button', { name: 'Clear filters' }))
+    await screen.findByRole('row', { name: 'View details for task task-12' })
+    await user.click(screen.getByRole('combobox', { name: 'Task type' }))
+    await user.click(
+      await screen.findByRole('option', { name: 'Resource processing' }),
+    )
+    await screen.findByText('4 / 0')
+    expectRunningRows(4)
+  })
+
+  it.each([
+    ['en', 'Pending', 'Task status'],
+    ['zh-CN', '等待中', '任务状态'],
+  ])(
+    'renders and filters actual pending tasks in %s',
+    async (lng, pendingLabel, filterLabel) => {
+      records.push(
+        ...[1, 2].map((index) => ({
+          task_id: `pending-${index}`,
+          task_type: 'add_resource',
+          resource_id: `pending-resource-${index}`,
+          status: 'pending',
+          created_at: 200 + index,
+        })),
+      )
+      const user = await renderPage(lng)
+      await screen.findByRole('row', { name: /pending-2/ })
+      expect(screen.getByText('12 / 2')).toBeDefined()
+
+      await user.click(screen.getByRole('combobox', { name: filterLabel }))
+      await user.click(
+        await screen.findByRole('option', { name: pendingLabel }),
+      )
+      await screen.findByText('0 / 2')
+      expect(taskRows()).toHaveLength(2)
+      for (const row of taskRows()) {
+        expect(within(row).getByText(pendingLabel)).toBeDefined()
+      }
+    },
+  )
+
+  it('preserves task statuses when grouping and pagination change the visible rows', async () => {
+    records = runningTasks(26)
+    records[25].resource_id = records[0].resource_id
+    const user = await renderPage()
+    await screen.findByRole('row', { name: 'View details for task task-26' })
+    expectRunningRows(20)
+    expect(screen.getByText('25 / 0')).toBeDefined()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Latest per Resource' }),
+    )
+    expect(screen.getByText('26 / 0')).toBeDefined()
+    expectRunningRows(20)
+
+    await user.click(screen.getByRole('button', { name: 'Go to next page' }))
+    expectRunningRows(6)
+    expect(screen.getByText('26 / 0')).toBeDefined()
+  })
+})

--- a/web-studio/src/routes/tasks/route.tsx
+++ b/web-studio/src/routes/tasks/route.tsx
@@ -295,11 +295,7 @@ function TasksRoute() {
               : 'size-3.5'
           }
         />
-        <span>
-          {status === 'pending'
-            ? (i18n.language.startsWith('zh') ? '队首等待中' : 'Queued')
-            : t(`status.${status}`)}
-        </span>
+        <span>{t(`status.${status}`)}</span>
         {status === 'running' && (
           <span className="font-mono font-semibold ml-0.5">
             {pct}%


### PR DESCRIPTION
## Description / 变更说明

**English**
Pending rows in `/studio/tasks` still display `Queued` / `队首等待中` while the status filter uses `Pending` / `等待中`. This change uses the existing translation for row labels and adds regression coverage for the actual task page. It implements the incremental improvements requested in [#4823](https://github.com/volcengine/OpenViking/pull/4823#issuecomment-5595424950), on top of the API-status fixes merged in #4825.

**中文**
`/studio/tasks` 的等待中行标签仍显示 `Queued` / “队首等待中”，与筛选项的 `Pending` / “等待中”不一致。本次复用已有翻译，并补充真实任务页面的回归覆盖；基于 #4825 已合入的状态修复，落实维护者在 #4823 中建议的增量改进。

## Human Involvement / 人工参与

- [x] A human participated in the implementation or review loop / 有人参与实现或评审过程
- [ ] This PR was generated entirely by AI agents without human participation in the loop / 此 PR 完全由 AI 生成，无人参与实现或评审过程

## Related Issue / 关联问题

Fixes #4855

## Type of Change / 变更类型

- [x] Bug fix (non-breaking change that fixes an issue) / Bug 修复（兼容性保持）
- [x] Test update / 测试更新

## Changes Made / 主要改动

**English**
- Render pending through the existing status translation; remove the unused `getEffectiveTaskStatus` helper and its implementation-specific test.
- Exercise row labels, Running/Pending counts, status/type filters, resource grouping and pagination with the real page and English/Chinese resources. Strengthen the existing request test with 200 newer completed tasks and one older failure.
- Import `Route.options.component` in the page test and preload it when needed, following the existing Playground test pattern. `TasksRoute` stays private and automatic code splitting remains enabled.

**中文**
- 等待中行标签统一使用已有状态翻译；删除未使用的 `getEffectiveTaskStatus` 及其实现细节测试。
- 通过真实页面与中英文资源覆盖行标签、运行中/等待中计数、状态/类型筛选、资源分组和分页；将已有请求测试加强为“200 条较新完成任务之后仍能找到旧失败任务”。
- 测试沿用 Playground 的 `Route.options.component` 入口，按需预加载。`TasksRoute` 保持内部函数，保留自动代码拆分。

## Testing / 验证结果

**English**
Validated on macOS with Node.js 24.19.0. Before the production change, the page tests fail in both languages on the pending row label; the other three page cases pass. After the change: **9 focused tests and all 312 tests in 63 Studio files pass**. Production build passes. The task page remains a separate dynamically imported chunk (36,624 → 36,555 bytes); there is no `TasksRoute` export/code-splitting warning. ESLint reports 0 errors; existing route warnings decrease from 36 to 34. Prettier passes on the task-list files and new test; the route retains its existing formatting. The existing large-chunk build warning remains.

**中文**
在 macOS、Node.js 24.19.0 下验证。实现修改前，等待中行标签的中英文测试均失败，其余 3 项页面用例通过；修改后，**专项 9 项、完整 Studio 63 个文件共 312 项测试全部通过**，生产构建通过。任务页保持独立动态导入分包（36,624 → 36,555 字节），没有 `TasksRoute` 导出/代码拆分警告。ESLint 0 错误，路由既有警告由 36 降至 34；任务列表文件及新增测试通过 Prettier，路由保留原有格式。构建保留既有大分包警告。

Commands run from `web-studio` / 在 `web-studio` 执行：

```sh
node node_modules/vitest/vitest.mjs run src/routes/tasks/route.test.tsx src/routes/tasks/-lib/task-list.test.ts
node node_modules/vitest/vitest.mjs run
node node_modules/vite/bin/vite.js build --base=/studio/
node node_modules/eslint/bin/eslint.js src/routes/tasks/-lib/task-list.ts src/routes/tasks/-lib/task-list.test.ts src/routes/tasks/route.tsx src/routes/tasks/route.test.tsx --format json
node node_modules/prettier/bin/prettier.cjs --check src/routes/tasks/-lib/task-list.ts src/routes/tasks/-lib/task-list.test.ts src/routes/tasks/route.test.tsx
git diff --check
```

Browser verification used the production build with controlled GET task responses: 12 running + 2 pending show `12 / 2`; Pending filtering shows exactly two rows and `0 / 2`, with consistent labels in both languages. This validates frontend behavior; it does not exercise model-worker concurrency or the full Python suite. / 浏览器使用生产构建和受控 GET 响应验证：12 条运行中加 2 条等待中显示 `12 / 2`；等待中筛选恰好返回 2 行、计数 `0 / 2`，中英文标签一致。此验证覆盖前端行为，未运行模型工作进程并发验证或完整 Python 测试。

## Checklist / 检查清单

- [x] My code follows the project's coding style / 遵循项目代码风格
- [x] I have performed a self-review of my code / 已完成代码自审
- [x] I have added tests that prove my fix is effective / 已添加能捕获修复前问题的测试
- [x] New and existing unit tests pass locally / 新增与既有测试本地通过
- [x] My changes generate no new warnings / 未引入新警告
- [x] Any dependent changes have been merged and published / 依赖改动已合入

## Additional Notes / 补充说明

No API, dependency, routing configuration or count-scope changes. This UI consistency fix does not require documentation or migration changes. / API、依赖、路由配置及计数范围保持不变；此次界面文案一致性修复无需文档或迁移变更。
