### PR TITLE
fix(sdk): refuse search_context's target_uri instead of sending it

### DIFF
--- a/sdk/python/openviking_sdk/client.py
+++ b/sdk/python/openviking_sdk/client.py
@@ -1415,6 +1415,13 @@ class AsyncHTTPClient:
         image: Any = None,
         options: Optional[SearchContextOptions] = None,
     ) -> SearchContextResult:
+        # POST /search rejects target_uri in context mode: the context path picks its own
+        # roots per bucket, so there is nowhere for a caller-supplied one to apply. Any
+        # non-empty value here has always come back as a server error, so say so before
+        # spending a round trip on it. SyncHTTPClient.search_context delegates here, so
+        # both clients are covered.
+        if target_uri:
+            raise ValueError("target_uri is not supported by search_context")
         search_options = dict(options or {})
         if image is not None:
             search_options["image"] = image

--- a/sdk/python/tests/test_search_context_target_uri.py
+++ b/sdk/python/tests/test_search_context_target_uri.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""``search_context`` must refuse ``target_uri`` rather than send it.
+
+``POST /search`` rejects ``target_uri`` in context mode — the context path picks its own
+roots per bucket, so a caller-supplied one has nowhere to apply. The SDK carried the
+parameter anyway, so it read as supported and every non-empty value came back as a server
+error one round trip later.
+
+``SyncHTTPClient.search_context`` delegates to the async client, so both are covered by
+the one guard; the sync case is exercised here to pin that.
+"""
+
+import pytest
+from openviking_sdk import AsyncHTTPClient, SyncHTTPClient
+
+
+def _client() -> AsyncHTTPClient:
+    return AsyncHTTPClient(url="http://localhost:1933", api_key="k")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "target_uri",
+    ["viking://user/u/memories", ["viking://user/u/memories"]],
+    ids=["str", "list"],
+)
+async def test_async_search_context_refuses_a_target_uri(target_uri):
+    with pytest.raises(ValueError, match="target_uri is not supported by search_context"):
+        await _client().search_context(query="q", target_uri=target_uri)
+
+
+def test_sync_search_context_refuses_a_target_uri():
+    client = SyncHTTPClient(url="http://localhost:1933", api_key="k")
+
+    with pytest.raises(ValueError, match="target_uri is not supported by search_context"):
+        client.search_context(query="q", target_uri="viking://user/u/memories")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("target_uri", ["", []], ids=["empty-str", "empty-list"])
+async def test_the_empty_default_is_still_accepted(target_uri, monkeypatch):
+    # The guard must not reject the default, which is what every caller that does not use
+    # target_uri passes. Stop at the request so no server is needed.
+    class _Sent(Exception):
+        pass
+
+    async def _request(self, method, path, **kwargs):
+        raise _Sent(path)
+
+    monkeypatch.setattr(AsyncHTTPClient, "_request", _request)
+
+    with pytest.raises(_Sent, match="/api/v1/search/search"):
+        await _client().search_context(query="q", target_uri=target_uri)


### PR DESCRIPTION
## Description

`POST /search` rejects `target_uri` in context mode — the context path picks its own roots
per bucket, so a caller-supplied one has nowhere to apply (`routers/search.py:231-232`):

```python
if self.target_uri:
    raise ValueError("target_uri is not supported in mode='context'")
```

`search_context` sends `mode="context"` **and** `target_uri` in the same payload. The
parameter is in the signature, so it reads as supported, and every non-empty value comes
back as a server error one round trip later.

Building the payload the client would send and feeding it to `SearchRequest`, no server
needed:

```
search_context(target_uri='')                            -> REST: accepted
search_context(target_uri='viking://user/u/memories')    -> REST: Value error,
                                                            target_uri is not supported
                                                            in mode='context'
```

Same for a list — the parameter is `Union[str, List[str]]` and both shapes reach the
server.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

No related issue — found while comparing the three faces of `search` (MCP tool, REST route,
SDK client) after #4885. Happy to open one if you would rather have it tracked.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- `AsyncHTTPClient.search_context` raises `ValueError` when `target_uri` is non-empty,
  rather than sending a payload the server always rejects.
- `SyncHTTPClient.search_context` delegates to the async client, so the one guard covers
  both; the tests exercise the sync path anyway to pin that it stays true.
- `sdk/python/tests/test_search_context_target_uri.py`: both clients, both `str` and
  `List[str]` shapes, and — the case that matters most — the empty default still reaching
  the request, since that is what every caller who does not use `target_uri` passes.

`ValueError` matches how the client already validates arguments locally
(`client.py:323`, `:535`, `:561`, `:729`).

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

`sdk/python/tests/test_search_context_target_uri.py` — **5 passed**. Reverting only
`client.py` and keeping the tests gives **3 failed, 2 passed**; the two that pass either
way are the empty-default cases, which is the evidence the guard did not narrow the path
every existing caller takes.

Full SDK suite: **134 passed**. `ruff check` clean.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

The constraint is the one `POST /search` already documents; nothing new to document.

## Additional Notes

**Compatibility.** No caller can be relying on this: a non-empty `target_uri` has never
worked through `search_context`. What changes is where the failure surfaces — locally,
before the request, with the constraint named.

I left the parameter in the signature rather than removing it, so the change is
source-compatible: removing it would break at import for code that passes it by keyword,
rather than at the call that was already failing. Removing it is the cleaner end state if
you would rather take the break — say the word and I will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
