### PR TITLE
fix(skills): 让 Experience 技能兼容没有 viking://~ 的旧服务端

### DIFF
--- a/agent-plugins/plugin.json
+++ b/agent-plugins/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "openviking",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Semantic long-term memory and context engine for coding agents. Recall prior knowledge with the find/search/read MCP tools and persist durable facts with remember/write, backed by an OpenViking server.",
   "author": {
     "name": "Volcano Engine",

--- a/agent-plugins/skills/openviking-memory/SKILL.md
+++ b/agent-plugins/skills/openviking-memory/SKILL.md
@@ -37,7 +37,12 @@ without memory.
    `limit` around 5-10. Use `search` when deeper intent analysis helps, or use
    `search` with `mode="context"` for a server-assembled, token-budgeted
    context block. In list mode, scope with `target_uri` when you know where to look, e.g.
-   `viking://~/memories/experiences` for prior task experience.
+   `viking://~/memories/experiences` for prior task experience. `viking://~` is
+   the home alias for your own user root; a server that predates the alias
+   rejects every `viking://~` URI with `INVALID_URI`. Against such a server use
+   the explicit `viking://user/<user_id>/...` root taken from a URI already
+   visible in this session, or drop `target_uri` and keep the hits whose URI
+   contains `/memories/experiences/`. Never guess a user ID.
 4. Judge results by task and environment fit, not title similarity. `read` the
    one to three exact file URIs likely to change how you execute. Ignore
    sidecar files such as `.abstract.md`, `.overview.md`, and

--- a/examples/claude-code-memory-plugin/.claude-plugin/plugin.json
+++ b/examples/claude-code-memory-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "openviking-memory",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Long-term semantic memory for Claude Code, powered by OpenViking. Auto-recall relevant memories at session start and capture important information during conversations.",
   "author": {
     "name": "OpenViking",

--- a/examples/claude-code-memory-plugin/package.json
+++ b/examples/claude-code-memory-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-openviking-memory",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "OpenViking memory plugin for Claude Code — semantic long-term memory",
   "type": "module",
   "scripts": {

--- a/examples/claude-code-memory-plugin/skills/ov-experience-memory/SKILL.md
+++ b/examples/claude-code-memory-plugin/skills/ov-experience-memory/SKILL.md
@@ -55,7 +55,8 @@ context or deeper intent analysis is useful.
 
    For tools using MCP-style parameters, set `target_uri` to this root. For
    OpenClaw `ov_search`, set `uri` to this root. Never hardcode `default`,
-   `test`, or another user ID.
+   `test`, or another user ID. If the server rejects the URI, resolve the root
+   as described in *Servers Without the Home Alias* and retry once.
 4. Start with `limit=5` and the tool's normal score threshold. Judge results by
    task, environment, preconditions, and likely effect; title similarity alone
    is insufficient. If no result is relevant, continue without Experience and
@@ -72,6 +73,26 @@ context or deeper intent analysis is useful.
 8. If execution fails for a materially new reason, perform at most one focused
    follow-up search using the failure evidence, then read only newly relevant
    Experience files.
+
+## Servers Without the Home Alias
+
+`viking://~` is the home alias for the caller's own space. A server released
+before the alias (OpenViking v0.4.16) does not resolve it and rejects the
+request with `INVALID_URI` (HTTP 400) instead of searching. Retry once against
+the caller's explicit root, resolved from evidence rather than guessed:
+
+- If a canonical `viking://user/<user_id>/...` URI is already visible in this
+  session — injected memory context, or an earlier OpenViking tool result —
+  reuse that `<user_id>` and search
+  `viking://user/<user_id>/memories/experiences`.
+- Otherwise repeat the same query with no target scope, narrowed to memories
+  with `context_type` when the tool accepts it, and keep only hits whose URI
+  contains `/memories/experiences/`. Those hits carry the canonical user ID;
+  reuse it for the reads and for any later Experience search in this task.
+
+Do not fall back to the uid-less `viking://user/memories/experiences`: only
+some older servers and roles expand it, and current servers reject it. If no
+explicit root can be resolved, continue without Experience.
 
 ## Applying Retrieved Experience
 

--- a/examples/codex-memory-plugin/.codex-plugin/plugin.json
+++ b/examples/codex-memory-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "openviking-memory",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Long-term semantic memory for Codex, powered by OpenViking. Recall on UserPromptSubmit, incremental add_message on Stop (per turn), commit on SessionEnd (Codex >= 0.145) and on PreCompact, with an idle/ended sweep on SessionStart as the fallback for signals, crashes and older Codex builds. Includes a local stdio MCP proxy that reads OpenViking credentials from env/ovcli.conf.",
   "author": {
     "name": "OpenViking",

--- a/examples/codex-memory-plugin/skills/ov-experience-memory/SKILL.md
+++ b/examples/codex-memory-plugin/skills/ov-experience-memory/SKILL.md
@@ -55,7 +55,8 @@ context or deeper intent analysis is useful.
 
    For tools using MCP-style parameters, set `target_uri` to this root. For
    OpenClaw `ov_search`, set `uri` to this root. Never hardcode `default`,
-   `test`, or another user ID.
+   `test`, or another user ID. If the server rejects the URI, resolve the root
+   as described in *Servers Without the Home Alias* and retry once.
 4. Start with `limit=5` and the tool's normal score threshold. Judge results by
    task, environment, preconditions, and likely effect; title similarity alone
    is insufficient. If no result is relevant, continue without Experience and
@@ -72,6 +73,26 @@ context or deeper intent analysis is useful.
 8. If execution fails for a materially new reason, perform at most one focused
    follow-up search using the failure evidence, then read only newly relevant
    Experience files.
+
+## Servers Without the Home Alias
+
+`viking://~` is the home alias for the caller's own space. A server released
+before the alias (OpenViking v0.4.16) does not resolve it and rejects the
+request with `INVALID_URI` (HTTP 400) instead of searching. Retry once against
+the caller's explicit root, resolved from evidence rather than guessed:
+
+- If a canonical `viking://user/<user_id>/...` URI is already visible in this
+  session — injected memory context, or an earlier OpenViking tool result —
+  reuse that `<user_id>` and search
+  `viking://user/<user_id>/memories/experiences`.
+- Otherwise repeat the same query with no target scope, narrowed to memories
+  with `context_type` when the tool accepts it, and keep only hits whose URI
+  contains `/memories/experiences/`. Those hits carry the canonical user ID;
+  reuse it for the reads and for any later Experience search in this task.
+
+Do not fall back to the uid-less `viking://user/memories/experiences`: only
+some older servers and roles expand it, and current servers reject it. If no
+explicit root can be resolved, continue without Experience.
 
 ## Applying Retrieved Experience
 

--- a/examples/memory-plugin-shared/sync.test.mjs
+++ b/examples/memory-plugin-shared/sync.test.mjs
@@ -113,6 +113,30 @@ async function findSkillFiles(dir) {
   return found;
 }
 
+// viking://~ is the home alias for the caller's own space, and a server older
+// than the alias rejects it outright instead of searching. A skill that sends
+// the agent to the Experience root therefore has to name the explicit
+// viking://user/<user_id> root it falls back to, or the whole workflow stops
+// against those servers.
+test("skills scoping the Experience root document the explicit-root fallback", async () => {
+  const files = [
+    ...(await findSkillFiles(join(ROOT, "examples"))),
+    ...(await findSkillFiles(join(ROOT, "agent-plugins"))),
+  ];
+  const scoped = [];
+  for (const file of files) {
+    const source = await readFile(file, "utf-8");
+    if (!source.includes("viking://~/memories/experiences")) continue;
+    scoped.push(file);
+    assert.match(
+      source,
+      /viking:\/\/user\/<user_id>/,
+      `${relative(ROOT, file)} scopes by viking://~ without naming the viking://user/<user_id> fallback`,
+    );
+  }
+  assert.ok(scoped.length > 0, "expected at least one skill scoping the Experience root");
+});
+
 test("shipped skill descriptions stay within the loader limit", async () => {
   const files = await findSkillFiles(join(ROOT, "examples"));
   assert.ok(files.length > 0, "expected at least one SKILL.md");

--- a/examples/openclaw-plugin/skills/ov-experience-memory/SKILL.md
+++ b/examples/openclaw-plugin/skills/ov-experience-memory/SKILL.md
@@ -55,7 +55,8 @@ context or deeper intent analysis is useful.
 
    For tools using MCP-style parameters, set `target_uri` to this root. For
    OpenClaw `ov_search`, set `uri` to this root. Never hardcode `default`,
-   `test`, or another user ID.
+   `test`, or another user ID. If the server rejects the URI, resolve the root
+   as described in *Servers Without the Home Alias* and retry once.
 4. Start with `limit=5` and the tool's normal score threshold. Judge results by
    task, environment, preconditions, and likely effect; title similarity alone
    is insufficient. If no result is relevant, continue without Experience and
@@ -72,6 +73,26 @@ context or deeper intent analysis is useful.
 8. If execution fails for a materially new reason, perform at most one focused
    follow-up search using the failure evidence, then read only newly relevant
    Experience files.
+
+## Servers Without the Home Alias
+
+`viking://~` is the home alias for the caller's own space. A server released
+before the alias (OpenViking v0.4.16) does not resolve it and rejects the
+request with `INVALID_URI` (HTTP 400) instead of searching. Retry once against
+the caller's explicit root, resolved from evidence rather than guessed:
+
+- If a canonical `viking://user/<user_id>/...` URI is already visible in this
+  session — injected memory context, or an earlier OpenViking tool result —
+  reuse that `<user_id>` and search
+  `viking://user/<user_id>/memories/experiences`.
+- Otherwise repeat the same query with no target scope, narrowed to memories
+  with `context_type` when the tool accepts it, and keep only hits whose URI
+  contains `/memories/experiences/`. Those hits carry the canonical user ID;
+  reuse it for the reads and for any later Experience search in this task.
+
+Do not fall back to the uid-less `viking://user/memories/experiences`: only
+some older servers and roles expand it, and current servers reject it. If no
+explicit root can be resolved, continue without Experience.
 
 ## Applying Retrieved Experience
 

--- a/examples/skills/ov-experience-memory/SKILL.md
+++ b/examples/skills/ov-experience-memory/SKILL.md
@@ -55,7 +55,8 @@ context or deeper intent analysis is useful.
 
    For tools using MCP-style parameters, set `target_uri` to this root. For
    OpenClaw `ov_search`, set `uri` to this root. Never hardcode `default`,
-   `test`, or another user ID.
+   `test`, or another user ID. If the server rejects the URI, resolve the root
+   as described in *Servers Without the Home Alias* and retry once.
 4. Start with `limit=5` and the tool's normal score threshold. Judge results by
    task, environment, preconditions, and likely effect; title similarity alone
    is insufficient. If no result is relevant, continue without Experience and
@@ -72,6 +73,26 @@ context or deeper intent analysis is useful.
 8. If execution fails for a materially new reason, perform at most one focused
    follow-up search using the failure evidence, then read only newly relevant
    Experience files.
+
+## Servers Without the Home Alias
+
+`viking://~` is the home alias for the caller's own space. A server released
+before the alias (OpenViking v0.4.16) does not resolve it and rejects the
+request with `INVALID_URI` (HTTP 400) instead of searching. Retry once against
+the caller's explicit root, resolved from evidence rather than guessed:
+
+- If a canonical `viking://user/<user_id>/...` URI is already visible in this
+  session — injected memory context, or an earlier OpenViking tool result —
+  reuse that `<user_id>` and search
+  `viking://user/<user_id>/memories/experiences`.
+- Otherwise repeat the same query with no target scope, narrowed to memories
+  with `context_type` when the tool accepts it, and keep only hits whose URI
+  contains `/memories/experiences/`. Those hits carry the canonical user ID;
+  reuse it for the reads and for any later Experience search in this task.
+
+Do not fall back to the uid-less `viking://user/memories/experiences`: only
+some older servers and roles expand it, and current servers reject it. If no
+explicit root can be resolved, continue without Experience.
 
 ## Applying Retrieved Experience
 


### PR DESCRIPTION
## Description

`ov-experience-memory` 让 Agent 用 `viking://~/memories/experiences` 作为检索根，而 `viking://~` 这个 home alias 是 v0.4.16（#4167）才加的：更早的服务端没有 `~` 这个 scope 的解析分支，URI 落不到任何命名空间，请求直接返回 `INVALID_URI`（HTTP 400）而不是检索结果。技能里没有第二种写法，Agent 也就无从降级——工作流第一步失败，Experience 检索就停在那里。#4828 的反馈里，手动换成调用方自己的 `viking://user/<user_id>/memories/...` 之后，所有读取和检索都正常。

修复保留 `viking://~` 作为首选（在支持它的服务端上这是唯一无歧义的写法），补上被拒绝之后怎么解析出显式根：优先复用会话里已经出现过的规范 `viking://user/<user_id>/` 前缀（注入的记忆上下文，或之前任意一次 OpenViking 工具结果），否则把同一个查询不带 scope 再跑一次、只留 URI 含 `/memories/experiences/` 的结果，这些结果自带规范 URI，后续 read 直接用。两条路径都从证据里解析身份，"绝不硬编码 default" 这条既有规则因此仍然成立——反馈者的服务端恰好解析成 `default`，换个账号就不是。

顺带写明 uid-less 的 `viking://user/memories/experiences` 不是降级选项：它只在 v0.4.17 之前的服务端、且调用方是 USER/ADMIN 角色时才展开，#4196 之后的服务端直接拒绝，Agent 顺手去猜这个写法会在版本区间两头都失败。

`agent-plugins` 的 openviking-memory 技能用同样的方式限定 recall 范围，一并补了同样的说明。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

#4828（异常 2：技能和 doctor 使用的用户 URI 简写不兼容）

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- `ov-experience-memory` 新增 Servers Without the Home Alias 一节，第 3 步在拒绝时指向它；四份已发布副本（`examples/skills` 源加 codex、claude-code、openclaw）同步。
- `agent-plugins` 的 openviking-memory 技能在 recall 步骤补同样的降级路径。
- `sync.test.mjs` 加守卫：凡是让 Agent 用 `viking://~/memories/experiences` 限定范围的 SKILL.md，必须写明 `viking://user/<user_id>` 的兜底写法。
- 三个按版本缓存的插件各进一位 patch（claude-code 0.4.5 → 0.4.6，`package.json` 与 manifest 保持一致；codex 0.8.1 → 0.8.2；agent-plugins 0.1.0 → 0.1.1），否则已安装用户 `plugin update` 拿不到改动。openclaw 的版本在发版时生成，不需要手动进位。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

`node --test examples/memory-plugin-shared/sync.test.mjs` 5 项通过，codex 与 claude-code 的 `marketplace.test.mjs` 共 23 项通过。把 SKILL.md 还原成修复前的版本后，新守卫会失败，确认它拦得住回退。没有跑完整测试集。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

这个 PR 只改技能侧的指引。插件运行时同样带着这个假设：`examples/memory-plugin-shared/lib/recall-core.mjs` 的 recall 源固定是 `viking://~/memories` 和 `viking://~/skills`，老服务端上会被拒绝、静默拿不到结果；doctor 的 `fs/ls` 探针也用 `viking://~/memories`，目前至少会给出 "the server may be too old for the viking://~ home alias" 的告警。要不要在客户端做改写（探到老服务端就换成显式 uid，`resolveUserSpace` 已经有现成的解析逻辑），适合另开一个 PR 讨论。
