### PR TITLE
fix(watch): deactivate deleted Feishu wiki roots

### DIFF
--- a/docs/en/api/15-watches.md
+++ b/docs/en/api/15-watches.md
@@ -8,6 +8,8 @@ The Watch API manages periodic resource checks, pausing, resuming, and manual tr
 
 List, inspect, update, and trigger watch tasks created via [`add_resource`](02-resources.md#add_resource) with `watch_interval > 0`. The control plane is mirrored across REST (`/api/v1/watches`), the `ov task watch` CLI subcommand group, and a minimum-closure MCP surface (`list_watches` / `cancel_watch`) for agents.
 
+When Feishu reports that the watched wiki root has been deleted (`131005` during root resolution), the scheduler deactivates that watch and preserves the failure in `last_error`. The watch remains inactive after a restart. Permission errors, temporary failures, generic HTTP 404 responses, and missing child nodes do not deactivate the root watch. After restoring the source, use the update API or `ov task watch resume` to resume checks.
+
 #### 1. API Implementation Overview
 
 This control plane wraps the `WatchManager` primitives without changing any server-side behavior. Every endpoint and CLI command resolves the target task by either its `task_id` (path) or its `to_uri` (query). The two keys are interchangeable; if both are supplied they must refer to the same task, otherwise the request is rejected with 400.

--- a/docs/zh/api/15-watches.md
+++ b/docs/zh/api/15-watches.md
@@ -8,6 +8,8 @@ Watch API 管理资源的周期检查、暂停、恢复和手动触发。
 
 列出、查看、更新和触发通过 [`add_resource`](02-resources.md#add_resource) 配合 `watch_interval > 0` 创建的监控任务。控制面在 REST（`/api/v1/watches`）、`ov task watch` CLI 子命令组以及面向 Agent 的最小闭包 MCP 接口（`list_watches` / `cancel_watch`）三处镜像。
 
+当飞书在解析被监控的 wiki 根节点时返回节点已删除错误（`131005`），调度器会停用该 watch，并在 `last_error` 中保留失败原因。重启后该 watch 仍保持停用。权限错误、临时故障、普通 HTTP 404 响应或子节点缺失不会因此停用根节点的 watch。恢复源节点后，可通过更新 API 或 `ov task watch resume` 恢复检查。
+
 #### 1. API 实现介绍
 
 此控制面封装了 `WatchManager` 原语，未改动任何服务端行为。每个端点和 CLI 命令都支持通过 `task_id`（路径）或 `to_uri`（查询参数）定位目标任务，两种键可以互换；如果同时提供，二者必须指向同一任务，否则返回 400。

--- a/openviking/parse/accessors/feishu_accessor.py
+++ b/openviking/parse/accessors/feishu_accessor.py
@@ -34,6 +34,7 @@ logger = get_logger(__name__)
 
 _FEISHU_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(feishu://image/([^)]+)\)")
 _FEISHU_DOCUMENT_FORBIDDEN = 1770032
+_FEISHU_WIKI_NODE_DELETED = 131005
 _FEISHU_WIKI_NODE_PERMISSION_DENIED = 131006
 _FEISHU_BITABLE_PERMISSION_REQUIRED = 99991672
 _FEISHU_LEGACY_DOC_LOGIN_REQUIRED = 91404
@@ -832,6 +833,25 @@ class FeishuAccessor(DataAccessor):
         has_drive_folder_path = len(path_parts) >= 3 and path_parts[:2] == ["drive", "folder"]
         has_file_path = path_parts[0] == "file"
         return is_feishu_domain and (has_doc_path or has_drive_folder_path or has_file_path)
+
+    @classmethod
+    def is_deleted_wiki_source_error(cls, source: str, error: Exception) -> bool:
+        """Identify a deleted source root, excluding missing descendants and generic HTTP errors."""
+        if not isinstance(error, OpenVikingError):
+            return False
+        if error.details.get("feishu_code") != _FEISHU_WIKI_NODE_DELETED:
+            return False
+        try:
+            if not cls._is_feishu_url(source):
+                return False
+            doc_type, token = cls._parse_feishu_url(source)
+        except ValueError:
+            return False
+        return (
+            doc_type == "wiki"
+            and error.details.get("resource") == token
+            and error.details.get("operation") == f"resolve wiki node {token}"
+        )
 
     @staticmethod
     def _parse_feishu_url(url: str) -> Tuple[str, str]:

--- a/openviking/resource/watch_scheduler.py
+++ b/openviking/resource/watch_scheduler.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from typing import Any, Dict, Optional, Set
 
 from openviking.connector.delegate import ConnectorDelegate
+from openviking.parse.accessors.feishu_accessor import FeishuAccessor
 from openviking.resource.feishu_watch_auth import (
     FeishuOAuthClient,
     FeishuTokenRefreshError,
@@ -478,6 +479,9 @@ class WatchScheduler:
         except Exception as e:
             execution_status = "failed"
             execution_error = str(e) or type(e).__name__
+            if FeishuAccessor.is_deleted_wiki_source_error(task.path, e):
+                should_deactivate = True
+                deactivation_reason = f"Watched Feishu wiki source no longer exists: {e}"
             logger.error(
                 f"[WatchScheduler] Task {task.task_id} execution failed, "
                 f"error_type={type(e).__name__}"

--- a/tests/resource/test_watch_scheduler.py
+++ b/tests/resource/test_watch_scheduler.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -122,6 +123,96 @@ class TestWatchSchedulerExecutionHold:
 
 
 class TestWatchSchedulerResourceExistence:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "source,failed_token,code,http_status,recursive,deactivate",
+        [
+            ("https://team.feishu.cn/wiki/root", "root", 131005, 400, False, True),
+            ("https://team.larkoffice.com/wiki/root", "root", 131005, 400, True, True),
+            ("https://team.feishu.cn/wiki/root", "root", 131006, 400, True, False),
+            ("https://team.feishu.cn/wiki/root", "root", 999, 500, True, False),
+            ("https://team.feishu.cn/wiki/root", "root", 999, 404, True, False),
+            ("https://team.feishu.cn/wiki/root", "child", 131005, 400, True, False),
+            ("https://team.feishu.cn/docx/root", "root", 131005, 400, False, False),
+            ("https://example.com/wiki/root", "root", 131005, 400, False, False),
+        ],
+        ids=[
+            "deleted",
+            "deleted-recursive",
+            "permission",
+            "transient",
+            "http404",
+            "child",
+            "document",
+            "other-host",
+        ],
+    )
+    async def test_feishu_deleted_root_watch_stays_inactive_after_reload(
+        self, monkeypatch, source, failed_token, code, http_status, recursive, deactivate
+    ):
+        from openviking.parse.accessors.feishu_accessor import FeishuAccessor
+        from openviking_cli.exceptions import NotFoundError
+
+        accessor = FeishuAccessor()
+
+        def get_node(request):
+            assert request.token == failed_token
+            return SimpleNamespace(
+                code=code,
+                msg="provider error",
+                raw=SimpleNamespace(status_code=http_status),
+                success=lambda: False,
+            )
+
+        client = SimpleNamespace(
+            wiki=SimpleNamespace(v2=SimpleNamespace(space=SimpleNamespace(get_node=get_node)))
+        )
+        monkeypatch.setattr(accessor, "_get_client", lambda **kwargs: client)
+
+        class FakeResourceService(ResourceService):
+            async def refresh_resource(self, *args, **kwargs):
+                if failed_token == "root" and "/wiki/" in source:
+                    return await accessor.preflight_source(
+                        kwargs["path"], feishu_recursive=recursive
+                    )
+                # A child disappearing must not deactivate the root watch.
+                return accessor._fetch_wiki_node(failed_token)
+
+        class FakeVikingFS:
+            def __init__(self):
+                self.files: dict[str, str] = {}
+
+            async def read_file(self, uri, ctx=None):
+                if uri not in self.files:
+                    raise NotFoundError(uri)
+                return self.files[uri]
+
+            async def write_file(self, uri, content, ctx=None):
+                self.files[uri] = content
+
+        storage = FakeVikingFS()
+        manager = WatchManager(viking_fs=storage)
+        await manager.initialize()
+        scheduler = WatchScheduler(resource_service=FakeResourceService(), check_interval=1)
+        scheduler._watch_manager = manager
+        task = await manager.create_task(
+            path=source, to_uri="viking://resources/wiki", watch_interval=60
+        )
+
+        await scheduler._execute_task(task)
+
+        reloaded = WatchManager(viking_fs=storage)
+        await reloaded.initialize()
+        updated = await reloaded.get_task(task.task_id)
+        assert updated is not None
+        assert updated.is_active is not deactivate
+        assert updated.last_status == "failed"
+        assert updated.last_error is not None
+        assert f"code={code}" in updated.last_error
+        assert (updated.next_execution_time is None) is deactivate
+        updated.next_execution_time = datetime.now() - timedelta(minutes=1)
+        assert bool(await reloaded.get_due_tasks()) is not deactivate
+
     def test_url_like_sources_are_treated_as_existing(self):
         rs = ResourceService()
         scheduler = WatchScheduler(resource_service=rs, check_interval=1)


### PR DESCRIPTION
## Description

When a watched Feishu wiki root is deleted, source preflight raises an `OpenVikingError` containing Feishu code `131005`. The scheduler records an ordinary failure and keeps scheduling the watch, including after a restart.

I reused the existing deactivation and persistence path to stop those refreshes and retain `last_error`. The classification requires a Feishu/Lark wiki URL and an SDK error matching both the root token and root-resolution operation. Permission errors, temporary failures, generic HTTP 404 responses, and missing child nodes retain their existing retry behavior.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Addresses #4891. This patch covers repeated refreshes after root deletion; queue-wide attribution, historical counters, and configurable failure policies remain outside its scope.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Test update

## Changes Made

- Classify the deleted-root error in `FeishuAccessor` and reuse the scheduler's existing deactivation logic.
- Extend the existing scheduler test with eight deletion and non-terminal error scenarios, including persisted state reload and due-task filtering.
- Update both watch API guides, including how to resume a restored source. No new configuration, dependencies, or public error codes.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Python 3.12.3. The contract test uses the SDK request builder and response mapping, the actual accessor, scheduler, and WatchManager serialization/reload. It substitutes `ResourceService.refresh_resource`, the SDK network response, and the storage backend; it is not a live Feishu or complete service end-to-end test.

- Before the source fix: **2 failed / 6 passed** in the eight new cases. Both deleted-root cases stayed active after reload.
- With the fix: **19 passed** in `tests/resource/test_watch_scheduler.py` (`--confcutdir=tests/resource -o addopts=''`).
- Related checks: **181 passed / 1 failed** across scheduler, watch manager, Feishu watch authentication, Feishu errors, accessor, and unified import tests (`--noconftest -o addopts=''`, with a placeholder local test configuration and no model requests). The existing `TestWatchManager.test_get_all_tasks` ordering failure also reproduces on the clean base when creation timestamps tie.
- Ruff 0.15.5 lint passed on the three changed Python files. Accessor/test formatting passed; the scheduler retains two formatting differences also present on the clean base.
- Mypy 1.19.1 reports **1,547 errors in 211 files on both the clean base and patch**, with no changed error diagnostics after normalizing line numbers. Type checking is not clean.
- `git diff --check` passed.

I did not run the full Python integration suite, native builds, Linux/macOS tests, or live Feishu verification. Tests used the published binary distribution's dependencies while importing the current checkout.

## Checklist

- [x] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- Dependent changes: none.

## Additional Notes

Root resolution fails during source preflight before ingestion is enqueued. After restoring the source, the existing update API or `ov task watch resume` can reactivate the watch.
