### PR TITLE
fix(vlm): preserve explicit Ollama chat routes

### DIFF
--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -195,7 +195,7 @@ class LiteLLMVLMProvider(VLMBase):
         """Resolve model name by applying provider prefixes."""
         if _has_litellm_prefix(model, EXPLICIT_LITELLM_PREFIXES):
             return model
-        if model.lower().startswith("openai/"):
+        if model.lower().startswith(("openai/", *OLLAMA_LITELLM_PREFIXES)):
             return model
 
         provider = self._detected_provider or detect_provider_by_model(model)

--- a/tests/unit/test_litellm_vlm_provider_detection.py
+++ b/tests/unit/test_litellm_vlm_provider_detection.py
@@ -2,9 +2,12 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Tests for LiteLLM VLM provider detection and model prefix resolution."""
 
+import asyncio
 import os
+from unittest.mock import AsyncMock, Mock
 
 import pytest
+from litellm import ModelResponse
 
 from openviking.models.vlm.backends.litellm_vlm import (
     LiteLLMVLMProvider,
@@ -73,3 +76,43 @@ class TestLiteLLMVLMProviderDetection:
     )
     def test_existing_provider_detection_still_matches(self, model, provider):
         assert detect_provider_by_model(model) == provider
+
+
+@pytest.mark.parametrize(
+    "model", ["ollama_chat/qwen2.5:7b", "ollama/qwen2.5:7b", "openai/qwen2.5:7b"]
+)
+@pytest.mark.parametrize("api_key", [None, "test-key"])
+@pytest.mark.parametrize("api_base", [None, "http://localhost:11434"])
+@pytest.mark.parametrize("extra_body", [{}, {"num_ctx": 32768, "think": True}])
+def test_explicit_local_routes_reach_completion_unchanged(
+    monkeypatch, model, api_key, api_base, extra_body
+):
+    monkeypatch.setenv("OLLAMA_API_KEY", "")
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "")
+    provider = LiteLLMVLMProvider(
+        {
+            "provider": "litellm",
+            "model": model,
+            "api_key": api_key,
+            "api_base": api_base,
+            "extra_request_body": extra_body,
+        }
+    )
+    tools = [{"type": "function", "function": {"name": "read", "parameters": {"type": "object"}}}]
+    response = ModelResponse(choices=[{"message": {"role": "assistant", "content": "ok"}}])
+    sync_call = Mock(return_value=response)
+    async_call = AsyncMock(return_value=response)
+    monkeypatch.setattr("openviking.models.vlm.backends.litellm_vlm.completion", sync_call)
+    monkeypatch.setattr("openviking.models.vlm.backends.litellm_vlm.acompletion", async_call)
+
+    provider.get_completion(prompt="test", tools=tools)
+    asyncio.run(provider.get_completion_async(prompt="test", tools=tools))
+
+    for call in (sync_call, async_call):
+        kwargs = call.call_args.kwargs
+        assert kwargs["model"] == model
+        assert kwargs["tools"] == tools
+        assert kwargs.get("api_key") == api_key
+        assert kwargs.get("api_base") == api_base
+        if model.startswith(("ollama/", "ollama_chat/")):
+            assert kwargs["extra_body"] == {"num_ctx": 16384, "think": False} | extra_body


### PR DESCRIPTION
## Description

An explicit `ollama_chat/qwen2.5:7b` model currently becomes `ollama/ollama_chat/qwen2.5:7b` before reaching LiteLLM. Preserve the configured local route through the existing prefix handling, so users can select Ollama's chat backend.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Refs #4879; [the reproduced routing defect and proposed boundary](https://github.com/volcengine/OpenViking/issues/4879#issuecomment-5614460709).

This addresses explicit route preservation. The report does not establish that this route caused every symptom; local-model DSL output quality and deployed tool delivery are outside this fix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Changes Made

Reuse `OLLAMA_LITELLM_PREFIXES` when recognizing complete model routes. Provider inference and request-option handling keep their existing behavior. Exercise the real constructor and synchronous/asynchronous completion entrypoints, replacing only the outbound LiteLLM calls with recording mocks.

## Testing

- [x] I have added tests that prove my fix is effective
- [x] New and existing focused unit tests pass locally
- [x] Tested on macOS

`python -m pytest -o addopts="" tests/unit/test_litellm_vlm_provider_detection.py tests/unit/test_vlm_thinking_param.py tests/unit/test_litellm_vlm_gemini_cache.py tests/unit/test_extra_headers_vlm.py tests/unit/test_stream_config_vlm.py -q`: **91 passed**.

On the original production source, the eight new `ollama_chat` cases fail and the other 27 provider-detection cases pass. The fixed tests cover keyed/keyless construction, explicit/default API base, both completion entrypoints, ordinary `ollama/` and `openai/` routes, tool definitions, and default/custom `num_ctx` and `think` options.

Ruff check/format and `git diff --check` pass. No live Ollama inference or full repository suite was run; outbound dispatch is the tested boundary. Existing Pydantic deprecation warnings remain.

`python -m mypy` on both changed paths is not clean on the baseline: it reports 1,531 existing errors across 209 imported modules. The patched run reports the same errors plus one missing PyYAML-stubs diagnostic in unchanged `parser_config.py`; the provider file has the same pre-existing `content` annotation finding. No new diagnostic is on a changed line.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of the complete diff
- [x] Existing route options and other provider regressions are covered

## Additional Notes

No configuration migration or default-provider change is required.
