### PR TITLE
fix(resources): reject file target used as directory

### DIFF
--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -80,6 +80,7 @@ from openviking.utils.skill_processor import SkillProcessingPreparation, SkillPr
 from openviking_cli.exceptions import (
     ConflictError,
     DeadlineExceededError,
+    FailedPreconditionError,
     InternalError,
     InvalidArgumentError,
     NotInitializedError,
@@ -1156,6 +1157,7 @@ class ResourceService:
                 create_parent=create_parent,
                 source_info=plan.source_identity,
                 defer_candidate_resolution=defer_candidate_resolution,
+                to_is_directory=planned_to_is_directory,
             )
             lock_handoff = await self._lock_to_handoff_payload(resource_lock)
             message_path = plan.path
@@ -1270,6 +1272,7 @@ class ResourceService:
         create_parent: bool,
         source_info: _ResourceSourceInfo,
         defer_candidate_resolution: bool,
+        to_is_directory: bool,
     ) -> tuple[str, Optional[Dict[str, Any]], bool, bool]:
         """Resolve the target and track ownership of a newly reserved empty path."""
         if not self._resource_processor or not self._viking_fs:
@@ -1313,6 +1316,16 @@ class ResourceService:
         )
         try:
             await self._viking_fs._ensure_access(root_uri, ctx, action=AclAction.WRITE)
+            if to_is_directory and await self._viking_fs.exists(root_uri, ctx=ctx):
+                target_stat = await self._viking_fs.stat(root_uri, ctx=ctx, skip_count=True)
+                if not target_stat.get("isDir"):
+                    raise FailedPreconditionError(
+                        "Target URI already exists as a file and cannot be used as a "
+                        f"resource directory: {root_uri}. Choose another 'to', use "
+                        "'parent' to add a new resource under a directory, or use "
+                        "content/write to update the existing file.",
+                        details={"resource": root_uri, "type": "file"},
+                    )
         except BaseException:
             await self._release_lock_ref(resource_lock)
             raise

--- a/tests/service/test_resource_service_reserved_target_cleanup.py
+++ b/tests/service/test_resource_service_reserved_target_cleanup.py
@@ -6,6 +6,7 @@ import pytest
 from openviking.server.identity import RequestContext, Role
 from openviking.service.resource_service import ResourceService
 from openviking.storage.queuefs.add_resource_msg import AddResourceMsg
+from openviking_cli.exceptions import FailedPreconditionError
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -108,6 +109,7 @@ async def test_explicit_target_plan_tracks_reservation_ownership(
 
     viking_fs = SimpleNamespace(
         exists=AsyncMock(side_effect=target_exists),
+        stat=AsyncMock(return_value={"isDir": True}),
         _ensure_access=AsyncMock(side_effect=ensure_access),
         _uri_to_path=lambda uri, ctx: f"/agfs/{uri}",
         _async_agfs=SimpleNamespace(pathlock_acquire_tree=AsyncMock(side_effect=acquire_lock)),
@@ -131,6 +133,7 @@ async def test_explicit_target_plan_tracks_reservation_ownership(
             source_format="zip",
         ),
         defer_candidate_resolution=False,
+        to_is_directory=True,
     )
 
     assert planned == (
@@ -139,7 +142,56 @@ async def test_explicit_target_plan_tracks_reservation_ownership(
         False,
         cleanup_empty_target_on_failure,
     )
-    assert calls == ["acl", "exists", "lock", "acl"]
+    assert calls == ["acl", "exists", "lock", "acl", "exists"]
+
+
+@pytest.mark.asyncio
+async def test_explicit_directory_target_rejects_existing_file():
+    lock = {"lease_ref": "lock-1"}
+    ctx = _ctx()
+    async_agfs = SimpleNamespace(
+        pathlock_acquire_tree=AsyncMock(return_value=lock),
+        pathlock_release=AsyncMock(),
+    )
+    viking_fs = SimpleNamespace(
+        exists=AsyncMock(return_value=True),
+        stat=AsyncMock(return_value={"isDir": False}),
+        _ensure_access=AsyncMock(),
+        _uri_to_path=lambda uri, ctx: f"/agfs/{uri}",
+        _async_agfs=async_agfs,
+    )
+    processor = SimpleNamespace(
+        tree_builder=SimpleNamespace(
+            resolve_target_uri=AsyncMock(return_value=("viking://resources/report.md", None))
+        )
+    )
+    service = _service(viking_fs, processor)
+
+    with pytest.raises(
+        FailedPreconditionError,
+        match="already exists as a file",
+    ):
+        await service._plan_source_job_target(
+            path="report.md",
+            ctx=ctx,
+            to="viking://resources/report.md",
+            parent="",
+            create_parent=False,
+            source_info=SimpleNamespace(
+                source_path="report.md",
+                source_name="report.md",
+                source_format="markdown",
+            ),
+            defer_candidate_resolution=False,
+            to_is_directory=True,
+        )
+
+    viking_fs.stat.assert_awaited_once_with(
+        "viking://resources/report.md",
+        ctx=ctx,
+        skip_count=True,
+    )
+    async_agfs.pathlock_release.assert_awaited_once_with(lock)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

修复 `add_resource` 中目录目标与已有文件冲突时的处理逻辑。

当 `to` 被解析为目录目标时，如果目标 URI 已经存在且实际是文件，当前请求不应该继续进入资源目录导入流程。这个 PR 在入队前的目标规划阶段提前拒绝这种不合法输入，避免后续把文件路径当目录资源根处理。

典型场景：

```text
add report.zip to viking://resources/report.md
```

如果 `to` 被视为目录目标，但 `viking://resources/report.md` 已经是文件，则直接返回 `FAILED_PRECONDITION`，不会入队，也不会触发后台资源解析。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4919

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 在 `ResourceService._plan_source_job_target` 中增加文件/目录目标类型检查：
  - 仅当 `to_is_directory=true` 且目标已存在时读取 `stat`。
  - 如果目标已存在但不是目录，直接抛出 `FailedPreconditionError`。
- 将拒绝检查放在 `pathlock_acquire_tree` 之前：
  - 避免对确定不合法的文件目标申请 tree lock。
  - 避免重复执行锁后的 `exists/stat` 检查。
  - 不会进入 `AddResourceMsg` 入队和后台解析流程。
- 保留锁后的 ACL recheck 和异常释放锁逻辑：
  - 合法目录目标仍会获取 tree lock。
  - 锁后 ACL 失败时仍会释放已获取的锁。
- 更新单测覆盖目标规划行为：
  - 已存在目录目标仍按原流程拿锁。
  - 已存在文件被当作目录目标时会提前拒绝。
  - 提前拒绝路径不会 acquire/release tree lock。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

已运行定向单测：

```bash
python -m pytest tests/service/test_resource_service_reserved_target_cleanup.py
```

结果：`10 passed`。

说明：本次只运行了与目标规划和预留目标清理相关的定向测试，没有运行全量测试套件。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

这个 PR 的边界很窄：只处理“目录目标实际指向已有文件”的前置拒绝。它不引入文件覆盖语义，也不改变合法目录目标的锁和入队流程。
