### PR TITLE
fix(parse): stop treating .ts TypeScript as video

### DIFF
--- a/openviking/parse/parsers/media/constants.py
+++ b/openviking/parse/parsers/media/constants.py
@@ -8,8 +8,10 @@ IMAGE_EXTENSIONS = [".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".svg", ".
 # Audio extensions supported by AudioParser
 AUDIO_EXTENSIONS = [".mp3", ".wav", ".ogg", ".flac", ".aac", ".m4a", ".opus", ".ac3"]
 
-# Video extensions supported by VideoParser
-VIDEO_EXTENSIONS = [".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".wmv", ".ts"]
+# Video extensions supported by VideoParser.
+# Do not include ".ts" — that extension is TypeScript source (#3266), not MPEG-TS.
+# Prefer ".mts" / ".m2ts" for MPEG transport streams.
+VIDEO_EXTENSIONS = [".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".wmv", ".mts", ".m2ts"]
 
 # All media extensions combined
 MEDIA_EXTENSIONS = set(IMAGE_EXTENSIONS + AUDIO_EXTENSIONS + VIDEO_EXTENSIONS)

--- a/tests/unit/test_media_extensions_typescript.py
+++ b/tests/unit/test_media_extensions_typescript.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""TypeScript .ts must not be classified as video (#3266)."""
+
+from openviking.parse.parsers.media.constants import MEDIA_EXTENSIONS, VIDEO_EXTENSIONS
+
+
+def test_typescript_extension_is_not_video():
+    assert ".ts" not in VIDEO_EXTENSIONS
+    assert ".ts" not in MEDIA_EXTENSIONS
+
+
+def test_mpeg_ts_uses_dedicated_extensions():
+    assert ".mts" in VIDEO_EXTENSIONS
+    assert ".m2ts" in VIDEO_EXTENSIONS


### PR DESCRIPTION
## Summary

Fixes #3266.

`VIDEO_EXTENSIONS` included `.ts`, so TypeScript sources were routed through the video summary stub instead of the text/AST path.

## Fix

- Remove `.ts` from `VIDEO_EXTENSIONS` / `MEDIA_EXTENSIONS`
- Keep `.mts` / `.m2ts` for MPEG transport streams
- Unit test locking the classification

## Related

- Closes #3266
