### PR TITLE
fix(startup): 避免预置目录摘要格式异常阻断启动

### DIFF
--- a/openviking/core/directories.py
+++ b/openviking/core/directories.py
@@ -19,6 +19,7 @@ from openviking.core.namespace import (
     user_space_fragment,
 )
 from openviking.server.identity import RequestContext
+from openviking.storage.abstract_overview import AbstractOverviewFormatError
 from openviking.storage.queuefs.embedding_msg_converter import EmbeddingMsgConverter
 from openviking.storage.vector_ids import vector_record_id
 
@@ -304,7 +305,18 @@ class DirectoryInitializer:
         from openviking_cli.utils.logger import get_logger
 
         logger = get_logger(__name__)
-        if await self._check_agfs_files_exist(target.uri, ctx=target.ctx):
+        try:
+            directory_exists = await self._check_agfs_files_exist(target.uri, ctx=target.ctx)
+        except AbstractOverviewFormatError as exc:
+            logger.warning(
+                "[VikingFS] Directory %s (account=%s) has an invalid abstract; "
+                "preserving existing contents: %s",
+                target.uri,
+                target.ctx.account_id,
+                exc,
+            )
+            return False
+        if directory_exists:
             logger.debug(f"[VikingFS] Directory {target.uri} already exists")
             return False
         logger.debug(f"[VikingFS] Creating directory: {target.uri} for scope {target.scope}")

--- a/tests/unit/test_directory_initializer.py
+++ b/tests/unit/test_directory_initializer.py
@@ -1,3 +1,5 @@
+from unittest.mock import AsyncMock
+
 import pytest
 
 from openviking.core.directories import PRESET_DIRECTORIES, DirectoryInitializer
@@ -7,6 +9,7 @@ from openviking.core.namespace import (
     may_include_hidden_actor_peers,
 )
 from openviking.server.identity import RequestContext, Role
+from openviking.storage.abstract_overview import body_for_preview
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -30,7 +33,7 @@ class _FakeVikingFS:
     async def abstract(self, uri, ctx):
         if uri not in self.contexts:
             raise FileNotFoundError(uri)
-        return self.contexts[uri]["abstract"]
+        return body_for_preview(self.contexts[uri]["abstract"])
 
     async def write_context(self, uri, abstract, overview, is_leaf, ctx):
         if ctx.actor_peer_id and may_include_hidden_actor_peers(uri, ctx):
@@ -43,7 +46,7 @@ class _FakeVikingFS:
 
 
 @pytest.mark.asyncio
-async def test_initialize_account_workspace_batches_preset_directories():
+async def test_initialize_account_workspace_batches_preset_directories(monkeypatch):
     vikingdb = _FakeVikingDB()
     viking_fs = _FakeVikingFS()
     initializer = DirectoryInitializer(vikingdb, viking_fs=viking_fs)
@@ -66,11 +69,21 @@ async def test_initialize_account_workspace_batches_preset_directories():
     assert len(vikingdb.get_calls[0][0]) == 2 * len(vectorized_uris)
     assert len(vikingdb.embedding_messages) == 2 * len(vectorized_uris)
 
+    malformed_abstract = "---\ndirectory: viking://resources/\n"
+    viking_fs.contexts["viking://resources"]["abstract"] = malformed_abstract
+
     second_account_count, second_user_count = await initializer.initialize_account_workspace(ctx)
 
     assert (second_account_count, second_user_count) == (0, 0)
+    assert viking_fs.contexts["viking://resources"]["abstract"] == malformed_abstract
     assert set(viking_fs.contexts) == expected_uris
     assert len(vikingdb.get_calls) == 1
+
+    storage_error = PermissionError("storage access denied")
+    monkeypatch.setattr(viking_fs, "abstract", AsyncMock(side_effect=storage_error))
+    with pytest.raises(PermissionError) as exc_info:
+        await initializer.initialize_account_workspace(ctx)
+    assert exc_info.value is storage_error
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

预置目录存在但摘要格式异常时，目录初始化会把 `AbstractOverviewFormatError` 传到服务启动流程，导致整个服务退出。

例如 `viking://resources/.abstract.md` 的内容为 `---\ndirectory: viking://resources/\n`，缺少 frontmatter 结束标记：修改前，初始化报错退出；修改后，记录账号、URI 和格式错误，保留目录及原始摘要，继续初始化其他预置目录。

仅在目录初始化边界处理这一类异常。摘要读取仍使用原有解析规则，存储访问等其他错误仍正常抛出，目录创建和已有目录跳过规则保持不变。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

无。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- 预置目录初始化只捕获 `AbstractOverviewFormatError`，输出包含账号、URI 和原因的告警，并跳过已有目录的重建。
- 改写已有目录初始化契约测试，覆盖异常摘要不阻断初始化、原内容不被覆盖，以及存储权限错误继续传播。

## Testing

修复前，修改后的现有契约测试复现相同的 frontmatter 异常；修复后，目录初始化测试文件中的 2 个测试均通过。未新增测试函数或测试文件。

- `python -m pytest -q --noconftest -o addopts='' tests/unit/test_directory_initializer.py`：2 passed。
- `ruff check`、`ruff format --check`（两个变更文件）以及 `git diff --check` 均通过。

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

无配置或公开 API 变更，无依赖变更。本 PR 隔离摘要格式问题对启动的影响，不修复或覆盖异常摘要内容。
