### PR TITLE
fix(mcp): bound search's context arguments the way POST /search does

### DIFF
--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -22,7 +22,7 @@ import os
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import PurePosixPath
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 from urllib.parse import quote
 
 from mcp.server.fastmcp import FastMCP
@@ -47,6 +47,7 @@ from openviking.parse.mode import ParseMode, normalize_parse_mode
 from openviking.resource.processing_mode import DEFAULT_PROCESSING_MODE, ProcessingMode
 from openviking.retrieve.context_assembler import (
     DEFAULT_MAX_TOKENS,
+    MAX_EXCLUDE_URIS,
     AssembleParams,
     assemble_context,
 )
@@ -283,18 +284,18 @@ async def search(
     context_type: Optional[Union[str, List[str]]] = None,
     mode: Literal["list", "context"] = "list",
     query_expansion: Literal["off", "auto"] = "auto",
-    max_tokens: int = DEFAULT_MAX_TOKENS,
+    max_tokens: Annotated[int, Field(ge=64, le=32000)] = DEFAULT_MAX_TOKENS,
     quotas: Optional[Dict[str, int]] = None,
     purpose: Optional[Literal["chat", "coding"]] = None,
     detail: Literal["auto", "abstract", "overview", "full"] = "auto",
     detail_by_category: Optional[Dict[str, str]] = None,
-    dedup_turns: int = 0,
-    exclude_uris: Optional[List[str]] = None,
+    dedup_turns: Annotated[int, Field(ge=0, le=100)] = 0,
+    exclude_uris: Annotated[Optional[List[str]], Field(max_length=MAX_EXCLUDE_URIS)] = None,
     peer_scope: Literal["actor", "all"] = "all",
     other_peer_penalty: Optional[float] = None,
     other_peer_penalties: Optional[Dict[str, float]] = None,
     rewrite: Literal["off", "auto"] = "off",
-    rewrite_max_bullets: int = 6,
+    rewrite_max_bullets: Annotated[int, Field(ge=1, le=20)] = 6,
     read_content: bool = False,
 ) -> str:
     """Deep semantic retrieval with optional session context and intent analysis.

--- a/tests/server/test_mcp_search_bounds.py
+++ b/tests/server/test_mcp_search_bounds.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""The MCP ``search`` tool must bound its context arguments the way ``POST /search`` does.
+
+``SearchRequest`` constrains four of them with pydantic ``Field``; the tool declared them
+as plain ints and a plain list, so the MCP face accepted values the REST face rejects.
+
+``exclude_uris`` is the one where that is not merely permissive: ``normalize_exclude_uris``
+slices to ``MAX_EXCLUDE_URIS`` regardless, so a caller passing more got the extra ones
+dropped in silence and the URIs it asked to exclude came back in the results. Over REST the
+same request is a validation error.
+
+Bounds are asserted on the tool's published input schema and through ``call_tool``, which
+is the path an MCP client actually takes — a direct call to the undecorated function is not
+validated by either face.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+import openviking.server.mcp_endpoint as mcp_endpoint
+from openviking.retrieve.context_assembler import MAX_EXCLUDE_URIS
+from openviking.server.routers.search import SearchRequest
+
+# name -> (REST field bound as it appears in the JSON schema, out-of-range value)
+BOUNDED = {
+    "max_tokens": ({"minimum": 64, "maximum": 32000}, 32001),
+    "dedup_turns": ({"minimum": 0, "maximum": 100}, 101),
+    "rewrite_max_bullets": ({"minimum": 1, "maximum": 20}, 21),
+}
+
+
+async def _search_schema() -> dict:
+    tools = await mcp_endpoint.mcp.list_tools()
+    search = next(tool for tool in tools if tool.name == "search")
+    return search.inputSchema["properties"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name,expected", sorted((n, b) for n, (b, _) in BOUNDED.items()))
+async def test_schema_publishes_the_same_bounds_as_rest(name, expected):
+    # The bounds have to reach the schema, not just the validator: it is what the model
+    # driving the tool reads before it picks a value.
+    prop = (await _search_schema())[name]
+
+    assert {key: prop.get(key) for key in expected} == expected
+
+
+@pytest.mark.asyncio
+async def test_exclude_uris_schema_carries_the_shared_cap():
+    prop = (await _search_schema())["exclude_uris"]
+
+    assert prop.get("maxItems") == MAX_EXCLUDE_URIS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name,value", sorted((n, v) for n, (_, v) in BOUNDED.items()))
+async def test_call_tool_rejects_an_out_of_range_value(name, value):
+    with pytest.raises(Exception) as excinfo:
+        await mcp_endpoint.mcp.call_tool("search", {"query": "q", "mode": "context", name: value})
+
+    assert name in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_call_tool_rejects_more_exclusions_than_it_can_apply():
+    too_many = [f"viking://user/u/memories/m{i}.md" for i in range(MAX_EXCLUDE_URIS + 1)]
+
+    with pytest.raises(Exception) as excinfo:
+        await mcp_endpoint.mcp.call_tool(
+            "search", {"query": "q", "mode": "context", "exclude_uris": too_many}
+        )
+
+    assert "exclude_uris" in str(excinfo.value)
+
+
+def test_rest_rejects_the_same_values():
+    # The point of this file is parity, so pin the side being matched too: if a bound is
+    # relaxed over REST, this fails next to the tool test that would then be wrong.
+    for name, (_, value) in BOUNDED.items():
+        with pytest.raises(ValidationError):
+            SearchRequest(query="q", mode="context", **{name: value})
+
+    with pytest.raises(ValidationError):
+        SearchRequest(
+            query="q",
+            mode="context",
+            exclude_uris=[f"viking://user/u/m{i}.md" for i in range(MAX_EXCLUDE_URIS + 1)],
+        )


### PR DESCRIPTION
## Description

`SearchRequest` constrains four of its context fields with pydantic `Field`. The MCP
`search` tool declared the same four as plain ints and a plain list, so the MCP face
accepted values the REST face rejects:

| argument | `POST /search` | MCP tool (before) |
|---|---|---|
| `max_tokens` | `ge=64, le=32000` | any int |
| `dedup_turns` | `ge=0, le=100` | any int |
| `rewrite_max_bullets` | `ge=1, le=20` | any int |
| `exclude_uris` | `max_length=MAX_EXCLUDE_URIS` | any length |

Three of those are only permissive — the values are clamped downstream, so nothing goes
wrong, the bound simply is not there.

`exclude_uris` is not. `normalize_exclude_uris` slices to `MAX_EXCLUDE_URIS` regardless
(`params.py:191-192`), so the extra exclusions were dropped in silence and the URIs the
caller asked to exclude came back in the results:

```
MAX_EXCLUDE_URIS = 200; asking to exclude 250 URIs
  MCP path  -> normalize_exclude_uris kept 200 of 250; silently dropped 50
  e.g. still eligible to come back in results: ['viking://user/u/memories/m200.md', ...]
  REST path -> too_long: List should have at most 200 items after validation, not 250
```

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

No related issue — found while checking whether the divergence in #4885 was the only one
between the two faces of `search`. Happy to open one if you would rather have it tracked.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- The four arguments are declared with `Annotated[..., Field(...)]` carrying the same
  bounds as `SearchRequest`.
- `MAX_EXCLUDE_URIS` is imported rather than repeated, so the cap and the slice that
  motivated it cannot drift apart.
- `tests/server/test_mcp_search_bounds.py`: the bounds appear in the published schema,
  `call_tool` rejects out-of-range values, and — so the parity is pinned from both sides —
  `SearchRequest` rejects the same values.

Declaring rather than checking in the body is the point: FastMCP puts the bounds in the
tool's input schema (`minimum`/`maximum`/`maxItems`), so the model driving the tool sees
them before it picks a value, and enforces them on `call_tool`, which is the path an MCP
client takes. A body check would do neither.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

`tests/server/test_mcp_search_bounds.py` — **9 passed**. Reverting only
`mcp_endpoint.py` and keeping the tests gives **8 failed, 1 passed**; the one that passes
either way is the REST-side anchor, which is what makes this a parity test rather than a
restatement of the tool's own behaviour.

The file takes no service fixture, so it needs neither the AGFS binding nor a live store.
`ruff check` and `ruff format --check` clean.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

The bounds are the ones already documented for `POST /search`; the tool schema now carries
them too, so there is nothing new to document.

## Additional Notes

**Compatibility.** A caller passing an out-of-range value gets a validation error where it
previously got a silently clamped or truncated result. For `exclude_uris` that is strictly
better — the previous result was wrong. For the other three the previous result was correct
and the value inert, so this only turns "ignored" into "refused", matching REST.

Independent of #4886: that one guards list mode, this one bounds context mode, and they
touch different lines. Either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
