### PR TITLE
docs: remove duplicate CLI API key block

### DIFF
--- a/docs/images/agents/zh/cli.md
+++ b/docs/images/agents/zh/cli.md
@@ -18,8 +18,6 @@ npm i -g @openviking/cli && ov config
 
 {{OPENVIKING_API_KEY_BLOCK}}
 
-{{OPENVIKING_API_KEY_BLOCK}}
-
 
 ### 步骤3：配置完成后，可运行以下命令查看 CLI 用法：
 


### PR DESCRIPTION
Remove the duplicated `{{OPENVIKING_API_KEY_BLOCK}}` placeholder from the Chinese CLI agent guide so the API key appears only once.

Validation:
- `git diff --check`