### PR TITLE
fix(openclaw): recall from the incoming assembly prompt

### DIFF
--- a/examples/openclaw-plugin/auto-recall.ts
+++ b/examples/openclaw-plugin/auto-recall.ts
@@ -331,6 +331,7 @@ export async function buildAutoRecallContext(params: {
   rawUserTextPreview?: string;
   queryTruncated?: boolean;
   resourceTypes?: RecallResourceType[];
+  dedupTurns?: number;
 }): Promise<{ block?: string; memoryCount: number; estimatedTokens: number }> {
   const { cfg, client, agentId, actorPeerId, queryText, logger, verbose } = params;
   const queryConfig = params.queryConfig;
@@ -373,7 +374,7 @@ export async function buildAutoRecallContext(params: {
           queryExpansion: "auto",
           maxTokens,
           detail: recallPreferAbstract ? "abstract" : undefined,
-          dedupTurns: params.ovSessionId ? AUTO_RECALL_DEDUP_TURNS : undefined,
+          dedupTurns: params.dedupTurns ?? (params.ovSessionId ? AUTO_RECALL_DEDUP_TURNS : undefined),
           peerScope: "actor",
           actorPeerId,
           requestTimeoutMs: cfg.autoRecallTimeoutMs,

--- a/examples/openclaw-plugin/client.ts
+++ b/examples/openclaw-plugin/client.ts
@@ -508,6 +508,7 @@ export class OpenVikingClient {
     };
     const body = {
       ...buildContextSearchBody(contractConfig, { sessionId: options.sessionId }),
+      ...(options.dedupTurns === 0 ? { dedup_turns: 0 } : {}),
       query,
       ...(options.contextType !== undefined ? { context_type: options.contextType } : {}),
       ...(options.detail !== undefined ? { detail: options.detail } : {}),

--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -394,6 +394,7 @@ export function createMemoryOpenVikingContextEngine(params: {
         sessionId: assembleParams.sessionId,
         sessionKey: resolveSessionKey(assembleParams),
         messages: assembleParams.messages,
+        prompt: assembleParams.prompt,
         tokenBudget,
         runtimeContext: assembleParams.runtimeContext,
         isMainAssemble,

--- a/examples/openclaw-plugin/services/context-lifecycle-service.ts
+++ b/examples/openclaw-plugin/services/context-lifecycle-service.ts
@@ -72,6 +72,7 @@ export type AssembleOpenVikingSessionParams = {
   sessionId: string;
   sessionKey?: string;
   messages: AgentMessage[];
+  prompt?: string;
   tokenBudget: number;
   runtimeContext?: Record<string, unknown>;
   isMainAssemble: boolean;
@@ -423,28 +424,96 @@ function isSessionNotFoundError(err: unknown): boolean {
   return errorMessage.includes("[NOT_FOUND]") && errorMessage.includes("Session not found");
 }
 
-export async function assembleOpenVikingSession({
-  sessionId,
-  sessionKey,
-  messages,
-  tokenBudget,
-  runtimeContext,
-  isMainAssemble,
-  cfg,
-  getClient,
-  logger,
-  resolveAgentId,
-  rememberSessionAgentId,
-  isBypassedSession,
-  queryConfigStore,
-  traceRecorder,
-  diag,
-  roughEstimate,
-  messageDigest,
-  extractAgentMessageText,
-  hasAutoRecallBlock,
-  prependRecallToLatestUserMessage,
-}: AssembleOpenVikingSessionParams): Promise<AssembleOpenVikingSessionResult> {
+async function recallForAssemble(
+  params: AssembleOpenVikingSessionParams,
+  recallQuery: ReturnType<typeof prepareRecallQuery>,
+) {
+  const { sessionId, sessionKey, cfg, getClient, resolveAgentId, queryConfigStore, logger, traceRecorder } = params;
+  const ovSessionId = openClawSessionToOvStorageId(sessionId, sessionKey);
+  const sender = extractRuntimeSenderId(params.runtimeContext);
+  const client = await getClient();
+  const routingRef = sessionId ?? sessionKey ?? ovSessionId;
+  const agentId = resolveAgentId(routingRef, sessionKey, ovSessionId);
+  const actorPeerId = resolveOpenVikingActorPeerId({
+    peerRole: cfg.peer_role ?? "none",
+    senderPeerId: sanitizeOpenVikingPeerId(sender.senderId),
+    assistantPeerId: agentId,
+  });
+  const queryConfig = await queryConfigStore?.getEffective({
+    agentId,
+    sessionId,
+    sessionKey,
+    ovSessionId,
+  });
+  return buildAutoRecallContext({
+    cfg,
+    queryConfig,
+    client,
+    agentId,
+    actorPeerId,
+    queryText: recallQuery.query,
+    logger,
+    verbose: (message) => logger.info(message),
+    traceRecorder: traceRecorder as never,
+    sessionId,
+    sessionKey,
+    ovSessionId,
+    queryTruncated: recallQuery.truncated,
+    rawUserTextPreview: recallQuery.query,
+  });
+}
+
+export async function assembleOpenVikingSession(
+  params: AssembleOpenVikingSessionParams,
+): Promise<AssembleOpenVikingSessionResult> {
+  const assembled = await assembleSessionContext(params);
+  // Current OpenClaw supplies the pending turn separately from history. Keep
+  // recalled context out of persisted messages and let the host own that turn.
+  if (
+    !params.isMainAssemble || !params.cfg.autoRecall || !params.prompt ||
+    params.isBypassedSession(params)
+  ) {
+    return assembled;
+  }
+  const query = prepareRecallQuery(params.prompt);
+  if (query.query.length < 5) return assembled;
+
+  try {
+    const recall = await recallForAssemble(params, query);
+    if (!recall.block) return assembled;
+    const systemPromptAddition = [assembled.systemPromptAddition, recall.block].filter(Boolean).join("\n\n");
+    const estimatedTokens = assembled.estimatedTokens
+      + estimateTextTokens(systemPromptAddition)
+      - estimateTextTokens(assembled.systemPromptAddition ?? "");
+    if (estimatedTokens > params.tokenBudget) return assembled;
+    return { ...assembled, systemPromptAddition, estimatedTokens };
+  } catch (err) {
+    params.logger.warn?.(`openviking: auto-recall failed: ${String(err)}`);
+    return assembled;
+  }
+}
+
+async function assembleSessionContext(params: AssembleOpenVikingSessionParams): Promise<AssembleOpenVikingSessionResult> {
+  const {
+    sessionId,
+    sessionKey,
+    messages,
+    tokenBudget,
+    runtimeContext,
+    isMainAssemble,
+    cfg,
+    getClient,
+    logger,
+    resolveAgentId,
+    rememberSessionAgentId,
+    isBypassedSession,
+    diag,
+    roughEstimate,
+    messageDigest,
+    extractAgentMessageText,
+    hasAutoRecallBlock,
+    prependRecallToLatestUserMessage,
+  } = params;
   const latestMessage = messages.at(-1);
   const isTransformContextAssemble = !isMainAssemble;
 
@@ -497,36 +566,7 @@ export async function assembleOpenVikingSession({
     }
 
     try {
-      const client = await getClient();
-      const routingRef = sessionId ?? sessionKey ?? ovSessionId;
-      const agentId = resolveAgentId(routingRef, sessionKey, ovSessionId);
-      const actorPeerId = resolveOpenVikingActorPeerId({
-        peerRole: cfg.peer_role ?? "none",
-        senderPeerId: sanitizeOpenVikingPeerId(sender.senderId),
-        assistantPeerId: agentId,
-      });
-      const queryConfig = await queryConfigStore?.getEffective({
-        agentId,
-        sessionId,
-        sessionKey,
-        ovSessionId,
-      });
-      const recall = await buildAutoRecallContext({
-        cfg,
-        queryConfig,
-        client,
-        agentId,
-        actorPeerId,
-        queryText: recallQuery.query,
-        logger,
-        verbose: (message) => logger.info(message),
-        traceRecorder: traceRecorder as never,
-        sessionId,
-        sessionKey,
-        ovSessionId,
-        queryTruncated: recallQuery.truncated,
-        rawUserTextPreview: recallQuery.query,
-      });
+      const recall = await recallForAssemble(params, recallQuery);
 
       if (!recall.block) {
         return assemblePassthrough({

--- a/examples/openclaw-plugin/services/context-lifecycle-service.ts
+++ b/examples/openclaw-plugin/services/context-lifecycle-service.ts
@@ -460,6 +460,8 @@ async function recallForAssemble(
     ovSessionId,
     queryTruncated: recallQuery.truncated,
     rawUserTextPreview: recallQuery.query,
+    // System additions are transient; the next turn must be able to recall the same URI.
+    dedupTurns: params.isMainAssemble ? 0 : undefined,
   });
 }
 

--- a/examples/openclaw-plugin/tests/ut/client.test.ts
+++ b/examples/openclaw-plugin/tests/ut/client.test.ts
@@ -554,6 +554,17 @@ describe("OpenVikingClient tenant headers (advanced accountId / userId overrides
 });
 
 describe("OpenVikingClient canonical namespace policy", () => {
+  it("sends an explicit zero cooldown instead of inheriting the server default", async () => {
+    const transport = vi.fn().mockResolvedValue(okResponse({ entries: [], rendered: "", stats: {} }));
+    const client = new OpenVikingClient(
+      "http://127.0.0.1:1933", "", "agent", 5000,
+      "", "", undefined, false, true, { transport },
+    );
+    await client.searchContext("What region should I deploy in?", { sessionId: "session", dedupTurns: 0 });
+    const [, init] = transport.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toMatchObject({ session_id: "session", dedup_turns: 0 });
+  });
+
   it("keeps server-assembled context requests aligned with the shared contract", async () => {
     const transport = vi.fn().mockResolvedValue(okResponse({
       entries: [{ uri: "viking://user/memories/events/a.md" }],

--- a/examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts
@@ -93,6 +93,68 @@ function makeEngine(
 }
 
 describe("context-engine assemble()", () => {
+  describe("recall from the separately supplied prompt", () => {
+    const prompt = "what backend language should we use?";
+    const memory = "User prefers Rust for backend tasks.";
+    function mockRecall(client: ReturnType<typeof makeEngine>["client"]) {
+      client.searchContext.mockResolvedValue({
+        entries: [{ uri: "viking://user/default/memories/rust-pref", category: "preferences", text: memory, score: 0.93 }],
+        rendered: `<memory>${memory}</memory>`,
+        stats: { candidates: 1, used_tokens: 18 },
+      });
+    }
+
+    it.each([false, true])("recalls on a fresh session (missing session: %s) without manufacturing a user turn", async (missing) => {
+      const { engine, client } = makeEngine(undefined, { cfgOverrides: { autoRecall: true } });
+      if (missing) client.getSessionContext.mockRejectedValue(new Error("[NOT_FOUND] Session not found"));
+      mockRecall(client);
+      const messages: [] = [];
+      const result = await engine.assemble({ sessionId: "new-session", messages, prompt, availableTools: new Set() });
+      expect(client.searchContext).toHaveBeenCalledWith(prompt, expect.objectContaining({ sessionId: "new-session" }));
+      expect(result.messages).toBe(messages);
+      expect(result.systemPromptAddition).toContain(memory);
+      expect(result.systemPromptAddition).not.toContain(prompt);
+      expect(result.estimatedTokens).toBeGreaterThan(systemPromptTokens(result.systemPromptAddition));
+    });
+
+    it("keeps archive guidance and recalls the current prompt rather than the history tail", async () => {
+      const { engine, client } = makeEngine({
+        latest_archive_overview: "Previously discussed repository setup.",
+        pre_archive_abstracts: [], messages: [], estimatedTokens: 10, stats: makeStats(),
+      }, { cfgOverrides: { autoRecall: true } });
+      mockRecall(client);
+      const messages = [{ role: "user", content: "an unrelated old question" }];
+      const result = await engine.assemble({ sessionId: "archived-session", messages, prompt });
+      expect(client.searchContext).toHaveBeenCalledWith(prompt, expect.anything());
+      expect(result.systemPromptAddition).toContain("Session Context Guide");
+      expect(result.systemPromptAddition).toContain(memory);
+      expect(JSON.stringify(result.messages)).not.toContain(memory);
+      expect(messages).toEqual([{ role: "user", content: "an unrelated old question" }]);
+    });
+
+    it.each([
+      { autoRecall: false, prompt, bypassSessionPatterns: [] },
+      { autoRecall: true, prompt: "", bypassSessionPatterns: [] },
+      { autoRecall: true, prompt: "hi", bypassSessionPatterns: [] },
+      { autoRecall: true, prompt, bypassSessionPatterns: ["agent:*:cron:**"] },
+    ])("respects disabled, empty and bypassed recall: %j", async ({ prompt: currentPrompt, ...cfgOverrides }) => {
+      const { engine, client } = makeEngine(undefined, { cfgOverrides });
+      const result = await engine.assemble({ sessionId: "session", sessionKey: "agent:main:cron:task", messages: [], prompt: currentPrompt });
+      expect(client.searchContext).not.toHaveBeenCalled();
+      expect(result.systemPromptAddition).toBeUndefined();
+    });
+
+    it.each(["no hits", "search failure", "budget exhausted"])("preserves history on %s", async (scenario) => {
+      const { engine, client } = makeEngine(undefined, { cfgOverrides: { autoRecall: true } });
+      if (scenario === "search failure") client.searchContext.mockRejectedValue(new Error("unavailable"));
+      if (scenario === "budget exhausted") mockRecall(client);
+      const messages = [{ role: "assistant", content: "previous answer" }];
+      const result = await engine.assemble({ sessionId: "session", messages, prompt, tokenBudget: scenario === "budget exhausted" ? 1 : 128_000 });
+      expect(result.messages).toBe(messages);
+      expect(result.systemPromptAddition).toBeUndefined();
+    });
+  });
+
   it("prepends auto-recall to the latest user message during transformContext", async () => {
       const { engine, client } = makeEngine(
         {

--- a/examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts
@@ -117,6 +117,37 @@ describe("context-engine assemble()", () => {
       expect(result.estimatedTokens).toBeGreaterThan(systemPromptTokens(result.systemPromptAddition));
     });
 
+    it("recalls another detail from the same memory on a follow-up turn", async () => {
+      const { engine, client } = makeEngine(undefined, { cfgOverrides: { autoRecall: true } });
+      const savedMemory = "Use Rust; deploy in eu-west.";
+      let messageCount = 2;
+      let lastServedAt: number | undefined;
+      client.searchContext.mockImplementation(async (_query, options) => {
+        const cooled = lastServedAt !== undefined && messageCount - lastServedAt < (options.dedupTurns ?? 0);
+        if (cooled) return { entries: [], rendered: "", stats: {} };
+        lastServedAt = messageCount;
+        return {
+          entries: [{ uri: "viking://user/default/memories/development", category: "preferences", text: savedMemory, score: 0.95 }],
+          rendered: `<memory>${savedMemory}</memory>`, stats: {},
+        };
+      });
+      const common = { sessionId: "existing-session", availableTools: new Set<string>() };
+      const messages = [{ role: "user", content: "Hello" }, { role: "assistant", content: "Hello" }];
+      const first = await engine.assemble({ ...common, messages, prompt: "What language should I use?" });
+      expect(first.systemPromptAddition).toContain(savedMemory);
+
+      const followupMessages = [...messages,
+        { role: "user", content: "What language should I use?" },
+        { role: "assistant", content: "Rust." },
+      ];
+      messageCount = followupMessages.length;
+      const second = await engine.assemble({ ...common, messages: followupMessages, prompt: "What region should I deploy in?" });
+      expect(second.systemPromptAddition).toContain("eu-west");
+      expect(second.messages).toBe(followupMessages);
+      expect(JSON.stringify(second.messages)).not.toContain("eu-west");
+      expect(client.searchContext).toHaveBeenLastCalledWith("What region should I deploy in?", expect.objectContaining({ dedupTurns: 0 }));
+    });
+
     it("keeps archive guidance and recalls the current prompt rather than the history tail", async () => {
       const { engine, client } = makeEngine({
         latest_archive_overview: "Previously discussed repository setup.",

--- a/examples/openclaw-plugin/tests/ut/plugin-normal-flow-real-server.test.ts
+++ b/examples/openclaw-plugin/tests/ut/plugin-normal-flow-real-server.test.ts
@@ -288,10 +288,14 @@ describe("plugin normal flow with healthy backend", () => {
       context_type: "memory",
       query_expansion: "auto",
       max_tokens: 1000,
-      dedup_turns: 5,
+      dedup_turns: 0,
       peer_scope: "actor",
     });
     expect(contextSearchBody).not.toHaveProperty("limit");
+    const recallRequests = requests.filter(
+      (entry) => entry.method === "POST" && entry.path === "/api/v1/search/search",
+    );
+    expect(recallRequests.map((entry) => JSON.parse(entry.body ?? "{}").dedup_turns)).toEqual([0, 5]);
     expect(
       requests.some((entry) => entry.method === "GET" && entry.path.startsWith("/api/v1/sessions/session-normal/context")),
     ).toBe(true);


### PR DESCRIPTION
OpenClaw can pass the incoming question as `assemble.prompt` while `messages` contains only prior history. The plugin ignores that prompt and only recalls from a user-message tail during transformContext, so automatic recall can be skipped entirely on a fresh session.

Forward the prompt and reuse the existing recall query, routing, and configuration logic. Return recalled context through `systemPromptAddition`, preserving archive guidance and leaving the pending user turn to OpenClaw. Disabled or bypassed recall, empty queries, failed searches, and insufficient token budget preserve the assembled history. The legacy message-based recall path remains supported.

System additions are transient, so prompt-based recall explicitly sends `dedup_turns: 0` to allow the same memory to be retrieved on a follow-up turn. Preserve the explicit zero in the HTTP request instead of inheriting the server default. Legacy message-based recall retains its existing cooldown.

Validation on Linux VPS with OpenClaw 2026.9.3 and published OpenViking 0.4.19:
- Typecheck, build, and all 787 plugin tests passed. The follow-up-turn and explicit-zero HTTP regression tests both fail on e157103 and pass with the follow-up fix.
- The normal-flow HTTP test verifies prompt recall sends zero and legacy recall still sends five.
- Live ovtest compaction passed (82.3 seconds).

Only the OpenClaw plugin changes; no server API or capture protocol changes. Avoiding repeated searches during deferred tool-loop assembly remains a separate follow-up.

