### PR TITLE
fix(server): remap AGFSPluginError directory/exists phrases before 503

### DIFF
--- a/openviking/server/error_mapping.py
+++ b/openviking/server/error_mapping.py
@@ -521,6 +521,9 @@ def map_exception(
         return ResourceExhaustedError(str(exc), details=_resource_details(resource))
     if isinstance(exc, AGFSInvalidOperationError):
         return InvalidArgumentError(str(exc), details=_resource_details(resource))
+
+    # Opaque plugin/IO errors often still carry typed phrases from older backends.
+    # Remap those before collapsing the whole class into Unavailable (#4772 follow-up).
     if isinstance(
         exc,
         (
@@ -533,7 +536,19 @@ def map_exception(
             AGFSSerializationError,
         ),
     ):
-        return UnavailableError("storage backend", reason=str(exc))
+        message = str(exc)
+        lowered = message.lower()
+        if "not a directory" in lowered:
+            return FailedPreconditionError(message, details=_resource_details(resource))
+        if "is a directory" in lowered:
+            return InvalidArgumentError(message, details=_file_directory_details(resource))
+        if "directory not empty" in lowered:
+            return FailedPreconditionError(message, details=_resource_details(resource))
+        if "file exists" in lowered or "already exists" in lowered:
+            return ConflictError(message, resource=resource)
+        if "permission denied" in lowered:
+            return PermissionDeniedError(message, resource=resource)
+        return UnavailableError("storage backend", reason=message)
     if isinstance(exc, AGFSClientError):
         message = str(exc)
         if is_not_found_error(exc):
@@ -544,7 +559,7 @@ def map_exception(
         if "not a directory" in lowered:
             return FailedPreconditionError(message, details=_resource_details(resource))
         if "is a directory" in lowered:
-            return InvalidArgumentError(message, details=_resource_details(resource))
+            return InvalidArgumentError(message, details=_file_directory_details(resource))
         if "directory not empty" in lowered:
             return FailedPreconditionError(message, details=_resource_details(resource))
         if "permission denied" in lowered:

--- a/tests/server/test_error_mapping.py
+++ b/tests/server/test_error_mapping.py
@@ -8,6 +8,7 @@ from openviking.pyagfs.exceptions import (
     AGFSHTTPError,
     AGFSIsADirectoryError,
     AGFSNotSupportedError,
+    AGFSPluginError,
     AGFSResourceExhaustedError,
     GitConcurrentCommitError,
 )
@@ -15,6 +16,7 @@ from openviking.server.error_mapping import map_exception
 from openviking.server.models import ERROR_CODE_TO_HTTP_STATUS
 from openviking.storage.errors import LockAcquisitionError, ResourceBusyError
 from openviking_cli.exceptions import (
+    ConflictError,
     FailedPreconditionError,
     InvalidArgumentError,
     InvalidURIError,
@@ -89,6 +91,32 @@ def test_agfs_is_directory_maps_to_structured_invalid_argument():
         "expected": "file",
         "actual": "directory",
     }
+
+
+def test_agfs_plugin_is_directory_message_maps_before_unavailable():
+    mapped = map_exception(
+        AGFSPluginError("is a directory: /docs"),
+        resource="viking://resources/docs",
+        resource_type="file",
+    )
+
+    assert isinstance(mapped, InvalidArgumentError)
+    assert mapped.code == "INVALID_ARGUMENT"
+    assert mapped.details == {
+        "resource": "viking://resources/docs",
+        "expected": "file",
+        "actual": "directory",
+    }
+
+
+def test_agfs_plugin_already_exists_message_maps_to_conflict():
+    mapped = map_exception(
+        AGFSPluginError("failed to create directory: File exists (os error 17)"),
+        resource="viking://user/default/tasks",
+    )
+
+    assert isinstance(mapped, ConflictError)
+    assert mapped.code == "CONFLICT"
 
 
 def test_agfs_not_supported_maps_to_unimplemented():


### PR DESCRIPTION
## Summary

HTTP `map_exception` treated every `AGFSPluginError` as storage `Unavailable` (503), even when the message was `is a directory` / `directory not empty` / `File exists`.

## Fix

- Before collapsing plugin/IO/config classes to Unavailable, remap known phrases to InvalidArgument / FailedPrecondition / Conflict / PermissionDenied
- Align `is a directory` details with typed `AGFSIsADirectoryError` (`expected=file`, `actual=directory`)
- Unit tests for plugin message remaps

## Related

- Defense-in-depth for #4772 / localfs+pyagfs typed remaps
