### PR TITLE
fix(web-studio): don't build scope-less viking:// uri when joining root sidecars

### DIFF
--- a/web-studio/src/lib/viking-uri.test.ts
+++ b/web-studio/src/lib/viking-uri.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   cleanVikingUri,
   isDirectorySemanticSidecarUri,
+  joinUri,
   retrievalResultNameFromUri,
 } from './viking-uri'
 
@@ -43,5 +44,24 @@ describe('retrievalResultNameFromUri', () => {
         'viking://resources/openviking-release/README.md',
       ),
     ).toBe('README.md')
+  })
+})
+
+describe('joinUri', () => {
+  it.each(['.abstract.md', '.overview.md'])(
+    'does not build a scope-less uri when joining %s onto the bare root',
+    (sidecar) => {
+      expect(joinUri('viking://', sidecar)).toBe('viking://')
+    },
+  )
+
+  it('still joins ordinary sidecars under a real scope', () => {
+    expect(joinUri('viking://resources/foo/', '.abstract.md')).toBe(
+      'viking://resources/foo/.abstract.md',
+    )
+  })
+
+  it('still joins ordinary file names under the bare root', () => {
+    expect(joinUri('viking://', 'resources/')).toBe('viking://resources/')
   })
 })

--- a/web-studio/src/lib/viking-uri.ts
+++ b/web-studio/src/lib/viking-uri.ts
@@ -70,6 +70,15 @@ export function joinUri(baseUri: string, child: string): string {
   }
 
   const normalizedBase = normalizeDirUri(baseUri)
+  // The bare scheme root (`viking://`) has no real scope segment of its own,
+  // so it never has directory-semantic sidecars to summarize. Without this
+  // guard, joining `.abstract.md`/`.overview.md` onto the root produces
+  // `viking://.abstract.md`, which the server rejects with
+  // "Invalid scope '.abstract.md'" since that fragment gets parsed as the
+  // scope instead of a filename.
+  if (normalizedBase === 'viking://' && isDirectorySemanticSidecarUri(raw)) {
+    return normalizedBase
+  }
   return `${normalizedBase}${raw.replace(/^\//, '')}`
 }
 


### PR DESCRIPTION
## Summary

`joinUri('viking://', '.abstract.md')` and `joinUri('viking://', '.overview.md')` produce `viking://.abstract.md` / `viking://.overview.md` — URIs with no real scope segment. The server's URI validator (`openviking/core/uri_validation.py`) parses the first path segment after the scheme as the *scope*, so these get rejected:

```json
{
  "reason": "Invalid scope '.abstract.md'. Must be one of: agent, queue, resources, session, temp, upload, user"
}
```

This surfaces as a real 400 on `GET /api/v1/content/read` (and the abstract/overview equivalents) whenever the Studio dashboard tries to preview the abstract/overview of a directory listing at the bare `viking://` root. `web-studio/src/routes/resources/-lib/normalize.ts` calls `joinUri(currentUri, item)` on every entry returned by a directory listing — including the two hidden semantic-sidecar filenames — so at the root this always builds the malformed URI and the read 400s.

## Root cause

The bare scheme root (`viking://`) has no scope segment of its own and therefore never has directory-semantic sidecars (`.abstract.md`/`.overview.md`) to summarize — those only exist under a real scope (`resources/`, `user/`, etc.). `joinUri` didn't special-case this, so it happily concatenated the sidecar filename straight onto the bare root.

## Fix

`joinUri` now short-circuits and returns the (normalized) root unchanged when asked to join one of the two sidecar filenames onto the bare `viking://` root. Every other join — real scopes, ordinary filenames, non-sidecar children at the root — is unaffected.

## Testing

Added 3 new cases to `viking-uri.test.ts` covering the exact regression (root + each sidecar name) and a non-regression check that ordinary root joins and scoped sidecar joins still work as before:

```
✓ src/lib/viking-uri.test.ts (9 tests) 2ms
Tests  9 passed (9)
```

Also verified against a live self-hosted `v0.4.19` server: reproduced the real 400 from the Studio dashboard first, confirmed the patched `joinUri` returns `viking://` unchanged for both sidecar names via a direct module import against the built `dist` bundle, and confirmed ordinary (non-root, non-sidecar) joins are unchanged.

## Related

Similar in spirit to #4219 (a different code path — server-side semantic parent-refresh hitting `viking://user`, already fixed via #4232) but this is a distinct client-side bug in the Studio URI-join helper, not a duplicate. Searched issues for "Invalid scope", "abstract.md", "overview.md" and found no existing report for this specific dashboard-preview-at-root case.