### PR TITLE
fix(openclaw): capture accepted turns before acknowledging delivery

### DIFF
--- a/examples/openclaw-plugin/README.md
+++ b/examples/openclaw-plugin/README.md
@@ -13,7 +13,18 @@ outbox for retry, including after restart or session compaction.
 This path requires an OpenViking server that supports the accepted-turn endpoint;
 upgrade the server together with the plugin. An older server rejects the request,
 and the plugin does not fall back to message POSTs that could duplicate a turn.
-Older OpenClaw hosts calling `afterTurn` retain the existing capture behavior.
+The plugin uses the host's `api.runtime.version` to choose one capture path:
+OpenClaw before 2026.8.1 uses legacy `afterTurn`; 2026.8.1 and later capture only
+through `commitTurn`, even if the host also calls `afterTurn` during tool loops.
+An unknown host version cannot use legacy capture because guessing could duplicate messages.
+
+With `peer_role=sender`, accepted user turns require trusted sender identity in
+`commitTurn.runtimeContext.senderId`. Published OpenClaw 2026.9.3 does not supply
+this field: these turns fail explicitly and remain in its outbox rather than being
+stored as self-owned memory. Sender-scoped accepted-turn capture therefore needs
+a host that forwards sender identity on every delivery, including retries.
+The default `peer_role=none` and `peer_role=assistant` do not require sender identity.
+Do not change ownership mode merely to drain pending sender-scoped turns.
 
 ## Quick Start
 

--- a/examples/openclaw-plugin/README.md
+++ b/examples/openclaw-plugin/README.md
@@ -2,6 +2,19 @@
 
 Use [OpenViking](https://github.com/volcengine/OpenViking) as OpenClaw's long-term context engine: automatic recall, session archive, memory extraction, semantic search, and RAG over a remote OpenViking server.
 
+## Accepted-turn capture compatibility
+
+Current OpenClaw delivers accepted turns through `commitTurn` instead of `afterTurn`.
+This plugin stores that entire turn through `POST /api/v1/sessions/{id}/turns`,
+using OpenClaw's `advancementKey` as the durable retry key. It acknowledges the
+turn only after the server confirms storage. Failed requests remain in OpenClaw's
+outbox for retry, including after restart or session compaction.
+
+This path requires an OpenViking server that supports the accepted-turn endpoint;
+upgrade the server together with the plugin. An older server rejects the request,
+and the plugin does not fall back to message POSTs that could duplicate a turn.
+Older OpenClaw hosts calling `afterTurn` retain the existing capture behavior.
+
 ## Quick Start
 
 ```bash
@@ -23,7 +36,7 @@ The agent runs install → setup → restart → verify automatically. See [INST
 
 | Stage | What happens |
 |-------|-------------|
-| **Every turn** (`afterTurn`) | New messages are appended to an OpenViking session; commit/extraction is threshold-triggered |
+| **Every accepted turn** (`commitTurn`; legacy `afterTurn`) | New messages are appended to an OpenViking session; commit/extraction is threshold-triggered |
 | **Explicit remember** (`memory_store`) | Important long-term facts can be written and committed immediately |
 | **On `/compact`** (`compact`) | Pending session messages are committed and extracted into long-term memories |
 | **Before each reply** (`assemble`) | Relevant memories are auto-retrieved and injected into context |

--- a/examples/openclaw-plugin/client.ts
+++ b/examples/openclaw-plugin/client.ts
@@ -804,6 +804,28 @@ export class OpenVikingClient {
     );
   }
 
+  async addSessionTurn(
+    sessionId: string,
+    advancementKey: string,
+    messages: Array<{
+      role: string;
+      parts: Parameters<OpenVikingClient["addSessionMessage"]>[2];
+      created_at?: string;
+      peer_id?: string;
+    }>,
+  ): Promise<"committed" | "duplicate"> {
+    // A separate endpoint fails safely on older servers; it must never fall
+    // back to non-idempotent message POSTs after an ambiguous response.
+    const result = await this.request<{ status: string }>(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/turns`,
+      { method: "POST", body: JSON.stringify({ advancement_key: advancementKey, messages }) },
+    );
+    if (result.status !== "committed" && result.status !== "duplicate") {
+      throw new Error(`Invalid accepted-turn status: ${String(result.status)}`);
+    }
+    return result.status;
+  }
+
   /** GET session — server auto-creates if absent; returns session meta including message stats and token usage. */
   async getSession(sessionId: string, actorPeerId?: string): Promise<{
     message_count?: number;

--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -247,10 +247,22 @@ function validTokenBudget(raw: unknown): number | undefined {
   return undefined;
 }
 
+// OpenClaw introduced accepted-turn delivery in 2026.8.1. Its early
+// implementations still call afterTurn inside tool loops, so hook presence
+// alone cannot select the capture path. Use the host's public runtime version.
+function usesAcceptedTurns(version: string | undefined): boolean | undefined {
+  const match = version?.match(/^(\d{4})\.(\d{1,2})\.(\d{1,2})(?:[-+].*)?$/);
+  if (!match) return undefined;
+  const [, year, month, day] = match;
+  const date = Number(year) * 10_000 + Number(month) * 100 + Number(day);
+  return date >= 20260801;
+}
+
 export function createMemoryOpenVikingContextEngine(params: {
   id: string;
   name: string;
   version?: string;
+  hostVersion?: string;
   cfg: ParsedMemoryOpenVikingConfig;
   logger: Logger;
   getClient: () => Promise<OpenVikingClient>;
@@ -278,6 +290,7 @@ export function createMemoryOpenVikingContextEngine(params: {
     traceRecorder,
   } = params;
 
+  const acceptedTurns = usesAcceptedTurns(params.hostVersion);
   const diagEnabled = cfg.emitStandardDiagnostics;
   const bypassSessionPatterns = compileSessionPatterns(cfg.bypassSessionPatterns);
   const diag = (stage: string, sessionId: string, data: Record<string, unknown>) =>
@@ -398,6 +411,9 @@ export function createMemoryOpenVikingContextEngine(params: {
     // Accepted turns arrive here instead of afterTurn on current OpenClaw.
     // The server owns the durable receipt, including retry-after-restart safety.
     async commitTurn(params): Promise<{ status: "committed" | "duplicate" }> {
+      if (acceptedTurns === false) {
+        throw new Error("openviking: commitTurn is unavailable on this legacy OpenClaw host");
+      }
       if (!params.advancementKey?.trim()) throw new Error("commitTurn requires advancementKey");
       const sessionKey = resolveSessionKey(params) ?? params.sessionTarget?.sessionKey;
       const ovSessionId = openClawSessionToOvStorageId(params.sessionId, sessionKey);
@@ -422,6 +438,12 @@ export function createMemoryOpenVikingContextEngine(params: {
     },
 
     async afterTurn(afterTurnParams): Promise<void> {
+      // Accepted-turn hosts own delivery via their outbox. A loop checkpoint
+      // must not append the same messages through the ordinary message API.
+      if (acceptedTurns === true || !cfg.autoCapture) return;
+      if (acceptedTurns === undefined) {
+        throw new Error("openviking: cannot select capture path without a valid OpenClaw runtime.version");
+      }
       const tokenBudget = validTokenBudget(afterTurnParams.tokenBudget) ?? 128_000;
       await afterTurnOpenVikingSession({
         sessionId: afterTurnParams.sessionId,

--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -90,6 +90,8 @@ type ContextEngine = {
   /** OpenClaw >=2026.8.1 durable turn advancement; retried with the same advancementKey after host failure. */
   commitTurn: (params: {
     advancementKey: string;
+    sessionTarget?: { agentId?: string; sessionKey?: string };
+    runtimeContext?: Record<string, unknown>;
     messages: AgentMessage[];
     sessionId: string;
     sessionKey?: string;
@@ -332,7 +334,7 @@ export function createMemoryOpenVikingContextEngine(params: {
     };
   }
 
-  const committedTurnKeys = new Set<string>();
+  const turnBudgets = new Map<string, number>();
 
   return {
     info: {
@@ -360,6 +362,11 @@ export function createMemoryOpenVikingContextEngine(params: {
 
     async assemble(assembleParams): Promise<AssembleResult> {
       const tokenBudget = validTokenBudget(assembleParams.tokenBudget) ?? 128_000;
+      const { ovSessionId } = resolveSessionIdentity(assembleParams);
+      turnBudgets.set(ovSessionId, tokenBudget);
+      if (turnBudgets.size > 1024) {
+        turnBudgets.delete(turnBudgets.keys().next().value as string);
+      }
       const isMainAssemble =
         Object.prototype.hasOwnProperty.call(assembleParams, "availableTools") ||
         Object.prototype.hasOwnProperty.call(assembleParams, "citationsMode") ||
@@ -388,20 +395,30 @@ export function createMemoryOpenVikingContextEngine(params: {
       });
     },
 
-    // Capture still happens in afterTurn (host calls it per LLM call + on finalize);
-    // commitTurn only acknowledges the accepted turn so OpenClaw drains its outbox.
-    // ponytail: in-memory key set, not durable across restarts — the host outbox is.
-    async commitTurn({ advancementKey, sessionId }): Promise<{ status: "committed" | "duplicate" }> {
-      if (committedTurnKeys.has(advancementKey)) {
-        diag("commitTurn_duplicate", sessionId, { advancementKey });
-        return { status: "duplicate" };
-      }
-      committedTurnKeys.add(advancementKey);
-      if (committedTurnKeys.size > 1024) {
-        committedTurnKeys.delete(committedTurnKeys.values().next().value as string);
-      }
-      diag("commitTurn", sessionId, { advancementKey });
-      return { status: "committed" };
+    // Accepted turns arrive here instead of afterTurn on current OpenClaw.
+    // The server owns the durable receipt, including retry-after-restart safety.
+    async commitTurn(params): Promise<{ status: "committed" | "duplicate" }> {
+      if (!params.advancementKey?.trim()) throw new Error("commitTurn requires advancementKey");
+      const sessionKey = resolveSessionKey(params) ?? params.sessionTarget?.sessionKey;
+      const ovSessionId = openClawSessionToOvStorageId(params.sessionId, sessionKey);
+      const status = await afterTurnOpenVikingSession({
+        advancementKey: params.advancementKey,
+        sessionId: params.sessionId,
+        sessionKey,
+        messages: params.messages,
+        prePromptMessageCount: 0,
+        isHeartbeat: params.isHeartbeat,
+        runtimeContext: { agentId: params.sessionTarget?.agentId, ...params.runtimeContext },
+        tokenBudget: turnBudgets.get(ovSessionId) ?? 128_000,
+        cfg,
+        getClient,
+        logger,
+        resolveAgentId,
+        rememberSessionAgentId,
+        isBypassedSession,
+        diag,
+      });
+      return { status: status ?? "committed" };
     },
 
     async afterTurn(afterTurnParams): Promise<void> {

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -95,6 +95,7 @@ type ToolContext = {
 };
 
 type OpenClawPluginApi = {
+  runtime?: { version?: string };
   pluginConfig?: unknown;
   openVikingTransport?: HttpTransport;
   logger: PluginLogger;

--- a/examples/openclaw-plugin/plugin/openviking-context-engine-registration.ts
+++ b/examples/openclaw-plugin/plugin/openviking-context-engine-registration.ts
@@ -1,4 +1,5 @@
 export type OpenVikingContextEngineRegistrationApi = {
+  runtime?: { version?: string };
   registerContextEngine?: (id: string, factory: () => unknown) => void;
 };
 
@@ -22,6 +23,7 @@ export type OpenVikingContextEngineCreateParams<
   id: string;
   name: string;
   version: string;
+  hostVersion?: string;
   cfg: TCfg;
   logger: TLogger;
   getClient: () => Promise<TClient>;
@@ -80,6 +82,7 @@ export function registerOpenVikingContextEngine<
       id: deps.plugin.id,
       name: deps.plugin.name,
       version: deps.version,
+      hostVersion: deps.api.runtime?.version,
       cfg: deps.cfg,
       logger: deps.logger,
       getClient: deps.getClient,
@@ -92,6 +95,6 @@ export function registerOpenVikingContextEngine<
     return contextEngine;
   });
   deps.logger.info(
-    "openviking: registered context-engine (assemble=archive+active+auto-recall, afterTurn=auto-capture, session→OV id=uuid-or-sha256 + diag/Phase2 options)",
+    "openviking: registered context-engine (assemble=archive+active+auto-recall, commitTurn/legacy afterTurn=auto-capture, session→OV id=uuid-or-sha256 + diag/Phase2 options)",
   );
 }

--- a/examples/openclaw-plugin/services/context-lifecycle-service.ts
+++ b/examples/openclaw-plugin/services/context-lifecycle-service.ts
@@ -122,9 +122,10 @@ export type CompactOpenVikingSessionParams = {
   diag: (stage: string, sessionId: string, data: Record<string, unknown>) => void;
 };
 
-type AfterTurnClient = Pick<OpenVikingClient, "addSessionMessage" | "getSession" | "commitSession" | "getTask">;
+type AfterTurnClient = Pick<OpenVikingClient, "addSessionMessage" | "addSessionTurn" | "getSession" | "commitSession" | "getTask">;
 
 export type AfterTurnOpenVikingSessionParams = {
+  advancementKey?: string;
   sessionId: string;
   sessionKey?: string;
   messages?: AgentMessage[];
@@ -786,6 +787,7 @@ function messageDigest(messages: AgentMessage[], maxCharsPerMsg = 2000): Array<{
 }
 
 export async function afterTurnOpenVikingSession({
+  advancementKey,
   sessionId,
   sessionKey,
   messages: rawMessages,
@@ -800,7 +802,7 @@ export async function afterTurnOpenVikingSession({
   rememberSessionAgentId,
   isBypassedSession,
   diag,
-}: AfterTurnOpenVikingSessionParams): Promise<void> {
+}: AfterTurnOpenVikingSessionParams): Promise<"committed" | "duplicate" | void> {
   if (!cfg.autoCapture) {
     return;
   }
@@ -885,6 +887,8 @@ export async function afterTurnOpenVikingSession({
     const client = await getClient();
     const createdAt = pickLatestCreatedAt(turnMessages);
     const senderRoleId = toRoleId(sender.senderId);
+    const captured: Parameters<OpenVikingClient["addSessionTurn"]>[2] = [];
+    let status: "committed" | "duplicate" = "committed";
     for (const msg of extractedMessages) {
       const ovParts = msg.parts.map((part) => {
         if (part.type === "text") {
@@ -905,20 +909,21 @@ export async function afterTurnOpenVikingSession({
       });
 
       if (ovParts.length > 0) {
-        await client.addSessionMessage(
-          ovSessionId,
-          msg.role,
-          ovParts,
-          undefined,
-          createdAt,
-          resolveOpenVikingMessagePeerId({
-            peerRole: cfg.peer_role ?? "none",
-            role: msg.role,
-            senderPeerId: senderRoleId,
-            assistantPeerId: agentId,
-          }),
-        );
+        const peerId = resolveOpenVikingMessagePeerId({
+          peerRole: cfg.peer_role ?? "none",
+          role: msg.role,
+          senderPeerId: senderRoleId,
+          assistantPeerId: agentId,
+        });
+        if (advancementKey) {
+          captured.push({ role: msg.role, parts: ovParts, created_at: createdAt, peer_id: peerId });
+        } else {
+          await client.addSessionMessage(ovSessionId, msg.role, ovParts, undefined, createdAt, peerId);
+        }
       }
+    }
+    if (advancementKey && captured.length > 0) {
+      status = await client.addSessionTurn(ovSessionId, advancementKey, captured);
     }
 
     const session = await client.getSession(ovSessionId);
@@ -936,7 +941,7 @@ export async function afterTurnOpenVikingSession({
         senderIdFound: sender.found,
         senderId: sender.senderId ?? null,
       });
-      return;
+      return status;
     }
 
     const commitResult = await client.commitSession(ovSessionId, {
@@ -968,6 +973,7 @@ export async function afterTurnOpenVikingSession({
       );
       void pollPhase2ExtractionOutcome(client, commitResult.task_id, logger, ovSessionId);
     }
+    return status;
   } catch (err) {
     logger.warn?.(`openviking: afterTurn failed: ${String(err)}`);
     const sender = extractRuntimeSenderId(runtimeContext);
@@ -976,6 +982,7 @@ export async function afterTurnOpenVikingSession({
       senderIdFound: sender.found,
       senderId: sender.senderId ?? null,
     });
+    if (advancementKey) throw err;
   }
 }
 

--- a/examples/openclaw-plugin/services/context-lifecycle-service.ts
+++ b/examples/openclaw-plugin/services/context-lifecycle-service.ts
@@ -884,9 +884,18 @@ export async function afterTurnOpenVikingSession({
       messages: newMsgFull,
     });
 
+    const senderRoleId = toRoleId(sender.senderId);
+    if (advancementKey && cfg.peer_role === "sender" && !senderRoleId &&
+        extractedMessages.some((message) => message.role === "user")) {
+      // Do not acknowledge a turn under the wrong memory owner. The host must
+      // supply trusted sender context on delivery (including outbox retries).
+      throw new Error(
+        "openviking: peer_role=sender requires a trusted sender identity in commitTurn; " +
+        "this host did not supply one, so the turn remains pending",
+      );
+    }
     const client = await getClient();
     const createdAt = pickLatestCreatedAt(turnMessages);
-    const senderRoleId = toRoleId(sender.senderId);
     const captured: Parameters<OpenVikingClient["addSessionTurn"]>[2] = [];
     let status: "committed" | "duplicate" = "committed";
     for (const msg of extractedMessages) {

--- a/examples/openclaw-plugin/tests/ut/client.test.ts
+++ b/examples/openclaw-plugin/tests/ut/client.test.ts
@@ -794,3 +794,21 @@ describe("OpenVikingClient canonical namespace policy", () => {
     expect(body).not.toHaveProperty("role_id");
   });
 });
+
+describe("accepted turn delivery", () => {
+  it("sends the stable key and accepts a durable duplicate receipt", async () => {
+    const transport = vi.fn().mockResolvedValue(okResponse({ status: "duplicate" }));
+    const client = new OpenVikingClient("http://127.0.0.1:1933", "", "agent", 5000, "", "", undefined, false, true, { transport });
+    const messages = [{ role: "user", parts: [{ type: "text" as const, text: "hello" }] }];
+    await expect(client.addSessionTurn("session", "key", messages)).resolves.toBe("duplicate");
+    expect(transport.mock.calls[0][0]).toBe("http://127.0.0.1:1933/api/v1/sessions/session/turns");
+    expect(JSON.parse(String(transport.mock.calls[0][1].body))).toEqual({ advancement_key: "key", messages });
+  });
+
+  it("does not fall back to message POSTs on an older server", async () => {
+    const transport = vi.fn().mockResolvedValue(new Response('{"detail":"Not Found"}', { status: 404 }));
+    const client = new OpenVikingClient("http://127.0.0.1:1933", "", "agent", 5000, "", "", undefined, false, true, { transport });
+    await expect(client.addSessionTurn("session", "key", [])).rejects.toThrow();
+    expect(transport).toHaveBeenCalledTimes(1);
+  });
+});

--- a/examples/openclaw-plugin/tests/ut/context-engine-afterTurn.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-afterTurn.test.ts
@@ -61,6 +61,7 @@ function makeEngine(opts?: {
     id: "openviking",
     name: "Test Engine",
     version: "test",
+    hostVersion: "2026.5.27",
     cfg,
     logger,
     getClient,

--- a/examples/openclaw-plugin/tests/ut/context-engine-commit-turn.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-commit-turn.test.ts
@@ -4,9 +4,9 @@ import { memoryOpenVikingConfigSchema } from "../../config.js";
 import { createMemoryOpenVikingContextEngine } from "../../context-engine.js";
 import { openClawSessionToOvStorageId } from "../../routing/identity-routing.js";
 
-function makeEngine(client: Record<string, unknown>, overrides: Record<string, unknown> = {}) {
+function makeEngine(client: Record<string, unknown>, overrides: Record<string, unknown> = {}, hostVersion: string | undefined = "2026.9.3") {
   return createMemoryOpenVikingContextEngine({
-    id: "openviking", name: "OpenViking", version: "test",
+    id: "openviking", name: "OpenViking", version: "test", hostVersion,
     cfg: memoryOpenVikingConfigSchema.parse({ mode: "remote", baseUrl: "http://127.0.0.1:1933", ...overrides }),
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     getClient: vi.fn().mockResolvedValue(client as unknown as OpenVikingClient),
@@ -45,7 +45,7 @@ describe("accepted-turn capture", () => {
     expect(c.addSessionMessage).not.toHaveBeenCalled();
   });
 
-  it("preserves sender identity from a host runtime context", async () => {
+  it("preserves explicitly supplied trusted sender context (not supplied by 2026.9.3)", async () => {
     const c = client();
     await makeEngine(c, { peer_role: "sender" }).commitTurn({
       ...turn, runtimeContext: { senderId: "alice" },
@@ -54,6 +54,79 @@ describe("accepted-turn capture", () => {
       expect.objectContaining({ role: "user", peer_id: "alice" }),
       expect.objectContaining({ role: "assistant" }),
     ]);
+  });
+
+  // 2026.8.1 tool-result-context-guard calls afterTurn at loop checkpoints;
+  // context-engine-turn-outbox later supplies the entire accepted turn.
+  it.each(["2026.8.1", "2026.8.1-1", "2026.9.3"])(
+    "captures a tool turn once when %s calls both hooks", async (hostVersion) => {
+      const c = client();
+      const engine = makeEngine(c, {}, hostVersion);
+      const messages = [
+        { role: "user", content: "Check my saved color." },
+        { role: "assistant", content: [{ type: "toolCall", id: "tool-1", name: "lookup", arguments: {} }] },
+        { role: "toolResult", toolCallId: "tool-1", content: [{ type: "text", text: "cobalt" }] },
+        { role: "assistant", content: [{ type: "text", text: "Your color is cobalt." }] },
+      ];
+      await engine.afterTurn!({ ...turn, sessionFile: "", messages: messages.slice(0, 3), prePromptMessageCount: 0 });
+      expect(c.addSessionMessage).not.toHaveBeenCalled();
+      expect(c.getSession).not.toHaveBeenCalled();
+      await expect(engine.commitTurn({ ...turn, messages })).resolves.toEqual({ status: "committed" });
+      expect(c.addSessionTurn).toHaveBeenCalledTimes(1);
+      expect(c.addSessionTurn.mock.calls[0][2]).toHaveLength(3);
+      // Even an extra finalization hook cannot write the accepted turn again.
+      await engine.afterTurn!({ ...turn, sessionFile: "", messages, prePromptMessageCount: 3 });
+      expect(c.addSessionMessage).not.toHaveBeenCalled();
+    },
+  );
+
+  it("retains ordinary capture on hosts before accepted-turn delivery", async () => {
+    const c = client();
+    const engine = makeEngine(c, {}, "2026.7.31");
+    await engine.afterTurn!({ ...turn, sessionFile: "", prePromptMessageCount: 0 });
+    expect(c.addSessionMessage).toHaveBeenCalledTimes(2);
+    expect(c.addSessionTurn).not.toHaveBeenCalled();
+    await expect(engine.commitTurn(turn)).rejects.toThrow("legacy OpenClaw host");
+  });
+
+  it.each(["", "unknown"])("does not guess the capture path for host version %j", async (version) => {
+    const c = client();
+    const engine = makeEngine(c, {}, version);
+    await expect(engine.afterTurn!({ ...turn, sessionFile: "", prePromptMessageCount: 0 }))
+      .rejects.toThrow("runtime.version");
+    expect(c.addSessionMessage).not.toHaveBeenCalled();
+    // An actual commitTurn delivery is authoritative and can safely use receipts.
+    await expect(engine.commitTurn(turn)).resolves.toEqual({ status: "committed" });
+  });
+
+  // Exact identity shape from published 2026.9.3 context-engine-turn-outbox:
+  // sessionTarget has agent/session identifiers, but no runtimeContext/senderId.
+  it("retains a sender-scoped turn instead of silently writing self-owned messages", async () => {
+    const c = client();
+    const delivered = { ...turn, sessionTarget: { agentId: "main", sessionKey: turn.sessionKey } };
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const engine = makeEngine(c, { peer_role: "sender" });
+      await expect(engine.commitTurn(delivered)).rejects.toThrow("trusted sender identity");
+    }
+    expect(c.addSessionTurn).not.toHaveBeenCalled();
+    expect(c.addSessionMessage).not.toHaveBeenCalled();
+    expect(c.getSession).not.toHaveBeenCalled();
+  });
+
+  it.each(["", "   ", "@#$"])("rejects unusable sender identity %j before writing", async (senderId) => {
+    const c = client();
+    await expect(makeEngine(c, { peer_role: "sender" }).commitTurn({ ...turn, runtimeContext: { senderId } }))
+      .rejects.toThrow("trusted sender identity");
+    expect(c.addSessionTurn).not.toHaveBeenCalled();
+  });
+
+  it.each(["none", "assistant"])("accepts real host identity with peer_role=%s", async (peer_role) => {
+    const c = client();
+    await expect(makeEngine(c, { peer_role }).commitTurn({ ...turn, sessionTarget: { agentId: "main" } }))
+      .resolves.toEqual({ status: "committed" });
+    const messages = c.addSessionTurn.mock.calls[0][2];
+    expect(messages[0].peer_id).toBeUndefined();
+    expect(messages[1].peer_id).toBe(peer_role === "assistant" ? "agent" : undefined);
   });
 
   it("uses the server receipt after an engine restart", async () => {
@@ -86,6 +159,8 @@ describe("accepted-turn capture", () => {
 
   it.each([
     [{ autoCapture: false }, {}],
+    [{ autoCapture: false, peer_role: "sender" }, {}],
+    [{ peer_role: "sender" }, { isHeartbeat: true }],
     [{}, { isHeartbeat: true }],
     [{ bypassSessionPatterns: ["agent:main:explicit:*"] }, {}],
   ])("preserves capture exclusions %j %j", async (cfg, extra) => {

--- a/examples/openclaw-plugin/tests/ut/context-engine-commit-turn.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-commit-turn.test.ts
@@ -1,37 +1,97 @@
 import { describe, expect, it, vi } from "vitest";
-
 import type { OpenVikingClient } from "../../client.js";
 import { memoryOpenVikingConfigSchema } from "../../config.js";
 import { createMemoryOpenVikingContextEngine } from "../../context-engine.js";
+import { openClawSessionToOvStorageId } from "../../routing/identity-routing.js";
 
-function makeEngine() {
-  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+function makeEngine(client: Record<string, unknown>, overrides: Record<string, unknown> = {}) {
   return createMemoryOpenVikingContextEngine({
-    id: "openviking",
-    name: "Context Engine (OpenViking)",
-    version: "test",
-    cfg: memoryOpenVikingConfigSchema.parse({ mode: "remote", baseUrl: "http://127.0.0.1:1933" }),
-    logger,
-    getClient: vi.fn().mockResolvedValue({} as OpenVikingClient),
+    id: "openviking", name: "OpenViking", version: "test",
+    cfg: memoryOpenVikingConfigSchema.parse({ mode: "remote", baseUrl: "http://127.0.0.1:1933", ...overrides }),
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    getClient: vi.fn().mockResolvedValue(client as unknown as OpenVikingClient),
     resolveAgentId: vi.fn(() => "agent"),
   });
 }
 
-// OpenClaw >=2026.8.1 degrades the engine to "legacy" every turn unless both
-// transcript semantics are declared and commitTurn exists.
-describe("context-engine durable turn contract (OpenClaw 2026.8.1)", () => {
-  it("declares transcript semantics", () => {
-    expect(makeEngine().info.transcriptSemantics).toEqual({
-      currentTurnFence: "before-current-turn-entry-v1",
-      turnAdvancementIdempotency: "atomic-idempotent-v1",
-    });
+const turn = {
+  advancementKey: "accepted-1", sessionId: "s", sessionKey: "agent:main:explicit:s",
+  messages: [
+    { role: "user", content: "My preferred color is cobalt." },
+    { role: "assistant", content: [{ type: "text", text: "Acknowledged." }] },
+  ],
+};
+
+function client() {
+  return {
+    addSessionTurn: vi.fn().mockResolvedValue("committed"),
+    addSessionMessage: vi.fn(),
+    getSession: vi.fn().mockResolvedValue({ pending_tokens: 0 }),
+    commitSession: vi.fn().mockResolvedValue({ status: "accepted" }),
+  };
+}
+
+describe("accepted-turn capture", () => {
+  it("captures the whole accepted turn without an afterTurn callback", async () => {
+    const c = client();
+    const engine = makeEngine(c);
+    expect(engine.info.transcriptSemantics?.turnAdvancementIdempotency).toBe("atomic-idempotent-v1");
+    await expect(engine.commitTurn(turn)).resolves.toEqual({ status: "committed" });
+    expect(c.addSessionTurn).toHaveBeenCalledWith(
+      openClawSessionToOvStorageId(turn.sessionId, turn.sessionKey), turn.advancementKey,
+      [expect.objectContaining({ role: "user", parts: [{ type: "text", text: "My preferred color is cobalt." }] }),
+       expect.objectContaining({ role: "assistant", parts: [{ type: "text", text: "Acknowledged." }] })],
+    );
+    expect(c.addSessionMessage).not.toHaveBeenCalled();
   });
 
-  it("commitTurn is idempotent per advancementKey", async () => {
-    const engine = makeEngine();
-    const params = { advancementKey: "k1", sessionId: "s", messages: [] };
-    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "committed" });
-    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "duplicate" });
-    await expect(engine.commitTurn({ ...params, advancementKey: "k2" })).resolves.toEqual({ status: "committed" });
+  it("preserves sender identity from a host runtime context", async () => {
+    const c = client();
+    await makeEngine(c, { peer_role: "sender" }).commitTurn({
+      ...turn, runtimeContext: { senderId: "alice" },
+    });
+    expect(c.addSessionTurn.mock.calls[0][2]).toEqual([
+      expect.objectContaining({ role: "user", peer_id: "alice" }),
+      expect.objectContaining({ role: "assistant" }),
+    ]);
+  });
+
+  it("uses the server receipt after an engine restart", async () => {
+    const c = client();
+    c.addSessionTurn.mockResolvedValueOnce("committed").mockResolvedValue("duplicate");
+    await expect(makeEngine(c).commitTurn(turn)).resolves.toEqual({ status: "committed" });
+    await expect(makeEngine(c).commitTurn(turn)).resolves.toEqual({ status: "duplicate" });
+  });
+
+  it("propagates delivery failures so the host retains the turn for retry", async () => {
+    const c = client();
+    c.addSessionTurn.mockRejectedValueOnce(new Error("lost response"));
+    const engine = makeEngine(c);
+    await expect(engine.commitTurn(turn)).rejects.toThrow("lost response");
+    expect(c.commitSession).not.toHaveBeenCalled();
+    await expect(engine.commitTurn(turn)).resolves.toEqual({ status: "committed" });
+    expect(c.addSessionTurn.mock.calls[0]).toEqual(c.addSessionTurn.mock.calls[1]);
+  });
+
+  it("retries auto-commit failure without falling back to message POSTs", async () => {
+    const c = client();
+    c.getSession.mockResolvedValue({ pending_tokens: 10 });
+    c.commitSession.mockRejectedValueOnce(new Error("commit failed"));
+    const engine = makeEngine(c, { commitTokenThresholdRatio: 0 });
+    await expect(engine.commitTurn(turn)).rejects.toThrow("commit failed");
+    c.addSessionTurn.mockResolvedValue("duplicate");
+    await expect(engine.commitTurn(turn)).resolves.toEqual({ status: "duplicate" });
+    expect(c.addSessionMessage).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [{ autoCapture: false }, {}],
+    [{}, { isHeartbeat: true }],
+    [{ bypassSessionPatterns: ["agent:main:explicit:*"] }, {}],
+  ])("preserves capture exclusions %j %j", async (cfg, extra) => {
+    const c = client();
+    await makeEngine(c, cfg).commitTurn({ ...turn, ...extra });
+    expect(c.addSessionTurn).not.toHaveBeenCalled();
+    expect(c.getSession).not.toHaveBeenCalled();
   });
 });

--- a/examples/openclaw-plugin/tests/ut/plugin-normal-flow-real-server.test.ts
+++ b/examples/openclaw-plugin/tests/ut/plugin-normal-flow-real-server.test.ts
@@ -182,6 +182,7 @@ describe("plugin normal flow with healthy backend", () => {
     let contextEngineFactory: (() => unknown) | null = null;
 
     plugin.register({
+      runtime: { version: "2026.5.27" },
       logger: {
         debug: () => {},
         error: () => {},

--- a/examples/openclaw-plugin/tests/ut/plugin-registration.test.ts
+++ b/examples/openclaw-plugin/tests/ut/plugin-registration.test.ts
@@ -34,6 +34,7 @@ function withOpenVikingEnv<T>(
 function createPluginApi(pluginConfig: Record<string, unknown>) {
   return {
     pluginConfig,
+    runtime: { version: "2026.8.1" },
     logger: {
       info: vi.fn(),
       warn: vi.fn(),
@@ -86,6 +87,18 @@ describe("plugin registration", () => {
         expect(api.registerContextEngine).toHaveBeenCalledWith("openviking", expect.any(Function));
       },
     );
+  });
+
+  it("passes the host runtime version to the registered engine", async () => {
+    const api = createPluginApi({ mode: "remote", baseUrl: "http://127.0.0.1:1", autoRecall: false });
+    contextEnginePlugin.register(api as any);
+    const engine = api.registerContextEngine.mock.calls[0][1]();
+    // Would try a message POST if registration lost the host version.
+    await expect(engine.afterTurn({
+      sessionId: "s", sessionFile: "", prePromptMessageCount: 0,
+      messages: [{ role: "user", content: "hello" }],
+    })).resolves.toBeUndefined();
+    expect(api.logger.error).not.toHaveBeenCalled();
   });
 
   it("registers the feature-gates Gateway RPC when Gateway methods are available", () => {

--- a/openviking/server/routers/sessions.py
+++ b/openviking/server/routers/sessions.py
@@ -166,6 +166,15 @@ class BatchAddMessageRequest(BaseModel):
     telemetry: TelemetryRequest = False
 
 
+class AddTurnRequest(BaseModel):
+    """An accepted harness turn with a stable delivery key."""
+
+    advancement_key: str = Field(..., min_length=1, max_length=512)
+    messages: List[AddMessageRequest] = Field(..., min_length=1, max_length=20_000)
+
+    model_config = {"extra": "forbid"}
+
+
 class UsedRequest(BaseModel):
     """Request model for recording usage."""
 
@@ -830,6 +839,34 @@ async def batch_add_messages(
         fn=_batch_add,
     )
     return Response(status="ok", result=execution.result, telemetry=execution.telemetry)
+
+
+@router.post("/{session_id}/turns")
+async def add_turn(
+    request: AddTurnRequest,
+    session_id: str = Path(..., description="Session ID"),
+    _ctx: RequestContext = Depends(get_session_request_context),
+):
+    """Durably accept a turn once; retries survive restarts and session commits."""
+    service = get_service()
+    session = await service.sessions.get(session_id, _ctx, auto_create=True)
+    specs = [
+        {
+            "role": message.role,
+            "parts": _resolve_message_parts(message, _ctx),
+            "peer_id": message.peer_id,
+            "created_at": message.created_at,
+            "turn_id": message.turn_id,
+            "message_kind": message.message_kind,
+            "source_message_ids": message.source_message_ids,
+        }
+        for message in request.messages
+    ]
+    status = await session.add_turn_async(specs, request.advancement_key)
+    await service.sessions.maybe_schedule_auto_commit(
+        session_id, _ctx, reason_hint="message_write", session=session
+    )
+    return Response(status="ok", result={"status": status, "session_id": session_id})
 
 
 @router.post("/{session_id}/used")

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -1316,43 +1316,53 @@ class Session:
             session_path, timeout_secs=_SESSION_PHASE1_LOCK_TIMEOUT_SECONDS
         )
         try:
-            live_messages_missing = False
-            try:
-                self._messages = await self._read_live_messages_strict()
-            except Exception as exc:
-                if not _is_storage_not_found(exc):
-                    raise
-                self._messages = []
-                live_messages_missing = True
-            in_memory_meta = self._meta
-            try:
-                meta_content = await self._viking_fs.read_file(
-                    f"{self._session_uri}/.meta.json",
-                    ctx=self.ctx,
-                )
-                self._meta = SessionMeta.from_dict(json.loads(meta_content))
-            except Exception:
-                # Legacy/malformed metadata must not prevent an otherwise safe
-                # append. Message correctness remains rooted in messages.jsonl.
-                self._meta = in_memory_meta
-
-            await self._apply_appended_messages_to_state(messages)
-            batch_content = "".join(message.to_jsonl() + "\n" for message in messages)
-            if live_messages_missing:
-                await self._viking_fs.write_file(
-                    f"{self._session_uri}/messages.jsonl",
-                    batch_content,
-                    ctx=self.ctx,
-                )
-            else:
-                await self._viking_fs.append_file(
-                    f"{self._session_uri}/messages.jsonl",
-                    batch_content,
-                    ctx=self.ctx,
-                )
-            await self._save_meta()
+            await self._append_messages_locked(messages)
         finally:
             await self._viking_fs._async_agfs.pathlock_release(lease)
+
+    async def _append_messages_locked(self, messages: List[Message]) -> None:
+        """Append while the caller holds the session path lock."""
+        live_messages_missing = False
+        try:
+            self._messages = await self._read_live_messages_strict()
+        except Exception as exc:
+            if not _is_storage_not_found(exc):
+                raise
+            self._messages = []
+            live_messages_missing = True
+        in_memory_meta = self._meta
+        try:
+            meta_content = await self._viking_fs.read_file(
+                f"{self._session_uri}/.meta.json",
+                ctx=self.ctx,
+            )
+            self._meta = SessionMeta.from_dict(json.loads(meta_content))
+        except Exception:
+            # Legacy/malformed metadata must not prevent an otherwise safe
+            # append. Message correctness remains rooted in messages.jsonl.
+            self._meta = in_memory_meta
+
+        await self._apply_appended_messages_to_state(messages)
+        batch_content = "".join(message.to_jsonl() + "\n" for message in messages)
+        if live_messages_missing:
+            await self._viking_fs.write_file(
+                f"{self._session_uri}/messages.jsonl",
+                batch_content,
+                ctx=self.ctx,
+            )
+        else:
+            await self._viking_fs.append_file(
+                f"{self._session_uri}/messages.jsonl",
+                batch_content,
+                ctx=self.ctx,
+            )
+        await self._save_meta()
+
+    async def add_turn_async(self, messages_spec: List[dict], advancement_key: str) -> str:
+        """Persist one accepted harness turn, idempotently across worker restarts."""
+        from openviking.session.turn_ingestion import append_turn
+
+        return await append_turn(self, messages_spec, advancement_key)
 
     async def _apply_appended_messages_to_state(self, messages: List[Message]) -> None:
         """Update in-memory counters after an authoritative root reload."""

--- a/openviking/session/turn_ingestion.py
+++ b/openviking/session/turn_ingestion.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Accepted-turn receipts, serialized by the existing session append/commit lock."""
+
+import hashlib
+import json
+import re
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+from openviking.message import Message
+from openviking_cli.exceptions import FailedPreconditionError, InvalidArgumentError
+
+if TYPE_CHECKING:
+    from openviking.session.session import Session
+
+
+async def append_turn(session: "Session", messages_spec: list[dict], advancement_key: str) -> str:
+    from openviking.session.session import (
+        _SESSION_PHASE1_LOCK_TIMEOUT_SECONDS,
+        _is_storage_not_found,
+    )
+
+    if not isinstance(advancement_key, str) or not advancement_key or len(advancement_key) > 512:
+        raise InvalidArgumentError("advancement_key must contain 1 to 512 characters")
+    fs = session._viking_fs
+    if not messages_spec or len(messages_spec) > 20_000:
+        raise InvalidArgumentError("Accepted turns require 1 to 20000 messages")
+    if fs is None:
+        raise FailedPreconditionError("Accepted turns require durable session storage")
+    canonical = [
+        {**spec, "parts": [asdict(part) for part in spec["parts"]]} for spec in messages_spec
+    ]
+    fingerprint = hashlib.sha256(
+        json.dumps(canonical, sort_keys=True, ensure_ascii=False).encode()
+    ).hexdigest()
+    key_hash = hashlib.sha256(advancement_key.encode()).hexdigest()
+    receipt_uri = f"{session.uri}/.turn-{key_hash}.json"
+    path = fs._uri_to_path(session.uri, ctx=session.ctx)
+    lease = await fs._async_agfs.pathlock_acquire_exact(
+        path, timeout_secs=_SESSION_PHASE1_LOCK_TIMEOUT_SECONDS
+    )
+    try:
+        recovered_total = None
+        try:
+            receipt = json.loads(await fs.read_file(receipt_uri, ctx=session.ctx))
+        except Exception as exc:
+            if not _is_storage_not_found(exc):
+                raise
+            receipt = None
+        if receipt is not None:
+            if receipt.get("fingerprint") != fingerprint:
+                raise InvalidArgumentError(
+                    "advancement_key was already used for different messages"
+                )
+            if receipt.get("state") == "committed":
+                return "duplicate"
+            if receipt.get("state") != "pending":
+                raise FailedPreconditionError("Invalid accepted-turn receipt")
+            messages = [Message.from_dict(item) for item in receipt["messages"]]
+            # A lost append/receipt response must not append again. Commits can
+            # move those durable message IDs into archives before this retry.
+            live = await session._read_live_messages_strict()
+            seen = {message.id for message in live}
+            try:
+                history = await fs.ls(f"{session.uri}/history", ctx=session.ctx)
+            except Exception as exc:
+                if not _is_storage_not_found(exc):
+                    raise
+                history = []
+            for item in history:
+                name = item.get("name") if isinstance(item, dict) else item
+                if not isinstance(name, str) or not re.fullmatch(r"archive_\d+", name):
+                    continue
+                seen.update(
+                    message.id
+                    for message in await session._read_archive_messages(
+                        f"{session.uri}/history/{name}"
+                    )
+                )
+            messages = [message for message in messages if message.id not in seen]
+            recovered_total = len(seen) + len(messages)
+        else:
+            messages = session._build_messages(messages_spec)
+            receipt = {
+                "state": "pending",
+                "fingerprint": fingerprint,
+                "messages": [message.to_dict() for message in messages],
+            }
+            # Save generated IDs before appending: recovery reuses the same
+            # messages even when the worker died after storage accepted a write.
+            await fs.write_file(receipt_uri, json.dumps(receipt), ctx=session.ctx)
+        await session._append_messages_locked(messages)
+        # Recompute pending tokens if append succeeded but its metadata write
+        # was interrupted. Normal appends retain their existing fast path.
+        if recovered_total is not None:
+            session._meta.total_message_count = recovered_total
+        await session._rebuild_pending_tokens()
+        await session._save_meta()
+        await fs.write_file(
+            receipt_uri,
+            json.dumps({"state": "committed", "fingerprint": fingerprint}),
+            ctx=session.ctx,
+        )
+        return "committed"
+    finally:
+        await fs._async_agfs.pathlock_release(lease)

--- a/tests/server/test_api_sessions.py
+++ b/tests/server/test_api_sessions.py
@@ -1481,3 +1481,32 @@ async def test_commit_failed_when_summary_fails_does_not_block_next_commit(
     body = resp.json()
     assert body["status"] == "ok"
     assert body["result"]["archived"] is True
+
+
+async def test_accepted_turn_endpoint_retries_and_rejects_key_reuse(
+    client: httpx.AsyncClient, service
+):
+    payload = {
+        "advancement_key": "test-delivery",
+        "messages": [
+            {"role": "user", "content": "Remember cobalt.", "peer_id": "alice"},
+            {"role": "assistant", "content": "Acknowledged.", "peer_id": "assistant"},
+        ],
+    }
+    path = "/api/v1/sessions/accepted-turn-http/turns"
+    first = await client.post(path, json=payload)
+    assert first.status_code == 200, first.text
+    assert first.json()["result"]["status"] == "committed"
+    replay = await client.post(path, json=payload)
+    assert replay.status_code == 200, replay.text
+    assert replay.json()["result"]["status"] == "duplicate"
+    ctx = RequestContext(user=DEFAULT_USER, role=Role.ROOT)
+    session = await service.sessions.get("accepted-turn-http", ctx)
+    assert [message.peer_id for message in session.messages] == ["alice", "assistant"]
+    assert [message.content for message in session.messages] == ["Remember cobalt.", "Acknowledged."]
+    payload["messages"][0]["content"] = "Different message"
+    conflict = await client.post(path, json=payload)
+    assert conflict.status_code == 400, conflict.text
+    invalid = await client.post(path, json={"advancement_key": "", "messages": []})
+    assert invalid.status_code == 400
+    assert invalid.json()["error"]["code"] == "INVALID_ARGUMENT"

--- a/tests/session/test_turn_ingestion.py
+++ b/tests/session/test_turn_ingestion.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+import asyncio
+import json
+
+import pytest
+
+from openviking.message import TextPart
+from openviking_cli.exceptions import InvalidArgumentError
+
+
+def messages(text="My preferred color is cobalt."):
+    return [
+        {"role": "user", "parts": [TextPart(text)]},
+        {"role": "assistant", "parts": [TextPart("Acknowledged.")]},
+    ]
+
+
+async def test_accepted_turn_survives_restart_and_concurrent_delivery(client):
+    a = client(session_id="turn-retry")
+    await a.ensure_exists()
+    b = client(session_id=a.session_id)
+    await b.load()
+    results = await asyncio.gather(
+        a.add_turn_async(messages(), "k"), b.add_turn_async(messages(), "k")
+    )
+    assert sorted(results) == ["committed", "duplicate"]
+    fresh = client(session_id=a.session_id)
+    await fresh.load()
+    assert len(fresh.messages) == 2
+    assert await fresh.add_turn_async(messages(), "k") == "duplicate"
+    with pytest.raises(InvalidArgumentError, match="different messages"):
+        await fresh.add_turn_async(messages("different"), "k")
+    assert len(await fresh._read_live_messages_strict()) == 2
+    assert await fresh.add_turn_async(messages(), "next-key") == "committed"
+    assert len(await fresh._read_live_messages_strict()) == 4
+
+
+@pytest.mark.parametrize("failure_point", ["before_append", "after_append", "receipt"])
+async def test_pending_turn_recovers_interrupted_delivery(client, monkeypatch, failure_point):
+    a = client(session_id=f"pending-turn-{failure_point}")
+    await a.ensure_exists()
+    fs = a._viking_fs
+    if failure_point == "receipt":
+        original = fs.write_file
+
+        async def fail_receipt(uri=None, content=None, **kwargs):
+            if "/.turn-" in uri and json.loads(content)["state"] == "committed":
+                raise OSError("lost receipt write")
+            return await original(uri, content, **kwargs)
+
+        with monkeypatch.context() as patch:
+            patch.setattr(fs, "write_file", fail_receipt)
+            with pytest.raises(OSError, match="lost receipt"):
+                await a.add_turn_async(messages(), "k")
+    elif failure_point == "after_append":
+        original_append = fs.append_file
+
+        async def lost_append_response(*args, **kwargs):
+            await original_append(*args, **kwargs)
+            raise OSError("lost append response")
+
+        with monkeypatch.context() as patch:
+            patch.setattr(fs, "append_file", lost_append_response)
+            with pytest.raises(OSError, match="lost append response"):
+                await a.add_turn_async(messages(), "k")
+    else:
+        with monkeypatch.context() as patch:
+
+            async def fail_append(*args, **kwargs):
+                raise OSError("append unavailable")
+
+            patch.setattr(a, "_append_messages_locked", fail_append)
+            with pytest.raises(OSError, match="append unavailable"):
+                await a.add_turn_async(messages(), "k")
+    fresh = client(session_id=a.session_id)
+    await fresh.load()
+    assert await fresh.add_turn_async(messages(), "k") == "committed"
+    assert len(await fresh._read_live_messages_strict()) == 2
+    assert fresh._meta.total_message_count == 2
+    assert fresh._meta.pending_tokens > 0
+    assert await fresh.add_turn_async(messages(), "k") == "duplicate"
+
+
+async def test_receipt_survives_compaction(client):
+    a = client(session_id="turn-archive")
+    await a.ensure_exists()
+    await a.add_turn_async(messages(), "k")
+    await a.commit_async(
+        memory_policy={
+            "working_memory": {"enabled": False},
+            "self": {"enabled": False},
+            "peer": {"enabled": False},
+        }
+    )
+    fresh = client(session_id=a.session_id)
+    await fresh.load()
+    assert await fresh.add_turn_async(messages(), "k") == "duplicate"
+    assert await fresh._read_live_messages_strict() == []
+    assert len(await fresh._list_archive_refs()) == 1
+
+
+async def test_pending_receipt_recovers_after_compaction_and_other_appends(client, monkeypatch):
+    a = client(session_id="pending-turn-archive")
+    await a.ensure_exists()
+    fs = a._viking_fs
+    original = fs.write_file
+
+    async def fail_receipt(uri=None, content=None, **kwargs):
+        if "/.turn-" in uri and json.loads(content)["state"] == "committed":
+            raise OSError("lost receipt write")
+        return await original(uri, content, **kwargs)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(fs, "write_file", fail_receipt)
+        with pytest.raises(OSError, match="lost receipt"):
+            await a.add_turn_async(messages(), "k")
+    await a.commit_async(
+        memory_policy={
+            "working_memory": {"enabled": False},
+            "self": {"enabled": False},
+            "peer": {"enabled": False},
+        }
+    )
+    await a.add_turn_async(messages("another turn"), "other")
+    fresh = client(session_id=a.session_id)
+    await fresh.load()
+    assert await fresh.add_turn_async(messages(), "k") == "committed"
+    live = await fresh._read_live_messages_strict()
+    assert len(live) == 2
+    assert live[0].parts[0].text == "another turn"
+    assert fresh._meta.total_message_count == 4
+    assert await fresh.add_turn_async(messages(), "k") == "duplicate"
+
+
+async def test_pending_receipt_does_not_ignore_unreadable_history(client, monkeypatch):
+    a = client(session_id="pending-turn-history-error")
+    await a.ensure_exists()
+    with monkeypatch.context() as patch:
+
+        async def fail_append(*args, **kwargs):
+            raise OSError("append unavailable")
+
+        patch.setattr(a, "_append_messages_locked", fail_append)
+        with pytest.raises(OSError, match="append unavailable"):
+            await a.add_turn_async(messages(), "k")
+    with monkeypatch.context() as patch:
+
+        async def fail_ls(*args, **kwargs):
+            raise OSError("history unavailable")
+
+        patch.setattr(a._viking_fs, "ls", fail_ls)
+        with pytest.raises(OSError, match="history unavailable"):
+            await a.add_turn_async(messages(), "k")
+    assert await a._read_live_messages_strict() == []
+    assert await a.add_turn_async(messages(), "k") == "committed"


### PR DESCRIPTION
## Description

OpenClaw 2026.9.3 delivers accepted transcript turns through `commitTurn` and skips `afterTurn` for those turns. The plugin acknowledged `commitTurn` without capturing its messages, so OpenViking had no transcript to compact or extract.

Capture accepted turns before acknowledging delivery. A new `POST /api/v1/sessions/{session_id}/turns` endpoint uses the existing session append/commit lock and durable receipts to make retries safe across plugin/server restarts and session archival. Reusing a delivery key with different messages is rejected. The plugin propagates delivery errors so OpenClaw retains its outbox entry.

The server endpoint is necessary because ordinary message POSTs cannot distinguish a lost response from an uncommitted write. The host runtime version selects one capture path: before 2026.8.1, keep legacy `afterTurn`; on 2026.8.1 and later, capture only through `commitTurn`, even when the host also invokes `afterTurn` during tool loops. Capture exclusions remain in place. An unknown host version cannot use legacy capture because guessing risks duplicate writes.

**Compatibility:** upgrade the server with the plugin when using accepted-turn delivery. Older servers reject the new endpoint; the plugin deliberately avoids a fallback that could duplicate messages. Older OpenClaw hosts before 2026.8.1 keep their existing capture behavior.

**Sender ownership:** `peer_role=sender` requires trusted sender identity on accepted-turn delivery. Published OpenClaw 2026.9.3 omits it. The plugin now rejects such user turns before writing anything and leaves delivery pending, rather than acknowledging self-owned messages. This prevents incorrect attribution; it does not restore sender-scoped capture on that host. Successful sender-scoped delivery requires the host to forward identity on every delivery and retry. Default `peer_role=none` and `peer_role=assistant` remain supported.

## Human Involvement

- [x] A human participated in the implementation or review loop

## Type of Change

- [x] Bug fix
- [x] Documentation update
- [x] Test update

## Testing

Validation ran on Linux AMD64 using published OpenClaw 2026.9.3. The server used this branch's Python code with native libraries from the OpenViking 0.4.19 wheel; the plugin was built from this branch.

- Live: the unchanged `openclaw-openviking-compaction` ovtest case passed: accepted-turn capture, real gateway RPC, extraction, retrieval and tool-free recall. The isolated CLI was configured with its required display-language preference before verification could complete.
- Live restart: an accepted two-message turn returned `duplicate` after restarting the server; the session still contained exactly two messages.
- Plugin/server replay: the 2026.8.1 overlapping hook sequence stored three messages and remained at three after a fresh-engine retry. The 2026.9.3 sender payload was rejected on both deliveries with zero stored messages. Legacy 2026.5.27 capture still stored two messages.
- Plugin: 783 tests passed across 45 files; TypeScript checking and build passed.
- Server: all 8 new regression tests passed, covering concurrent delivery, key conflicts, interrupted append/receipt writes, replay after compaction, metadata recovery, HTTP validation and peer identity preservation.
- Ruff checks passed for the changed Python files.
- Session/API regression comparison: base `00e5e79da` had 96 passes and 7 failures; this branch had 104 passes and the same 7 failures. Both runs used the same temporary fixture adjustment for `MockLocalAGFS` returning `FileNotFoundError` for a missing account settings file. That adjustment is outside this PR.

The seven existing failures concern two working-memory fake-VLM signatures, a legacy session URI alias, and four auto-commit policy/default expectations. They were reproduced on the unchanged base.

## Checklist

- [x] I have added tests that prove my fix is effective
- [x] I have performed a self-review of my code
- [x] I have documented the compatibility requirement
- [x] Tested on Linux
- [ ] All existing tests pass without fixture adjustments (see baseline failures above)
- [ ] The new server endpoint is available in a published release
