### PR TITLE
fix(resources): finalize failed imports on hotfix branch

### DIFF
--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -718,54 +718,35 @@ class ResourceService:
                 from openviking.parse.understanding_api import PREPARED_RESPONSE_ID_ARG
 
                 internal_kwargs[PREPARED_RESPONSE_ID_ARG] = msg.understanding_response_id
-            try:
-                result = await self._execute_resource_ingestion(
-                    path=msg.path,
-                    ctx=ctx,
-                    to=target_uri,
-                    parent=parent_uri,
-                    to_is_directory=msg.to_is_directory,
-                    reason=msg.reason,
-                    instruction=msg.instruction,
-                    defer_post_processing=False,
-                    timeout=msg.timeout,
-                    build_index=msg.build_index,
-                    summarize=msg.summarize,
-                    processing_mode=msg.processing_mode,
-                    parse_mode=msg.parse_mode,
-                    watch_interval=msg.watch_interval,
-                    is_active=msg.is_active,
-                    manage_watch=not msg.skip_watch_management,
-                    tags=msg.tags,
-                    tag_mode=msg.tag_mode,
-                    allow_local_path_resolution=msg.allow_local_path_resolution,
-                    enforce_public_remote_targets=msg.enforce_public_remote_targets,
-                    resource_lock=resource_lock,
-                    stage_callback=stage_callback,
-                    watch_auth_state=watch_auth_state,
-                    prepared_resource=prepared_resource,
-                    internal_task=msg.internal_task,
-                    on_watch_ready=lambda task_id: setattr(msg, "watch_task_id", task_id),
-                    **internal_kwargs,
-                )
-            except BaseException:
-                if msg.cleanup_empty_target_on_failure and resource_lock is not None:
-                    await self._cleanup_reserved_target_if_empty(
-                        root_uri=msg.root_uri,
-                        ctx=ctx,
-                        resource_lock=resource_lock,
-                    )
-                raise
-            if (
-                result.get("status") == "error"
-                and msg.cleanup_empty_target_on_failure
-                and resource_lock is not None
-            ):
-                await self._cleanup_reserved_target_if_empty(
-                    root_uri=msg.root_uri,
-                    ctx=ctx,
-                    resource_lock=resource_lock,
-                )
+            result = await self._execute_resource_ingestion(
+                path=msg.path,
+                ctx=ctx,
+                to=target_uri,
+                parent=parent_uri,
+                to_is_directory=msg.to_is_directory,
+                reason=msg.reason,
+                instruction=msg.instruction,
+                defer_post_processing=False,
+                timeout=msg.timeout,
+                build_index=msg.build_index,
+                summarize=msg.summarize,
+                processing_mode=msg.processing_mode,
+                parse_mode=msg.parse_mode,
+                watch_interval=msg.watch_interval,
+                is_active=msg.is_active,
+                manage_watch=not msg.skip_watch_management,
+                tags=msg.tags,
+                tag_mode=msg.tag_mode,
+                allow_local_path_resolution=msg.allow_local_path_resolution,
+                enforce_public_remote_targets=msg.enforce_public_remote_targets,
+                resource_lock=resource_lock,
+                stage_callback=stage_callback,
+                watch_auth_state=watch_auth_state,
+                prepared_resource=prepared_resource,
+                internal_task=msg.internal_task,
+                on_watch_ready=lambda task_id: setattr(msg, "watch_task_id", task_id),
+                **internal_kwargs,
+            )
             if msg.staged_source is not None:
                 result["source_path"] = msg.source_path
             stage_result = stage_callback("processing_queue")

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -1725,10 +1725,15 @@ class ResourceService:
             return completed
         if task.status == TaskStatus.CANCELLED:
             return {"status": "cancelled"}
-        return {
+        failure: Dict[str, Any] = {
             "status": "error",
             "errors": [task.error],
         }
+        if isinstance(task.result, dict):
+            code = task.result.get("code")
+            if isinstance(code, str) and code:
+                failure["code"] = code
+        return failure
 
     async def _execute_resource_ingestion(
         self,

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -540,9 +540,17 @@ class TaskTracker:
         error: str,
         account_id: Optional[str] = None,
         user_id: Optional[str] = None,
+        *,
+        result: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """Record failure and finalize after owned work settles."""
-        await self._record_outcome(task_id, account_id, user_id, error=error)
+        """Record failure and optional structured metadata, then finalize."""
+        await self._record_outcome(
+            task_id,
+            account_id,
+            user_id,
+            result=result,
+            error=error,
+        )
 
     async def mark_cancelled(
         self,

--- a/tests/server/test_api_resources.py
+++ b/tests/server/test_api_resources.py
@@ -136,6 +136,43 @@ async def _wait_task_terminal(client: httpx.AsyncClient, task_id: str, timeout: 
     raise AssertionError(f"Task {task_id} did not finish; last_result={last_result}")
 
 
+@pytest.mark.parametrize(
+    ("code", "expected_status", "expected_code"),
+    [
+        ("INVALID_ARGUMENT", 400, "INVALID_ARGUMENT"),
+        ("PERMISSION_DENIED", 403, "PERMISSION_DENIED"),
+        (None, 500, "PROCESSING_ERROR"),
+    ],
+)
+async def test_add_resource_wait_preserves_queued_failure_code(
+    client: httpx.AsyncClient,
+    sample_markdown_file,
+    upload_temp_dir,
+    monkeypatch,
+    code,
+    expected_status,
+    expected_code,
+):
+    from openviking.utils.resource_processor import ResourceProcessor
+
+    async def reject_resource(self, **kwargs):
+        failure = {"status": "error", "errors": ["source rejected during processing"]}
+        if code is not None:
+            failure["code"] = code
+        return failure
+
+    monkeypatch.setattr(ResourceProcessor, "process_resource", reject_resource)
+    response = await client.post(
+        "/api/v1/resources",
+        json={"temp_file_id": sample_markdown_file.name, "wait": True, "timeout": 10},
+    )
+
+    assert response.status_code == expected_status, response.text
+    error = response.json()["error"]
+    assert error["code"] == expected_code
+    assert "source rejected during processing" in error["message"]
+
+
 async def test_add_resource_success(
     client: httpx.AsyncClient,
     sample_markdown_file,

--- a/tests/service/test_resource_service_watch.py
+++ b/tests/service/test_resource_service_watch.py
@@ -337,6 +337,33 @@ class TestWatchTaskCreation:
         assert task.processor_kwargs["tag_mode"] == "replace"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("raises", [False, True])
+    async def test_source_job_preserves_ingestion_failure(
+        self, resource_service: ResourceService, request_context: RequestContext, raises: bool
+    ):
+        error = ValueError("Not a valid ZIP file")
+        failure = {"status": "error", "errors": [str(error)]}
+        resource_service._execute_resource_ingestion = AsyncMock(
+            side_effect=error if raises else None, return_value=failure
+        )
+        msg = AddResourceMsg(
+            task_id="failed-source",
+            path="/test/corrupted.zip",
+            root_uri="viking://resources/corrupted",
+            account_id=request_context.account_id,
+            user_id=request_context.user.user_id,
+            role=str(request_context.role),
+        )
+        kwargs = {"ctx": request_context, "resource_lock": None, "stage_callback": AsyncMock()}
+        if raises:
+            with pytest.raises(ValueError, match="Not a valid ZIP file") as exc:
+                await resource_service.execute_add_resource_job(msg, **kwargs)
+            assert exc.value is error
+        else:
+            result = await resource_service.execute_add_resource_job(msg, **kwargs)
+            assert result == failure
+
+    @pytest.mark.asyncio
     async def test_execute_prepared_add_resource_job_forwards_tags_to_ingest(
         self,
         resource_service: ResourceService,

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -193,6 +193,21 @@ async def test_task_result_redacts_user_key(tracker: TaskTracker):
     assert "user_key" not in json.dumps(retrieved.to_dict())
 
 
+@pytest.mark.parametrize("result", [None, {"code": "PROCESSING_ERROR"}])
+async def test_fail_task_with_result(tracker: TaskTracker, result):
+    task = await tracker.create("add_resource", **_owner_kwargs())
+    await tracker.start(task.task_id, stage="parsing")
+    await tracker.fail(task.task_id, "Parse error", result=result, **_owner_kwargs())
+
+    reloaded = TaskTracker(store=tracker._store)
+    retrieved = await reloaded.get(task.task_id, **_owner_kwargs())
+    assert retrieved is not None
+    assert retrieved.status == TaskStatus.FAILED
+    assert retrieved.stage == "failed"
+    assert retrieved.error == "Parse error"
+    assert retrieved.result == result
+
+
 async def test_fail_task(tracker: TaskTracker):
     task = await tracker.create("session_commit", **_owner_kwargs())
     await tracker.start(task.task_id)


### PR DESCRIPTION
## Why

- Failed imports stay `running/parsing` after #4705: callers pass `result=` but `TaskTracker.fail()` rejects it. Backport the matching signature and persistence from #4571.
- Source failure handling also references an absent cleanup field and helper. Restore 0.4.17.1 handling so original parser errors survive; retain watch wiring.

- Preserve queued failure codes in `wait=true` responses: `INVALID_ARGUMENT` returns 400, `PERMISSION_DENIED` returns 403; uncoded failures remain 500 / `PROCESSING_ERROR`.

## Tested

- `python -m pytest tests/test_task_tracker.py tests/service/test_resource_service_watch.py tests/server/test_api_resources.py -o addopts='' -q` — 149 passed with isolated test config and fake models. Regression tests reproduce failures before fixes; HTTP tests cover 400, 403, and 500 through queued processing.
- `ruff check openviking/service/task_tracker.py openviking/service/resource_service.py tests/test_task_tracker.py tests/service/test_resource_service_watch.py` — passed.
- Local server + CLI: supplied SVG and corrupt ZIP now reach `failed` in 0.14s / 0.07s with original parser errors. Before fix both remain `running/parsing` beyond 86s. Internal parser; shared 0.4.17.1 native dependencies.
