### PR TITLE
fix(fs): normalize S3 virtual-directory ls rows without modTime

### DIFF
--- a/openviking/storage/viking_fs/_ops.py
+++ b/openviking/storage/viking_fs/_ops.py
@@ -1978,15 +1978,35 @@ class _OpsMixin:
                     "access": "denied",
                 }
             else:
-                new_entry = dict(entry)
+                new_entry = self._normalize_ls_entry(dict(entry))
                 new_entry["uri"] = entry_uri
-            if entry.get("isDir"):
+            if new_entry.get("isDir"):
                 all_entries.append(new_entry)
             elif not name.startswith("."):
                 all_entries.append(new_entry)
             elif show_all_hidden:
                 all_entries.append(new_entry)
         return all_entries
+
+    @staticmethod
+    def _normalize_ls_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
+        """Fill synthetic metadata for virtual directory rows (#4859).
+
+        S3/TOS CommonPrefixes under ``directory_marker_mode=none`` may omit
+        ``modTime`` / ``size``. Keep those rows listable instead of letting
+        downstream WebDAV/CLI paths treat them as incomplete and drop them.
+        """
+        is_dir = bool(entry.get("isDir", False))
+        mode = entry.get("mode")
+        # Some backends omit isDir but still advertise a directory mode bit.
+        if not is_dir and isinstance(mode, int) and (mode & 0o170000) == 0o040000:
+            is_dir = True
+            entry["isDir"] = True
+        if is_dir:
+            entry.setdefault("size", 0)
+            if not entry.get("modTime") and entry.get("mtime") is None:
+                entry["modTime"] = format_iso8601(datetime.now(timezone.utc))
+        return entry
 
     async def _ls_browsable_items(
         self,

--- a/tests/unit/test_ls_normalize_virtual_dirs.py
+++ b/tests/unit/test_ls_normalize_virtual_dirs.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Virtual-directory ls rows must stay listable without modTime (#4859)."""
+
+from openviking.storage.viking_fs._ops import _OpsMixin
+
+
+def test_normalize_ls_entry_fills_missing_directory_metadata():
+    entry = _OpsMixin._normalize_ls_entry(
+        {"name": "my-doc", "isDir": True, "mode": 0o755}
+    )
+
+    assert entry["isDir"] is True
+    assert entry["size"] == 0
+    assert entry.get("modTime")
+
+
+def test_normalize_ls_entry_infers_directory_from_mode_bits():
+    entry = _OpsMixin._normalize_ls_entry(
+        {"name": "my-doc", "mode": 0o040755, "size": 0}
+    )
+
+    assert entry["isDir"] is True
+    assert entry.get("modTime")


### PR DESCRIPTION
## Summary

Fixes #4859.

On S3/TOS with `directory_marker_mode=none`, `ls` CommonPrefixes rows can omit `modTime`/`size` (and occasionally `isDir`). WebDAV `PROPFIND /webdav/resources` Depth:1 then returns only the root entry.

## Fix

- Normalize ls directory rows: default `size=0`, synthesize `modTime` when missing
- Infer `isDir` from Unix directory mode bits when the flag is absent
- Unit tests for the normalizer

## Related

- Closes #4859
