### PR TITLE
fix(bot): deliver explicit OpenViking images in Feishu cards

### DIFF
--- a/bot/tests/test_feishu_outbound_images.py
+++ b/bot/tests/test_feishu_outbound_images.py
@@ -173,12 +173,11 @@ async def test_image_delivery_instructions_are_scoped_to_feishu(tmp_path, channe
     prompt = await context.build_system_prompt(session_key, ov_tools_enable=False)
 
     if channel_type == "feishu":
-        assert "![description](viking://path/to/image.png)" in prompt
-        assert "URI citations do not send images" in prompt
-        assert "it does not send the image to the user" in prompt
-        assert "do not claim confirmed delivery" in prompt
+        assert "![description](viking://...) outside code" in prompt
+        assert "To cite an image URI without displaying it, use inline code" in prompt
+        assert "Reading an image does not send it to the user" in prompt
     else:
-        assert "## Feishu image delivery" not in prompt
+        assert "## Feishu images" not in prompt
 
 
 @pytest.mark.asyncio

--- a/bot/tests/test_feishu_outbound_images.py
+++ b/bot/tests/test_feishu_outbound_images.py
@@ -1,0 +1,299 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression coverage for knowledge-base images in Feishu cards."""
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from vikingbot.bus.events import OutboundMessage
+from vikingbot.bus.queue import MessageBus
+from vikingbot.channels.feishu import FeishuChannel
+from vikingbot.channels.manager import ChannelManager
+from vikingbot.config.schema import Config, FeishuChannelConfig, SessionKey
+from vikingbot.openviking_mount.ov_server import VikingClient
+from vikingbot.utils.session_paths import workspace_name
+
+from openviking.utils.media_limits import MAX_INLINE_TOOL_RESULT_MEDIA_BYTES
+
+PNG = b"\x89PNG\r\n\x1a\nfake-png"
+URI = "viking://resources/knowledge/image.png"
+
+
+@pytest.fixture
+def delivery(monkeypatch):
+    config = Config()
+    channel = FeishuChannel(FeishuChannelConfig(app_id="cli_app"), MessageBus(), bot_config=config)
+    client = SimpleNamespace(
+        stat=AsyncMock(return_value={"size": len(PNG)}),
+        download_bytes=AsyncMock(return_value=PNG),
+        close=AsyncMock(),
+    )
+    create = AsyncMock(return_value=client)
+    monkeypatch.setattr(VikingClient, "create", create)
+    channel._upload_image_to_feishu = AsyncMock(return_value="img_uploaded")
+    msg = OutboundMessage(
+        session_key=SessionKey(type="feishu", channel_id="cli_app", chat_id="oc_chat"),
+        content=f"正文\n![示意图]({URI})\n结尾",
+        metadata={"reply_to": "oc_chat", "sender_id": "ou_sender"},
+    )
+    return channel, client, create, msg, config
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "reference, expected_uri",
+    [
+        (f"![示意图]({URI})", URI),
+        (f'![示意图](<{URI}> "标题")', URI),
+        ("![图片](viking://~/resources/image.PNG)", "viking://~/resources/image.PNG"),
+        (
+            "![图片](viking://resources/image.png?version=1#preview)",
+            "viking://resources/image.png?version=1#preview",
+        ),
+        ("![图片](viking://resources/image(1).png)", "viking://resources/image(1).png"),
+        (
+            "![图片](<viking://resources/image with spaces.png>)",
+            "viking://resources/image with spaces.png",
+        ),
+    ],
+)
+async def test_viking_image_upload_uses_sender_and_config(delivery, reference, expected_uri):
+    channel, client, create, msg, config = delivery
+    cleaned, images = await channel._extract_and_upload_images(f"正文\n{reference}\n结尾", msg)
+
+    assert cleaned == "正文\n\n结尾"
+    assert images == [{"image_key": "img_uploaded"}]
+    create.assert_awaited_once_with(
+        workspace_name(msg.session_key, config.sandbox.mode, portable=False),
+        actor_peer_id="ou_sender",
+        config=config,
+    )
+    client.stat.assert_awaited_once_with(expected_uri)
+    client.download_bytes.assert_awaited_once_with(expected_uri)
+    channel._upload_image_to_feishu.assert_awaited_once_with(PNG)
+    client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scheme", ["send", "viking"])
+async def test_repeated_images_upload_once_and_viking_citation_stays(delivery, scheme):
+    channel, client, create, msg, config = delivery
+    uri = f"{scheme}://image.png"
+    channel._parse_data_uri = AsyncMock(return_value=(False, PNG))
+    cleaned, images = await channel._extract_and_upload_images(
+        f"![图片]({uri})\n{uri}\n![重复]({uri})", msg
+    )
+
+    assert cleaned == (uri if scheme == "viking" else "")
+    assert images == [{"image_key": "img_uploaded"}]
+    channel._upload_image_to_feishu.assert_awaited_once_with(PNG)
+    if scheme == "send":
+        create.assert_not_awaited()
+        channel._parse_data_uri.assert_awaited_once_with(uri)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "content",
+    [
+        URI,
+        f"- `{URI}`",
+        f"[查看图片]({URI})",
+        f'[查看图片]({URI} "标题")',
+        f"`![示例]({URI})`",
+        f"``![示例]({URI})``",
+        f"```markdown\n![示例]({URI})\n```",
+        f"~~~markdown\n![示例]({URI})\n~~~",
+        f"```markdown\n![示例]({URI})",  # Unclosed code fence
+        f"\\![示例]({URI})",
+        "`send://image.png`",
+        "```markdown\n![示例](send://image.png)\n```",
+    ],
+)
+async def test_citations_and_code_examples_do_not_send_images(delivery, content):
+    channel, client, create, msg, config = delivery
+
+    assert await channel._extract_and_upload_images(content, msg) == (content, [])
+    create.assert_not_awaited()
+    channel._upload_image_to_feishu.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_explicit_image_after_code_block_still_sends(delivery):
+    channel, client, create, msg, config = delivery
+    example = f"```markdown\n![示例]({URI})\n```"
+    content = f"{example}\n图片如下：\n![照片]({URI})\n来源：`{URI}`"
+
+    cleaned, images = await channel._extract_and_upload_images(content, msg)
+
+    assert cleaned == f"{example}\n图片如下：\n\n来源：`{URI}`"
+    assert images == [{"image_key": "img_uploaded"}]
+    channel._upload_image_to_feishu.assert_awaited_once_with(PNG)
+
+
+@pytest.mark.asyncio
+async def test_image_listing_card_preserves_uri_without_attaching_image(delivery):
+    pytest.importorskip("lark_oapi")
+    channel, client, create, msg, config = delivery
+    msg.content = (
+        f"目前 OpenViking 中有 **1 张图片**：\n\n- `{URI}`\n\n"
+        "如果你愿意，我还可以继续帮你查看这张图片。"
+    )
+    send = Mock(return_value=SimpleNamespace(success=lambda: True))
+    channel._client = SimpleNamespace(
+        im=SimpleNamespace(v1=SimpleNamespace(message=SimpleNamespace(create=send)))
+    )
+
+    await channel.send(msg)
+
+    send.assert_called_once()
+    card = json.loads(send.call_args.args[0].request_body.content)
+    assert card["elements"] == [{"tag": "markdown", "content": msg.content}]
+    create.assert_not_awaited()
+    channel._upload_image_to_feishu.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("channel_type", ["feishu", "telegram"])
+async def test_image_delivery_instructions_are_scoped_to_feishu(tmp_path, channel_type):
+    from vikingbot.agent.context import ContextBuilder
+
+    context = ContextBuilder(tmp_path)
+    context._templates_ensured = True
+    context._skills = SimpleNamespace(get_always_skills=lambda: [], build_skills_summary=lambda: "")
+    session_key = SessionKey(type=channel_type, channel_id="app", chat_id="chat")
+
+    prompt = await context.build_system_prompt(session_key, ov_tools_enable=False)
+
+    if channel_type == "feishu":
+        assert "![description](viking://path/to/image.png)" in prompt
+        assert "URI citations do not send images" in prompt
+        assert "it does not send the image to the user" in prompt
+        assert "do not claim confirmed delivery" in prompt
+    else:
+        assert "## Feishu image delivery" not in prompt
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stage", ["stat", "download_bytes", "upload"])
+async def test_image_failure_keeps_body_and_removes_invalid_markdown(delivery, stage):
+    channel, client, create, msg, config = delivery
+    operation = channel._upload_image_to_feishu if stage == "upload" else getattr(client, stage)
+    operation.side_effect = RuntimeError("image unavailable")
+
+    cleaned, images = await channel._extract_and_upload_images(msg.content, msg)
+
+    assert cleaned == "正文\n[图片发送失败]\n结尾"
+    assert images == []
+    client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [None, True, -1, 0, MAX_INLINE_TOOL_RESULT_MEDIA_BYTES + 1])
+async def test_invalid_image_size_is_not_downloaded(delivery, size):
+    channel, client, create, msg, config = delivery
+    client.stat.return_value = {"size": size}
+
+    cleaned, images = await channel._extract_and_upload_images(msg.content, msg)
+
+    assert "[图片发送失败]" in cleaned
+    assert images == []
+    client.download_bytes.assert_not_awaited()
+    channel._upload_image_to_feishu.assert_not_awaited()
+    client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("data", [b"not an image", PNG + b"changed"])
+async def test_invalid_or_changed_bytes_are_not_uploaded(delivery, data):
+    channel, client, create, msg, config = delivery
+    client.download_bytes.return_value = data
+
+    cleaned, images = await channel._extract_and_upload_images(msg.content, msg)
+
+    assert "[图片发送失败]" in cleaned
+    assert images == []
+    channel._upload_image_to_feishu.assert_not_awaited()
+    client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_missing_sender_does_not_fall_back_to_unscoped_access(delivery):
+    channel, client, create, msg, config = delivery
+    msg.metadata.pop("sender_id")
+
+    cleaned, images = await channel._extract_and_upload_images(msg.content, msg)
+
+    assert "viking://" not in cleaned
+    assert images == []
+    create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failed_image_does_not_block_other_images(delivery):
+    channel, client, create, msg, config = delivery
+    channel._upload_image_to_feishu.side_effect = [RuntimeError("rejected"), "img_second"]
+
+    cleaned, images = await channel._extract_and_upload_images(
+        f"正文 ![坏图]({URI}) ![好图](viking://resources/other.png) 结尾", msg
+    )
+
+    assert cleaned == "正文 [图片发送失败]  结尾"
+    assert images == [{"image_key": "img_second"}]
+
+
+@pytest.mark.asyncio
+async def test_normal_text_and_web_images_are_preserved(delivery):
+    channel, client, create, msg, config = delivery
+    content = "正文 [链接](https://example.com) ![图片](https://example.com/image.png)"
+
+    assert await channel._extract_and_upload_images(content, msg) == (content, [])
+    create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reply", [False, True])
+@pytest.mark.parametrize("fail", [False, True])
+async def test_send_builds_valid_card_after_image_conversion(delivery, reply, fail):
+    pytest.importorskip("lark_oapi")
+    channel, client, create, msg, config = delivery
+    if reply:
+        msg.metadata["message_id"] = "om_original"
+    if fail:
+        client.download_bytes.side_effect = RuntimeError("not found")
+    send = Mock(return_value=SimpleNamespace(success=lambda: True))
+    channel._client = SimpleNamespace(
+        im=SimpleNamespace(v1=SimpleNamespace(message=SimpleNamespace(create=send, reply=send)))
+    )
+
+    await channel.send(msg)
+
+    send.assert_called_once()
+    request = send.call_args.args[0]
+    assert request.request_body.msg_type == "interactive"
+    card = json.loads(request.request_body.content)
+    assert "viking://" not in request.request_body.content
+    assert "正文" in request.request_body.content
+    image_elements = [element for element in card["elements"] if element["tag"] == "img"]
+    if fail:
+        assert image_elements == []
+        assert "图片发送失败" in request.request_body.content
+    else:
+        assert [element["img_key"] for element in image_elements] == ["img_uploaded"]
+
+
+def test_manager_passes_active_config_to_feishu():
+    config = Config(channels=[FeishuChannelConfig(app_id="cli_app", enabled=True)])
+    manager = ChannelManager(MessageBus())
+
+    manager.load_channels_from_config(config)
+
+    channel = next(iter(manager.channels.values()))
+    assert channel._bot_config is config

--- a/bot/vikingbot/agent/context.py
+++ b/bot/vikingbot/agent/context.py
@@ -129,6 +129,24 @@ class ContextBuilder:
         # Core identity
         parts.append(await self._get_identity(session_key))
 
+        if session_key.type == "feishu":
+            parts.append(
+                "## Feishu image delivery\n\n"
+                "To show an OpenViking image to the user, explicitly include "
+                "![description](viking://path/to/image.png) in your reply or message content, "
+                "outside code spans/blocks. This requests image delivery: the channel downloads "
+                "the image with the sender's permissions and attaches it to the reply. "
+                "Use this only when you intend to show the image. "
+                "When listing or citing resources, write the URI as inline code, "
+                "e.g. `viking://path/to/image.png`; URI citations do not send images. "
+                "Reading an image with openviking_multi_read only lets you inspect it; "
+                "it does not send the image to the user. "
+                "Describe your reply consistently with whether you requested an image attachment. "
+                "Delivery happens after composing the reply; do not claim confirmed delivery "
+                "without a receipt. If image conversion fails, the channel displays a text "
+                "placeholder and keeps the rest of the reply."
+            )
+
         # Sandbox environment info
         if self.sandbox_manager:
             sandbox_cwd = await self.sandbox_manager.get_sandbox_cwd(session_key)

--- a/bot/vikingbot/agent/context.py
+++ b/bot/vikingbot/agent/context.py
@@ -131,20 +131,10 @@ class ContextBuilder:
 
         if session_key.type == "feishu":
             parts.append(
-                "## Feishu image delivery\n\n"
-                "To show an OpenViking image to the user, explicitly include "
-                "![description](viking://path/to/image.png) in your reply or message content, "
-                "outside code spans/blocks. This requests image delivery: the channel downloads "
-                "the image with the sender's permissions and attaches it to the reply. "
-                "Use this only when you intend to show the image. "
-                "When listing or citing resources, write the URI as inline code, "
-                "e.g. `viking://path/to/image.png`; URI citations do not send images. "
-                "Reading an image with openviking_multi_read only lets you inspect it; "
-                "it does not send the image to the user. "
-                "Describe your reply consistently with whether you requested an image attachment. "
-                "Delivery happens after composing the reply; do not claim confirmed delivery "
-                "without a receipt. If image conversion fails, the channel displays a text "
-                "placeholder and keeps the rest of the reply."
+                "## Feishu images\n\n"
+                "To display an OpenViking image, use ![description](viking://...) outside code.\n"
+                "To cite an image URI without displaying it, use inline code.\n"
+                "Reading an image does not send it to the user."
             )
 
         # Sandbox environment info

--- a/bot/vikingbot/channels/feishu.py
+++ b/bot/vikingbot/channels/feishu.py
@@ -31,7 +31,9 @@ except ImportError:
 from vikingbot.bus.events import OutboundMessage
 from vikingbot.bus.queue import MessageBus
 from vikingbot.channels.base import BaseChannel
-from vikingbot.config.schema import BotMode, FeishuChannelConfig
+from vikingbot.config.schema import BotMode, Config, FeishuChannelConfig
+from vikingbot.utils.image_format import sniff_image_format
+from vikingbot.utils.session_paths import workspace_name
 
 try:
     import lark_oapi as lark
@@ -98,9 +100,17 @@ class FeishuChannel(BaseChannel):
         "EatingFood",
     ]
 
-    def __init__(self, config: FeishuChannelConfig, bus: MessageBus, **kwargs):
+    def __init__(
+        self,
+        config: FeishuChannelConfig,
+        bus: MessageBus,
+        *,
+        bot_config: Config | None = None,
+        **kwargs,
+    ):
         super().__init__(config, bus, **kwargs)
         self.config: FeishuChannelConfig = config
+        self._bot_config = bot_config
         self._client: Any = None
         self._ws_client: Any = None
         self._ws_thread: threading.Thread | None = None
@@ -549,7 +559,7 @@ class FeishuChannel(BaseChannel):
                 receive_id_type = "open_id"
 
             # Process images and get cleaned content
-            cleaned_content, images = await self._extract_and_upload_images(msg.content)
+            cleaned_content, images = await self._extract_and_upload_images(msg.content, msg)
 
             content_with_mentions = cleaned_content
 
@@ -1070,41 +1080,88 @@ class FeishuChannel(BaseChannel):
         except Exception:
             logger.exception("Error processing Feishu message")
 
-    async def _extract_and_upload_images(self, content: str) -> tuple[str, list[dict]]:
-        """Extract images from markdown content, upload to Feishu, and return cleaned content."""
-        images = []
-        cleaned_content = content
+    async def _download_viking_image(self, uri: str, msg: OutboundMessage | None) -> bytes:
+        """Read an image with the same sender scope used by OpenViking tools."""
+        from openviking.utils.media_limits import MAX_INLINE_TOOL_RESULT_MEDIA_BYTES
+        from vikingbot.openviking_mount.ov_server import VikingClient
 
-        # Pattern 1: ![alt](send://...)
-        markdown_pattern = r"!\[([^\]]*)\]\((send://[^)\s]+\.(png|jpeg|jpg|gif|bmp|webp))\)"
-        for m in re.finditer(markdown_pattern, content):
-            img_url = m.group(2)
-            try:
-                is_content, result = await self._parse_data_uri(img_url)
+        sender_id = msg.metadata.get("sender_id") if msg else None
+        if not isinstance(sender_id, str) or not sender_id.strip():
+            raise ValueError("OpenViking image delivery requires the original sender identity")
 
-                if not is_content and isinstance(result, bytes):
+        config = self._bot_config or load_config()
+        client = await VikingClient.create(
+            workspace_name(msg.session_key, config.sandbox.mode, portable=False),
+            actor_peer_id=sender_id,
+            config=config,
+        )
+        try:
+            stat = await client.stat(uri)
+            size = stat.get("size")
+            if (
+                isinstance(size, bool)
+                or not isinstance(size, int)
+                or not 0 < size <= MAX_INLINE_TOOL_RESULT_MEDIA_BYTES
+            ):
+                raise ValueError(
+                    "OpenViking image size is unavailable or exceeds the delivery limit"
+                )
+            data = await client.download_bytes(uri)
+            if len(data) > size or sniff_image_format(data) is None:
+                raise ValueError("OpenViking image changed size or has an unsupported format")
+            return data
+        finally:
+            await client.close()
+
+    async def _extract_and_upload_images(
+        self, content: str, msg: OutboundMessage | None = None
+    ) -> tuple[str, list[dict]]:
+        """Upload explicit images, preserving URI citations and Markdown examples."""
+        # Viking URIs also appear in listings and citations: only image Markdown
+        # requests delivery. Keep bare send:// support for the image generation tool.
+        # Consume code spans/blocks first so syntax examples never send an image.
+        path = r"(?:[^\s()<>]|\([^()\n]*\))"
+        uri = rf"send://{path}+?\.(?:png|jpe?g|gif|bmp|webp)(?:[?#][^\s<>)]*)?"
+        image_uri = rf"(?:<(?:send|viking)://[^<>\n]+>|(?:send|viking)://{path}+?)"
+        pattern = re.compile(
+            r"(?P<literal>^[ \t]{0,3}(?P<fence>`{3,}|~{3,})[^\n]*(?:\n|$)"
+            r"[\s\S]*?(?:^[ \t]{0,3}(?P=fence)[`~]*[ \t]*(?:\n|$)|\Z)"
+            r"|(?P<ticks>`+)(?!`)[\s\S]*?(?<!`)(?P=ticks)(?!`)"
+            r"|\\.)"
+            rf"|!\[[^\]]*\]\(\s*(?P<image>{image_uri})"
+            r"(?:\s+[\"'][^\n]*?[\"'])?\s*\)"
+            rf"|(?P<bare>{uri})(?=$|[\s<>`\[\](){{}},;.!?。，；！：])",
+            re.IGNORECASE | re.MULTILINE,
+        )
+        images: list[dict] = []
+        replacements: dict[str, str] = {}
+        parts: list[str] = []
+        last_end = 0
+        for match in pattern.finditer(content):
+            if match.group("literal") is not None:
+                continue
+            img_url = match.group("image") or match.group("bare")
+            img_url = img_url.removeprefix("<").removesuffix(">")
+            scheme, location = img_url.split("://", 1)
+            img_url = f"{scheme.lower()}://{location}"
+            if img_url not in replacements:
+                try:
+                    if img_url.lower().startswith("viking://"):
+                        result = await asyncio.wait_for(
+                            self._download_viking_image(img_url, msg), timeout=60.0
+                        )
+                    else:
+                        is_content, result = await self._parse_data_uri(img_url)
+                        if is_content or not isinstance(result, bytes):
+                            raise ValueError("Image reference did not resolve to image bytes")
                     image_key = await self._upload_image_to_feishu(result)
                     images.append({"image_key": image_key})
-            except Exception as e:
-                logger.exception(f"Failed to upload Markdown image {img_url[:100]}: {e}")
-
-        # Remove markdown image syntax
-        cleaned_content = re.sub(markdown_pattern, "", cleaned_content)
-
-        # Pattern 2: send://... (without alt text)
-        send_pattern = r"(send://[^)\s]+\.(png|jpeg|jpg|gif|bmp|webp))\)?"
-        for m in re.finditer(send_pattern, content):
-            img_url = m.group(1) or ""
-            try:
-                is_content, result = await self._parse_data_uri(img_url)
-
-                if not is_content and isinstance(result, bytes):
-                    image_key = await self._upload_image_to_feishu(result)
-                    images.append({"image_key": image_key})
-            except Exception as e:
-                logger.exception(f"Failed to upload Markdown image {img_url[:100]}: {e}")
-
-        # Remove standalone send:// URLs
-        cleaned_content = re.sub(send_pattern, "", cleaned_content)
-
-        return cleaned_content.strip(), images
+                    replacements[img_url] = ""
+                except Exception as exc:
+                    logger.warning(f"Failed to send image {img_url[:100]}: {exc}")
+                    replacements[img_url] = "[图片发送失败]"
+            parts.append(content[last_end : match.start()])
+            parts.append(replacements[img_url])
+            last_end = match.end()
+        parts.append(content[last_end:])
+        return "".join(parts).strip(), images

--- a/bot/vikingbot/channels/manager.py
+++ b/bot/vikingbot/channels/manager.py
@@ -72,6 +72,7 @@ class ChannelManager:
                     channel_config,
                     self.bus,
                     workspace_path=workspace_path,
+                    bot_config=additional_deps.get("bot_config"),
                 )
 
             elif channel_config.type == ChannelType.DISCORD:
@@ -161,6 +162,7 @@ class ChannelManager:
             self.add_channel_from_config(
                 channel_config,
                 workspace_path=workspace_path,
+                bot_config=config,
             )
 
     async def _start_channel(self, name: str, channel: BaseChannel) -> None:


### PR DESCRIPTION
## Description

Feishu replies containing `![description](viking://...png)` currently pass an internal URI into card Markdown without uploading the image. Resolve explicit OpenViking image references into Feishu image elements before sending the card, with a text placeholder when an image cannot be delivered.

Plain URI citations, ordinary links, inline code, and fenced examples remain text. For example, listing an image as `` `viking://resources/image.png` `` keeps the URI visible and does not attach a photo, while `![photo](viking://resources/image.png)` requests an attachment.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

No linked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Pass the active Bot configuration into the Feishu channel and download images using the original sender's peer identity and session workspace. Reject missing sender identity, invalid sizes, unsupported image bytes, and downloads that exceed the checked size; close the client and bound the download operation to 60 seconds.
- Upload each distinct image once per message, retaining compatibility with generated images delivered through `send://`. Replace individual conversion failures with a text placeholder so the body and other images can still be sent.
- Add Feishu-specific agent instructions distinguishing image inspection, URI citation, and explicit image delivery, without claiming a confirmed delivery receipt.
- Add regression coverage for card creation and replies, citation preservation, code examples, duplicate references, identity/config propagation, and failure handling.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

66 tests passed across `bot/tests/test_feishu_outbound_images.py`, `bot/tests/test_channel_delivery_metadata.py`, and `bot/tests/test_image_tool_sandbox.py`, using a temporary config with stdout logging. Ruff lint/format checks and `git diff --check` pass for the changed files.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

Tests mock OpenViking downloads and Feishu API calls; live Feishu delivery has not been verified for the final patch. The test run reports existing dependency deprecation warnings. Delivery receipts are not fed back into the agent by this change.
