### PR TITLE
ci: include crates changes in build and test path gates

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -148,7 +148,7 @@ jobs:
           git fetch origin ${{ github.base_ref }}
           
           # Define grep pattern for dependency files
-          PATTERN="pyproject\.toml|setup\.py|uv\.lock|src/CMakeLists\.txt|third_party/|\.github/workflows/_build\.yml"
+          PATTERN="pyproject\.toml|setup\.py|uv\.lock|src/CMakeLists\.txt|third_party/|crates/|\.github/workflows/_build\.yml"
           
           # Check for changes
           CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }} HEAD | grep -E "$PATTERN" || true)
@@ -164,7 +164,7 @@ jobs:
 
           # Run the CPU-only cuVS regression suite when the optional backend,
           # its native filter bridge, or its focused tests are modified.
-          CUVS_PATTERN="openviking/storage/vectordb/|openviking/storage/vectordb_adapters/(factory|local_adapter)\.py|openviking_cli/utils/config/vectordb_config\.py|src/|tests/(vectordb/test_cuvs_|benchmark/test_cuvs_)|benchmark/cuvs/|examples/cuvs_smoke\.py|\.github/workflows/_test_lite\.yml"
+          CUVS_PATTERN="crates/|openviking/storage/vectordb/|openviking/storage/vectordb_adapters/(factory|local_adapter)\.py|openviking_cli/utils/config/vectordb_config\.py|src/|tests/(vectordb/test_cuvs_|benchmark/test_cuvs_)|benchmark/cuvs/|examples/cuvs_smoke\.py|\.github/workflows/_test_lite\.yml"
           CUVS_CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }} HEAD | grep -E "$CUVS_PATTERN" || true)
 
           if [ -n "$CUVS_CHANGED_FILES" ]; then


### PR DESCRIPTION
## Description

A `crates/**`-only change can currently bypass every workflow that compiles the Rust code, so a Rust build breakage can land on `main` and stay there until someone notices independently. This recently happened: #4908 introduced a malformed test module in `crates/ragfs/src/lock/provider.rs` that broke the `ragfs` crate, and it took a separate PR (#4925) to repair it because no CI check was triggered by that change.

The existing checks are present but their path gates exclude `crates/`:

- `_test_lite.yml` runs `cargo check -p ragfs-python`, but `pr.yml` only invokes it when `cuvs_changed == 'true'`, and `CUVS_PATTERN` does not include `crates/`
- `_build.yml` (native build + wheel validation) is gated on `deps_changed`, whose `PATTERN` also does not include `crates/`
- `rust-cli.yml` builds only `-p ov_cli`; `ci.yml` runs CodeQL only

This PR adds `crates/` to the two existing patterns so the workflows that already own Rust validation actually run for Rust changes. No new workflow or job is introduced.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

None.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- `.github/workflows/pr.yml`: add `crates/` to `PATTERN` (gates `_build.yml`) and to `CUVS_PATTERN` (gates `_test_lite.yml`, which runs `cargo check -p ragfs-python`)

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [x] macOS
  - [ ] Windows

Validation for a path-gate change is the gate logic itself. Simulating a `crates/`-only diff against the modified pattern:

```
$ FILES="crates/ragfs/src/lock/provider.rs"
$ echo "$FILES" | grep -E 'pyproject\.toml|setup\.py|uv\.lock|src/CMakeLists\.txt|third_party/|crates/|\.github/workflows/_build\.yml'
crates/ragfs/src/lock/provider.rs        # _build.yml now runs

$ echo "$FILES" | grep -E 'crates/|openviking/storage/vectordb/|...'
crates/ragfs/src/lock/provider.rs        # _test_lite.yml (cargo check -p ragfs-python) now runs
```

`cargo check -p ragfs-python` passes on current `main` (after #4925) and the modified workflow parses (`python3 -c "import yaml; yaml.safe_load(...)"`). No Python changes, so ruff/mypy are not applicable.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Scope note: the `_test_lite.yml` job also runs cuVS regression tests, so a Rust-only change will run slightly more than strictly needed. I kept the change to the existing gate patterns rather than adding a dedicated Rust job, following the "reuse the existing owner of a rule" guidance — happy to restructure into a focused Rust check job if maintainers prefer.

Area owners per CONTRIBUTING routing: @yufeng201 / @ZaynJarvis (.github/workflows)
