### PR TITLE
fix(tasks): 修复过期任务文件缺失时反复清理报错

### DIFF
--- a/openviking/service/task_store.py
+++ b/openviking/service/task_store.py
@@ -91,13 +91,17 @@ class PersistentTaskStore:
         return tasks
 
     async def delete(self, task_id: str, *, account_id: str, user_id: Optional[str] = None) -> None:
+        """Delete a task record, succeeding if it has already been removed."""
         if not user_id:
             return
-        await self._agfs.rm(
-            self._task_path(account_id, user_id, task_id),
-            force=True,
-            auto_pathlock=False,
-        )
+        try:
+            await self._agfs.rm(
+                self._task_path(account_id, user_id, task_id),
+                force=True,
+                auto_pathlock=False,
+            )
+        except (AGFSNotFoundError, FileNotFoundError):
+            return
 
     async def _write_task(self, task: Any) -> None:
         account_id = getattr(task, "account_id", None)

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 
 import pytest
 
-from openviking.pyagfs.exceptions import AGFSAlreadyExistsError
+from openviking.pyagfs.exceptions import AGFSAlreadyExistsError, AGFSNotFoundError
 from openviking.server.identity import RequestContext, Role
 from openviking.service.session_service import SessionService
 from openviking.service.task_store import PersistentTaskStore, _task_to_payload
@@ -140,7 +140,9 @@ class _FakeAgfs:
         )
         if self.fail_rm:
             raise OSError("simulated delete failure")
-        self.files.pop(path, None)
+        if path not in self.files:
+            raise AGFSNotFoundError(path)
+        del self.files[path]
         return {"message": "removed", "recursive": recursive, "force": force}
 
 
@@ -524,11 +526,16 @@ async def test_sanitize_preserves_safe_error():
 # ── TTL / Eviction ──
 
 
-async def test_evict_expired_completed(tracker: TaskTracker):
+@pytest.mark.parametrize("already_missing", [False, True])
+async def test_evict_expired_completed(already_missing):
+    agfs = _FakeAgfs()
+    tracker = TaskTracker(store=PersistentTaskStore(agfs))
     t = await tracker.create("session_commit", **_owner_kwargs())
     await tracker.start(t.task_id)
     await tracker.complete(t.task_id, {})
     assert await tracker._store.get(t.task_id, **_owner_kwargs()) is not None
+    if already_missing:
+        agfs.files.clear()
     # Simulate old timestamp (access internal state; get() returns defensive copies)
     tracker._tasks[t.task_id].updated_at = time.time() - tracker.TTL_COMPLETED - 1
     await tracker._evict_expired()


### PR DESCRIPTION
## Description

过期任务文件已经不存在时，清理仍会因 `AGFSNotFoundError` 保留内存记录，并在后续清理轮次重复报错。现在由 `PersistentTaskStore.delete` 将文件不存在视为删除成功，让 TaskTracker 正常移除缓存；其他存储错误仍向上传播，保留后续重试行为。

例如，内存中保留已过期的 `task-1`，对应 JSON 文件已被删除：

- **Before:** 清理后文件不存在、缓存仍保留，每轮清理继续报错。
- **After:** 清理后文件不存在、缓存已移除，后续轮次不再重复清理该任务。

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

无。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- 在任务存储的删除边界处理 `AGFSNotFoundError` 和 `FileNotFoundError`。
- 改写已有过期清理契约测试，覆盖文件存在与已删除两种状态，并让存储替身如实报告缺失文件；保留已有的删除失败后重试测试。

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

改写已有测试，未新增测试函数或文件。缺失文件场景在修复前复现失败，修复后通过。

- `python -m pytest tests/test_task_tracker.py tests/test_task_tracker_concurrency.py -q -o addopts=''`：96 passed。
- 使用真实 RAGFS 绑定连续删除同一任务文件两次，均成功。
- `ruff check`、`ruff format --check`（两个改动文件）及 `git diff --check` 均通过。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

无需文档更新或依赖其他变更。

## Screenshots (if applicable)

不适用。

## Additional Notes

无 API 或配置变更。
