### PR TITLE
fix: support hash characters in file paths and Markdown references

### DIFF
--- a/bot/tests/test_compile.py
+++ b/bot/tests/test_compile.py
@@ -379,6 +379,24 @@ def test_renderer_creates_okf_pages_links_and_source_fallbacks():
     assert "- [source](viking://resources/source)" in first["content"]
 
 
+@pytest.mark.parametrize("name", ["a#one.md", "a%23one.md"])
+@pytest.mark.parametrize("inline", [True, False])
+def test_renderer_encodes_literal_source_filenames(name, inline):
+    source = f"viking://resources/source#1/{name}"
+    bundle = WikiBundleDraft.model_validate(
+        {"pages": [_page(1, "Overview", body_markdown=f"Source: {source}" if inline else "Body")]}
+    )
+    rendered = WikiRenderer().render(
+        bundle=bundle,
+        target_uri="viking://resources/wiki",
+        source_roots={"src_1": source},
+        catalog_uris=set(),
+        existing_raw={},
+    )
+    encoded = source.replace("%", "%25").replace("#", "%23")
+    assert rendered.operations[0]["content"].count(f"]({encoded})") == 1
+
+
 def test_renderer_preserves_existing_link_without_adding_another_mention_or_backlink():
     bundle = WikiBundleDraft.model_validate(
         {
@@ -4499,7 +4517,8 @@ async def test_salvage_copies_workspace_and_repairs_links(tmp_path: Path):
         "caseonly.md": b"case mismatch",
         "Foo.md": b"first",
         "foo.md": b"duplicate",
-        "bad#name.txt": b"unsafe URI",
+        "hash#name.txt": b"literal hash",
+        "bad?name.txt": b"unsafe URI",
         "__compile_staging__/work/notes.txt": b"notes",
         "__compile_staging__/tmp/check.txt": b"check",
         READLIST_PATH: b"compile_resources/src_1/a.md\n",
@@ -4570,7 +4589,8 @@ async def test_salvage_copies_workspace_and_repairs_links(tmp_path: Path):
     assert "sandboxes/cmp-srt-settings.json" not in payloads
     assert "sandboxes/cmp-srt-settings.json" not in {path for path, _limit in sandbox.reads}
     assert sum(path.casefold() == "foo.md" for path in payloads) == 1
-    assert "bad#name.txt" not in payloads
+    assert payloads["hash#name.txt"] == b"literal hash"
+    assert "bad?name.txt" not in payloads
     topic = payloads["guide/topic.md"].decode()
     assert "[Home](../home.md#top)" in topic
     assert "[Meta](../meta/readme.md)" in topic

--- a/bot/vikingbot/compile/renderer.py
+++ b/bot/vikingbot/compile/renderer.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import base64
+import posixpath
 import re
 from dataclasses import dataclass, field
 from typing import Any, Mapping
-from urllib.parse import unquote
 
 import yaml
 
@@ -190,9 +190,10 @@ def _linkify_source_uris(body: str, source_roots: Mapping[str, str]) -> str:
             continue
         if not _citation_target_allowed(target, source_roots):
             continue
-        label = unquote(target.rstrip("/").rsplit("/", 1)[-1]).removesuffix(".md")
+        label = target.rstrip("/").rsplit("/", 1)[-1].removesuffix(".md")
         label = label.replace("[", r"\[").replace("]", r"\]") or "Source"
-        replacements.append((start, end, f"[{label}]({target})"))
+        encoded_target = LinkRenderer.encode_markdown_target(target)
+        replacements.append((start, end, f"[{label}]({encoded_target})"))
 
     rendered = list(body)
     for start, end, replacement in reversed(replacements):
@@ -201,7 +202,7 @@ def _linkify_source_uris(body: str, source_roots: Mapping[str, str]) -> str:
 
 
 def _wiki_page_basename(uri: str) -> str:
-    name = unquote(uri.rstrip("/").rsplit("/", 1)[-1])
+    name = uri.rstrip("/").rsplit("/", 1)[-1]
     return name[:-3] if name.casefold().endswith(".md") else name
 
 
@@ -218,10 +219,9 @@ def _wiki_mention_targets(uris: set[str]) -> dict[str, str]:
 
 def _has_link_to(body: str, source_uri: str, target_uri: str) -> bool:
     relative = LinkRenderer.relative_path(source_uri, target_uri)
-    expected = {
-        LinkRenderer.normalize_markdown_target(target_uri),
-        LinkRenderer.normalize_markdown_target(relative if relative is not None else target_uri),
-    }
+    expected = {target_uri.rstrip("/")}
+    if relative is not None:
+        expected.add(posixpath.normpath(relative))
     return any(
         link.start == 0 or body[link.start - 1] != "!"
         for link in LinkRenderer.iter_markdown_links(body)
@@ -355,8 +355,8 @@ def _render_source_fallback(
             for linked in linked_targets
         ):
             continue
-        label = unquote(target.rstrip("/").rsplit("/", 1)[-1]) or f"Source {source_id}"
-        missing.append((label, target))
+        label = target.rstrip("/").rsplit("/", 1)[-1] or f"Source {source_id}"
+        missing.append((label, LinkRenderer.encode_markdown_target(target)))
     if not missing:
         return body.rstrip()
     heading = "来源" if wiki_language == "zh-CN" else "Sources"

--- a/bot/vikingbot/compile/service.py
+++ b/bot/vikingbot/compile/service.py
@@ -1591,7 +1591,7 @@ class BotCompileService:
                 return link.text
             if "/" not in corrected and not corrected.startswith("."):
                 corrected = f"./{corrected}"
-            corrected = corrected.replace(" ", "%20").replace("(", "%28").replace(")", "%29")
+            corrected = LinkRenderer.encode_markdown_target(corrected)
             image_marker = "!" if image else ""
             return f"{image_marker}[{link.text}]({corrected}{suffix})"
 

--- a/docs/en/api/12-content.md
+++ b/docs/en/api/12-content.md
@@ -213,6 +213,8 @@ openviking read viking://resources/docs/api.md
 
 Write a file and automatically refresh related semantics and vectors.
 
+File URIs contain literal filenames: pass `viking://resources/docs/a#one.md` to write a file named `a#one.md`. In Markdown references, encode filename `#` as `%23` and literal `%` as `%25`: `[Open](./a%23one.md)` or `[Section](./a%23one.md#intro)`. Link parsing separates the fragment before decoding the path once; `a#one.md` and `a%23one.md` remain distinct filenames.
+
 **Parameters**
 
 | Parameter | Type | Required | Default | Description |

--- a/docs/zh/api/12-content.md
+++ b/docs/zh/api/12-content.md
@@ -213,6 +213,8 @@ openviking read viking://resources/docs/api.md
 
 写入文件，并自动刷新相关语义与向量。
 
+文件 URI 使用原始文件名：传入 `viking://resources/docs/a#one.md` 会写入名为 `a#one.md` 的文件。在 Markdown 引用中，文件名中的 `#` 编码为 `%23`，字面量 `%` 编码为 `%25`，例如 `[打开](./a%23one.md)` 或 `[章节](./a%23one.md#intro)`。链接解析先分离锚点，再对路径解码一次；`a#one.md` 与 `a%23one.md` 是两个不同的文件名。
+
 **参数**
 
 | 参数 | 类型 | 必填 | 默认值 | 说明 |

--- a/openviking/session/memory/utils/link_renderer.py
+++ b/openviking/session/memory/utils/link_renderer.py
@@ -2,7 +2,7 @@ import posixpath
 import re
 from dataclasses import dataclass
 from typing import Callable, Dict, Iterator, List, Optional
-from urllib.parse import unquote
+from urllib.parse import quote, unquote
 
 from openviking.core.namespace import uri_parts
 
@@ -182,13 +182,18 @@ class LinkRenderer:
         return None
 
     @staticmethod
+    def encode_markdown_target(path: str) -> str:
+        """Encode a literal file path for Markdown; append any fragment afterward."""
+        return re.sub(r"[%# ()]", lambda match: quote(match.group(), safe=""), path)
+
+    @staticmethod
     def normalize_markdown_target(target: str) -> str:
-        """Decode and normalize a parsed Markdown link destination."""
-        target = unquote(target.strip())
+        """Decode a Markdown destination once, after removing its fragment."""
+        target = target.strip()
         if target.startswith("<") and target.endswith(">"):
             target = target[1:-1]
         target = LinkRenderer._BACKSLASH_ESCAPE_RE.sub(r"\1", target)
-        target = target.split("#", 1)[0]
+        target = unquote(target.split("#", 1)[0])
         return target.rstrip("/") if "://" in target else posixpath.normpath(target)
 
     @staticmethod
@@ -207,12 +212,9 @@ class LinkRenderer:
         link_spans = {(link.start, link.end) for link in markdown_links}
         non_link_protected = [span for span in protected_spans if span not in link_spans]
         relative_target = LinkRenderer.relative_path(source_uri, target_uri)
-        expected_targets = {
-            LinkRenderer.normalize_markdown_target(target_uri),
-            LinkRenderer.normalize_markdown_target(
-                relative_target if relative_target is not None else target_uri
-            ),
-        }
+        expected_targets = {target_uri.rstrip("/")}
+        if relative_target is not None:
+            expected_targets.add(posixpath.normpath(relative_target))
 
         for link in markdown_links:
             if link.start > 0 and content[link.start - 1] == "!":
@@ -273,12 +275,7 @@ class LinkRenderer:
             if any(not (end <= rs or start >= re_) for rs, re_, _ in replacements):
                 continue
 
-            # Percent-encode spaces in the rendered target so the link is portable
-            # across markdown renderers (e.g. `[Frank](entities/frank ocean.md)`
-            # would otherwise be ambiguous). We accept the literal-space form when
-            # matching existing links, but always emit the encoded form when
-            # generating new ones.
-            encoded_target = link_target.replace(" ", "%20").replace("(", "%28").replace(")", "%29")
+            encoded_target = LinkRenderer.encode_markdown_target(link_target)
             rendered = f"[{content[start:end]}]({encoded_target})"
             replacements.append((start, end, rendered))
 

--- a/openviking/utils/path_safety.py
+++ b/openviking/utils/path_safety.py
@@ -43,9 +43,9 @@ def sanitize_relative_viking_path(rel_path: str) -> str:
 
 
 def validate_safe_viking_uri_path(uri: str) -> str:
-    """Reject ambiguous or traversal-bearing path syntax in a Viking URI."""
+    """Validate a literal storage path, where ``#`` is part of the filename."""
     normalized = VikingURI(uri.strip()).uri.rstrip("/")
-    if "?" in normalized or "#" in normalized:
+    if "?" in normalized:
         raise ValueError(f"Unsafe Viking URI path rejected: {uri}")
     path = normalized[len(f"{VikingURI.SCHEME}://") :]
     if not path:

--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -793,9 +793,10 @@ async def test_write_direct_reuses_outer_lease_for_viking_fs(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_resource_write_updates_target_and_queues_refresh_before_return(monkeypatch):
-    file_uri = "viking://resources/demo/doc.md"
-    root_uri = "viking://resources/demo"
+@pytest.mark.parametrize("path", ["demo/doc.md", "demo#1/a#one.md"])
+async def test_resource_write_updates_target_and_queues_refresh_before_return(monkeypatch, path):
+    file_uri = f"viking://resources/{path}"
+    root_uri = file_uri.rsplit("/", 1)[0]
     ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
     viking_fs = _FakeVikingFS(file_uri=file_uri, root_uri=root_uri)
     coordinator = ContentWriteCoordinator(viking_fs=viking_fs)

--- a/tests/test_link_renderer.py
+++ b/tests/test_link_renderer.py
@@ -1,6 +1,28 @@
+import pytest
+
 from openviking.session.memory.dataclass import MemoryFile
 from openviking.session.memory.utils.link_renderer import LinkRenderer
 from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
+
+
+@pytest.mark.parametrize(
+    ("name", "encoded"),
+    [("a#one.md", "a%23one.md"), ("a%23one.md", "a%2523one.md")],
+)
+def test_hash_filename_links_round_trip_without_aliasing(name, encoded):
+    source = "viking://resources/wiki/index.md"
+    target = f"viking://resources/wiki/{name}"
+    assert (
+        LinkRenderer.render_links("Details", source, [{"match_text": "Details", "to_uri": target}])
+        == f"[Details](./{encoded})"
+    )
+    for prefix in ("./", "viking://resources/wiki/"):
+        content = f"[Details]({prefix}{encoded}#intro)"
+        assert LinkRenderer.can_render_link(content, "Details", source, target)
+        for other in {"a#one.md", "a#two.md", "a%23one.md", "a"} - {name}:
+            assert not LinkRenderer.can_render_link(
+                content, "Details", source, f"viking://resources/wiki/{other}"
+            )
 
 
 class TestRelativePath:

--- a/web-studio/src/routes/resources/-components/file-preview.test.tsx
+++ b/web-studio/src/routes/resources/-components/file-preview.test.tsx
@@ -113,6 +113,11 @@ function renderPreview(
 }
 
 describe('FilePreview Markdown links', () => {
+  beforeEach(() => cleanup())
+  afterEach(() => {
+    previewState.override = null
+  })
+
   it('opens internal Markdown links in the resource preview', () => {
     const onNavigate = vi.fn()
     renderPreview(file, onNavigate)
@@ -172,6 +177,26 @@ describe('FilePreview Markdown links', () => {
     fireEvent.click(screen.getByRole('link', { name: '目标' }))
 
     expect(onNavigate).toHaveBeenCalledWith('viking://resources/资料/目标.md')
+  })
+
+  it.each([file, directory])('opens encoded filenames from $name', (entry) => {
+    const onNavigate = vi.fn()
+    const prefix = entry.isDir ? 'viking://resources/wiki/' : './'
+    const content = `[One](${prefix}a%23one.md#intro)\n\n[Percent](${prefix}a%2523one.md#intro)`
+    previewState.override = entry.isDir
+      ? null
+      : { content, fileType: 'markdown' }
+    renderPreview(entry, onNavigate, content)
+    fireEvent.click(screen.getByRole('link', { name: 'One' }))
+    fireEvent.click(screen.getByRole('link', { name: 'Percent' }))
+    expect(onNavigate).toHaveBeenNthCalledWith(
+      1,
+      'viking://resources/wiki/a#one.md',
+    )
+    expect(onNavigate).toHaveBeenNthCalledWith(
+      2,
+      'viking://resources/wiki/a%23one.md',
+    )
   })
 
   it('preserves non-viking links in a directory overview', () => {

--- a/web-studio/src/routes/resources/-components/file-preview.tsx
+++ b/web-studio/src/routes/resources/-components/file-preview.tsx
@@ -294,6 +294,7 @@ function dirnameVikingUri(fileUri: string): string {
   return `${trimmed.slice(0, idx + 1)}`
 }
 
+/** Resolve a decoded file path without interpreting literal # or percent signs. */
 function resolveRelativeVikingUri(
   baseFileUri: string,
   rawPath: string,
@@ -301,11 +302,8 @@ function resolveRelativeVikingUri(
   const baseDir = dirnameVikingUri(baseFileUri)
   const baseBody = baseDir.slice(vikingPrefix.length, -1)
 
-  const pathPart = rawPath.split('#')[0]?.split('?')[0] || ''
-  const suffix = rawPath.slice(pathPart.length)
-
   const baseSegments = baseBody ? baseBody.split('/').filter(Boolean) : []
-  const relativeSegments = pathPart.split('/').filter(Boolean)
+  const relativeSegments = rawPath.split('/').filter(Boolean)
 
   const merged = [...baseSegments]
   for (const segment of relativeSegments) {
@@ -320,7 +318,7 @@ function resolveRelativeVikingUri(
   }
 
   const resolved = `${vikingPrefix}${merged.join('/')}`
-  return `${resolved}${suffix}`
+  return resolved
 }
 
 type MarkdownAssetTarget =
@@ -349,11 +347,8 @@ function resolveMarkdownAssetTarget(
     return { kind: 'external', value: trimmed }
   }
 
-  // react-markdown percent-encodes the URL it passes via `src`/`href`
-  // (e.g. Chinese characters become %E4%BA%92). Decode it back to the literal
-  // form so the API client's query serializer encodes it exactly once and we
-  // avoid a double-encoded URI that the backend rejects with HTTP 400.
-  const decoded = safeDecodeUri(trimmed)
+  // Split URL components before decoding; %23 is literal filename data.
+  const decoded = safeDecodeUri(trimmed.split(/[?#]/, 1)[0])
 
   const vikingUri = decoded.startsWith(vikingPrefix)
     ? decoded
@@ -361,8 +356,7 @@ function resolveMarkdownAssetTarget(
   return { kind: 'viking', value: vikingUri }
 }
 
-function resolveMarkdownAssetUrl(assetPath: string, fileUri: string): string {
-  const target = resolveMarkdownAssetTarget(assetPath, fileUri)
+function resolveMarkdownAssetUrl(target: MarkdownAssetTarget): string {
   if (target.kind === 'viking') {
     return toDownloadUrl(target.value)
   }
@@ -389,7 +383,7 @@ function MarkdownLink({
   const resolvedHref = target
     ? isInternal
       ? target.value
-      : resolveMarkdownAssetUrl(target.value, fileUri)
+      : resolveMarkdownAssetUrl(target)
     : ''
   const isExternal = /^(https?:|mailto:|tel:)/i.test(resolvedHref)
 
@@ -427,7 +421,7 @@ function DirectoryMarkdownLink({
   }
 
   return (
-    <MarkdownLink href={decodedHref} fileUri={fileUri} onNavigate={onNavigate}>
+    <MarkdownLink href={href} fileUri={fileUri} onNavigate={onNavigate}>
       {children}
     </MarkdownLink>
   )


### PR DESCRIPTION
## Description

Allow normal content writes to filenames containing `#`, and preserve those filenames when generating and following Markdown references.

The shared Viking URI path validator rejects `#` to avoid confusing filenames with compile reference fragments, but normal content writes also use that validator. Separately, link normalization percent-decodes before removing the fragment, so `a%23one.md` and `a%23two.md` can both resolve to `a`.

Storage URIs now retain literal filenames, such as `viking://resources/docs/a#one.md`. Markdown destinations encode filename `#` as `%23` and literal `%` as `%25`; parsing separates the fragment before decoding the path once. For example, `./a%23one.md#intro` resolves to file `a#one.md`, while `./a%2523one.md` resolves to the distinct file `a%23one.md`.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

No linked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes Made

- Permit literal `#` in storage paths while retaining query-marker and traversal validation.
- Use consistent destination encoding in memory links, compile source citations, fallback references, and salvaged links. Compare decoded link paths against literal storage URIs to keep distinct filenames separate.
- Update Web Studio file and directory previews to split URL components before decoding and avoid decoding internal destinations twice.
- Document literal file URIs and encoded Markdown references in the English and Chinese Content API guides.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

No schema migration or new dependency is required. Stored filenames remain literal; percent encoding applies to reference destinations. An unencoded `#` in a Markdown destination continues to delimit a fragment.

Web Studio resolves links containing fragments to the target file; this change does not add scrolling to headings in another file.
