### PR TITLE
fix(openclaw): persist closed-turn messages inside commitTurn

### DIFF
--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -388,19 +388,39 @@ export function createMemoryOpenVikingContextEngine(params: {
       });
     },
 
-    // Capture still happens in afterTurn (host calls it per LLM call + on finalize);
-    // commitTurn only acknowledges the accepted turn so OpenClaw drains its outbox.
-    // ponytail: in-memory key set, not durable across restarts — the host outbox is.
-    async commitTurn({ advancementKey, sessionId }): Promise<{ status: "committed" | "duplicate" }> {
+    // OpenClaw >=2026.9.3 suppresses afterTurn when durable turn advancement is
+    // active and delivers the closed turn only via commitTurn({ messages, ... }).
+    // Persist those messages before acknowledging so the host can drain its outbox.
+    async commitTurn(commitParams): Promise<{ status: "committed" | "duplicate" }> {
+      const { advancementKey, sessionId, messages, isHeartbeat } = commitParams;
       if (committedTurnKeys.has(advancementKey)) {
         diag("commitTurn_duplicate", sessionId, { advancementKey });
         return { status: "duplicate" };
       }
+
+      await afterTurnOpenVikingSession({
+        sessionId,
+        sessionKey: resolveSessionKey(commitParams),
+        messages: messages ?? [],
+        // messages is already the closed-turn range from the transcript anchors.
+        prePromptMessageCount: 0,
+        isHeartbeat,
+        tokenBudget: 128_000,
+        runtimeContext: undefined,
+        cfg,
+        getClient,
+        logger,
+        resolveAgentId,
+        rememberSessionAgentId,
+        isBypassedSession,
+        diag,
+      });
+
       committedTurnKeys.add(advancementKey);
       if (committedTurnKeys.size > 1024) {
         committedTurnKeys.delete(committedTurnKeys.values().next().value as string);
       }
-      diag("commitTurn", sessionId, { advancementKey });
+      diag("commitTurn", sessionId, { advancementKey, messageCount: (messages ?? []).length });
       return { status: "committed" };
     },
 

--- a/examples/openclaw-plugin/tests/ut/context-engine-commit-turn.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-commit-turn.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const afterTurnOpenVikingSession = vi.fn().mockResolvedValue(undefined);
+const { afterTurnOpenVikingSession } = vi.hoisted(() => ({
+  afterTurnOpenVikingSession: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock("../../services/context-lifecycle-service.js", async () => {
   const actual = await vi.importActual<typeof import("../../services/context-lifecycle-service.js")>(

--- a/examples/openclaw-plugin/tests/ut/context-engine-commit-turn.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-commit-turn.test.ts
@@ -1,4 +1,16 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const afterTurnOpenVikingSession = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("../../services/context-lifecycle-service.js", async () => {
+  const actual = await vi.importActual<typeof import("../../services/context-lifecycle-service.js")>(
+    "../../services/context-lifecycle-service.js",
+  );
+  return {
+    ...actual,
+    afterTurnOpenVikingSession,
+  };
+});
 
 import type { OpenVikingClient } from "../../client.js";
 import { memoryOpenVikingConfigSchema } from "../../config.js";
@@ -17,6 +29,10 @@ function makeEngine() {
   });
 }
 
+beforeEach(() => {
+  afterTurnOpenVikingSession.mockClear();
+});
+
 // OpenClaw >=2026.8.1 degrades the engine to "legacy" every turn unless both
 // transcript semantics are declared and commitTurn exists.
 describe("context-engine durable turn contract (OpenClaw 2026.8.1)", () => {
@@ -32,6 +48,39 @@ describe("context-engine durable turn contract (OpenClaw 2026.8.1)", () => {
     const params = { advancementKey: "k1", sessionId: "s", messages: [] };
     await expect(engine.commitTurn(params)).resolves.toEqual({ status: "committed" });
     await expect(engine.commitTurn(params)).resolves.toEqual({ status: "duplicate" });
-    await expect(engine.commitTurn({ ...params, advancementKey: "k2" })).resolves.toEqual({ status: "committed" });
+    await expect(engine.commitTurn({ ...params, advancementKey: "k2" })).resolves.toEqual({
+      status: "committed",
+    });
+  });
+
+  it("commitTurn persists closed-turn messages before acknowledging (#4850)", async () => {
+    const engine = makeEngine();
+    const messages = [{ role: "user", content: "hello" }] as never[];
+    await expect(
+      engine.commitTurn({
+        advancementKey: "persist-1",
+        sessionId: "sess-1",
+        sessionKey: "agent:main:sess-1",
+        messages,
+      }),
+    ).resolves.toEqual({ status: "committed" });
+
+    expect(afterTurnOpenVikingSession).toHaveBeenCalledTimes(1);
+    expect(afterTurnOpenVikingSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "sess-1",
+        messages,
+        prePromptMessageCount: 0,
+      }),
+    );
+
+    await expect(
+      engine.commitTurn({
+        advancementKey: "persist-1",
+        sessionId: "sess-1",
+        messages,
+      }),
+    ).resolves.toEqual({ status: "duplicate" });
+    expect(afterTurnOpenVikingSession).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #4850.

OpenClaw >=2026.9.3 activates durable turn advancement when `transcriptSemantics` + `commitTurn` are declared, and **suppresses `afterTurn`**. The plugin previously only recorded `advancementKey` in `commitTurn`, so gateway-dispatched turns never reached OpenViking.

## Fix

- Call `afterTurnOpenVikingSession` from `commitTurn` with the closed-turn `messages` before acknowledging
- Keep duplicate `advancementKey` short-circuit (no double write)
- Unit test that capture runs once on first commit

## Related

- Closes #4850
