### PR TITLE
docs(readme): add research publications and their OpenViking relevance

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,14 +229,14 @@ The two editions below answer "who operates it and where it runs", not "can I us
 
 ## Research
 
-OpenViking open-sources a subset of the core capabilities described in the VikingMem paper:
+**Memory that evolves with your agent.** VikingMem develops an event-driven approach to extracting, updating, and consolidating long-term memory, giving stateful agents a way to retain useful experience as interactions accumulate. OpenViking open-sources a subset of these core capabilities.
 
 > **VikingMem: A Memory Base Management System for Stateful LLM-based Applications**
 > Jiajie Fu, Junwen Chen, Mengzhao Wang, Aoxiang He, Maojia Sheng, Xiangyu Ke, Yifan Zhu, and Yunjun Gao.
 > arXiv:2605.29640, 2026. Presented at VLDB 2026 in September.
 > 📄 [Read the paper on arXiv](https://arxiv.org/abs/2605.29640) · [Read PDF](https://arxiv.org/pdf/2605.29640)
 
-OpenViking integrates TrieHI from the following paper to support filesystem-style context organization and directory-recursive retrieval:
+**Directory structure as retrieval context.** This paper provides the formal foundations, index design, and experimental evidence behind OpenViking’s directory-aware retrieval. It defines directory-scoped query and maintenance operations and introduces TrieHI, which OpenViking integrates to resolve directory scopes before vector ranking. This connects the filesystem paradigm to retrieval: agents can search a project or memory subtree, retain its surrounding context, and reorganize it as knowledge evolves.
 
 > **Directory-Aware Query and Maintenance in Vector Databases**
 > Mengzhao Wang, Zheng Gong, Jingpei Hu, Jiajie Fu, Maojia Sheng, Junwen Chen, and Yifan Zhu.

--- a/README.md
+++ b/README.md
@@ -243,6 +243,13 @@ The two editions below answer "who operates it and where it runs", not "can I us
 > arXiv:2606.16903, 2026. Accepted by ICDE.
 > 📄 [Read the paper on arXiv](https://arxiv.org/abs/2606.16903) · [Read PDF](https://arxiv.org/pdf/2606.16903)
 
+**Retrieve the evidence you need with fewer tokens.** VikingRAG combines semantic search with document structure, exposing relevant directory segments as evidence gaps arise. Its core mechanisms are integrated into OpenViking. The paper further explores reusing retrieval traces and escalating to multi-round retrieval only when needed, reducing repeated exploration while preserving answer quality.
+
+> **VikingRAG: Accurate and Token-efficient Retrieval-augmented Generation over Structured Documents**
+> Peiyuan Gao, Gaoyuan Zhang, Haojie Qin, Yahui Sun, Qianyi Zhang, Yunhao Zhang, Zeyu Wang, and Wei Lu.
+> arXiv:2609.11390, 2026. Submitted.
+> 📄 [Read the paper on arXiv](https://arxiv.org/abs/2609.11390) · [Read PDF](https://arxiv.org/pdf/2609.11390)
+
 ## Partner Projects
 
 OpenViking welcomes collaboration with other open-source projects to build the context data ecosystem. Our confirmed partners include:

--- a/README.md
+++ b/README.md
@@ -233,8 +233,15 @@ OpenViking open-sources a subset of the core capabilities described in the Vikin
 
 > **VikingMem: A Memory Base Management System for Stateful LLM-based Applications**
 > Jiajie Fu, Junwen Chen, Mengzhao Wang, Aoxiang He, Maojia Sheng, Xiangyu Ke, Yifan Zhu, and Yunjun Gao.
-> arXiv:2605.29640, 2026. Accepted by VLDB 2026.
-> 📄 [Read the paper on arXiv](https://arxiv.org/abs/2605.29640)
+> arXiv:2605.29640, 2026. Presented at VLDB 2026 in September.
+> 📄 [Read the paper on arXiv](https://arxiv.org/abs/2605.29640) · [Read PDF](https://arxiv.org/pdf/2605.29640)
+
+OpenViking integrates TrieHI from the following paper to support filesystem-style context organization and directory-recursive retrieval:
+
+> **Directory-Aware Query and Maintenance in Vector Databases**
+> Mengzhao Wang, Zheng Gong, Jingpei Hu, Jiajie Fu, Maojia Sheng, Junwen Chen, and Yifan Zhu.
+> arXiv:2606.16903, 2026. Accepted by ICDE.
+> 📄 [Read the paper on arXiv](https://arxiv.org/abs/2606.16903) · [Read PDF](https://arxiv.org/pdf/2606.16903)
 
 ## Partner Projects
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -242,8 +242,15 @@ OpenViking 开源了 VikingMem 论文中描述的部分核心能力：
 
 > **VikingMem: A Memory Base Management System for Stateful LLM-based Applications**
 > Jiajie Fu, Junwen Chen, Mengzhao Wang, Aoxiang He, Maojia Sheng, Xiangyu Ke, Yifan Zhu, and Yunjun Gao.
-> arXiv:2605.29640, 2026。已被 VLDB 2026 接收。
-> 📄 [在 arXiv 阅读论文](https://arxiv.org/abs/2605.29640)
+> arXiv:2605.29640, 2026。已于 2026 年 9 月在 VLDB 2026 完成演讲。
+> 📄 [在 arXiv 阅读论文](https://arxiv.org/abs/2605.29640) · [阅读 PDF](https://arxiv.org/pdf/2605.29640)
+
+OpenViking 集成了以下论文中的 TrieHI，支持文件系统式上下文组织和目录递归检索：
+
+> **Directory-Aware Query and Maintenance in Vector Databases**
+> Mengzhao Wang, Zheng Gong, Jingpei Hu, Jiajie Fu, Maojia Sheng, Junwen Chen, and Yifan Zhu.
+> arXiv:2606.16903, 2026。已被 ICDE 接收。
+> 📄 [在 arXiv 阅读论文](https://arxiv.org/abs/2606.16903) · [阅读 PDF](https://arxiv.org/pdf/2606.16903)
 
 ## 合作伙伴
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -238,14 +238,14 @@ ov chat   # 在另一个终端运行
 
 ## 研究
 
-OpenViking 开源了 VikingMem 论文中描述的部分核心能力：
+**让 Agent 的记忆随交互演化。** VikingMem 以事件驱动长期记忆的提取、更新与整合，让有状态 Agent 在持续交互中积累可复用的经验。OpenViking 开源了其中的部分核心能力。
 
 > **VikingMem: A Memory Base Management System for Stateful LLM-based Applications**
 > Jiajie Fu, Junwen Chen, Mengzhao Wang, Aoxiang He, Maojia Sheng, Xiangyu Ke, Yifan Zhu, and Yunjun Gao.
 > arXiv:2605.29640, 2026。已于 2026 年 9 月在 VLDB 2026 完成演讲。
 > 📄 [在 arXiv 阅读论文](https://arxiv.org/abs/2605.29640) · [阅读 PDF](https://arxiv.org/pdf/2605.29640)
 
-OpenViking 集成了以下论文中的 TrieHI，支持文件系统式上下文组织和目录递归检索：
+**让目录结构成为检索上下文。** 这篇论文为 OpenViking 的目录语义检索提供形式化基础、索引设计与实验验证。论文定义了目录范围查询与结构维护操作，并提出 TrieHI，OpenViking 已将其集成，用于在向量排序前确定目录检索范围。文件系统范式由此贯穿组织与检索：Agent 可以在项目或记忆子树内查找证据、保留周边上下文，并随知识演化调整目录结构。
 
 > **Directory-Aware Query and Maintenance in Vector Databases**
 > Mengzhao Wang, Zheng Gong, Jingpei Hu, Jiajie Fu, Maojia Sheng, Junwen Chen, and Yifan Zhu.

--- a/README_CN.md
+++ b/README_CN.md
@@ -252,6 +252,13 @@ ov chat   # 在另一个终端运行
 > arXiv:2606.16903, 2026。已被 ICDE 接收。
 > 📄 [在 arXiv 阅读论文](https://arxiv.org/abs/2606.16903) · [阅读 PDF](https://arxiv.org/pdf/2606.16903)
 
+**用更少的 Token 找齐回答所需的证据。** VikingRAG 将语义检索与文档结构结合，按证据缺口展开相关目录片段，核心机制已集成到 OpenViking。论文进一步研究检索轨迹复用与按需升级多轮检索，在保持回答质量的同时减少重复探索。
+
+> **VikingRAG: Accurate and Token-efficient Retrieval-augmented Generation over Structured Documents**
+> Peiyuan Gao, Gaoyuan Zhang, Haojie Qin, Yahui Sun, Qianyi Zhang, Yunhao Zhang, Zeyu Wang, and Wei Lu.
+> arXiv:2609.11390, 2026。投递中。
+> 📄 [在 arXiv 阅读论文](https://arxiv.org/abs/2609.11390) · [阅读 PDF](https://arxiv.org/pdf/2609.11390)
+
 ## 合作伙伴
 
 OpenViking 欢迎与其他开源项目合作建设上下文数据生态。目前已确认的合作项目包括：

--- a/README_JA.md
+++ b/README_JA.md
@@ -242,8 +242,15 @@ OpenViking は、VikingMem 論文に記載されたコア機能の一部をオ�
 
 > **VikingMem: A Memory Base Management System for Stateful LLM-based Applications**
 > Jiajie Fu, Junwen Chen, Mengzhao Wang, Aoxiang He, Maojia Sheng, Xiangyu Ke, Yifan Zhu, and Yunjun Gao.
-> arXiv:2605.29640, 2026. Accepted by VLDB 2026.
-> 📄 [arXiv で論文を読む](https://arxiv.org/abs/2605.29640)
+> arXiv:2605.29640, 2026. 2026 年 9 月に VLDB 2026 で発表済み。
+> 📄 [arXiv で論文を読む](https://arxiv.org/abs/2605.29640) · [PDF を読む](https://arxiv.org/pdf/2605.29640)
+
+OpenViking は以下の論文の TrieHI を統合し、ファイルシステム形式のコンテキスト整理とディレクトリ再帰検索を実現しています:
+
+> **Directory-Aware Query and Maintenance in Vector Databases**
+> Mengzhao Wang, Zheng Gong, Jingpei Hu, Jiajie Fu, Maojia Sheng, Junwen Chen, and Yifan Zhu.
+> arXiv:2606.16903, 2026. ICDE 採択済み。
+> 📄 [arXiv で論文を読む](https://arxiv.org/abs/2606.16903) · [PDF を読む](https://arxiv.org/pdf/2606.16903)
 
 ## パートナープロジェクト
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -238,14 +238,14 @@ ov chat   # 別のターミナルで実行
 
 ## 研究
 
-OpenViking は、VikingMem 論文に記載されたコア機能の一部をオープンソースとして公開しています:
+**対話とともに進化するエージェントの記憶。** VikingMem は、イベントを起点に長期記憶を抽出・更新・統合し、状態を持つエージェントが対話を通じて再利用できる経験を蓄積する仕組みを示しています。OpenViking は、そのコア機能の一部をオープンソースとして公開しています。
 
 > **VikingMem: A Memory Base Management System for Stateful LLM-based Applications**
 > Jiajie Fu, Junwen Chen, Mengzhao Wang, Aoxiang He, Maojia Sheng, Xiangyu Ke, Yifan Zhu, and Yunjun Gao.
 > arXiv:2605.29640, 2026. 2026 年 9 月に VLDB 2026 で発表済み。
 > 📄 [arXiv で論文を読む](https://arxiv.org/abs/2605.29640) · [PDF を読む](https://arxiv.org/pdf/2605.29640)
 
-OpenViking は以下の論文の TrieHI を統合し、ファイルシステム形式のコンテキスト整理とディレクトリ再帰検索を実現しています:
+**ディレクトリ構造を検索のコンテキストに。** 本論文は、OpenViking のディレクトリを考慮した検索に形式的基盤、インデックス設計、実験による検証を提供します。ディレクトリ範囲のクエリと構造の保守操作を定義し、TrieHI を提案しています。OpenViking はこれを統合し、ベクトルによる順位付けの前に検索範囲を確定します。エージェントはプロジェクトや記憶のサブツリー内で根拠を探し、周辺のコンテキストを保ちながら、知識の変化に応じてディレクトリを再編できます。
 
 > **Directory-Aware Query and Maintenance in Vector Databases**
 > Mengzhao Wang, Zheng Gong, Jingpei Hu, Jiajie Fu, Maojia Sheng, Junwen Chen, and Yifan Zhu.

--- a/README_JA.md
+++ b/README_JA.md
@@ -252,6 +252,13 @@ ov chat   # 別のターミナルで実行
 > arXiv:2606.16903, 2026. ICDE 採択済み。
 > 📄 [arXiv で論文を読む](https://arxiv.org/abs/2606.16903) · [PDF を読む](https://arxiv.org/pdf/2606.16903)
 
+**少ないトークンで回答に必要な根拠を集める。** VikingRAG は意味検索と文書構造を組み合わせ、根拠の不足に応じて関連するディレクトリ部分を取得します。そのコア機構は OpenViking に統合されています。さらに、検索履歴の再利用と必要な場合のみ複数ラウンドの検索へ移行する手法を研究し、回答品質を保ちながら探索の繰り返しを減らします。
+
+> **VikingRAG: Accurate and Token-efficient Retrieval-augmented Generation over Structured Documents**
+> Peiyuan Gao, Gaoyuan Zhang, Haojie Qin, Yahui Sun, Qianyi Zhang, Yunhao Zhang, Zeyu Wang, and Wei Lu.
+> arXiv:2609.11390, 2026. 投稿中。
+> 📄 [arXiv で論文を読む](https://arxiv.org/abs/2609.11390) · [PDF を読む](https://arxiv.org/pdf/2609.11390)
+
 ## パートナープロジェクト
 
 OpenViking は、コンテキストデータエコシステムを構築するために他のオープンソースプロジェクトとのコラボレーションを歓迎します。確認済みのパートナーは以下の通りです:


### PR DESCRIPTION
## Why

- Add three research papers and their conference/submission status in English, Chinese, and Japanese.
- Connect VikingMem to evolving memory, Directory-Aware Query and Maintenance to directory-aware retrieval, and VikingRAG to token-efficient evidence gathering.
- Mark VikingRAG as submitted. Preserve the partial open-source scope of VikingMem; do not imply acceptance or universal performance guarantees.

## Tested

- `git diff --check`
- Checked all three READMEs for each paper's title, authors, arXiv/PDF links, and status.
- Reviewed claims against the papers; no runtime changes.
