### PR TITLE
perf(session): offload authoritative JSONL decoding

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -4216,6 +4216,11 @@ class Session:
             f"{self._session_uri}/messages.jsonl",
             ctx=self.ctx,
         )
+        return await asyncio.to_thread(self._decode_live_messages_strict, content)
+
+    @staticmethod
+    def _decode_live_messages_strict(content: str) -> List[Message]:
+        """Decode a storage snapshot without mutating session state."""
         messages: List[Message] = []
         # Split on "\n" only, not str.splitlines(): the latter also treats
         # U+2028 / U+2029 / NEL (\x85) / \r / \v / \f as line boundaries, which

--- a/tests/unit/session/test_session_commit_resume.py
+++ b/tests/unit/session/test_session_commit_resume.py
@@ -1,9 +1,12 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 
+import asyncio
 import inspect
 import json
+import threading
 from dataclasses import fields
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -49,6 +52,9 @@ class _MemoryVikingFS:
 
     async def write_file(self, uri, content, ctx=None, lease_ref=None):
         self.files[uri] = content
+
+    async def append_file(self, uri, content, ctx=None):
+        self.files[uri] += content
 
 
 def test_phase2_auto_commit_policy_parameters_are_appended():
@@ -97,9 +103,9 @@ async def test_resume_queued_commit_continues_phase2(monkeypatch):
     assert session._run_memory_extraction.await_args.kwargs["auto_commit_policy"] == {
         "pending_token_threshold": 8000
     }
-    assert [
-        item.id for item in session._run_memory_extraction.await_args.kwargs["messages"]
-    ] == ["archived"]
+    assert [item.id for item in session._run_memory_extraction.await_args.kwargs["messages"]] == [
+        "archived"
+    ]
 
 
 @pytest.mark.asyncio
@@ -150,9 +156,7 @@ async def test_session_context_skips_pending_archive_with_missing_messages(monke
         session,
         "_list_archive_refs",
         AsyncMock(
-            return_value=[
-                {"archive_id": "archive_001", "archive_uri": archive_uri, "index": 1}
-            ]
+            return_value=[{"archive_id": "archive_001", "archive_uri": archive_uri, "index": 1}]
         ),
     )
 
@@ -225,3 +229,79 @@ def test_session_commit_message_ignores_unknown_fields():
     assert message.task_id == "task-1"
     assert message.auto_commit_policy == {}
     assert "actor_peer_id" not in message.to_dict()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel", [False, True])
+async def test_append_keeps_loop_responsive_while_decoding_live_messages(monkeypatch, cancel):
+    session_uri = "viking://user/default/sessions/session-1"
+    uri = f"{session_uri}/messages.jsonl"
+    original = Message(id="old", role="assistant", parts=[TextPart("before\u2028after")])
+    content = "\r\n" + original.to_jsonl() + "\r\n"
+    fs: Any = _MemoryVikingFS({uri: content})
+    fs.append_file = AsyncMock(wraps=fs.append_file)
+    session = Session(viking_fs=fs, session_id="session-1", session_uri=session_uri)
+    decoded = asyncio.Event()
+    release = threading.Event()
+    finished = threading.Event()
+    loop = asyncio.get_running_loop()
+    from_dict = Message.from_dict
+
+    def slow_decode(data):
+        loop.call_soon_threadsafe(decoded.set)
+        try:
+            # Bound the wait so a regression cannot hang the test runner.
+            assert release.wait(2), "live JSONL decoding blocked the event loop"
+            return from_dict(data)
+        finally:
+            finished.set()
+
+    monkeypatch.setattr(Message, "from_dict", slow_decode)
+    append = asyncio.create_task(
+        session.add_messages_async([{"role": "user", "parts": [TextPart("next")]}])
+    )
+    try:
+        await asyncio.wait_for(decoded.wait(), timeout=5)
+        assert not append.done()
+        if cancel:
+            append.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await append
+            fs.append_file.assert_not_awaited()
+            assert session.messages == []
+        release.set()
+        if not cancel:
+            await append
+            assert [message.content for message in session.messages] == [
+                "before\u2028after",
+                "next",
+            ]
+            fs.append_file.assert_awaited_once()
+        assert await asyncio.to_thread(finished.wait, 2)
+        if cancel:
+            assert session.messages == []
+            assert fs.files[uri] == content
+        else:
+            assert fs.files[uri] == content + session.messages[-1].to_jsonl() + "\n"
+        fs._async_agfs.pathlock_release.assert_awaited_once()
+    finally:
+        release.set()
+        await asyncio.gather(append, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("row", ["{invalid", '{"role":"user"}'])
+async def test_append_rejects_corrupt_live_jsonl_without_writing(row):
+    session_uri = "viking://user/default/sessions/session-1"
+    uri = f"{session_uri}/messages.jsonl"
+    fs: Any = _MemoryVikingFS({uri: "\r\n" + row + "\r\n"})
+    fs.append_file = AsyncMock(wraps=fs.append_file)
+    session = Session(viking_fs=fs, session_id="session-1", session_uri=session_uri)
+
+    with pytest.raises(ValueError, match="Invalid live message JSONL at line 2") as error:
+        await session.add_messages_async([{"role": "user", "parts": [TextPart("next")]}])
+
+    assert error.value.__cause__ is not None
+    assert session.messages == []
+    fs.append_file.assert_not_awaited()
+    fs._async_agfs.pathlock_release.assert_awaited_once()


### PR DESCRIPTION
## Description

Appending to a long persisted session decodes the entire authoritative `messages.jsonl` on the event loop, delaying unrelated requests. Move that decoding into `asyncio.to_thread`; the existing parser operates only on the immutable storage snapshot and returns newly constructed messages. The caller retains the path lock and applies session state on the event loop.

This addresses the residual decode path in #4842. The token-rebuild offload from #4557 is already present. Decoding remains O(n), and worker threads still contend for the GIL; this is a responsiveness improvement, not a claim of constant-time appends or a fix for every reported latency source.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Refs #4842.

## Type of Change

- [x] Performance improvement
- [x] Test update

## Changes Made

- Run strict live JSONL decoding in a worker while retaining the existing newline handling, line-number errors, exception causes, and lock-protected authoritative read.
- Exercise the public append entrypoint while decoding is paused: other loop work can proceed, cancellation releases the lock and leaves messages/storage intact, and a completed append preserves CRLF/Unicode content.
- Check that malformed JSON and invalid message records still reject appends before writing.

## Testing

- `python -m pytest tests/unit/session/test_session_commit_resume.py --no-cov -q`: 12 passed. Both responsiveness/cancellation cases fail on unmodified main `98f7dfe`.
- `ruff check` and `ruff format --check` on both changed files; `git diff --check`.
- Local A/B benchmark uses the real `Session.add_messages_async` and `/health` ASGI route, with an in-memory storage fixture, four concurrent appenders, and approximately 7 MB of ASCII or mixed CJK/tool JSONL. Health probes run every 5 ms and include scheduling delay. Three alternating A/B trials (80 appends per variant/workload/trial) gave median trial p95 scheduling-inclusive health latency of ascii: 162.2 → 76.4 ms; mixed_cjk_tool: 141.1 → 78.1 ms. Append latency was broadly similar. This is an isolated responsiveness measurement, not an end-to-end deployment benchmark.
- The extra `test_event_tag_concurrency.py` check has one existing failure: its `_MetaVikingFS` lacks `exists`. This reproduces on unmodified main using an isolated empty config. The other case passes.
- Mypy reports pre-existing errors: nine in `session.py` (confirmed on unmodified main), plus existing test-double typing errors. No error is in the added decoder or new test cases. Full-suite/native-storage and Windows validation were not run; native bindings are unavailable in this isolated environment.

- [x] New and existing tests in the changed file pass locally
- [x] Tested on macOS, CPython 3.12.14 with the GIL enabled

## Checklist

- [x] I have performed a self-review of the complete diff
- [x] No public API or persisted-format migration is required
