### PR TITLE
Feat/trusted identity registration

### DIFF
--- a/docs/en/guides/04-authentication.md
+++ b/docs/en/guides/04-authentication.md
@@ -555,6 +555,7 @@ Trusted mode skips user-key lookup and instead trusts explicit identity headers 
 - `/api/v1/admin/*` is special: when a configured `root_api_key` is presented, trusted mode treats the request as ROOT. Explicit account/user headers are allowed only when they are complete and match the target URL.
 - For ordinary trusted data APIs, role is determined by `X-OpenViking-Role` when present and authorized; otherwise by looking up the account/user in APIKeyManager. If the user exists, their configured role is used; otherwise it defaults to `USER`.
 - Trusted identity comes from the headers, not from a user key. If `root_api_key` is configured, it acts as proof that the caller is an approved trusted upstream.
+- Trusted data-plane identities are asynchronously registered in batches (five minutes by default) so they eventually appear in the existing account/user management APIs. Registration creates no user API key and never changes groups or an existing user's role. Set `server.trusted_identity_flush_interval_seconds` to `0` to disable registration entirely; `/api/v1/admin/*` requests are never registered.
 - If `root_api_key` is also configured, every request must still provide a matching API key.
 - Only expose this mode behind a trusted network boundary or an identity-injecting gateway.
 

--- a/docs/zh/guides/04-authentication.md
+++ b/docs/zh/guides/04-authentication.md
@@ -451,6 +451,12 @@ Role.register("operator", rank=1)  # 权限介于 USER (0) 与 ADMIN (1) 之间
 
 ### Trusted 模式
 
+trusted 模式的普通数据面请求无需预先注册 user 或创建 user API Key。服务端会异步批量注册
+该 account/user，使其最终出现在既有 account/user 管理接口中（默认五分钟刷盘）。注册不会
+创建 user API Key，也不会修改 group 或已有 user 的角色。设置
+`server.trusted_identity_flush_interval_seconds` 为 `0` 可完全关闭注册能力；
+`/api/v1/admin/*` 请求不会被注册。
+
 ```bash
 # 创建工作区 + 首个 admin
 curl -X POST http://localhost:1933/api/v1/admin/accounts \

--- a/openviking/server/api_keys/legacy.py
+++ b/openviking/server/api_keys/legacy.py
@@ -104,9 +104,17 @@ class LegacyAPIKeyManager:
         # Prefix index: key_prefix -> list[UserKeyEntry]
         self._prefix_index: Dict[str, list[UserKeyEntry]] = {}
         self._user_group_ids: Dict[tuple[str, str], tuple[str, ...]] = {}
+        self._identity_registry_signatures: dict[str | None, tuple] = {}
         # Serializes reload() so overlapping refreshes can't interleave.
         self._reload_lock = asyncio.Lock()
+        # Serializes all mutations made by the unified manager in this process.
+        # File locks remain responsible for inter-instance coordination.
+        self._mutation_lock = asyncio.Lock()
         self._user_deletion_lock = asyncio.Lock()
+
+    @property
+    def mutation_lock(self) -> asyncio.Lock:
+        return self._mutation_lock
 
     def _discard_account_state(self, account_id: str) -> None:
         """Remove an account and its key index entries from in-memory state."""
@@ -135,38 +143,47 @@ class LegacyAPIKeyManager:
             if not self._prefix_index[key_prefix]:
                 del self._prefix_index[key_prefix]
 
-    async def _rollback_create_account(self, account_id: str) -> None:
+    async def _rollback_create_account(self, account_id: str, *, account_was_created: bool) -> None:
         """Best-effort rollback for partially persisted account creation."""
         self._discard_account_state(account_id)
+        if not account_was_created:
+            return
         try:
-            await self._save_accounts_json()
+            await self._save_accounts_json(delete_account_ids={account_id})
         except Exception:
             logger.exception("Failed to persist rollback for account %s", account_id)
 
     async def load(self) -> None:
         """Load keys into memory (writable startup path; migrates plaintext; see reload())."""
-        accounts_data = await self._read_json(ACCOUNTS_PATH)
-        if accounts_data is None:
-            # First run: create default account
-            now = datetime.now(timezone.utc).isoformat()
-            accounts_data = {"accounts": {"default": {"created_at": now}}}
-            await self._write_json(ACCOUNTS_PATH, accounts_data)
+        async with self._mutation_lock:
+            accounts_data = await self._read_json(ACCOUNTS_PATH)
+            if accounts_data is None:
+                # First run: create default account
+                now = datetime.now(timezone.utc).isoformat()
+                accounts_data = {"accounts": {"default": {"created_at": now}}}
+                await self._write_json(ACCOUNTS_PATH, accounts_data)
 
-        accounts, prefix_index, user_group_ids = await self._build_state(
-            accounts_data, allow_migration=True
-        )
-        self._accounts = accounts
-        self._prefix_index = prefix_index
-        self._user_group_ids = user_group_ids
+            accounts, prefix_index, user_group_ids = await self._build_state(
+                accounts_data, allow_migration=True
+            )
+            self._accounts = accounts
+            self._prefix_index = prefix_index
+            self._user_group_ids = user_group_ids
+            await self._update_identity_registry_signatures()
 
-        logger.info(
-            "LegacyAPIKeyManager loaded: %d accounts, %d user keys",
-            len(self._accounts),
-            sum(len(info.users) for info in self._accounts.values()),
-        )
+            logger.info(
+                "LegacyAPIKeyManager loaded: %d accounts, %d user keys",
+                len(self._accounts),
+                sum(len(info.users) for info in self._accounts.values()),
+            )
 
     async def reload(self) -> None:
         """Read-only refresh: re-read store and atomically swap state (never writes/migrates)."""
+        async with self._mutation_lock:
+            await self._reload_unlocked()
+
+    async def _reload_unlocked(self) -> None:
+        """Reload while holding ``_mutation_lock``."""
         async with self._reload_lock:
             accounts_data = await self._read_json(ACCOUNTS_PATH)
             if accounts_data is None:
@@ -180,12 +197,50 @@ class LegacyAPIKeyManager:
             self._accounts = accounts
             self._prefix_index = prefix_index
             self._user_group_ids = user_group_ids
+            await self._update_identity_registry_signatures()
 
             logger.debug(
                 "LegacyAPIKeyManager reloaded: %d accounts, %d user keys",
                 len(self._accounts),
                 sum(len(info.users) for info in self._accounts.values()),
             )
+
+    async def refresh_identity_registry_if_changed(
+        self, account_id: str | None = None
+    ) -> bool:
+        """Reload registry state only when the management read target has changed."""
+        async with self._mutation_lock:
+            scope = account_id
+            signature = await self._identity_registry_signature(account_id)
+            if self._identity_registry_signatures.get(scope) == signature:
+                return False
+            await self._reload_unlocked()
+            return True
+
+    async def _update_identity_registry_signatures(
+        self, account_ids: set[str] | None = None
+    ) -> None:
+        accounts_signature = await self._stat_signature(ACCOUNTS_PATH)
+        target_account_ids = self._accounts if account_ids is None else account_ids
+        signatures = {None: (accounts_signature,)}
+        for account_id in target_account_ids:
+            users_path = USERS_PATH_TEMPLATE.format(account_id=account_id)
+            signatures[account_id] = (
+                accounts_signature,
+                await self._stat_signature(users_path),
+            )
+
+        if account_ids is None:
+            self._identity_registry_signatures = signatures
+        else:
+            self._identity_registry_signatures.update(signatures)
+
+    async def _identity_registry_signature(self, account_id: str | None = None) -> tuple:
+        accounts_signature = await self._stat_signature(ACCOUNTS_PATH)
+        if account_id is not None:
+            users_path = USERS_PATH_TEMPLATE.format(account_id=account_id)
+            return (accounts_signature, await self._stat_signature(users_path))
+        return (accounts_signature,)
 
     async def _build_state(
         self, accounts_data: dict, *, allow_migration: bool
@@ -234,7 +289,7 @@ class LegacyAPIKeyManager:
                     key_prefix = self._get_key_prefix(key_or_hash)
                     user_info["key"] = stored_key
                     user_info["key_prefix"] = key_prefix
-                    await self._save_users_json_for(account_id, accounts)
+                    await self._save_users_json(account_id, {user_id: user_info})
                     logger.info("Migrated API key for user %s in account %s", user_id, account_id)
                 else:
                     # Keep plaintext (hashing off or read-only refresh); prefix on the fly.
@@ -389,12 +444,21 @@ class LegacyAPIKeyManager:
                 self._prefix_index[key_prefix] = []
             self._prefix_index[key_prefix].append(entry)
 
+        account_was_created = False
         try:
-            await self._save_accounts_json()
-            await self._save_users_json(account_id)
+            created_account_ids = await self._save_accounts_json(
+                updated_account_ids={account_id},
+                reject_existing_account_ids={account_id},
+            )
+            account_was_created = account_id in created_account_ids
+            await self._save_users_json(
+                account_id,
+                {admin_user_id: user_info},
+                replace_existing=account_id in created_account_ids,
+            )
             await self._write_groups_json(account_id, {})
         except Exception:
-            await self._rollback_create_account(account_id)
+            await self._rollback_create_account(account_id, account_was_created=account_was_created)
             raise
         return key
 
@@ -405,7 +469,7 @@ class LegacyAPIKeyManager:
 
         self._discard_account_state(account_id)
 
-        await self._save_accounts_json()
+        await self._save_accounts_json(delete_account_ids={account_id})
 
     async def register_user(
         self,
@@ -465,8 +529,103 @@ class LegacyAPIKeyManager:
                 self._prefix_index[key_prefix] = []
             self._prefix_index[key_prefix].append(entry)
 
-        await self._save_users_json(account_id)
+        try:
+            await self._save_users_json(
+                account_id, {user_id: user_info}, reject_existing_user_ids={user_id}
+            )
+        except Exception:
+            account.users.pop(user_id, None)
+            self._remove_key_index_entry(account_id, user_id, user_info)
+            raise
         return key
+
+    async def ensure_trusted_identities(self, identities: Dict[str, set[str]]) -> dict[str, int]:
+        """Merge trusted identities into the registry without creating API keys."""
+        async with self._mutation_lock:
+            return await self._ensure_trusted_identities_unlocked(identities)
+
+    async def _ensure_trusted_identities_unlocked(
+        self, identities: Dict[str, set[str]]
+    ) -> dict[str, int]:
+        normalized = {account_id: set(user_ids) for account_id, user_ids in identities.items() if user_ids}
+        if not normalized:
+            return {"created_accounts": 0, "created_users": 0}
+
+        for account_id, user_ids in normalized.items():
+            error = validate_account_id(account_id)
+            if error:
+                raise InvalidArgumentError(error)
+            for user_id in user_ids:
+                error = validate_user_id(user_id)
+                if error:
+                    raise InvalidArgumentError(error)
+
+        created_accounts = 0
+        created_users = 0
+        now = datetime.now(timezone.utc).isoformat()
+
+        try:
+            accounts_lease = await self._async_agfs.pathlock_acquire_exact(
+                ACCOUNTS_PATH, timeout_secs=10.0
+            )
+        except LockAcquisitionError as exc:
+            raise ResourceBusyError(
+                "Another account operation is in progress. Please retry.",
+                uri=ACCOUNTS_PATH,
+                conflict_type="account_registry_busy",
+            ) from exc
+        try:
+            accounts_data = await self._read_json(ACCOUNTS_PATH) or {"accounts": {}}
+            persisted_accounts = accounts_data.setdefault("accounts", {})
+            for account_id in normalized:
+                if account_id not in persisted_accounts:
+                    persisted_accounts[account_id] = {"created_at": now}
+                    created_accounts += 1
+            if created_accounts:
+                await self._write_json(ACCOUNTS_PATH, accounts_data, lease_ref=accounts_lease)
+        finally:
+            await self._async_agfs.pathlock_release(accounts_lease)
+
+        for account_id, user_ids in normalized.items():
+            path = USERS_PATH_TEMPLATE.format(account_id=account_id)
+            try:
+                users_lease = await self._async_agfs.pathlock_acquire_exact(path, timeout_secs=10.0)
+            except LockAcquisitionError as exc:
+                raise ResourceBusyError(
+                    "Another user operation is in progress for this account. Please retry.",
+                    uri=path,
+                    conflict_type="user_registry_busy",
+                ) from exc
+            try:
+                users_data = await self._read_json(path) or {"users": {}}
+                persisted_users = users_data.setdefault("users", {})
+                new_users = sorted(user_id for user_id in user_ids if user_id not in persisted_users)
+                for user_id in new_users:
+                    persisted_users[user_id] = {"role": "user"}
+                if new_users:
+                    await self._write_json(path, users_data, lease_ref=users_lease)
+                    created_users += len(new_users)
+                    logger.info(
+                        "Persisted trusted identities for account %s: %s",
+                        account_id,
+                        new_users,
+                    )
+
+                account = self._accounts.get(account_id)
+                if account is None:
+                    created_at = (
+                        (accounts_data.get("accounts", {}).get(account_id) or {}).get("created_at")
+                        or now
+                    )
+                    account = AccountInfo(created_at=created_at, users={}, groups={})
+                    self._accounts[account_id] = account
+                for user_id, user_info in persisted_users.items():
+                    account.users.setdefault(user_id, dict(user_info))
+            finally:
+                await self._async_agfs.pathlock_release(users_lease)
+
+        await self._update_identity_registry_signatures(set(normalized))
+        return {"created_accounts": created_accounts, "created_users": created_users}
 
     async def begin_user_deletion(
         self,
@@ -508,7 +667,7 @@ class LegacyAPIKeyManager:
             user_info["key"] = ""
             user_info.pop("key_prefix", None)
             try:
-                await self._save_users_json(account_id)
+                await self._save_users_json(account_id, {user_id: user_info})
             except Exception:
                 account.users[user_id] = original
                 raise
@@ -544,7 +703,7 @@ class LegacyAPIKeyManager:
             }
             user_info["deletion"] = replacement
             try:
-                await self._save_users_json(account_id)
+                await self._save_users_json(account_id, {user_id: user_info})
             except Exception:
                 user_info["deletion"] = current
                 raise
@@ -571,7 +730,7 @@ class LegacyAPIKeyManager:
                     group["members"] = [member for member in members if member != user_id]
             account.users.pop(user_id)
             try:
-                await self._save_users_json(account_id)
+                await self._save_users_json(account_id, deleted_user_ids={user_id})
                 if groups != old_groups:
                     await self._write_groups_json(account_id, groups)
             except Exception:
@@ -673,7 +832,7 @@ class LegacyAPIKeyManager:
                 self._prefix_index[new_key_prefix] = []
             self._prefix_index[new_key_prefix].append(entry)
 
-        await self._save_users_json(account_id)
+        await self._save_users_json(account_id, {user_id: account.users[user_id]})
         return new_key
 
     async def set_role(self, account_id: str, user_id: str, role: str) -> None:
@@ -704,7 +863,7 @@ class LegacyAPIKeyManager:
                         entry.role = resolved_role
                         break
 
-        await self._save_users_json(account_id)
+        await self._save_users_json(account_id, {user_id: account.users[user_id]})
 
     def get_accounts(
         self,
@@ -1054,8 +1213,35 @@ class LegacyAPIKeyManager:
         except AGFSAlreadyExistsError:
             return
 
-    async def _save_accounts_json(self) -> None:
-        """Persist the global accounts list."""
+    def _rebuild_prefix_index(self) -> None:
+        prefix_index: Dict[str, list[UserKeyEntry]] = {}
+        for account_id, account in self._accounts.items():
+            for user_id, user_info in account.users.items():
+                key_or_hash = user_info.get("key", "")
+                if not key_or_hash:
+                    continue
+                key_prefix = user_info.get("key_prefix", "") or self._get_key_prefix(key_or_hash)
+                if not key_prefix:
+                    continue
+                prefix_index.setdefault(key_prefix, []).append(
+                    UserKeyEntry(
+                        account_id=account_id,
+                        user_id=user_id,
+                        role=Role(user_info.get("role", "user")),
+                        key_or_hash=key_or_hash,
+                        is_hashed=key_or_hash.startswith("$argon2"),
+                    )
+                )
+        self._prefix_index = prefix_index
+
+    async def _save_accounts_json(
+        self,
+        *,
+        updated_account_ids: set[str] | None = None,
+        delete_account_ids: set[str] | None = None,
+        reject_existing_account_ids: set[str] | None = None,
+    ) -> set[str]:
+        """Merge local account changes into the latest locked registry snapshot."""
         try:
             lease = await self._async_agfs.pathlock_acquire_exact(ACCOUNTS_PATH, timeout_secs=10.0)
         except LockAcquisitionError as exc:
@@ -1065,21 +1251,36 @@ class LegacyAPIKeyManager:
                 conflict_type="account_registry_busy",
             ) from exc
         try:
-            data = {
-                "accounts": {
-                    aid: {"created_at": info.created_at} for aid, info in self._accounts.items()
-                }
-            }
+            data = await self._read_json(ACCOUNTS_PATH) or {"accounts": {}}
+            accounts = data.setdefault("accounts", {})
+            for account_id in reject_existing_account_ids or set():
+                if account_id in accounts:
+                    raise AlreadyExistsError(account_id, "account")
+            created_account_ids = set()
+            for account_id in updated_account_ids or set():
+                info = self._accounts.get(account_id)
+                if info is None:
+                    continue
+                if account_id not in accounts:
+                    created_account_ids.add(account_id)
+                accounts[account_id] = {"created_at": info.created_at}
+            for account_id in delete_account_ids or set():
+                accounts.pop(account_id, None)
             await self._write_json(ACCOUNTS_PATH, data, lease_ref=lease)
+            return created_account_ids
         finally:
             await self._async_agfs.pathlock_release(lease)
 
-    async def _save_users_json(self, account_id: str) -> None:
-        """Persist a single account's user registry."""
-        await self._save_users_json_for(account_id, self._accounts)
-
-    async def _save_users_json_for(self, account_id: str, accounts: Dict[str, AccountInfo]) -> None:
-        """Persist one account's user registry from the given accounts map."""
+    async def _save_users_json(
+        self,
+        account_id: str,
+        updated_users: Dict[str, dict] | None = None,
+        *,
+        deleted_user_ids: set[str] | None = None,
+        reject_existing_user_ids: set[str] | None = None,
+        replace_existing: bool = False,
+    ) -> None:
+        """Merge targeted user mutations, or initialize a newly created account."""
         path = USERS_PATH_TEMPLATE.format(account_id=account_id)
         try:
             lease = await self._async_agfs.pathlock_acquire_exact(path, timeout_secs=10.0)
@@ -1090,10 +1291,31 @@ class LegacyAPIKeyManager:
                 conflict_type="user_registry_busy",
             ) from exc
         try:
-            account = accounts.get(account_id)
-            if account is None:
-                return
-            await self._write_json(path, {"users": account.users}, lease_ref=lease)
+            if replace_existing:
+                users = copy.deepcopy(updated_users or {})
+                data = {"users": users}
+            else:
+                data = await self._read_json(path) or {"users": {}}
+                users = data.setdefault("users", {})
+            if updated_users is None:
+                account = self._accounts.get(account_id)
+                if account is None:
+                    return
+                users = copy.deepcopy(account.users)
+                data["users"] = users
+            elif not replace_existing:
+                for user_id, user_info in updated_users.items():
+                    if user_id in (reject_existing_user_ids or set()) and user_id in users:
+                        raise AlreadyExistsError(user_id, "user")
+                    users[user_id] = copy.deepcopy(user_info)
+            for user_id in deleted_user_ids or set():
+                users.pop(user_id, None)
+            await self._write_json(path, data, lease_ref=lease)
+
+            account = self._accounts.get(account_id)
+            if account is not None:
+                account.users = users
+                self._rebuild_prefix_index()
         finally:
             await self._async_agfs.pathlock_release(lease)
 

--- a/openviking/server/api_keys/new.py
+++ b/openviking/server/api_keys/new.py
@@ -125,6 +125,12 @@ class NewAPIKeyManager:
         """Return a cheap change signature for the on-disk key store."""
         return await self._legacy.compute_store_signature()
 
+    async def refresh_identity_registry_if_changed(
+        self, account_id: str | None = None
+    ) -> bool:
+        """Refresh account/user registry state for a management read when needed."""
+        return await self._legacy.refresh_identity_registry_if_changed(account_id)
+
     def resolve(self, api_key: str) -> ResolvedIdentity:
         """Resolve an API key to identity.
 
@@ -178,6 +184,15 @@ class NewAPIKeyManager:
         return self._legacy.resolve(api_key)
 
     async def create_account(
+        self,
+        account_id: str,
+        admin_user_id: str,
+        seed: Optional[str] = None,
+    ) -> str:
+        async with self._legacy.mutation_lock:
+            return await self._create_account_unlocked(account_id, admin_user_id, seed)
+
+    async def _create_account_unlocked(
         self,
         account_id: str,
         admin_user_id: str,
@@ -249,20 +264,46 @@ class NewAPIKeyManager:
                 self._legacy._prefix_index[key_prefix] = []
             self._legacy._prefix_index[key_prefix].append(entry)
 
+        account_was_created = False
         try:
-            await self._legacy._save_accounts_json()
-            await self._legacy._save_users_json(account_id)
+            created_account_ids = await self._legacy._save_accounts_json(
+                updated_account_ids={account_id},
+                reject_existing_account_ids={account_id},
+            )
+            account_was_created = account_id in created_account_ids
+            await self._legacy._save_users_json(
+                account_id,
+                {admin_user_id: user_info},
+                replace_existing=account_id in created_account_ids,
+            )
             await self._legacy._write_groups_json(account_id, {})
         except Exception:
-            await self._legacy._rollback_create_account(account_id)
+            await self._legacy._rollback_create_account(
+                account_id, account_was_created=account_was_created
+            )
             raise
         return key
 
     async def delete_account(self, account_id: str) -> None:
         """Delete an account and remove all its user keys from the index."""
-        await self._legacy.delete_account(account_id)
+        async with self._legacy.mutation_lock:
+            await self._legacy.delete_account(account_id)
+
+    async def ensure_trusted_identities(self, identities: dict[str, set[str]]) -> dict[str, int]:
+        """Merge trusted identities without generating API keys."""
+        return await self._legacy.ensure_trusted_identities(identities)
 
     async def register_user(
+        self,
+        account_id: str,
+        user_id: str,
+        role: str = "user",
+        seed: Optional[str] = None,
+    ) -> str:
+        async with self._legacy.mutation_lock:
+            return await self._register_user_unlocked(account_id, user_id, role, seed)
+
+    async def _register_user_unlocked(
         self,
         account_id: str,
         user_id: str,
@@ -321,7 +362,14 @@ class NewAPIKeyManager:
                 self._legacy._prefix_index[key_prefix] = []
             self._legacy._prefix_index[key_prefix].append(entry)
 
-        await self._legacy._save_users_json(account_id)
+        try:
+            await self._legacy._save_users_json(
+                account_id, {user_id: user_info}, reject_existing_user_ids={user_id}
+            )
+        except Exception:
+            account.users.pop(user_id, None)
+            self._legacy._remove_key_index_entry(account_id, user_id, user_info)
+            raise
         return key
 
     async def begin_user_deletion(
@@ -333,13 +381,14 @@ class NewAPIKeyManager:
         owner_account_id: str,
         owner_user_id: str,
     ) -> tuple[dict, bool]:
-        return await self._legacy.begin_user_deletion(
-            account_id,
-            user_id,
-            task_id=task_id,
-            owner_account_id=owner_account_id,
-            owner_user_id=owner_user_id,
-        )
+        async with self._legacy.mutation_lock:
+            return await self._legacy.begin_user_deletion(
+                account_id,
+                user_id,
+                task_id=task_id,
+                owner_account_id=owner_account_id,
+                owner_user_id=owner_user_id,
+            )
 
     async def replace_user_deletion_task(
         self,
@@ -351,17 +400,19 @@ class NewAPIKeyManager:
         owner_account_id: str,
         owner_user_id: str,
     ) -> dict:
-        return await self._legacy.replace_user_deletion_task(
-            account_id,
-            user_id,
-            expected_task_id=expected_task_id,
-            task_id=task_id,
-            owner_account_id=owner_account_id,
-            owner_user_id=owner_user_id,
-        )
+        async with self._legacy.mutation_lock:
+            return await self._legacy.replace_user_deletion_task(
+                account_id,
+                user_id,
+                expected_task_id=expected_task_id,
+                task_id=task_id,
+                owner_account_id=owner_account_id,
+                owner_user_id=owner_user_id,
+            )
 
     async def finish_user_deletion(self, account_id: str, user_id: str, task_id: str) -> bool:
-        return await self._legacy.finish_user_deletion(account_id, user_id, task_id)
+        async with self._legacy.mutation_lock:
+            return await self._legacy.finish_user_deletion(account_id, user_id, task_id)
 
     def get_user_deletion(self, account_id: str, user_id: str) -> Optional[dict]:
         return self._legacy.get_user_deletion(account_id, user_id)
@@ -373,6 +424,15 @@ class NewAPIKeyManager:
         return self._legacy.is_user_deleting(account_id, user_id)
 
     async def regenerate_key(
+        self,
+        account_id: str,
+        user_id: str,
+        seed: Optional[str] = None,
+    ) -> str:
+        async with self._legacy.mutation_lock:
+            return await self._regenerate_key_unlocked(account_id, user_id, seed)
+
+    async def _regenerate_key_unlocked(
         self,
         account_id: str,
         user_id: str,
@@ -446,12 +506,13 @@ class NewAPIKeyManager:
                 self._legacy._prefix_index[new_key_prefix] = []
             self._legacy._prefix_index[new_key_prefix].append(entry)
 
-        await self._legacy._save_users_json(account_id)
+        await self._legacy._save_users_json(account_id, {user_id: account.users[user_id]})
         return new_key
 
     async def set_role(self, account_id: str, user_id: str, role: str) -> None:
         """Update a user's role."""
-        await self._legacy.set_role(account_id, user_id, role)
+        async with self._legacy.mutation_lock:
+            await self._legacy.set_role(account_id, user_id, role)
 
     def get_accounts(
         self,
@@ -561,8 +622,8 @@ class NewAPIKeyManager:
     async def _ensure_parent_dirs_async(self, path: str) -> None:
         return await self._legacy._ensure_parent_dirs_async(path)
 
-    async def _save_accounts_json(self) -> None:
-        return await self._legacy._save_accounts_json()
+    async def _save_accounts_json(self, **kwargs) -> set[str]:
+        return await self._legacy._save_accounts_json(**kwargs)
 
     async def _save_users_json(self, account_id: str) -> None:
         return await self._legacy._save_users_json(account_id)

--- a/openviking/server/auth/plugins/trusted.py
+++ b/openviking/server/auth/plugins/trusted.py
@@ -4,24 +4,29 @@
 
 from __future__ import annotations
 
+import asyncio
 import hmac
+import random
 import sys
 from typing import Optional
 
 from fastapi import Request
 
+from openviking.core.identifiers import validate_account_id, validate_user_id
 from openviking.server.api_keys import APIKeyManager
 from openviking.server.auth.plugin import AuthPlugin
 from openviking.server.identity import ResolvedIdentity, Role
 from openviking_cli.exceptions import InvalidArgumentError, UnauthenticatedError
+from openviking_cli.utils import get_logger
 
 _LOCALHOST_HOSTS = {"127.0.0.1", "localhost", "::1"}
-_TRUSTED_RELAXED_IDENTITY_PREFIXES = ("/api/v1/admin",)
 _TRUSTED_ROLE_HEADER = "X-OpenViking-Role"
 _TRUSTED_ASSERTABLE_ROLES = {
     Role.USER: Role.USER,
     Role.ADMIN: Role.ADMIN,
 }
+
+logger = get_logger(__name__)
 
 
 def _is_localhost(host: str) -> bool:
@@ -57,9 +62,21 @@ def _explicit_identity_from_request(request: Request) -> tuple[Optional[str], Op
 
 
 def _trusted_request_requires_explicit_identity(path: str) -> bool:
-    if path.startswith(_TRUSTED_RELAXED_IDENTITY_PREFIXES):
-        return False
-    return True
+    return not _is_trusted_admin_path(path)
+
+
+def _validate_trusted_identity(account_id: str, user_id: str) -> None:
+    """Reject invalid identity path components before registry lookup or enqueueing."""
+    account_error = validate_account_id(account_id)
+    if account_error:
+        raise InvalidArgumentError(account_error)
+    user_error = validate_user_id(user_id)
+    if user_error:
+        raise InvalidArgumentError(user_error)
+
+
+def _is_trusted_admin_path(path: str) -> bool:
+    return path == "/api/v1/admin" or path.startswith("/api/v1/admin/")
 
 
 def _asserted_role_from_header(request: Request, *, allow_assertion: bool) -> Optional[Role]:
@@ -86,6 +103,16 @@ class TrustedAuthPlugin(AuthPlugin):
     """
 
     auth_mode = "trusted"
+
+    def __init__(self) -> None:
+        self._api_key_manager: Optional[APIKeyManager] = None
+        self._flush_interval_seconds = 300.0
+        self._pending_max_size = 10_000
+        self._pending: dict[str, set[str]] = {}
+        self._in_flight: dict[str, set[str]] = {}
+        self._pending_count = 0
+        self._in_flight_count = 0
+        self._flush_task: Optional[asyncio.Task] = None
 
     async def resolve_identity(
         self,
@@ -130,7 +157,7 @@ class TrustedAuthPlugin(AuthPlugin):
         # A verified Root key is the caller identity for admin routes. Path
         # parameters such as ``account_id`` identify the managed resource, so
         # they must not be mistaken for a partial caller identity.
-        is_admin_path = request.url.path.startswith(_TRUSTED_RELAXED_IDENTITY_PREFIXES)
+        is_admin_path = _is_trusted_admin_path(request.url.path)
         if is_admin_path:
             if configured_root_api_key:
                 return ResolvedIdentity(
@@ -162,7 +189,13 @@ class TrustedAuthPlugin(AuthPlugin):
                     "Trusted mode requests must include " + " and ".join(missing_fields) + "."
                 )
 
-        api_key_manager = getattr(request.app.state, "api_key_manager", None)
+        if effective_account_id and effective_user_id:
+            _validate_trusted_identity(effective_account_id, effective_user_id)
+
+        # In rootless trusted mode this manager stays private to the plugin so
+        # Admin routes remain disabled. It is still used to preserve a role
+        # explicitly assigned through the account/user management APIs.
+        api_key_manager = self._api_key_manager
         trusted_role = Role.USER
         if asserted_role is not None:
             trusted_role = asserted_role
@@ -171,11 +204,19 @@ class TrustedAuthPlugin(AuthPlugin):
             if looked_up_role is not None:
                 trusted_role = looked_up_role
 
-        return ResolvedIdentity(
+        identity = ResolvedIdentity(
             role=trusted_role,
             account_id=effective_account_id or "trusted",
             user_id=effective_user_id or "trusted",
         )
+        if (
+            self.should_auto_register_trusted_identity(request)
+            and not is_admin_path
+            and effective_account_id
+            and effective_user_id
+        ):
+            self._queue_trusted_identity(effective_account_id, effective_user_id)
+        return identity
 
     def validate_config(self, config) -> None:
         if config.root_api_key and config.root_api_key != "":
@@ -208,16 +249,91 @@ class TrustedAuthPlugin(AuthPlugin):
         sys.exit(1)
 
     async def initialize(self, app, service, config) -> None:
-        if config.root_api_key and config.root_api_key != "":
-            api_key_manager = APIKeyManager(
-                root_key=config.root_api_key,
-                viking_fs=service.viking_fs,
-                api_key_hashing_enabled=config.api_key_hashing_enabled,
+        api_key_manager = APIKeyManager(
+            root_key=config.root_api_key or "",
+            viking_fs=service.viking_fs,
+            api_key_hashing_enabled=config.api_key_hashing_enabled,
+        )
+        await api_key_manager.load()
+        self._api_key_manager = api_key_manager
+        # ``require_auth_role`` treats a populated app-state manager as the
+        # availability signal for the Admin API. A rootless trusted deployment
+        # must therefore keep this manager plugin-private even though it needs
+        # one for the optional identity registry.
+        app.state.api_key_manager = api_key_manager if config.root_api_key else None
+        self._flush_interval_seconds = config.trusted_identity_flush_interval_seconds
+        self._pending_max_size = config.trusted_identity_pending_max_size
+        if self._flush_interval_seconds > 0:
+            self._flush_task = asyncio.create_task(self._flush_loop())
+
+    def should_auto_register_trusted_identity(
+        self,
+        request: Request,
+    ) -> bool:
+        """Return whether this trusted request's identity should be batch registered."""
+        return self._flush_interval_seconds > 0
+
+    def _queue_trusted_identity(self, account_id: str, user_id: str) -> None:
+        if self._api_key_manager and self._api_key_manager.has_user(account_id, user_id):
+            return
+        if user_id in self._in_flight.get(account_id, set()):
+            return
+        if user_id in self._pending.get(account_id, set()):
+            return
+        if self._pending_count + self._in_flight_count >= self._pending_max_size:
+            logger.warning(
+                "Trusted identity registration queue is full; dropping %s/%s",
+                account_id,
+                user_id,
             )
-            await api_key_manager.load()
-            app.state.api_key_manager = api_key_manager
-        else:
-            app.state.api_key_manager = None
+            return
+        self._pending.setdefault(account_id, set()).add(user_id)
+        self._pending_count += 1
+
+    async def flush_trusted_identities(self) -> None:
+        if self._api_key_manager is None or not self._pending:
+            return
+        batch = self._pending
+        self._pending = {}
+        self._in_flight_count = self._pending_count
+        self._pending_count = 0
+        self._in_flight = batch
+        try:
+            await self._api_key_manager.ensure_trusted_identities(batch)
+        except Exception:
+            pending_after_failure = self._pending
+            for account_id, user_ids in batch.items():
+                pending_after_failure.setdefault(account_id, set()).update(user_ids)
+            self._pending = pending_after_failure
+            self._pending_count += self._in_flight_count
+            self._in_flight = {}
+            self._in_flight_count = 0
+            logger.warning("Trusted identity batch registration failed; will retry", exc_info=True)
+        finally:
+            self._in_flight = {}
+            self._in_flight_count = 0
+
+    async def _flush_loop(self) -> None:
+        try:
+            await asyncio.sleep(
+                self._flush_interval_seconds + random.uniform(0, self._flush_interval_seconds)
+            )
+            while True:
+                await self.flush_trusted_identities()
+                await asyncio.sleep(self._flush_interval_seconds)
+        except asyncio.CancelledError:
+            raise
+
+    async def shutdown(self) -> None:
+        if self._flush_task is not None:
+            self._flush_task.cancel()
+            try:
+                await self._flush_task
+            except asyncio.CancelledError:
+                pass
+            finally:
+                self._flush_task = None
+        await self.flush_trusted_identities()
 
     def requires_api_key_manager(self) -> bool:
         return False
@@ -230,7 +346,7 @@ class TrustedAuthPlugin(AuthPlugin):
         path: str,
         identity: ResolvedIdentity,
     ) -> None:
-        is_admin_path = path.startswith(_TRUSTED_RELAXED_IDENTITY_PREFIXES)
+        is_admin_path = _is_trusted_admin_path(path)
         if not is_admin_path:
             if not identity.account_id:
                 raise InvalidArgumentError(

--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -353,6 +353,9 @@ class ServerConfig(BaseModel):
     api_key_watch_enabled: bool = False
     # Poll interval; each check only stats registry files and reads fully on change.
     api_key_watch_interval_seconds: float = 30.0
+    # Trusted-mode identity registration is batched in memory; 0 disables it.
+    trusted_identity_flush_interval_seconds: float = Field(300.0, ge=0)
+    trusted_identity_pending_max_size: int = Field(10_000, gt=0)
     observability: ObservabilityConfig = Field(default_factory=ObservabilityConfig)
     usage_reporter: UsageReporterConfig = Field(default_factory=UsageReporterConfig)
     # Public-facing base URL emitted in MCP-issued upload instructions. See

--- a/openviking/server/routers/admin.py
+++ b/openviking/server/routers/admin.py
@@ -116,7 +116,7 @@ async def get_agent_evolution_status(
 ):
     """Return the effective Agent Evolution switch for the caller's account."""
     account_id = _agent_evolution_account_id(ctx)
-    _check_account_exists(request, account_id)
+    await _check_account_exists(request, account_id)
     enabled = await get_service().sessions.get_agent_evolution_enabled(account_id)
     return Response(
         status="ok",
@@ -133,7 +133,7 @@ async def set_agent_evolution_status(
 ):
     """Persist and hot-reload Agent Evolution for the caller's account."""
     account_id = _agent_evolution_account_id(ctx)
-    _check_account_exists(request, account_id)
+    await _check_account_exists(request, account_id)
     service = get_service()
     if service.viking_fs is None:
         raise FailedPreconditionError("OpenViking service is not initialized.")
@@ -167,13 +167,17 @@ def _check_account_access(ctx: RequestContext, account_id: str) -> None:
         raise PermissionDeniedError(f"ADMIN can only manage account: {ctx.account_id}")
 
 
-def _check_account_exists(request: Request, account_id: str) -> None:
+async def _check_account_exists(
+    request: Request, account_id: str, *, refresh_scope: str | None = None
+):
     manager = getattr(request.app.state, "api_key_manager", None)
     if manager is None:
-        return
+        return None
+    await manager.refresh_identity_registry_if_changed(refresh_scope)
     accounts = manager.get_accounts()
     if not any(item.get("account_id") == account_id for item in accounts):
         raise NotFoundError(account_id, "account")
+    return manager
 
 
 async def _account_settings_result(
@@ -234,8 +238,10 @@ async def _write_initial_user_config(
     await write_user_config(service.viking_fs, user_ctx, user_config)
 
 
-def _check_user_exists(request: Request, account_id: str, user_id: str) -> None:
-    manager = _get_api_key_manager(request)
+async def _check_user_exists(
+    request: Request, account_id: str, user_id: str, manager=None
+) -> None:
+    manager = manager or _get_api_key_manager(request)
     if not manager.has_user(account_id, user_id):
         raise NotFoundError(user_id, "user")
 
@@ -331,6 +337,7 @@ async def list_accounts(
 ):
     """List accounts in creation order. `name` supports wildcard (* and ?) matching."""
     manager = _get_api_key_manager(request)
+    await manager.refresh_identity_registry_if_changed()
     accounts = manager.get_accounts(name_filter=name, limit=limit, page=page)
     return Response(status="ok", result=accounts)
 
@@ -427,7 +434,7 @@ async def get_account_settings(
 ):
     """Return effective and explicitly overridden settings for one account."""
     _check_account_access(ctx, account_id)
-    _check_account_exists(request, account_id)
+    await _check_account_exists(request, account_id)
     service = get_service()
     if service.viking_fs is None:
         raise FailedPreconditionError("OpenViking service is not initialized.")
@@ -448,7 +455,7 @@ async def patch_account_settings(
 ):
     """Update allowlisted hot-reloadable settings for one account."""
     _check_account_access(ctx, account_id)
-    _check_account_exists(request, account_id)
+    await _check_account_exists(request, account_id)
     service = get_service()
     if service.viking_fs is None:
         raise FailedPreconditionError("OpenViking service is not initialized.")
@@ -511,6 +518,7 @@ async def list_users(
     """List users in an account, in creation order. `name` supports wildcard (* and ?) matching."""
     _check_account_access(ctx, account_id)
     manager = _get_api_key_manager(request)
+    await manager.refresh_identity_registry_if_changed(account_id)
     expose_key = _should_expose_user_key(request)
     users = manager.get_users(
         account_id,
@@ -533,8 +541,8 @@ async def get_user_settings(
 ):
     """Return the configured and effective memory policy for one User."""
     _check_account_access(ctx, account_id)
-    _check_account_exists(request, account_id)
-    _check_user_exists(request, account_id, user_id)
+    manager = await _check_account_exists(request, account_id, refresh_scope=account_id)
+    await _check_user_exists(request, account_id, user_id, manager)
     service = get_service()
     if service.viking_fs is None:
         raise FailedPreconditionError("OpenViking service is not initialized.")
@@ -565,8 +573,8 @@ async def patch_user_settings(
 ):
     """Update or clear the allowlisted User memory policy without restarting."""
     _check_account_access(ctx, account_id)
-    _check_account_exists(request, account_id)
-    _check_user_exists(request, account_id, user_id)
+    manager = await _check_account_exists(request, account_id, refresh_scope=account_id)
+    await _check_user_exists(request, account_id, user_id, manager)
     service = get_service()
     if service.viking_fs is None:
         raise FailedPreconditionError("OpenViking service is not initialized.")

--- a/tests/server/test_admin_api.py
+++ b/tests/server/test_admin_api.py
@@ -524,6 +524,40 @@ async def test_list_accounts(admin_client: httpx.AsyncClient):
     assert acct in account_ids
 
 
+async def test_identity_settings_refreshes_a_stale_registry_on_demand(
+    admin_client: httpx.AsyncClient,
+    admin_app: FastAPI,
+    admin_service: OpenVikingService,
+):
+    """Detail settings reads must not depend on a preceding list request."""
+    replica = admin_app.state.api_key_manager
+    writer = APIKeyManager(
+        root_key=ROOT_KEY,
+        viking_fs=admin_service.viking_fs,
+    )
+    await writer.load()
+    acct = _uid()
+
+    await writer.ensure_trusted_identities({acct: {"trusted-user"}})
+    assert replica.has_user(acct, "trusted-user") is False
+
+    account_settings = await admin_client.get(
+        f"/api/v1/admin/accounts/{acct}/settings",
+        headers=root_headers(),
+    )
+    assert account_settings.status_code == 200, account_settings.text
+    assert replica.has_user(acct, "trusted-user") is True
+
+    await writer.ensure_trusted_identities({acct: {"trusted-user-2"}})
+    assert replica.has_user(acct, "trusted-user-2") is False
+
+    user_settings = await admin_client.get(
+        f"/api/v1/admin/accounts/{acct}/users/trusted-user-2/settings",
+        headers=root_headers(),
+    )
+    assert user_settings.status_code == 200, user_settings.text
+
+
 async def test_delete_account(admin_client: httpx.AsyncClient):
     """ROOT can delete an account."""
     acct = _uid()

--- a/tests/server/test_api_key_manager.py
+++ b/tests/server/test_api_key_manager.py
@@ -12,7 +12,7 @@ import pytest_asyncio
 
 from openviking.pyagfs.exceptions import AGFSNotFoundError
 from openviking.server.api_keys import APIKeyManager
-from openviking.server.api_keys.legacy import ACCOUNTS_PATH
+from openviking.server.api_keys.legacy import ACCOUNTS_PATH, USERS_PATH_TEMPLATE
 from openviking.server.identity import Role
 from openviking.service.core import OpenVikingService
 from openviking_cli.exceptions import (
@@ -105,6 +105,278 @@ async def test_create_duplicate_account_raises(manager: APIKeyManager):
         await manager.create_account(acct, "bob")
 
 
+async def test_ensure_trusted_identities_creates_keyless_users_once(
+    manager: APIKeyManager, monkeypatch: pytest.MonkeyPatch
+):
+    """Trusted identity batches add only missing users and never mint keys."""
+    acme = _uid()
+    globex = _uid()
+
+    logged: list[tuple] = []
+
+    def _record_info(*args) -> None:
+        logged.append(args)
+
+    monkeypatch.setattr(manager._legacy.__module__ + ".logger.info", _record_info)
+    result = await manager.ensure_trusted_identities({acme: {"alice", "bob"}, globex: {"eve"}})
+
+    assert result == {"created_accounts": 2, "created_users": 3}
+    assert logged == [
+        ("Persisted trusted identities for account %s: %s", acme, ["alice", "bob"]),
+        ("Persisted trusted identities for account %s: %s", globex, ["eve"]),
+    ]
+    assert manager.get_user_role(acme, "alice") == Role.USER
+    assert "key" not in manager._legacy._accounts[acme].users["alice"]
+    assert manager.get_users(acme, expose_key=True) == [
+        {"user_id": "alice", "role": "user"},
+        {"user_id": "bob", "role": "user"},
+    ]
+
+    writes: list[str] = []
+    original_write = manager._legacy._write_json
+
+    async def _record_write(path: str, data: dict, lease_ref=None):
+        writes.append(path)
+        await original_write(path, data, lease_ref)
+
+    monkeypatch.setattr(manager._legacy, "_write_json", _record_write)
+    repeat = await manager.ensure_trusted_identities(
+        {acme: {"alice", "bob"}, globex: {"eve"}}
+    )
+
+    assert repeat == {"created_accounts": 0, "created_users": 0}
+    assert writes == []
+
+
+async def test_trusted_identity_merge_serializes_with_user_registration(
+    manager: APIKeyManager, monkeypatch: pytest.MonkeyPatch
+):
+    """A background merge cannot overlap a manager mutation in one process."""
+    acct = _uid()
+    await manager.create_account(acct, "alice")
+
+    entered_merge = asyncio.Event()
+    release_merge = asyncio.Event()
+    original_merge = manager._legacy._ensure_trusted_identities_unlocked
+
+    async def _blocked_merge(identities):
+        entered_merge.set()
+        await release_merge.wait()
+        return await original_merge(identities)
+
+    monkeypatch.setattr(manager._legacy, "_ensure_trusted_identities_unlocked", _blocked_merge)
+    merge_task = asyncio.create_task(
+        manager.ensure_trusted_identities({acct: {"trusted-user"}})
+    )
+    await entered_merge.wait()
+
+    register_task = asyncio.create_task(manager.register_user(acct, "bob"))
+    await asyncio.sleep(0)
+    assert not register_task.done()
+
+    release_merge.set()
+    await asyncio.gather(merge_task, register_task)
+    assert {item["user_id"] for item in manager.get_users(acct)} == {
+        "alice",
+        "bob",
+        "trusted-user",
+    }
+
+
+async def test_reload_serializes_with_account_deletion(
+    manager: APIKeyManager, monkeypatch: pytest.MonkeyPatch
+):
+    """Reload must not restore an account deleted while an old snapshot is building."""
+    acct = _uid()
+    await manager.create_account(acct, "alice")
+
+    entered_build = asyncio.Event()
+    release_build = asyncio.Event()
+    original_build = manager._legacy._build_state
+
+    async def _blocked_build(accounts_data, *, allow_migration):
+        entered_build.set()
+        await release_build.wait()
+        return await original_build(accounts_data, allow_migration=allow_migration)
+
+    monkeypatch.setattr(manager._legacy, "_build_state", _blocked_build)
+    reload_task = asyncio.create_task(manager.reload())
+    await entered_build.wait()
+
+    delete_task = asyncio.create_task(manager.delete_account(acct))
+    await asyncio.sleep(0)
+    assert not delete_task.done()
+
+    release_build.set()
+    await asyncio.gather(reload_task, delete_task)
+    assert all(item["account_id"] != acct for item in manager.get_accounts())
+
+
+async def test_identity_registry_refresh_reads_another_instances_trusted_user(
+    manager: APIKeyManager, manager_service
+):
+    """A management reader refreshes a changed account/user registry on demand."""
+    replica = APIKeyManager(root_key=ROOT_KEY, viking_fs=manager_service.viking_fs)
+    await replica.load()
+    acct = _uid()
+
+    await manager.ensure_trusted_identities({acct: {"alice"}})
+    assert replica.has_user(acct, "alice") is False
+
+    assert await replica.refresh_identity_registry_if_changed(acct) is True
+    assert replica.has_user(acct, "alice") is True
+
+
+async def test_account_registry_refresh_check_stats_only_accounts_file(
+    manager: APIKeyManager, monkeypatch: pytest.MonkeyPatch
+):
+    """The account-list fast path must not stat every account's users file."""
+    stat_paths: list[str] = []
+
+    async def _record_stat(path: str) -> tuple:
+        stat_paths.append(path)
+        return (path,)
+
+    monkeypatch.setattr(manager._legacy, "_stat_signature", _record_stat)
+
+    await manager._legacy._identity_registry_signature()
+
+    assert stat_paths == [ACCOUNTS_PATH]
+
+
+async def test_trusted_identity_merge_refreshes_only_affected_user_signatures(
+    manager: APIKeyManager, monkeypatch: pytest.MonkeyPatch
+):
+    """A trusted batch must not stat unrelated accounts' user registries."""
+    target = _uid()
+    unrelated = _uid()
+    await manager.create_account(target, "admin")
+    await manager.create_account(unrelated, "admin")
+
+    stat_paths: list[str] = []
+    original_stat = manager._legacy._stat_signature
+
+    async def _record_stat(path: str) -> tuple:
+        stat_paths.append(path)
+        return await original_stat(path)
+
+    monkeypatch.setattr(manager._legacy, "_stat_signature", _record_stat)
+
+    await manager.ensure_trusted_identities({target: {"trusted-user"}})
+
+    assert stat_paths.count(ACCOUNTS_PATH) == 1
+    assert stat_paths.count(USERS_PATH_TEMPLATE.format(account_id=target)) == 1
+    assert USERS_PATH_TEMPLATE.format(account_id=unrelated) not in stat_paths
+
+
+async def test_management_writer_preserves_a_trusted_identity_from_another_instance(
+    manager: APIKeyManager, manager_service
+):
+    """A stale manager write must merge, rather than replace, a trusted registry update."""
+    acct = _uid()
+    await manager.create_account(acct, "admin")
+
+    replica = APIKeyManager(root_key=ROOT_KEY, viking_fs=manager_service.viking_fs)
+    await replica.load()
+
+    await manager.ensure_trusted_identities({acct: {"trusted-user"}})
+    assert replica.has_user(acct, "trusted-user") is False
+
+    await replica.register_user(acct, "managed-user")
+
+    verifier = APIKeyManager(root_key=ROOT_KEY, viking_fs=manager_service.viking_fs)
+    await verifier.load()
+    assert {item["user_id"] for item in verifier.get_users(acct)} == {
+        "admin",
+        "trusted-user",
+        "managed-user",
+    }
+
+
+async def test_concurrent_management_registration_of_same_user_rejects_second_writer(
+    manager: APIKeyManager, manager_service
+):
+    """The second stale instance must not replace the first user's key."""
+    acct = _uid()
+    await manager.create_account(acct, "admin")
+    replica = APIKeyManager(root_key=ROOT_KEY, viking_fs=manager_service.viking_fs)
+    await replica.load()
+
+    first_key = await manager.register_user(acct, "alice")
+
+    with pytest.raises(AlreadyExistsError):
+        await replica.register_user(acct, "alice")
+    assert replica.has_user(acct, "alice") is False
+
+    verifier = APIKeyManager(root_key=ROOT_KEY, viking_fs=manager_service.viking_fs)
+    await verifier.load()
+    assert verifier.resolve(first_key).user_id == "alice"
+
+
+async def test_management_registration_does_not_replace_a_trusted_user(
+    manager: APIKeyManager, manager_service
+):
+    """A stale management writer must reject an identity created by trusted flush."""
+    acct = _uid()
+    await manager.create_account(acct, "admin")
+    replica = APIKeyManager(root_key=ROOT_KEY, viking_fs=manager_service.viking_fs)
+    await replica.load()
+
+    await manager.ensure_trusted_identities({acct: {"alice"}})
+
+    with pytest.raises(AlreadyExistsError):
+        await replica.register_user(acct, "alice")
+
+    verifier = APIKeyManager(root_key=ROOT_KEY, viking_fs=manager_service.viking_fs)
+    await verifier.load()
+    assert verifier.get_users(acct, expose_key=True) == [
+        {"user_id": "admin", "role": "admin", "api_key": manager._accounts[acct].users["admin"]["key"]},
+        {"user_id": "alice", "role": "user"},
+    ]
+
+
+async def test_management_account_writer_preserves_a_trusted_account_from_another_instance(
+    manager: APIKeyManager, manager_service
+):
+    """A stale account write must retain accounts registered by another instance."""
+    replica = APIKeyManager(root_key=ROOT_KEY, viking_fs=manager_service.viking_fs)
+    await replica.load()
+    trusted_account = _uid()
+    managed_account = _uid()
+
+    await manager.ensure_trusted_identities({trusted_account: {"trusted-user"}})
+    await replica.create_account(managed_account, "managed-admin")
+
+    verifier = APIKeyManager(root_key=ROOT_KEY, viking_fs=manager_service.viking_fs)
+    await verifier.load()
+    assert {item["account_id"] for item in verifier.get_accounts()} >= {
+        trusted_account,
+        managed_account,
+    }
+
+
+async def test_concurrent_management_creation_of_same_account_rejects_second_writer(
+    manager: APIKeyManager, manager_service
+):
+    """A stale instance cannot create a second admin for an existing account."""
+    replica = APIKeyManager(root_key=ROOT_KEY, viking_fs=manager_service.viking_fs)
+    await replica.load()
+    account_id = _uid()
+
+    first_key = await manager.create_account(account_id, "alice")
+
+    with pytest.raises(AlreadyExistsError):
+        await replica.create_account(account_id, "bob")
+    assert account_id not in replica._legacy._accounts
+
+    verifier = APIKeyManager(root_key=ROOT_KEY, viking_fs=manager_service.viking_fs)
+    await verifier.load()
+    assert verifier.resolve(first_key).user_id == "alice"
+    assert verifier.get_users(account_id, expose_key=False) == [
+        {"user_id": "alice", "role": "admin"}
+    ]
+
+
 async def test_create_account_rolls_back_when_user_persistence_fails(
     manager: APIKeyManager, monkeypatch: pytest.MonkeyPatch
 ):
@@ -112,10 +384,10 @@ async def test_create_account_rolls_back_when_user_persistence_fails(
     acct = _uid()
     original_save_users_json = manager._legacy._save_users_json
 
-    async def _fail_save_users_json(account_id: str) -> None:
+    async def _fail_save_users_json(account_id: str, *args, **kwargs) -> None:
         if account_id == acct:
             raise AGFSNotFoundError(account_id)
-        await original_save_users_json(account_id)
+        await original_save_users_json(account_id, *args, **kwargs)
 
     monkeypatch.setattr(manager._legacy, "_save_users_json", _fail_save_users_json)
 
@@ -139,6 +411,22 @@ async def test_delete_account(manager: APIKeyManager):
     await manager.delete_account(acct)
     with pytest.raises(UnauthenticatedError):
         manager.resolve(key)
+
+
+async def test_recreated_account_does_not_restore_deleted_users(manager: APIKeyManager):
+    """A same-name account starts with only its newly created admin."""
+    acct = _uid()
+    old_key = await manager.create_account(acct, "old-admin")
+
+    await manager.delete_account(acct)
+    new_key = await manager.create_account(acct, "new-admin")
+
+    with pytest.raises(UnauthenticatedError):
+        manager.resolve(old_key)
+    assert manager.resolve(new_key).user_id == "new-admin"
+    assert manager.get_users(acct, expose_key=False) == [
+        {"user_id": "new-admin", "role": "admin"}
+    ]
 
 
 async def test_delete_nonexistent_account_raises(manager: APIKeyManager):

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -1051,6 +1051,301 @@ async def test_trusted_mode_defaults_to_user_when_account_not_found(auth_app):
     assert identity.user_id == "some_user"
 
 
+async def test_trusted_identity_registration_batches_data_plane_identity(auth_service):
+    """Enabled trusted registration queues every data-plane identity until flush."""
+    from openviking.server.auth.plugins import TrustedAuthPlugin
+
+    config = ServerConfig(
+        auth_mode="trusted",
+        trusted_identity_flush_interval_seconds=300,
+    )
+    app = FastAPI()
+    app.state.config = config
+    plugin = TrustedAuthPlugin()
+    await plugin.initialize(app, auth_service, config)
+    try:
+        request = _make_request(
+            "/api/v1/resources",
+            headers={
+                "X-OpenViking-Account": "acme",
+                "X-OpenViking-User": "alice",
+            },
+            auth_enabled=False,
+            auth_mode="trusted",
+        )
+        request.app.state.config = config
+        request.app.state.api_key_manager = app.state.api_key_manager
+
+        identity = await plugin.resolve_identity(
+            request,
+            x_openviking_account="acme",
+            x_openviking_user="alice",
+        )
+        assert identity.account_id == "acme"
+        assert identity.user_id == "alice"
+        assert plugin._api_key_manager.has_user("acme", "alice") is False
+
+        await plugin.flush_trusted_identities()
+
+        assert plugin._api_key_manager.get_users("acme", expose_key=True) == [
+            {"user_id": "alice", "role": "user"}
+        ]
+    finally:
+        await plugin.shutdown()
+
+
+async def test_invalid_trusted_identity_does_not_block_later_registration(
+    auth_service,
+):
+    """An invalid trusted identity must not poison a later valid registration batch."""
+    from openviking.server.auth.plugins import TrustedAuthPlugin
+
+    config = ServerConfig(
+        auth_mode="trusted",
+        trusted_identity_flush_interval_seconds=300,
+    )
+    app = FastAPI()
+    app.state.config = config
+    plugin = TrustedAuthPlugin()
+    await plugin.initialize(app, auth_service, config)
+    try:
+        request = _make_request(
+            "/api/v1/resources",
+            headers={
+                "X-OpenViking-Account": "acme",
+                "X-OpenViking-User": "invalid/user",
+            },
+            auth_enabled=False,
+            auth_mode="trusted",
+        )
+        request.app.state.config = config
+
+        with pytest.raises(InvalidArgumentError, match="user_id"):
+            await plugin.resolve_identity(
+                request,
+                x_openviking_account="acme",
+                x_openviking_user="invalid/user",
+            )
+
+        assert plugin._pending == {}
+
+        valid_request = _make_request(
+            "/api/v1/resources",
+            headers={
+                "X-OpenViking-Account": "good-account",
+                "X-OpenViking-User": "alice",
+            },
+            auth_enabled=False,
+            auth_mode="trusted",
+        )
+        valid_request.app.state.config = config
+        await plugin.resolve_identity(
+            valid_request,
+            x_openviking_account="good-account",
+            x_openviking_user="alice",
+        )
+        await plugin.flush_trusted_identities()
+
+        assert plugin._api_key_manager.has_user("good-account", "alice")
+    finally:
+        await plugin.shutdown()
+
+
+async def test_trusted_identity_registration_skips_identity_loaded_from_registry(auth_service):
+    """A restarted plugin must not queue an identity already loaded from storage."""
+    from openviking.server.auth.plugins import TrustedAuthPlugin
+
+    config = ServerConfig(auth_mode="trusted")
+    app = FastAPI()
+    app.state.config = config
+    first_plugin = TrustedAuthPlugin()
+    await first_plugin.initialize(app, auth_service, config)
+    try:
+        await first_plugin._api_key_manager.ensure_trusted_identities({"acme": {"alice"}})
+    finally:
+        await first_plugin.shutdown()
+
+    restarted_app = FastAPI()
+    restarted_app.state.config = config
+    restarted_plugin = TrustedAuthPlugin()
+    await restarted_plugin.initialize(restarted_app, auth_service, config)
+    try:
+        request = _make_request(
+            "/api/v1/resources",
+            headers={
+                "X-OpenViking-Account": "acme",
+                "X-OpenViking-User": "alice",
+            },
+            auth_enabled=False,
+            auth_mode="trusted",
+        )
+        request.app.state.config = config
+
+        await restarted_plugin.resolve_identity(
+            request, x_openviking_account="acme", x_openviking_user="alice"
+        )
+
+        assert restarted_plugin._pending == {}
+    finally:
+        await restarted_plugin.shutdown()
+
+
+async def test_trusted_identity_registration_keeps_rootless_admin_api_disabled(auth_service):
+    """A private registry manager must not enable Admin APIs in rootless trusted mode."""
+    from openviking.server.auth import require_auth_root
+    from openviking.server.auth.plugins import TrustedAuthPlugin
+
+    config = ServerConfig(auth_mode="trusted")
+    app = _build_auth_http_test_app(
+        identity=None, auth_enabled=False, auth_mode="trusted"
+    )
+    app.state.config = config
+
+    @app.get("/api/v1/admin/guarded")
+    @require_auth_root
+    async def guarded_admin(request: FastAPIRequest, ctx=Depends(get_request_context)):
+        return {"status": "ok"}
+
+    plugin = TrustedAuthPlugin()
+    await plugin.initialize(app, auth_service, config)
+    try:
+        assert app.state.api_key_manager is None
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            admin_response = await client.get("/api/v1/admin/guarded")
+            assert admin_response.status_code == 403
+
+        request = _make_request(
+            "/api/v1/resources",
+            headers={
+                "X-OpenViking-Account": "acme",
+                "X-OpenViking-User": "alice",
+            },
+            auth_enabled=False,
+            auth_mode="trusted",
+        )
+        request.app.state.config = config
+        await plugin.resolve_identity(
+            request, x_openviking_account="acme", x_openviking_user="alice"
+        )
+        await plugin.flush_trusted_identities()
+        assert plugin._api_key_manager.has_user("acme", "alice")
+    finally:
+        await plugin.shutdown()
+
+
+async def test_disabled_trusted_identity_registration_and_admin_paths_do_not_enqueue(auth_service):
+    """A zero interval disables registration, and Admin paths never register."""
+    from openviking.server.auth.plugins import TrustedAuthPlugin
+
+    config = ServerConfig(auth_mode="trusted", trusted_identity_flush_interval_seconds=0)
+    app = FastAPI()
+    app.state.config = config
+    plugin = TrustedAuthPlugin()
+    await plugin.initialize(app, auth_service, config)
+    try:
+        assert plugin._flush_task is None
+        for path in ("/api/v1/resources", "/api/v1/admin/accounts"):
+            headers = {
+                "X-OpenViking-Account": "acme",
+                "X-OpenViking-User": "alice",
+            }
+            request = _make_request(
+                path, headers=headers, auth_enabled=False, auth_mode="trusted"
+            )
+            request.app.state.config = config
+            request.app.state.api_key_manager = app.state.api_key_manager
+            await plugin.resolve_identity(
+                request,
+                x_openviking_account="acme",
+                x_openviking_user="alice",
+            )
+
+        await plugin.flush_trusted_identities()
+        assert plugin._api_key_manager.has_user("acme", "alice") is False
+    finally:
+        await plugin.shutdown()
+
+
+async def test_trusted_identity_registration_excludes_admin_paths(auth_service):
+    """Enabled registration must still exclude Admin requests."""
+    from openviking.server.auth.plugins import TrustedAuthPlugin
+
+    config = ServerConfig(auth_mode="trusted")
+    app = FastAPI()
+    app.state.config = config
+    plugin = TrustedAuthPlugin()
+    await plugin.initialize(app, auth_service, config)
+    try:
+        request = _make_request(
+            "/api/v1/admin/accounts",
+            headers={
+                "X-OpenViking-Account": "acme",
+                "X-OpenViking-User": "alice",
+            },
+            auth_enabled=False,
+            auth_mode="trusted",
+        )
+        request.app.state.config = config
+        request.app.state.api_key_manager = app.state.api_key_manager
+
+        await plugin.resolve_identity(
+            request,
+            x_openviking_account="acme",
+            x_openviking_user="alice",
+        )
+
+        assert plugin._pending == {}
+    finally:
+        await plugin.shutdown()
+
+
+async def test_trusted_identity_registration_retries_failed_batch_without_exceeding_backlog(
+    auth_service, monkeypatch: pytest.MonkeyPatch
+):
+    """A failed flush returns its batch to the bounded queue for a later retry."""
+    from openviking.server.auth.plugins import TrustedAuthPlugin
+
+    config = ServerConfig(
+        auth_mode="trusted",
+        trusted_identity_pending_max_size=2,
+    )
+    app = FastAPI()
+    app.state.config = config
+    plugin = TrustedAuthPlugin()
+    await plugin.initialize(app, auth_service, config)
+    try:
+        plugin._queue_trusted_identity("acme", "alice")
+        plugin._queue_trusted_identity("acme", "bob")
+        plugin._queue_trusted_identity("acme", "eve")
+        assert plugin._pending == {"acme": {"alice", "bob"}}
+
+        original_ensure = plugin._api_key_manager.ensure_trusted_identities
+
+        async def _fail_once(identities):
+            monkeypatch.setattr(plugin._api_key_manager, "ensure_trusted_identities", original_ensure)
+            raise RuntimeError("temporary storage failure")
+
+        monkeypatch.setattr(plugin._api_key_manager, "ensure_trusted_identities", _fail_once)
+        await plugin.flush_trusted_identities()
+        assert plugin._pending == {"acme": {"alice", "bob"}}
+
+        await plugin.flush_trusted_identities()
+        assert plugin._api_key_manager.has_user("acme", "alice")
+        assert plugin._api_key_manager.has_user("acme", "bob")
+    finally:
+        await plugin.shutdown()
+
+
+def test_trusted_identity_registration_config_allows_disabling():
+    """A zero interval disables registration; negative values remain invalid."""
+    assert ServerConfig(trusted_identity_flush_interval_seconds=0).trusted_identity_flush_interval_seconds == 0
+    with pytest.raises(ValueError):
+        ServerConfig(trusted_identity_flush_interval_seconds=-1)
+    with pytest.raises(ValueError):
+        ServerConfig(trusted_identity_pending_max_size=0)
+
+
 async def test_trusted_mode_with_root_api_key_requires_matching_api_key():
     """Trusted mode should require the configured server API key when present."""
     request = _make_request(


### PR DESCRIPTION
# Trusted 模式身份批量注册

## 目标

Trusted 模式的请求通常只把 `X-OpenViking-Account` 和
`X-OpenViking-User` 作为当前请求的身份。本功能将这些身份异步注册进 registry，
使既有的 account 和 user 管理接口能够列出它们，同时不在数据面请求中增加 registry I/O。

## 启用方式

注册能力由 `server.trusted_identity_flush_interval_seconds` 控制：

- 配置大于 `0` 时，所有 trusted 数据面请求的 account/user 都会自动加入注册队列。
- 配置为 `0` 时完全关闭该能力：不入队，也不创建后台刷盘任务。
- `/api/v1/admin` 及其子路径不会自动注册身份，其他认证插件也不会执行注册。

示例：

```bash
curl -X POST http://localhost:1933/api/v1/sessions \
  -H 'X-API-Key: <root-key>' \
  -H 'X-OpenViking-Account: acme' \
  -H 'X-OpenViking-User: alice' \
  -H 'Content-Type: application/json' \
  -d '{"session_id":"session-001"}'
```

## 运行机制

`TrustedAuthPlugin` 复用 API key manager 已加载的 registry，作为本实例已持久化身份的索引；尚未写入的身份仅保存在有容量上限的 pending 和 in-flight batch 中。请求处理只进行内存去重，不会读取 registry 文件、获取 registry 锁、创建任务或写存储。

`pending + in-flight` 的总积压量受限；队列满时，新的身份不再自动注册，但业务请求保持正常执行。每个服务实例由一个 `asyncio.Task` 执行刷盘：首次执行等待 `interval + random(0, interval)`，避免多实例启动时同时刷盘；后续按固定间隔执行。关闭服务时会取消循环，并进行一次尽力而为的最终刷盘。

因此进程崩溃可能丢失最后一个间隔内仅存在于队列中的身份；后续新的 trusted 数据面请求会将该身份重新入队。

服务配置：

```json
{
  "server": {
    "trusted_identity_flush_interval_seconds": 300,
    "trusted_identity_pending_max_size": 10000
  }
}
```

刷盘间隔必须为非负数。默认值为五分钟，首次执行会在服务启动后随机延迟至五到十分钟；配置为 `0` 时不会创建后台任务，也不会注册身份。

## Registry 合并与范围

批量合并只读取一次 `accounts.json`，并为每个受影响的 account 读取一个 `users.json`。它使用现有的精确路径锁，在锁内重新读取数据，仅当文件确实有新增内容时才写入。因此并发实例能够收敛，不会出现重复报错，也不会覆盖已有用户的 API key 或角色。

每个 account 成功写入后，服务会记录 account 和本次新增的 user ID。自动创建的用户没有 API key，存储格式为：

```json
{
  "role": "user"
}
```

已有 user 记录绝不修改。本功能不读写 `groups.json`，不创建 group，也不分配 group 成员关系。删除冲突和 tombstone 有意不纳入第一版范围。

常规的 account 和 user 管理修改遵循同样的锁内读/合并/写规则。陈旧实例只会修改其目标 account 或 user，同时保留其他实例新写入的身份。新建 account 会初始化其 `users.json`，避免删除后重建同名 account 时恢复旧 user 或旧 API key。

trusted 模式没有 registry watcher。account/user 管理读取（包括 settings 详情读取）会按需检查 registry signature：未变化时直接使用本地快照，变化时在返回响应前重新加载。account 读取仅 stat `accounts.json`；user 读取则 stat `accounts.json` 及该 account 的 `users.json`。这样数据面请求和空闲服务实例均无需周期性轮询存储。
