### PR TITLE
fix(compile): 私密保存并透传 args.api_key

### DIFF
--- a/openviking/service/compile_service.py
+++ b/openviking/service/compile_service.py
@@ -20,7 +20,7 @@ from openviking.service.external_task_service import (
     ExternalTaskSnapshot,
 )
 from openviking.service.fs_service import FSService
-from openviking.service.task_tracker import TaskRecord
+from openviking.service.task_tracker import SENSITIVE_TASK_KEYS, TaskRecord
 from openviking_cli.exceptions import (
     InvalidArgumentError,
     NotFoundError,
@@ -429,12 +429,14 @@ class CompileService:
     def _split_payload(request: CompileRequest) -> tuple[dict[str, Any], dict[str, Any]]:
         payload = request.model_dump(mode="json", by_alias=True, exclude_none=True)
         args = payload.get("args")
-        if not isinstance(args, dict) or "user_key" not in args:
+        if not isinstance(args, dict):
             return payload, {}
-        private_payload = {"args": {"user_key": args.pop("user_key")}}
+        private_args = {key: args.pop(key) for key in SENSITIVE_TASK_KEYS if key in args}
+        if not private_args:
+            return payload, {}
         if not args:
             payload.pop("args", None)
-        return payload, private_payload
+        return payload, {"args": private_args}
 
     @staticmethod
     def _snapshot(task: CompileSessionStatus) -> ExternalTaskSnapshot:

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -142,7 +142,7 @@ _SENSITIVE_PATTERNS = re.compile(
 )
 
 _MAX_ERROR_LEN = 500
-_SENSITIVE_RESULT_KEYS = {"user_key"}
+SENSITIVE_TASK_KEYS = frozenset({"api_key", "user_key"})
 
 
 def _sanitize_error(error: str) -> str:
@@ -159,7 +159,7 @@ def _sanitize_task_result(result: Any) -> Any:
         return {
             key: _sanitize_task_result(value)
             for key, value in result.items()
-            if key not in _SENSITIVE_RESULT_KEYS
+            if key not in SENSITIVE_TASK_KEYS
         }
     if isinstance(result, list):
         return [_sanitize_task_result(item) for item in result]

--- a/tests/server/test_bot_proxy_auth.py
+++ b/tests/server/test_bot_proxy_auth.py
@@ -4,6 +4,7 @@
 """Regression tests for bot proxy endpoint auth enforcement."""
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
@@ -15,11 +16,14 @@ import openviking.service.compile_service as compile_service_module
 import openviking.service.external_task_service as external_task_service_module
 from openviking.server.auth.plugins import DevAuthPlugin, TrustedAuthPlugin
 from openviking.server.config import ServerConfig
-from openviking.server.identity import AuthMode
+from openviking.server.identity import AuthMode, RequestContext, Role
 from openviking.service.compile_service import CompileService
 from openviking.service.external_task_service import ExternalTaskService
-from openviking.service.task_tracker import TaskRecord, TaskStatus
+from openviking.service.task_store import PersistentTaskStore
+from openviking.service.task_tracker import TaskRecord, TaskStatus, TaskTracker
+from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils.config.open_viking_config import CompileApiConfig
+from tests.utils.mock_agfs import MockLocalAGFS
 
 
 def test_set_bot_api_key_updates_module_state():
@@ -287,7 +291,7 @@ async def test_compile_route_uses_ov_owned_task_and_rejects_legacy_routes(monkey
 
 
 @pytest.mark.asyncio
-async def test_compile_api_client_session_protocol_retry_and_cancellation(monkeypatch):
+async def test_compile_api_client_session_protocol_retry_and_cancellation(monkeypatch, tmp_path):
     forwarded = []
     response_status = {
         "cancel": "cancelled",
@@ -356,31 +360,52 @@ async def test_compile_api_client_session_protocol_retry_and_cancellation(monkey
         SimpleNamespace(),
     )
     tasks.register(service)
-    public_payload, private_payload = service._split_payload(
-        compile_service_module.CompileRequest.model_validate(
-            {
-                "from": ["viking://resources/source"],
-                "to": "viking://resources/wiki",
-                "skill": "viking://agent/skills/wiki",
-                "args": {"model_name": "model-1", "user_key": "model-user-key"},
-                "instruction": "Keep supporting evidence.",
-            }
-        )
-    )
-    assert public_payload["args"] == {"model_name": "model-1"}
-    assert private_payload == {"args": {"user_key": "model-user-key"}}
-    external_task_id = await service.submit(
-        "cmp_ov_1",
+    request = compile_service_module.CompileRequest.model_validate(
         {
             "from": ["viking://resources/source"],
             "to": "viking://resources/wiki",
             "skill": "viking://agent/skills/wiki",
             "instruction": "Keep supporting evidence.",
-        },
-        {
-            "args": {"user_key": "model-user-key"},
-        },
-        {"api_key": "active-user-key"},
+            "args": {
+                "model_name": "model-1",
+                "user_key": "model-user-key",
+                "api_key": "compile-api-key",
+            },
+        }
+    )
+    monkeypatch.setattr(service, "_normalize_request", AsyncMock(return_value=request))
+    store = PersistentTaskStore(MockLocalAGFS(root_path=tmp_path))
+    tracker = TaskTracker(store)
+    monkeypatch.setattr(external_task_service_module, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(
+        external_task_service_module,
+        "get_queue_manager",
+        lambda: SimpleNamespace(enqueue=AsyncMock()),
+    )
+    connection = {"api_key": "active-user-key"}
+    owner = {"account_id": "acct", "user_id": "alice"}
+    task = await service.create(
+        request,
+        connection=connection,
+        ctx=RequestContext(user=UserIdentifier("acct", "alice"), role=Role.USER),
+    )
+    assert task.to_dict()["meta"]["request"]["args"] == {"model_name": "model-1"}
+    stored = await store.get(task.task_id, **owner)
+    assert stored["meta"]["request"]["args"] == {"model_name": "model-1"}
+
+    tracker = TaskTracker(store)
+    restored = await tracker.get(task.task_id, **owner)
+    listed = (await tracker.list_tasks(**owner))[0]
+    assert restored.to_dict() == listed.to_dict() == task.to_dict()
+    auth = await tracker.get_task_auth(task.task_id, **owner)
+    assert auth["external_request_private"] == {
+        "args": {"user_key": "model-user-key", "api_key": "compile-api-key"}
+    }
+    external_task_id = await service.submit(
+        task.task_id,
+        restored.meta["request"],
+        auth["external_request_private"],
+        auth["openviking_connection"],
     )
     status_snapshot = await service.get(
         external_task_id,
@@ -399,7 +424,7 @@ async def test_compile_api_client_session_protocol_retry_and_cancellation(monkey
     ]
     assert all(request["method"] == "POST" for request in forwarded)
     assert "X-Gateway-Token" not in forwarded[0]["headers"]
-    assert forwarded[0]["headers"]["Idempotency-Key"] == "cmp_ov_1"
+    assert forwarded[0]["headers"]["Idempotency-Key"] == task.task_id
     assert forwarded[0]["headers"]["X-API-Key"] == "active-user-key"
     assert forwarded[0]["body"] == {
         "task_type": "compile",
@@ -408,12 +433,18 @@ async def test_compile_api_client_session_protocol_retry_and_cancellation(monkey
             "to": "viking://resources/wiki",
             "skill": "viking://agent/skills/wiki",
             "instruction": "Keep supporting evidence.",
-            "args": {"user_key": "model-user-key"},
+            "args": {
+                "model_name": "model-1",
+                "user_key": "model-user-key",
+                "api_key": "compile-api-key",
+            },
         },
     }
     assert forwarded[1]["body"] == {"session_id": "ma-session-1"}
     assert status_snapshot.meta == {"token_usage": {"total_tokens": 12}}
     assert cancel_snapshot.status == "cancelled"
+    await tracker.complete(task.task_id, {"output": "wiki"}, **owner)
+    assert await tracker.get_task_auth(task.task_id, **owner) == {}
 
     class Tracker:
         def __init__(self):

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -467,8 +467,8 @@ async def test_public_serialization_skips_private_payloads(tracker: TaskTracker)
     task = await tracker.create("session_commit", **_owner_kwargs())
     task.auth = PrivatePayload()
     task._extra_fields = PrivatePayload()
-    task.meta = {"nested": [{"user_key": "secret", "values": [1]}]}
-    task.result = {"nested": [{"user_key": "secret", "values": [2]}]}
+    task.meta = {"nested": [{"user_key": "secret", "api_key": "compile-key", "values": [1]}]}
+    task.result = {"nested": [{"user_key": "secret", "api_key": "compile-key", "values": [2]}]}
 
     public = task.to_dict()
     assert set(public) == {


### PR DESCRIPTION
## Description

外部调用 `POST /api/v1/compile` 时可以通过 `args.api_key` 提供本次 Compile 使用的密钥。该值需要传给执行端，同时不能出现在任务创建响应、详情或列表中。

同一个输入 `args={"model_name":"endpoint-id","api_key":"<compile-key>"}`：
- **Before**：`api_key` 随普通参数保存在 `meta.request.args`，查询 Task Info 会返回该值。
- **After**：任务公开参数只保留 `model_name`；`api_key` 随任务私密数据持久化，提交 Runtime 时还原到 `payload.args.api_key`，任务结束后清理。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

无。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 复用现有任务私密 `auth` 存储，在 Compile 创建时提取 `args.api_key`，继续支持已有 `args.user_key`；提交 Runtime 时复用现有参数合并逻辑。
- 提取私密参数与过滤任务 `meta` / `result` 共用一份敏感字段定义，避免公开响应回显 `api_key`。
- 改写两个现有契约测试，覆盖创建响应、持久化、重启恢复、任务详情和列表、下游请求内容及结束清理；未新增测试函数或文件。

## Testing

- 修改前：改写后的两个现有契约测试均因 `api_key` 出现在公开数据中失败。
- 修改后：`pytest tests/server/test_bot_proxy_auth.py tests/test_task_tracker.py -q --no-cov`，**62 passed**。
- 本次修改的四个 Python 文件通过 Ruff；`git diff --check` 通过。

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

`args.api_key` 是调用方显式提供给 Compile 执行端的参数；请求头 `X-API-Key` 继续承担 OV 认证和下游认证透传，不自动填入 `args`。HTTP、CLI、SDK 均复用已有的 `args` 输入。

本 PR 覆盖 OV 到 `/runtime/v1/tasks` 的私密参数传递。下游收到的请求为 `{"task_type":"compile","payload":{...,"args":{"model_name":"endpoint-id","api_key":"<compile-key>"}}}`；外部 Runtime 的实际密钥消费未做联调验证。
