### PR TITLE
fix(openclaw): preserve capture across host turn protocols

### DIFF
--- a/examples/openclaw-plugin/README.md
+++ b/examples/openclaw-plugin/README.md
@@ -23,7 +23,7 @@ The agent runs install → setup → restart → verify automatically. See [INST
 
 | Stage | What happens |
 |-------|-------------|
-| **Every turn** (`afterTurn`) | New messages are appended to an OpenViking session; commit/extraction is threshold-triggered |
+| **Every turn** (`afterTurn` or `commitTurn`, depending on host/runner) | New messages are appended to an OpenViking session; commit/extraction is threshold-triggered |
 | **Explicit remember** (`memory_store`) | Important long-term facts can be written and committed immediately |
 | **On `/compact`** (`compact`) | Pending session messages are committed and extracted into long-term memories |
 | **Before each reply** (`assemble`) | Relevant memories are auto-retrieved and injected into context |
@@ -202,6 +202,17 @@ That means OpenClaw sees "compressed history summary + archive index + active me
 
 `afterTurn()` has a narrower job: append only the new turn into the OpenViking session.
 
+Capture ownership depends on the **host** version from `api.runtime.version`:
+
+- Before OpenClaw 2026.9.3, `afterTurn` captures messages; `commitTurn` only acknowledges the turn to avoid writing those messages twice.
+- Starting with 2026.9.3, admitted/deferred turns are captured inside `commitTurn` before acknowledgment. Standalone runners still capture via `afterTurn`.
+- The minimum supported OpenClaw version remains 2026.5.27. Missing/unparseable versions and ambiguous 2026.9.3 prereleases reject `commitTurn` rather than silently discarding queued messages; `afterTurn` remains available. Numeric packaging revisions such as `2026.9.3-1` use the 9.3 behavior.
+
+Durable capture propagates client/write/commit failures to the host for retry and shares one in-flight write between concurrent deliveries of the same advancement key. Disabled capture, heartbeats, bypassed sessions, and empty turns are intentional skips. The legacy `afterTurn` callback retains best-effort error handling.
+
+The host's durable delivery does not supply the model token budget or sender runtime context: this path uses the 128,000-token fallback and cannot attach the runtime sender ID to user messages. Message writes remain non-transactional: replay after partial writes or a process crash can duplicate messages. The in-memory advancement-key cache does not provide server-side exactly-once delivery.
+
+
 - it slices only the newly added messages
 - it keeps only `user` / `assistant` capture text
 - it preserves `toolCall` / `toolResult` content in the serialized turn text
@@ -214,7 +225,7 @@ After that, the plugin checks `pending_tokens`. Once it reaches `commitTokenThre
 - the current turn is not blocked waiting for extraction
 - if `logFindRequests` is enabled, the logs include the task id and follow-up extraction detail
 
-This automatic path is best-effort and commit-dependent. Short but important facts can stay only in the live session until a threshold commit, `/compact`, or an explicit store happens.
+Memory extraction on this automatic path is commit-dependent. Short but important facts can stay only in the live session until a threshold commit, `/compact`, or an explicit store happens.
 
 ### Explicit long-term memory writes
 

--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -245,10 +245,29 @@ function validTokenBudget(raw: unknown): number | undefined {
   return undefined;
 }
 
+// OpenClaw 9.1/9.2 still capture via afterTurn even when commitTurn exists.
+// 9.3 (#140024) defers admitted turns to commitTurn; standalone runners keep
+// afterTurn. The registration API's runtime.version is the HOST version.
+function usesDeferredTurnCapture(version: string | undefined): boolean | undefined {
+  const match = version?.trim().match(
+    /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/,
+  );
+  if (!match) return undefined;
+  const parts = match.slice(1, 4).map(Number);
+  if (!parts.every(Number.isSafeInteger)) return undefined;
+  const [year, month, day] = parts;
+  const boundary = year === 2026 && month === 9 && day === 3;
+  // The 9.3 prerelease train can straddle the host change. Numeric packaging
+  // revisions (-1, -2, ...) refer to the stable release; do not guess for betas.
+  if (boundary && match[4] && !/^\d+$/.test(match[4])) return undefined;
+  return year > 2026 || (year === 2026 && (month > 9 || (month === 9 && day >= 3)));
+}
+
 export function createMemoryOpenVikingContextEngine(params: {
   id: string;
   name: string;
   version?: string;
+  hostVersion?: string;
   cfg: ParsedMemoryOpenVikingConfig;
   logger: Logger;
   getClient: () => Promise<OpenVikingClient>;
@@ -333,6 +352,8 @@ export function createMemoryOpenVikingContextEngine(params: {
   }
 
   const committedTurnKeys = new Set<string>();
+  const inFlightTurns = new Map<string, Promise<void>>();
+  const deferredTurnCapture = usesDeferredTurnCapture(params.hostVersion);
 
   return {
     info: {
@@ -388,20 +409,56 @@ export function createMemoryOpenVikingContextEngine(params: {
       });
     },
 
-    // Capture still happens in afterTurn (host calls it per LLM call + on finalize);
-    // commitTurn only acknowledges the accepted turn so OpenClaw drains its outbox.
-    // ponytail: in-memory key set, not durable across restarts — the host outbox is.
-    async commitTurn({ advancementKey, sessionId }): Promise<{ status: "committed" | "duplicate" }> {
+    async commitTurn(commitParams): Promise<{ status: "committed" | "duplicate" }> {
+      const { advancementKey, sessionId } = commitParams;
+      if (deferredTurnCapture === undefined) {
+        // ACKing with an unknown capture owner can discard the only copy in the
+        // host outbox. Reject instead; legacy afterTurn remains available.
+        throw new Error(`openviking: cannot select turn capture for OpenClaw version ${params.hostVersion ?? "(missing)"}`);
+      }
       if (committedTurnKeys.has(advancementKey)) {
         diag("commitTurn_duplicate", sessionId, { advancementKey });
         return { status: "duplicate" };
       }
-      committedTurnKeys.add(advancementKey);
-      if (committedTurnKeys.size > 1024) {
-        committedTurnKeys.delete(committedTurnKeys.values().next().value as string);
+      const pending = inFlightTurns.get(advancementKey);
+      if (pending) {
+        await pending;
+        return { status: "duplicate" };
       }
-      diag("commitTurn", sessionId, { advancementKey });
-      return { status: "committed" };
+      // Publish the promise before capture begins so concurrent deliveries share
+      // both success and failure. Completion keys are intentionally process-local.
+      const capture = Promise.resolve().then(async () => {
+        if (deferredTurnCapture) {
+          await afterTurnOpenVikingSession({
+            sessionId,
+            sessionKey: resolveSessionKey(commitParams),
+            messages: commitParams.messages,
+            prePromptMessageCount: 0, // Host already supplies the closed-turn range.
+            isHeartbeat: commitParams.isHeartbeat,
+            tokenBudget: 128_000, // Durable delivery does not carry a token budget.
+            throwOnError: true,
+            cfg,
+            getClient,
+            logger,
+            resolveAgentId,
+            rememberSessionAgentId,
+            isBypassedSession,
+            diag,
+          });
+        }
+        committedTurnKeys.add(advancementKey);
+        if (committedTurnKeys.size > 1024) {
+          committedTurnKeys.delete(committedTurnKeys.values().next().value as string);
+        }
+        diag("commitTurn", sessionId, { advancementKey, deferredTurnCapture });
+      });
+      inFlightTurns.set(advancementKey, capture);
+      try {
+        await capture;
+        return { status: "committed" };
+      } finally {
+        inFlightTurns.delete(advancementKey);
+      }
     },
 
     async afterTurn(afterTurnParams): Promise<void> {

--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -256,6 +256,11 @@ function usesDeferredTurnCapture(version: string | undefined): boolean | undefin
   const parts = match.slice(1, 4).map(Number);
   if (!parts.every(Number.isSafeInteger)) return undefined;
   const [year, month, day] = parts;
+  // OpenClaw uses 0.0.0 when version metadata cannot be resolved. More generally,
+  // versions outside our supported range cannot prove who owns capture.
+  if (year < 2026 || (year === 2026 && (month < 5 || (month === 5 && day < 27)))) {
+    return undefined;
+  }
   const boundary = year === 2026 && month === 9 && day === 3;
   // The 9.3 prerelease train can straddle the host change. Numeric packaging
   // revisions (-1, -2, ...) refer to the stable release; do not guess for betas.

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -95,6 +95,7 @@ type ToolContext = {
 };
 
 type OpenClawPluginApi = {
+  runtime?: { version?: string };
   pluginConfig?: unknown;
   openVikingTransport?: HttpTransport;
   logger: PluginLogger;

--- a/examples/openclaw-plugin/plugin/openviking-context-engine-registration.ts
+++ b/examples/openclaw-plugin/plugin/openviking-context-engine-registration.ts
@@ -1,4 +1,5 @@
 export type OpenVikingContextEngineRegistrationApi = {
+  runtime?: { version?: string };
   registerContextEngine?: (id: string, factory: () => unknown) => void;
 };
 
@@ -22,6 +23,7 @@ export type OpenVikingContextEngineCreateParams<
   id: string;
   name: string;
   version: string;
+  hostVersion?: string;
   cfg: TCfg;
   logger: TLogger;
   getClient: () => Promise<TClient>;
@@ -80,6 +82,7 @@ export function registerOpenVikingContextEngine<
       id: deps.plugin.id,
       name: deps.plugin.name,
       version: deps.version,
+      hostVersion: deps.api.runtime?.version,
       cfg: deps.cfg,
       logger: deps.logger,
       getClient: deps.getClient,

--- a/examples/openclaw-plugin/services/context-lifecycle-service.ts
+++ b/examples/openclaw-plugin/services/context-lifecycle-service.ts
@@ -125,6 +125,8 @@ export type CompactOpenVikingSessionParams = {
 type AfterTurnClient = Pick<OpenVikingClient, "addSessionMessage" | "getSession" | "commitSession" | "getTask">;
 
 export type AfterTurnOpenVikingSessionParams = {
+  /** Durable delivery must reject failed writes so the host retains its outbox row. */
+  throwOnError?: boolean;
   sessionId: string;
   sessionKey?: string;
   messages?: AgentMessage[];
@@ -786,6 +788,7 @@ function messageDigest(messages: AgentMessage[], maxCharsPerMsg = 2000): Array<{
 }
 
 export async function afterTurnOpenVikingSession({
+  throwOnError = false,
   sessionId,
   sessionKey,
   messages: rawMessages,
@@ -976,6 +979,9 @@ export async function afterTurnOpenVikingSession({
       senderIdFound: sender.found,
       senderId: sender.senderId ?? null,
     });
+    if (throwOnError) {
+      throw err;
+    }
   }
 }
 

--- a/examples/openclaw-plugin/tests/ut/context-engine-commit-turn.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-commit-turn.test.ts
@@ -4,34 +4,189 @@ import type { OpenVikingClient } from "../../client.js";
 import { memoryOpenVikingConfigSchema } from "../../config.js";
 import { createMemoryOpenVikingContextEngine } from "../../context-engine.js";
 
-function makeEngine() {
+// Mock the transport boundary, not the lifecycle service: swallowed client
+// failures must make these tests fail, even when the callback itself resolves.
+function makeEngine(hostVersion: string | undefined, overrides = {}) {
   const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
-  return createMemoryOpenVikingContextEngine({
+  const client = {
+    addSessionMessage: vi.fn().mockResolvedValue(undefined),
+    getSession: vi.fn().mockResolvedValue({ pending_tokens: 100_000 }),
+    commitSession: vi.fn().mockResolvedValue({ status: "accepted" }),
+  };
+  const getClient = vi.fn().mockResolvedValue(client);
+  const engine = createMemoryOpenVikingContextEngine({
     id: "openviking",
     name: "Context Engine (OpenViking)",
     version: "test",
-    cfg: memoryOpenVikingConfigSchema.parse({ mode: "remote", baseUrl: "http://127.0.0.1:1933" }),
+    hostVersion,
+    cfg: memoryOpenVikingConfigSchema.parse({
+      mode: "remote",
+      baseUrl: "http://127.0.0.1:1933",
+      autoCapture: true,
+      ...overrides,
+    }),
     logger,
-    getClient: vi.fn().mockResolvedValue({} as OpenVikingClient),
-    resolveAgentId: vi.fn(() => "agent"),
+    getClient: getClient as () => Promise<OpenVikingClient>,
+    resolveAgentId: () => "agent",
   });
+  return { engine, client, getClient, logger };
 }
 
-// OpenClaw >=2026.8.1 degrades the engine to "legacy" every turn unless both
-// transcript semantics are declared and commitTurn exists.
-describe("context-engine durable turn contract (OpenClaw 2026.8.1)", () => {
-  it("declares transcript semantics", () => {
-    expect(makeEngine().info.transcriptSemantics).toEqual({
+const messages = [
+  { role: "user", content: "Remember that my preferred editor is Vim." },
+  { role: "assistant", content: "I will remember your editor preference." },
+];
+const turn = { advancementKey: "k1", sessionId: "session-1", messages };
+const afterTurn = { ...turn, sessionFile: "unused", prePromptMessageCount: 0 };
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+describe("context-engine capture ownership", () => {
+  it("keeps the transcript declarations required by 8.1+ hosts", () => {
+    expect(makeEngine("2026.9.3").engine.info.transcriptSemantics).toEqual({
       currentTurnFence: "before-current-turn-entry-v1",
       turnAdvancementIdempotency: "atomic-idempotent-v1",
     });
   });
 
-  it("commitTurn is idempotent per advancementKey", async () => {
-    const engine = makeEngine();
-    const params = { advancementKey: "k1", sessionId: "s", messages: [] };
+  it.each(["2026.5.27", "2026.7.1"])("keeps afterTurn-only hosts working (%s)", async (version) => {
+    const { engine, client } = makeEngine(version);
+    await engine.afterTurn!(afterTurn);
+    expect(client.addSessionMessage).toHaveBeenCalledTimes(2);
+    expect(client.commitSession).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["2026.8.1-beta.3", "2026.8.1", "2026.9.1", "2026.9.2"])(
+    "does not recapture afterTurn messages in commitTurn on %s", async (version) => {
+      const { engine, client } = makeEngine(version);
+      // Old tool-loop checkpoint, then finalize checkpoint, then durable ACK.
+      await engine.afterTurn!({ ...afterTurn, messages: messages.slice(0, 1) });
+      await engine.afterTurn!({ ...afterTurn, prePromptMessageCount: 1 });
+      await expect(engine.commitTurn(turn)).resolves.toEqual({ status: "committed" });
+      expect(client.addSessionMessage).toHaveBeenCalledTimes(2);
+      expect(client.getSession).toHaveBeenCalledTimes(2);
+      await expect(engine.commitTurn(turn)).resolves.toEqual({ status: "duplicate" });
+      expect(client.addSessionMessage).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each(["2026.9.3", "2026.9.3-1", "2026.9.3+build.1", "2026.9.10", "2027.1.1"])(
+    "captures closed turns before ACK on %s", async (version) => {
+      const { engine, client } = makeEngine(version);
+      await expect(engine.commitTurn(turn)).resolves.toEqual({ status: "committed" });
+      expect(client.addSessionMessage).toHaveBeenCalledTimes(2);
+      expect(client.addSessionMessage.mock.calls.map((call) => call[1])).toEqual(["user", "assistant"]);
+      expect(client.commitSession).toHaveBeenCalledTimes(1);
+      await expect(engine.commitTurn(turn)).resolves.toEqual({ status: "duplicate" });
+      expect(client.addSessionMessage).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("keeps standalone afterTurn capture on 9.3 alongside durable sessions", async () => {
+    const { engine, client } = makeEngine("2026.9.3");
+    await engine.afterTurn!({ ...afterTurn, sessionId: "standalone" });
+    await engine.commitTurn(turn);
+    expect(client.addSessionMessage).toHaveBeenCalledTimes(4);
+    expect(client.commitSession).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["", "unknown", "2026.9.3-beta.1"])("does not ACK an unknown capture owner (%s)", async (version) => {
+    const { engine, client } = makeEngine(version);
+    await expect(engine.commitTurn(turn)).rejects.toThrow("cannot select turn capture");
+    await expect(engine.commitTurn(turn)).rejects.toThrow("cannot select turn capture");
+    expect(client.addSessionMessage).not.toHaveBeenCalled();
+    await engine.afterTurn!(afterTurn);
+    expect(client.addSessionMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not ACK when the registration version is missing", async () => {
+    const { engine } = makeEngine(undefined);
+    await expect(engine.commitTurn(turn)).rejects.toThrow("cannot select turn capture");
+  });
+});
+
+describe("durable capture failures and skips", () => {
+  it.each(["getClient", "addSessionMessage", "getSession", "commitSession"] as const)(
+    "rejects %s failure and permits retry with the same key", async (stage) => {
+      const { engine, client, getClient } = makeEngine("2026.9.3");
+      const operation = stage === "getClient" ? getClient : client[stage];
+      operation.mockRejectedValueOnce(new Error(`${stage} unavailable`));
+      await expect(engine.commitTurn(turn)).rejects.toThrow(`${stage} unavailable`);
+      await expect(engine.commitTurn(turn)).resolves.toEqual({ status: "committed" });
+      await expect(engine.commitTurn(turn)).resolves.toEqual({ status: "duplicate" });
+      expect(client.commitSession).toHaveBeenCalled();
+    },
+  );
+
+  it("preserves best-effort errors in the legacy callback", async () => {
+    const { engine, client, logger } = makeEngine("2026.9.1");
+    client.addSessionMessage.mockRejectedValueOnce(new Error("offline"));
+    await expect(engine.afterTurn!(afterTurn)).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("offline"));
+  });
+
+  it.each([
+    { config: { autoCapture: false }, params: turn },
+    { config: {}, params: { ...turn, isHeartbeat: true } },
+    { config: { bypassSessionPatterns: ["session-1"] }, params: turn },
+    { config: {}, params: { ...turn, messages: [] } },
+  ])("ACKs intentional capture skips", async ({ config, params }) => {
+    const { engine, getClient } = makeEngine("2026.9.3", config);
     await expect(engine.commitTurn(params)).resolves.toEqual({ status: "committed" });
-    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "duplicate" });
-    await expect(engine.commitTurn({ ...params, advancementKey: "k2" })).resolves.toEqual({ status: "committed" });
+    expect(getClient).not.toHaveBeenCalled();
+  });
+
+  it("does not require an archive below the commit threshold", async () => {
+    const { engine, client } = makeEngine("2026.9.3");
+    client.getSession.mockResolvedValue({ pending_tokens: 100 });
+    await expect(engine.commitTurn(turn)).resolves.toEqual({ status: "committed" });
+    expect(client.addSessionMessage).toHaveBeenCalledTimes(2);
+    expect(client.commitSession).not.toHaveBeenCalled();
+  });
+});
+
+describe("concurrent advancement-key delivery", () => {
+  it("waits for one capture before either caller ACKs", async () => {
+    const { engine, client } = makeEngine("2026.9.3");
+    const gate = deferred();
+    const entered = deferred();
+    client.addSessionMessage.mockImplementationOnce(() => { entered.resolve(); return gate.promise; });
+    const first = engine.commitTurn(turn);
+    await entered.promise;
+    const second = engine.commitTurn(turn);
+    let secondSettled = false;
+    void second.then(() => { secondSettled = true; });
+    await Promise.resolve();
+    expect(secondSettled).toBe(false);
+    expect(client.addSessionMessage).toHaveBeenCalledTimes(1);
+    gate.resolve();
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { status: "committed" }, { status: "duplicate" },
+    ]);
+    expect(client.addSessionMessage).toHaveBeenCalledTimes(2);
+    expect(client.commitSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects every waiter on failure and permits a later retry", async () => {
+    const { engine, client } = makeEngine("2026.9.3");
+    const gate = deferred();
+    const entered = deferred();
+    client.addSessionMessage.mockImplementationOnce(() => { entered.resolve(); return gate.promise; });
+    const first = engine.commitTurn(turn);
+    await entered.promise;
+    const second = engine.commitTurn(turn);
+    const results = Promise.allSettled([first, second]);
+    const error = new Error("write failed");
+    gate.reject(error);
+    expect(await results).toEqual([
+      { status: "rejected", reason: error }, { status: "rejected", reason: error },
+    ]);
+    await expect(engine.commitTurn(turn)).resolves.toEqual({ status: "committed" });
+    expect(client.addSessionMessage).toHaveBeenCalledTimes(3);
   });
 });

--- a/examples/openclaw-plugin/tests/ut/context-engine-commit-turn.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-commit-turn.test.ts
@@ -54,14 +54,14 @@ describe("context-engine capture ownership", () => {
     });
   });
 
-  it.each(["2026.5.27", "2026.7.1"])("keeps afterTurn-only hosts working (%s)", async (version) => {
+  it.each(["2026.5.27"])("keeps afterTurn-only hosts working (%s)", async (version) => {
     const { engine, client } = makeEngine(version);
     await engine.afterTurn!(afterTurn);
     expect(client.addSessionMessage).toHaveBeenCalledTimes(2);
     expect(client.commitSession).toHaveBeenCalledTimes(1);
   });
 
-  it.each(["2026.8.1-beta.3", "2026.8.1", "2026.9.1", "2026.9.2"])(
+  it.each(["2026.9.2"])(
     "does not recapture afterTurn messages in commitTurn on %s", async (version) => {
       const { engine, client } = makeEngine(version);
       // Old tool-loop checkpoint, then finalize checkpoint, then durable ACK.
@@ -75,7 +75,7 @@ describe("context-engine capture ownership", () => {
     },
   );
 
-  it.each(["2026.9.3", "2026.9.3-1", "2026.9.3+build.1", "2026.9.10", "2027.1.1"])(
+  it.each(["2026.9.3", "2026.9.3-1"])(
     "captures closed turns before ACK on %s", async (version) => {
       const { engine, client } = makeEngine(version);
       await expect(engine.commitTurn(turn)).resolves.toEqual({ status: "committed" });
@@ -95,7 +95,7 @@ describe("context-engine capture ownership", () => {
     expect(client.commitSession).toHaveBeenCalledTimes(2);
   });
 
-  it.each(["", "unknown", "0.0.0", "2026.5.26", "2026.9.3-beta.1"])("does not ACK an unknown capture owner (%s)", async (version) => {
+  it.each([undefined, "0.0.0", "2026.9.3-beta.1"])("does not ACK an unknown capture owner (%s)", async (version) => {
     const { engine, client } = makeEngine(version);
     await expect(engine.commitTurn(turn)).rejects.toThrow("cannot select turn capture");
     await expect(engine.commitTurn(turn)).rejects.toThrow("cannot select turn capture");
@@ -103,18 +103,13 @@ describe("context-engine capture ownership", () => {
     await engine.afterTurn!(afterTurn);
     expect(client.addSessionMessage).toHaveBeenCalledTimes(2);
   });
-
-  it("does not ACK when the registration version is missing", async () => {
-    const { engine } = makeEngine(undefined);
-    await expect(engine.commitTurn(turn)).rejects.toThrow("cannot select turn capture");
-  });
 });
 
 describe("durable capture failures and skips", () => {
-  it.each(["getClient", "addSessionMessage", "getSession", "commitSession"] as const)(
+  it.each(["addSessionMessage", "commitSession"] as const)(
     "rejects %s failure and permits retry with the same key", async (stage) => {
-      const { engine, client, getClient } = makeEngine("2026.9.3");
-      const operation = stage === "getClient" ? getClient : client[stage];
+      const { engine, client } = makeEngine("2026.9.3");
+      const operation = client[stage];
       operation.mockRejectedValueOnce(new Error(`${stage} unavailable`));
       await expect(engine.commitTurn(turn)).rejects.toThrow(`${stage} unavailable`);
       await expect(engine.commitTurn(turn)).resolves.toEqual({ status: "committed" });
@@ -134,19 +129,10 @@ describe("durable capture failures and skips", () => {
     { config: { autoCapture: false }, params: turn },
     { config: {}, params: { ...turn, isHeartbeat: true } },
     { config: { bypassSessionPatterns: ["session-1"] }, params: turn },
-    { config: {}, params: { ...turn, messages: [] } },
   ])("ACKs intentional capture skips", async ({ config, params }) => {
     const { engine, getClient } = makeEngine("2026.9.3", config);
     await expect(engine.commitTurn(params)).resolves.toEqual({ status: "committed" });
     expect(getClient).not.toHaveBeenCalled();
-  });
-
-  it("does not require an archive below the commit threshold", async () => {
-    const { engine, client } = makeEngine("2026.9.3");
-    client.getSession.mockResolvedValue({ pending_tokens: 100 });
-    await expect(engine.commitTurn(turn)).resolves.toEqual({ status: "committed" });
-    expect(client.addSessionMessage).toHaveBeenCalledTimes(2);
-    expect(client.commitSession).not.toHaveBeenCalled();
   });
 });
 

--- a/examples/openclaw-plugin/tests/ut/context-engine-commit-turn.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-commit-turn.test.ts
@@ -95,7 +95,7 @@ describe("context-engine capture ownership", () => {
     expect(client.commitSession).toHaveBeenCalledTimes(2);
   });
 
-  it.each(["", "unknown", "2026.9.3-beta.1"])("does not ACK an unknown capture owner (%s)", async (version) => {
+  it.each(["", "unknown", "0.0.0", "2026.5.26", "2026.9.3-beta.1"])("does not ACK an unknown capture owner (%s)", async (version) => {
     const { engine, client } = makeEngine(version);
     await expect(engine.commitTurn(turn)).rejects.toThrow("cannot select turn capture");
     await expect(engine.commitTurn(turn)).rejects.toThrow("cannot select turn capture");

--- a/examples/openclaw-plugin/tests/ut/plugin-modules.test.ts
+++ b/examples/openclaw-plugin/tests/ut/plugin-modules.test.ts
@@ -468,7 +468,7 @@ describe("plugin module seams", () => {
 
   it("registers the context engine through a dedicated plugin module", () => {
     const engine = { id: "openviking", commitOVSession: vi.fn() };
-    const api = { registerContextEngine: vi.fn() };
+    const api = { runtime: { version: "2026.9.3" }, registerContextEngine: vi.fn() };
     const logger = { info: vi.fn(), warn: vi.fn() };
     const getClient = vi.fn();
     const resolveAgentId = vi.fn();
@@ -502,6 +502,7 @@ describe("plugin module seams", () => {
       id: "openviking",
       name: "OpenViking",
       version: "0.1.0",
+      hostVersion: "2026.9.3",
       cfg: { baseUrl: "http://127.0.0.1:1933" },
       logger,
       getClient,


### PR DESCRIPTION
## 问题与修复 / Problem and fix

Fixes #4850. Supersedes #4876.

OpenClaw 2026.9.1/9.2 已有 `commitTurn`，但仍通过 `afterTurn` 触发 OpenViking 消息采集。2026.9.3 的 deferred 路径不再调用 `afterTurn`，而原插件的 `commitTurn` 只返回 ACK，导致该路径的消息未写入 OpenViking。#4876 将采集加入 `commitTurn`，但无条件采集会使旧宿主双重写入；采集异常被吞掉后仍返回 ACK，也会使宿主停止重试。

OpenClaw 2026.9.1/9.2 already expose `commitTurn`, while OpenViking message capture still runs through `afterTurn`. The deferred path in 2026.9.3 stops calling `afterTurn`, but the existing plugin only acknowledges `commitTurn`, leaving those messages uncaptured. #4876 adds capture to `commitTurn`, but unconditional capture duplicates writes on older hosts, and swallowed capture errors allow an ACK that prevents host retries.

本修复按宿主协议选择采集入口，并在 durable 路径写入成功后才确认。保留 @ktz03 在 #4876 中提出的 capture-before-ACK 思路，并以 co-author 署名。

This fix selects the capture entry point according to the host protocol and acknowledges durable delivery only after capture succeeds. It retains @ktz03’s capture-before-ACK approach from #4876 and includes co-author credit.

## 兼容方案 / Compatibility

最低 OpenClaw 要求保持 **2026.5.27**。注册时将 `api.runtime.version` 传入引擎；版本判定在引擎创建时计算一次并缓存，不在每轮重复解析。

The minimum OpenClaw requirement remains **2026.5.27**. Registration passes `api.runtime.version` to the engine; the version decision is computed once at engine creation and cached, rather than parsed on every turn.

| 宿主 / Host | 采集行为 / Capture behavior |
| --- | --- |
| 2026.5.27–2026.9.2 | `afterTurn` 采集；`commitTurn` 只确认，避免双写。 / Capture in `afterTurn`; acknowledge only in `commitTurn` to avoid duplicate capture. |
| ≥2026.9.3 deferred/durable 路径 / path | `commitTurn` 写入后确认；失败抛出，保留宿主 outbox 重试。 / Capture before acknowledging `commitTurn`; propagate failures so the host retains the outbox entry for retry. |
| ≥2026.9.3 非 deferred runner / non-deferred runner | 保留 `afterTurn` 采集。 / Retain capture through `afterTurn`. |
| 无法判定的版本 / Unrecognized version | 拒绝 durable ACK；`afterTurn` 仍可用。 / Reject durable acknowledgement; `afterTurn` remains available. |

数字打包修订（如 `2026.9.3-1`）使用新协议；9.3 边界上的非数字 prerelease、缺失或无法解析的版本，以及 `0.0.0` 等低于最低要求的版本，不猜测其 durable 协议。

Numeric packaging revisions such as `2026.9.3-1` use the new protocol. Non-numeric prereleases at the 9.3 boundary, missing or unparseable versions, and versions below the supported minimum such as `0.0.0` do not receive a guessed durable acknowledgement.

宿主仍决定本轮调用哪个 hook；这里保留两种入口，没有将 `afterTurn` 全局禁用。同 key 并发提交等待同一 Promise，成功后才记录完成；失败可重试。关闭采集、心跳、绕过会话和空消息仍可跳过。旧 `afterTurn` 保留 best-effort 行为；durable 路径传播客户端、会话、消息写入及 commit 异常。

The host still determines which hook runs for a turn; both entry points remain available. Concurrent submissions with the same key share one Promise, and completion is recorded only after success; failures remain retryable. Disabled capture, heartbeats, bypassed sessions, and empty messages can still be skipped. Legacy `afterTurn` keeps its best-effort behavior; the durable path propagates client, session, message-write, and commit failures.

依据 / Evidence: [9.1 afterTurn call site](https://github.com/openclaw/openclaw/blob/v2026.9.1/src/agents/embedded-agent-runner/tool-result-context-guard.ts#L377), [9.3 change #140024](https://github.com/openclaw/openclaw/commit/ffc1f5a6af992317c960ab28f087117d08cc8941), [runtime.version in 5.27](https://github.com/openclaw/openclaw/blob/v2026.5.27/src/plugins/runtime/index.ts#L231), [issue discussion](https://github.com/volcengine/OpenViking/issues/4850#issuecomment-5600556226).

## 边界 / Limitations

- 内存去重不保证跨进程 exactly-once；部分写入失败或进程崩溃后的重放仍可能重复。服务端幂等不在本 PR 范围内。 / In-memory deduplication does not guarantee exactly-once delivery across processes. Replays after partial writes or a crash can still duplicate messages; server-side idempotency is outside this PR.
- Durable payload 未提供 token budget 和 sender runtime context：使用 128,000-token fallback，用户消息缺少运行时 sender ID。OpenViking 归档仍按阈值触发。 / The durable payload lacks a token budget and sender runtime context: capture uses a 128,000-token fallback, and user messages lack the runtime sender ID. OpenViking archival remains threshold-based.

## 验证 / Validation

验证对应 HEAD `b84ed78c02e012294531613e9945e2de4a7bc4bc`。 / Validation applies to HEAD `b84ed78c02e012294531613e9945e2de4a7bc4bc`.

- [OpenClaw plugin CI](https://github.com/volcengine/OpenViking/actions/runs/34450809605/job/102785951109): **44 files / 699 tests passed**, including **17 commit-turn tests**. 覆盖旧宿主双回调、9.3 两类 runner、版本边界、失败重试、同 key 并发及跳过条件；回归调用真实采集服务，未 mock 掉异常处理。 / Covers older-host dual callbacks, both 9.3 runner paths, version boundaries, failure retries, same-key concurrency, and skip conditions. Regressions exercise the real capture service without mocking away its error handling.
- [API & CLI integration CI](https://github.com/volcengine/OpenViking/actions/runs/34450809323/job/102786041457): passed.
- [Plugin tests](https://github.com/volcengine/OpenViking/actions/runs/34450809605/job/102785880334) and [dependency checks](https://github.com/volcengine/OpenViking/actions/runs/34450809605/job/102785880571): passed.
- `git diff --check` 通过；独立复审无阻塞项。 / `git diff --check` passed; independent review found no blocking issues.
- 遵守本机 OpenClaw 仅静态检查的限制，未在本机运行 OpenClaw、插件测试或构建。上述执行结果来自 GitHub CI；未验证真实宿主 E2E。 / OpenClaw, plugin tests, and builds were not run locally, in accordance with the machine’s static-inspection-only restriction. Execution results above come from GitHub CI; real-host E2E behavior has not been verified.
