### PR TITLE
feat(reset-context): on session commit clear, reset context without changing session identity

### DIFF
--- a/docs/en/api/05-sessions.md
+++ b/docs/en/api/05-sessions.md
@@ -1421,7 +1421,7 @@ Commit a session. Message archiving (Phase 1) completes immediately. Summary gen
 |-----------|------|----------|---------|-------------|
 | session_id | str | Yes | - | Session ID to commit |
 | keep_recent_count | int | No | 0 | Number of recent live messages to retain (kept live, not archived) after commit. `0` (default) archives all messages. |
-| reset_context | bool | No | false | HTTP API: archive all live messages, then append an empty completed archive. Keeps the session ID and raw history, clears injected context and stops future summaries from inheriting pre-reset overviews. Requires `keep_recent_count=0` and no `retention_mode`. |
+| reset_context | bool | No | false | HTTP API: archive all live messages, then append a boundary archive containing only a `.done` marker with `context_reset`. Keeps the session ID and raw history, clears injected context and stops future summaries from inheriting pre-reset overviews. Requires `keep_recent_count=0` and no `retention_mode`. |
 
 `reset_context` is used by the OpenClaw plugin reset hook and `Session.commit_async()`. It also creates a boundary when there are no live messages, unless the newest archive is already a reset boundary. Memory extraction for older archives can finish independently; long-term memories are preserved. SDK/CLI convenience options are not added in this change.
 

--- a/docs/en/api/05-sessions.md
+++ b/docs/en/api/05-sessions.md
@@ -1421,6 +1421,10 @@ Commit a session. Message archiving (Phase 1) completes immediately. Summary gen
 |-----------|------|----------|---------|-------------|
 | session_id | str | Yes | - | Session ID to commit |
 | keep_recent_count | int | No | 0 | Number of recent live messages to retain (kept live, not archived) after commit. `0` (default) archives all messages. |
+| reset_context | bool | No | false | HTTP API: archive all live messages, then append an empty completed archive. Keeps the session ID and raw history, clears injected context and stops future summaries from inheriting pre-reset overviews. Requires `keep_recent_count=0` and no `retention_mode`. |
+
+`reset_context` is used by the OpenClaw plugin reset hook and `Session.commit_async()`. It also creates a boundary when there are no live messages. Memory extraction for older archives can finish independently; long-term memories are preserved. SDK/CLI convenience options are not added in this change.
+
 
 The effective policy is resolved in this order: Session `.meta.json`, latest
 `settings/user_config.json`, then the kernel default. The fully resolved policy

--- a/docs/en/api/05-sessions.md
+++ b/docs/en/api/05-sessions.md
@@ -1423,7 +1423,7 @@ Commit a session. Message archiving (Phase 1) completes immediately. Summary gen
 | keep_recent_count | int | No | 0 | Number of recent live messages to retain (kept live, not archived) after commit. `0` (default) archives all messages. |
 | reset_context | bool | No | false | HTTP API: archive all live messages, then append an empty completed archive. Keeps the session ID and raw history, clears injected context and stops future summaries from inheriting pre-reset overviews. Requires `keep_recent_count=0` and no `retention_mode`. |
 
-`reset_context` is used by the OpenClaw plugin reset hook and `Session.commit_async()`. It also creates a boundary when there are no live messages. Memory extraction for older archives can finish independently; long-term memories are preserved. SDK/CLI convenience options are not added in this change.
+`reset_context` is used by the OpenClaw plugin reset hook and `Session.commit_async()`. It also creates a boundary when there are no live messages, unless the newest archive is already a reset boundary. Memory extraction for older archives can finish independently; long-term memories are preserved. SDK/CLI convenience options are not added in this change.
 
 
 The effective policy is resolved in this order: Session `.meta.json`, latest

--- a/docs/zh/api/05-sessions.md
+++ b/docs/zh/api/05-sessions.md
@@ -1392,7 +1392,7 @@ curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/used \
 |------|------|------|--------|------|
 | session_id | str | 是 | - | 要提交的会话 ID |
 | keep_recent_count | int | 否 | 0 | 提交后保留为 live 状态的最近消息数 (保持 live, 不归档)。`0` (默认) 归档全部消息。 |
-| reset_context | bool | 否 | false | HTTP API：归档全部 live messages 后追加空的已完成 archive。保留 session ID 和原始历史，清空注入上下文，并阻止后续摘要继承 reset 前的 overview。要求 `keep_recent_count=0`，且不设置 `retention_mode`。 |
+| reset_context | bool | 否 | false | HTTP API：归档全部 live messages 后追加只含 `.done`（带 `context_reset`）的边界 archive，目录内没有消息文件。保留 session ID 和原始历史，清空注入上下文，并阻止后续摘要继承 reset 前的 overview。要求 `keep_recent_count=0`，且不设置 `retention_mode`。 |
 
 `reset_context` 供 OpenClaw 插件 reset hook 和 `Session.commit_async()` 使用；没有 live messages 时也会创建边界；若最新 archive 已是 reset 边界则不重复创建。旧 archive 的记忆提取可以继续完成，长期记忆保留。本次未增加 SDK/CLI 的专用参数。
 

--- a/docs/zh/api/05-sessions.md
+++ b/docs/zh/api/05-sessions.md
@@ -1392,6 +1392,10 @@ curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/used \
 |------|------|------|--------|------|
 | session_id | str | 是 | - | 要提交的会话 ID |
 | keep_recent_count | int | 否 | 0 | 提交后保留为 live 状态的最近消息数 (保持 live, 不归档)。`0` (默认) 归档全部消息。 |
+| reset_context | bool | 否 | false | HTTP API：归档全部 live messages 后追加空的已完成 archive。保留 session ID 和原始历史，清空注入上下文，并阻止后续摘要继承 reset 前的 overview。要求 `keep_recent_count=0`，且不设置 `retention_mode`。 |
+
+`reset_context` 供 OpenClaw 插件 reset hook 和 `Session.commit_async()` 使用；没有 live messages 时也会创建边界。旧 archive 的记忆提取可以继续完成，长期记忆保留。本次未增加 SDK/CLI 的专用参数。
+
 
 有效策略按 Session `.meta.json`、最新 `settings/user_config.json`、内核默认值的
 顺序解析。Phase 2 开始前会将完整有效策略固化到异步任务。

--- a/docs/zh/api/05-sessions.md
+++ b/docs/zh/api/05-sessions.md
@@ -1394,7 +1394,7 @@ curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/used \
 | keep_recent_count | int | 否 | 0 | 提交后保留为 live 状态的最近消息数 (保持 live, 不归档)。`0` (默认) 归档全部消息。 |
 | reset_context | bool | 否 | false | HTTP API：归档全部 live messages 后追加空的已完成 archive。保留 session ID 和原始历史，清空注入上下文，并阻止后续摘要继承 reset 前的 overview。要求 `keep_recent_count=0`，且不设置 `retention_mode`。 |
 
-`reset_context` 供 OpenClaw 插件 reset hook 和 `Session.commit_async()` 使用；没有 live messages 时也会创建边界。旧 archive 的记忆提取可以继续完成，长期记忆保留。本次未增加 SDK/CLI 的专用参数。
+`reset_context` 供 OpenClaw 插件 reset hook 和 `Session.commit_async()` 使用；没有 live messages 时也会创建边界；若最新 archive 已是 reset 边界则不重复创建。旧 archive 的记忆提取可以继续完成，长期记忆保留。本次未增加 SDK/CLI 的专用参数。
 
 
 有效策略按 Session `.meta.json`、最新 `settings/user_config.json`、内核默认值的

--- a/examples/openclaw-plugin/client.ts
+++ b/examples/openclaw-plugin/client.ts
@@ -80,6 +80,7 @@ export type CommitSessionResult = {
   task_id?: string;
   archive_uri?: string;
   archived?: boolean;
+  reset_context?: boolean;
   /** Present when wait=true and extraction completed. Keyed by category. */
   memories_extracted?: Record<string, number>;
   error?: string;
@@ -845,6 +846,8 @@ export class OpenVikingClient {
        * preserves the pre-v2 "archive everything" behavior.
       */
       keepRecentCount?: number;
+      /** Start empty context in the same session after archiving. */
+      resetContext?: boolean;
       agentId?: string;
     },
   ): Promise<CommitSessionResult> {
@@ -866,12 +869,19 @@ export class OpenVikingClient {
     if (keepRecentCount > 0) {
       body.keep_recent_count = keepRecentCount;
     }
+    if (options?.resetContext) {
+      body.reset_context = true;
+    }
     const result = await this.request<CommitSessionResult>(
       `/api/v1/sessions/${encodeURIComponent(sessionId)}/commit`,
       { method: "POST", body: JSON.stringify(body) },
       undefined,
       options?.agentId,
     );
+
+    if (options?.resetContext && result.reset_context !== true) {
+      throw new Error("OpenViking server did not confirm reset_context; upgrade the server with the plugin.");
+    }
 
     if (!options?.wait || !result.task_id) {
       return result;

--- a/examples/openclaw-plugin/services/context-lifecycle-service.ts
+++ b/examples/openclaw-plugin/services/context-lifecycle-service.ts
@@ -370,6 +370,7 @@ export async function commitOpenVikingSession({
     const commitResult = await client.commitSession(ovId, {
       wait: true,
       keepRecentCount: 0,
+      resetContext: true,
     });
     const memCount = totalExtractedMemories(commitResult.memories_extracted);
     if (commitResult.status === "failed") {

--- a/examples/openclaw-plugin/tests/ut/client.test.ts
+++ b/examples/openclaw-plugin/tests/ut/client.test.ts
@@ -805,3 +805,24 @@ describe("OpenVikingClient canonical namespace policy", () => {
     expect(body).not.toHaveProperty("role_id");
   });
 });
+
+
+describe("OpenVikingClient session reset", () => {
+  it("requests an empty archive boundary on the same session", async () => {
+    const transport = vi.fn().mockResolvedValue(okResponse({
+      session_id: "same-session", status: "skipped", reset_context: true,
+    }));
+    const client = new OpenVikingClient("http://127.0.0.1:1933", "", "agent", 5000, "", "", undefined, false, true, { transport });
+    await client.commitSession("same-session", { keepRecentCount: 0, resetContext: true });
+    const [url, init] = transport.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/sessions/same-session/commit");
+    expect(JSON.parse(String(init.body))).toEqual({ reset_context: true });
+  });
+});
+
+
+it("does not report reset success when an older server ignores reset_context", async () => {
+  const transport = vi.fn().mockResolvedValue(okResponse({ session_id: "s", status: "skipped" }));
+  const client = new OpenVikingClient("http://127.0.0.1:1933", "", "agent", 5000, "", "", undefined, false, true, { transport });
+  await expect(client.commitSession("s", { resetContext: true })).rejects.toThrow("did not confirm reset_context");
+});

--- a/examples/openclaw-plugin/tests/ut/context-engine-compact.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-compact.test.ts
@@ -120,7 +120,7 @@ describe("context-engine commitOVSession()", () => {
 
     await engine.commitOVSession({ sessionId: "s1" });
 
-    expect(client.commitSession.mock.calls[0][1]).toMatchObject({ wait: true });
+    expect(client.commitSession.mock.calls[0][1]).toMatchObject({ wait: true, keepRecentCount: 0, resetContext: true });
   });
 
   it("uses sessionKey-derived OV session ID for commitOVSession", async () => {

--- a/examples/openclaw-plugin/tests/ut/context-engine-modules.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-modules.test.ts
@@ -222,6 +222,7 @@ describe("context-engine lifecycle service seam", () => {
     expect(client.commitSession).toHaveBeenCalledWith(ovSessionId, {
       wait: true,
       keepRecentCount: 0,
+      resetContext: true,
     });
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("memories=5"));
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("trace_id=trace-1"));

--- a/openviking/server/routers/sessions.py
+++ b/openviking/server/routers/sessions.py
@@ -598,6 +598,11 @@ class CommitRequest(BaseModel):
     behavior.
     """
 
+    reset_context: bool = Field(
+        default=False,
+        strict=True,
+        description="Append an empty archive boundary after archiving all messages; keep session ID.",
+    )
     keep_recent_count: int = Field(
         default=0,
         ge=0,
@@ -643,6 +648,8 @@ class CommitRequest(BaseModel):
 
     @model_validator(mode="after")
     def validate_turn_retention_opt_in(self) -> "CommitRequest":
+        if self.reset_context and (self.keep_recent_count != 0 or self.retention_mode is not None):
+            raise ValueError("reset_context requires keep_recent_count=0 and no retention_mode")
         if self.retention_mode is None and any(
             value is not None
             for value in (
@@ -680,6 +687,8 @@ async def commit_session(
     commit_kwargs.update(
         {key: value for key, value in optional_retention.items() if value is not None}
     )
+    if body.reset_context:
+        commit_kwargs["reset_context"] = True
     event_tags = _commit_event_tags(body.extraction_metadata)
     if event_tags is not None:
         commit_kwargs["event_tags"] = event_tags

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -373,6 +373,7 @@ class SessionService:
         retained_message_token_budget: Optional[int] = None,
         min_raw_tail_steps: Optional[int] = None,
         event_tags: Optional[List[str]] = None,
+        reset_context: bool = False,
     ) -> Dict[str, Any]:
         """Commit a session (archive messages and extract memories).
 
@@ -394,6 +395,7 @@ class SessionService:
             retained_message_token_budget=retained_message_token_budget,
             min_raw_tail_steps=min_raw_tail_steps,
             event_tags=event_tags,
+            reset_context=reset_context,
         )
 
     async def commit_async(
@@ -407,6 +409,7 @@ class SessionService:
         retained_message_token_budget: Optional[int] = None,
         min_raw_tail_steps: Optional[int] = None,
         event_tags: Optional[List[str]] = None,
+        reset_context: bool = False,
     ) -> Dict[str, Any]:
         """Async commit a session.
 
@@ -436,6 +439,8 @@ class SessionService:
         )
         if event_tags is not None:
             commit_kwargs["event_tags"] = event_tags
+        if reset_context:
+            commit_kwargs["reset_context"] = True
         result = await session.commit_async(**commit_kwargs)
         self._record_lifecycle_metric("commit", "ok" if result.get("status") else "error")
         self._record_archive_metric("ok" if result.get("archived") else "skip")

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -1860,6 +1860,7 @@ class Session:
         persist_keep_recent_count: bool = True,
         record_auto_commit_success: bool = False,
         event_tags: Optional[List[str]] = None,
+        reset_context: bool = False,
     ) -> Dict[str, Any]:
         """Archive immediately and enqueue restart-safe Phase 2 processing.
 
@@ -1876,6 +1877,8 @@ class Session:
                 behavior of archiving everything. The plugin's afterTurn path
                 typically passes its configured value (default 10); the compact
                 path passes ``0``.
+            reset_context: Archive all live messages, then append an empty completed
+                archive to stop context and future summaries at this boundary.
             persist_keep_recent_count: When ``True`` (default), ``keep_recent_count``
                 is remembered in meta for subsequent add_message() accounting.
                 The idle full-commit path passes ``False`` with
@@ -1895,6 +1898,8 @@ class Session:
         from openviking.storage.queuefs import QueueManager, get_queue_manager
         from openviking.storage.queuefs.session_commit_msg import SessionCommitMsg
 
+        if reset_context and (keep_recent_count != 0 or retention_mode is not None):
+            raise ValueError("reset_context requires keep_recent_count=0 and no retention_mode")
         trace_id = tracer.get_trace_id()
         keep_recent_count = max(0, int(keep_recent_count or 0))
         if retention_mode not in (None, RETENTION_MODE_TURN_BUDGET):
@@ -2035,6 +2040,8 @@ class Session:
                     min_raw_tail_steps=effective_min_tail,
                 )
                 await self._save_meta()
+                if reset_context:
+                    await self._append_context_reset_archive()
                 get_current_telemetry().set("memory.extracted", 0)
                 return {
                     "session_id": self.session_id,
@@ -2044,6 +2051,7 @@ class Session:
                     "archived": False,
                     "reason": "no_messages",
                     "trace_id": trace_id,
+                    **({"reset_context": True} if reset_context else {}),
                 }
 
             total = len(self._messages)
@@ -2224,16 +2232,15 @@ class Session:
                 self._messages = original_messages
                 self._compression.compression_index -= 1
                 raise
+            if reset_context:
+                await self._append_context_reset_archive()
         finally:
             await self._viking_fs._async_agfs.pathlock_release(lease)
         # Lock released; Phase 1 intent, queue item, retained root, metadata and
         # ready metadata are all durable.
 
         self._compression.original_count += len(messages_to_archive)
-        logger.info(
-            f"Archived: {len(messages_to_archive)} messages → "
-            f"history/archive_{self._compression.compression_index:03d}/"
-        )
+        logger.info(f"Archived: {len(messages_to_archive)} messages → {archive_uri}/")
 
         return {
             "session_id": self.session_id,
@@ -2242,11 +2249,30 @@ class Session:
             "archive_uri": archive_uri,
             "archived": True,
             "trace_id": trace_id,
+            **({"reset_context": True} if reset_context else {}),
             "estimated_active_tokens": (
                 retention_plan.estimated_active_tokens if retention_plan else 0
             ),
             "budget_exceeded": retention_plan.budget_exceeded if retention_plan else False,
         }
+
+    async def _append_context_reset_archive(self) -> None:
+        """Publish an empty terminal archive while holding the Phase 1 session lock."""
+        # ponytail: reuse archive ordering; no second session identity or context store.
+        self._compression.compression_index += 1
+        archive_uri = (
+            f"{self._session_uri}/history/archive_{self._compression.compression_index:03d}"
+        )
+        await self._viking_fs.write_file(f"{archive_uri}/messages.jsonl", "", ctx=self.ctx)
+        await self._viking_fs.write_file(f"{archive_uri}/.overview.md", "", ctx=self.ctx)
+        # Publish last. Older Phase 2 jobs only update their own archive directories.
+        await self._viking_fs.write_file(
+            f"{archive_uri}/.done",
+            json.dumps({"context_reset": True, "working_memory_enabled": False}),
+            ctx=self.ctx,
+        )
+        self._meta.commit_count = self._compression.compression_index
+        await self._save_meta()
 
     async def finalize_cancelled_commit(self, archive_uri: str) -> None:
         """Make a cancelled queued commit terminal without discarding its raw archive."""
@@ -3252,14 +3278,25 @@ class Session:
                     ),
                 }
             else:
-                # A required overview that is missing or unreadable still keeps
-                # the archive terminal here; the warning is emitted by the full
-                # scan used for Phase 2 bookkeeping.
-                logger.warning(
-                    "Completed archive has no readable overview: %s",
-                    terminal["archive_uri"],
-                )
-                failed_archives = 1
+                try:
+                    done = json.loads(
+                        await self._viking_fs.read_file(
+                            f"{terminal['archive_uri']}/.done", ctx=self.ctx
+                        )
+                    )
+                except (OSError, ValueError):
+                    done = {}
+                if isinstance(done, dict) and done.get("context_reset") is True:
+                    terminal = None
+                else:
+                    # A required overview that is missing or unreadable still keeps
+                    # the archive terminal here; the warning is emitted by the full
+                    # scan used for Phase 2 bookkeeping.
+                    logger.warning(
+                        "Completed archive has no readable overview: %s",
+                        terminal["archive_uri"],
+                    )
+                    failed_archives = 1
         elif terminal is not None:
             failed_archives = 1
 
@@ -3523,6 +3560,7 @@ class Session:
                     "archive_id": state.archive_id,
                     "archive_uri": state.archive_uri,
                     "index": state.index,
+                    "context_reset": state.done.get("context_reset") is True,
                 }
             )
 
@@ -3588,6 +3626,8 @@ class Session:
             exclude_archive_uri,
             before_archive_index,
         ):
+            if archive.get("context_reset"):
+                break
             overview = await self._read_archive_overview(archive["archive_uri"])
             if not overview:
                 continue

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -2256,9 +2256,20 @@ class Session:
             "budget_exceeded": retention_plan.budget_exceeded if retention_plan else False,
         }
 
+    async def _is_context_reset_archive(self, archive_uri: str) -> bool:
+        """Return True when the archive's ``.done`` marks a context reset boundary."""
+        try:
+            done = json.loads(await self._viking_fs.read_file(f"{archive_uri}/.done", ctx=self.ctx))
+        except Exception:
+            return False
+        return isinstance(done, dict) and done.get("context_reset") is True
+
     async def _append_context_reset_archive(self) -> None:
         """Publish an empty terminal archive while holding the Phase 1 session lock."""
         # ponytail: reuse archive ordering; no second session identity or context store.
+        newest = f"{self._session_uri}/history/archive_{self._compression.compression_index:03d}"
+        if self._compression.compression_index > 0 and await self._is_context_reset_archive(newest):
+            return  # Context is already empty; no second boundary needed.
         self._compression.compression_index += 1
         archive_uri = (
             f"{self._session_uri}/history/archive_{self._compression.compression_index:03d}"
@@ -3283,26 +3294,17 @@ class Session:
                         terminal["archive_uri"], overview
                     ),
                 }
+            elif await self._is_context_reset_archive(terminal["archive_uri"]):
+                terminal = None
             else:
-                try:
-                    done = json.loads(
-                        await self._viking_fs.read_file(
-                            f"{terminal['archive_uri']}/.done", ctx=self.ctx
-                        )
-                    )
-                except (OSError, ValueError):
-                    done = {}
-                if isinstance(done, dict) and done.get("context_reset") is True:
-                    terminal = None
-                else:
-                    # A required overview that is missing or unreadable still keeps
-                    # the archive terminal here; the warning is emitted by the full
-                    # scan used for Phase 2 bookkeeping.
-                    logger.warning(
-                        "Completed archive has no readable overview: %s",
-                        terminal["archive_uri"],
-                    )
-                    failed_archives = 1
+                # A required overview that is missing or unreadable still keeps
+                # the archive terminal here; the warning is emitted by the full
+                # scan used for Phase 2 bookkeeping.
+                logger.warning(
+                    "Completed archive has no readable overview: %s",
+                    terminal["archive_uri"],
+                )
+                failed_archives = 1
         elif terminal is not None:
             failed_archives = 1
 

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -2265,7 +2265,11 @@ class Session:
         return isinstance(done, dict) and done.get("context_reset") is True
 
     async def _append_context_reset_archive(self) -> None:
-        """Publish an empty terminal archive while holding the Phase 1 session lock."""
+        """Publish a boundary archive while holding the Phase 1 session lock.
+
+        The directory holds only ``.done``: terminal archives never have their
+        ``messages.jsonl`` read, and a missing overview already reads as empty.
+        """
         # ponytail: reuse archive ordering; no second session identity or context store.
         newest = f"{self._session_uri}/history/archive_{self._compression.compression_index:03d}"
         if self._compression.compression_index > 0 and await self._is_context_reset_archive(newest):
@@ -2275,17 +2279,14 @@ class Session:
             f"{self._session_uri}/history/archive_{self._compression.compression_index:03d}"
         )
         try:
-            await self._viking_fs.write_file(f"{archive_uri}/messages.jsonl", "", ctx=self.ctx)
-            await self._viking_fs.write_file(f"{archive_uri}/.overview.md", "", ctx=self.ctx)
-            # Publish last. Older Phase 2 jobs only update their own archive directories.
             await self._viking_fs.write_file(
                 f"{archive_uri}/.done",
                 json.dumps({"context_reset": True, "working_memory_enabled": False}),
                 ctx=self.ctx,
             )
         except Exception as exc:
-            # No queue owns this empty archive: leave a terminal state so the
-            # next commit cannot wait forever for a failed reset.
+            # A directory left without any marker reads as pending and would
+            # block the next Phase 2 forever; no queue owns this archive.
             await self._write_failed_marker(archive_uri, stage="context_reset", error=str(exc))
             raise
         self._meta.commit_count = self._compression.compression_index

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -2263,14 +2263,20 @@ class Session:
         archive_uri = (
             f"{self._session_uri}/history/archive_{self._compression.compression_index:03d}"
         )
-        await self._viking_fs.write_file(f"{archive_uri}/messages.jsonl", "", ctx=self.ctx)
-        await self._viking_fs.write_file(f"{archive_uri}/.overview.md", "", ctx=self.ctx)
-        # Publish last. Older Phase 2 jobs only update their own archive directories.
-        await self._viking_fs.write_file(
-            f"{archive_uri}/.done",
-            json.dumps({"context_reset": True, "working_memory_enabled": False}),
-            ctx=self.ctx,
-        )
+        try:
+            await self._viking_fs.write_file(f"{archive_uri}/messages.jsonl", "", ctx=self.ctx)
+            await self._viking_fs.write_file(f"{archive_uri}/.overview.md", "", ctx=self.ctx)
+            # Publish last. Older Phase 2 jobs only update their own archive directories.
+            await self._viking_fs.write_file(
+                f"{archive_uri}/.done",
+                json.dumps({"context_reset": True, "working_memory_enabled": False}),
+                ctx=self.ctx,
+            )
+        except Exception as exc:
+            # No queue owns this empty archive: leave a terminal state so the
+            # next commit cannot wait forever for a failed reset.
+            await self._write_failed_marker(archive_uri, stage="context_reset", error=str(exc))
+            raise
         self._meta.commit_count = self._compression.compression_index
         await self._save_meta()
 

--- a/tests/server/test_api_session_reset.py
+++ b/tests/server/test_api_session_reset.py
@@ -111,7 +111,8 @@ async def test_reset_empty_archive_survives_late_summary_and_next_commit(
     assert (await context())["latest_archive_overview"] == ""
     fs = session._viking_fs
     boundary = f"{session._session_uri}/history/archive_003"
-    assert await fs.read_file(f"{boundary}/.overview.md", ctx=session.ctx) == ""
+    assert not await fs.exists(f"{boundary}/.overview.md", ctx=session.ctx)
+    assert not await fs.exists(f"{boundary}/messages.jsonl", ctx=session.ctx)
     assert json.loads(await fs.read_file(f"{boundary}/.done", ctx=session.ctx))["context_reset"]
     assert "old task two" in await fs.read_file(
         f"{jobs[1].archive_uri}/messages.jsonl", ctx=session.ctx
@@ -146,8 +147,7 @@ async def test_reset_rejects_retention_and_non_boolean_flag(client, options):
     assert response.json()["error"]["code"] == "INVALID_ARGUMENT"
 
 
-@pytest.mark.parametrize("failed_file", [".overview.md", ".done"])
-async def test_reset_write_failure_does_not_block_next_archive(service, monkeypatch, failed_file):
+async def test_reset_write_failure_does_not_block_next_archive(service, monkeypatch):
     ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
     session = service.sessions.session(ctx, session_id="reset-write-failure")
     await session.ensure_exists()
@@ -157,7 +157,7 @@ async def test_reset_write_failure_does_not_block_next_archive(service, monkeypa
 
     async def fail_once(uri, content, **kwargs):
         nonlocal failed
-        if uri.endswith(f"archive_001/{failed_file}") and not failed:
+        if uri.endswith("archive_001/.done") and not failed:
             failed = True
             raise OSError("transient reset write failure")
         return await write(uri, content, **kwargs)

--- a/tests/server/test_api_session_reset.py
+++ b/tests/server/test_api_session_reset.py
@@ -142,3 +142,34 @@ async def test_reset_rejects_retention_and_non_boolean_flag(client, options):
     response = await client.post("/api/v1/sessions/unused/commit", json=options)
     assert response.status_code == 400
     assert response.json()["error"]["code"] == "INVALID_ARGUMENT"
+
+
+@pytest.mark.parametrize("failed_file", [".overview.md", ".done"])
+async def test_reset_write_failure_does_not_block_next_archive(service, monkeypatch, failed_file):
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
+    session = service.sessions.session(ctx, session_id="reset-write-failure")
+    await session.ensure_exists()
+    fs = session._viking_fs
+    write = fs.write_file
+    failed = False
+
+    async def fail_once(uri, content, **kwargs):
+        nonlocal failed
+        if uri.endswith(f"archive_001/{failed_file}") and not failed:
+            failed = True
+            raise OSError("transient reset write failure")
+        return await write(uri, content, **kwargs)
+
+    monkeypatch.setattr(fs, "write_file", fail_once)
+    with pytest.raises(OSError, match="transient reset write failure"):
+        await session.commit_async(reset_context=True)
+
+    boundary = f"{session._session_uri}/history/archive_001"
+    assert await session._archive_terminal_state(boundary) == "failed"
+    assert await session._can_run_archive(2)
+    # Retrying reset publishes a new terminal boundary rather than reusing the partial one.
+    assert (await session.commit_async(reset_context=True))["reset_context"] is True
+    context = await session.get_session_context()
+    assert context["messages"] == []
+    assert context["latest_archive_overview"] == ""
+    assert context["stats"]["failedArchives"] == 0

--- a/tests/server/test_api_session_reset.py
+++ b/tests/server/test_api_session_reset.py
@@ -117,8 +117,10 @@ async def test_reset_empty_archive_survives_late_summary_and_next_commit(
         f"{jobs[1].archive_uri}/messages.jsonl", ctx=session.ctx
     )
 
-    # Reset an already-empty session, then summarize new work without old overview fallback.
+    # Reset an already-empty session: confirmed, but no second boundary directory.
     assert (await commit(reset_context=True))["reset_context"] is True
+    assert not await fs.exists(f"{session._session_uri}/history/archive_004", ctx=session.ctx)
+    # Summarize new work without old overview fallback.
     await add("new task")
     assert (await context())["messages"][0]["parts"][0]["text"] == "new task"
     await commit()

--- a/tests/server/test_api_session_reset.py
+++ b/tests/server/test_api_session_reset.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Reset keeps raw history without reviving context through late or future summaries."""
+
+import json
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.session.session import Session
+from openviking.storage.queuefs import SessionCommitMsg, get_queue_manager
+from openviking_cli.session.user_id import UserIdentifier
+from openviking_cli.utils.config import OPENVIKING_CONFIG_ENV
+from openviking_cli.utils.config.open_viking_config import OpenVikingConfigSingleton
+
+
+@pytest.fixture(autouse=True)
+def isolated_config(tmp_path, monkeypatch):
+    config = tmp_path / "ov.conf"
+    config.write_text(
+        json.dumps(
+            {
+                "storage": {
+                    "workspace": str(tmp_path / "data"),
+                    "agfs": {"backend": "local"},
+                    "vectordb": {"backend": "local"},
+                },
+                "embedding": {
+                    "dense": {
+                        "provider": "openai",
+                        "model": "test",
+                        "api_key": "test-key",
+                        "dimension": 2048,
+                    }
+                },
+            }
+        )
+    )
+    monkeypatch.setenv(OPENVIKING_CONFIG_ENV, str(config))
+    OpenVikingConfigSingleton.reset_instance()
+    yield
+    OpenVikingConfigSingleton.reset_instance()
+
+
+async def test_reset_empty_archive_survives_late_summary_and_next_commit(
+    client, service, monkeypatch
+):
+    jobs = []
+    summary_inputs = []
+
+    async def enqueue(queue_name, data):
+        jobs.append(SessionCommitMsg(**data))
+        return data["task_id"]
+
+    async def summarize(self, messages, latest_archive_overview="", **kwargs):
+        summary_inputs.append((messages[0].content, latest_archive_overview))
+        return "# Summary\n" + latest_archive_overview + "\n" + messages[0].content
+
+    monkeypatch.setattr(get_queue_manager(), "enqueue", enqueue)
+    monkeypatch.setattr(Session, "_generate_archive_summary_async", summarize)
+    base = "/api/v1/sessions/reset-same-id"
+    created = await client.post(
+        "/api/v1/sessions",
+        json={
+            "session_id": "reset-same-id",
+            "memory_policy": {"memory_types": [], "working_memory": {"enabled": True}},
+        },
+    )
+    assert created.status_code == 200, created.text
+
+    async def add(text):
+        response = await client.post(f"{base}/messages", json={"role": "user", "content": text})
+        assert response.status_code == 200, response.text
+
+    async def commit(**options):
+        response = await client.post(f"{base}/commit", json=options)
+        assert response.status_code == 200, response.text
+        return response.json()["result"]
+
+    async def context():
+        response = await client.get(f"{base}/context")
+        assert response.status_code == 200, response.text
+        return response.json()["result"]
+
+    async def finish(job):
+        ctx = RequestContext(user=UserIdentifier.from_dict(job.user), role=Role.USER)
+        session = service.sessions.session(
+            ctx, session_id=job.session_id, session_uri=job.session_uri
+        )
+        await session.load()
+        assert await session.resume_queued_commit(job)
+        assert await session._archive_terminal_state(job.archive_uri) == "completed"
+        return session
+
+    await add("old task one")
+    await commit()  # Leave Phase 2 pending across reset.
+    await add("old task two")
+    reset = await commit(reset_context=True)
+    assert reset["session_id"] == "reset-same-id"
+    assert reset["archive_uri"].endswith("archive_002")
+    empty = await context()
+    assert empty["messages"] == []
+    assert empty["latest_archive_overview"] == ""
+    assert empty["stats"]["failedArchives"] == 0
+    assert reset["reset_context"] is True
+
+    # Complete both old jobs after the boundary: raw history remains, context stays empty.
+    await finish(jobs[0])
+    session = await finish(jobs[1])
+    assert summary_inputs[1][1].endswith("old task one")
+    assert (await context())["latest_archive_overview"] == ""
+    fs = session._viking_fs
+    boundary = f"{session._session_uri}/history/archive_003"
+    assert await fs.read_file(f"{boundary}/.overview.md", ctx=session.ctx) == ""
+    assert json.loads(await fs.read_file(f"{boundary}/.done", ctx=session.ctx))["context_reset"]
+    assert "old task two" in await fs.read_file(
+        f"{jobs[1].archive_uri}/messages.jsonl", ctx=session.ctx
+    )
+
+    # Reset an already-empty session, then summarize new work without old overview fallback.
+    assert (await commit(reset_context=True))["reset_context"] is True
+    await add("new task")
+    assert (await context())["messages"][0]["parts"][0]["text"] == "new task"
+    await commit()
+    await finish(jobs[-1])
+    assert summary_inputs[-1] == ("new task", "")
+    final = await context()
+    assert "new task" in final["latest_archive_overview"]
+    assert "old task" not in final["latest_archive_overview"]
+    assert len(jobs) == 3  # Empty reset archives do not enqueue extraction.
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"reset_context": True, "keep_recent_count": 1},
+        {"reset_context": True, "retention_mode": "turn_budget"},
+        {"reset_context": "true"},
+    ],
+)
+async def test_reset_rejects_retention_and_non_boolean_flag(client, options):
+    response = await client.post("/api/v1/sessions/unused/commit", json=options)
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "INVALID_ARGUMENT"


### PR DESCRIPTION
## 中文

### 根因与修复

OpenClaw 原地 `/new`、`/reset` 保留 `sessionId`。插件原来的 `before_reset` 只归档消息，下一轮仍可能注入旧 overview；待完成 archive 也会作为原文进入 context。

- 保持 OV session ID：commit 请求增加 `reset_context=true`，在现有 Phase 1 锁内归档全部消息后，追加空 messages、空 overview 和带 `context_reset` 标记的 `.done`。
- 当前 context 在空 archive 处截断；后续摘要生成也在此停止回查。旧 Phase 2 可以完成，但不会恢复旧上下文。
- 空会话也可 reset。普通 commit/compaction 行为不变。插件检查服务端确认字段，避免旧服务端忽略参数后误报成功。
- 空 archive 写入失败时写入失败终态，避免阻塞后续 commit；若 `.done` 已成功发布，后续 meta 保存失败不会删除该边界。

### 范围

支持 HTTP、`Session`/`SessionService` 和 OpenClaw 插件；未增加 Python/Go/TypeScript SDK、Rust CLI 或 Studio 的专用入口。长期记忆和显式历史查询保留。本修复依赖 OpenClaw 在 reset hook 周围管理 turn 生命周期，不引入 revision/segment 或迟到消息路由。

### 验证

- 下方 Python 回归命令：**14 passed**。覆盖旧任务延迟完成、空会话重复 reset、后续摘要不继承旧上下文、无效参数，以及空 archive 写失败后恢复。
- 同一回归用例在未修改的 main 源码上失败：reset 后 context 仍包含两条旧消息；修复后为空。
- 下方插件测试命令：**101 passed**；TypeScript 类型检查、构建、变更 Python 文件 lint 和 diff 检查通过。
- `node /tmp/ov-reset-live.mjs`：HEAD `d4d6c4528` 启动临时 OV HTTP 服务（LocalFS，向量接口用本地 stub；种入旧摘要）。实际插件 `before_reset` → commit → 下一轮主 assemble：session ID 不变，旧摘要变为空、live messages=0，新上下文只有新任务；OpenAPI 确认 `reset_context` 字段。
- 未运行 OpenClaw；验证使用插件函数及 OV HTTP 路径。
- 独立复审绑定 HEAD `d4d6c45285c37ce10a8eb31c94fbc3f39778a12b`，无剩余 findings（本地审查，未发布 GitHub review）。
- 远端 openclaw-tests、plugin-tests、check-deps、Docs 通过；API & CLI Integration Tests 运行中。

## English

### Cause and fix

OpenClaw's in-place `/new` and `/reset` retain `sessionId`. The plugin's previous `before_reset` hook only archived messages, so the next turn could still receive the old overview or raw messages from pending archives.

- Keep the OV session ID. A commit with `reset_context=true` archives all live messages, then appends empty messages, an empty overview, and a `.done` marker carrying `context_reset`, under the existing Phase 1 lock.
- Context reads stop at the empty archive. Subsequent summary generation also stops looking backward at this boundary. Older Phase 2 jobs may finish without restoring pre-reset context.
- Empty sessions can also reset. Ordinary commit/compaction behavior is unchanged. The plugin requires server confirmation so an older server that ignores the option cannot report reset success.
- Failed empty-archive writes receive a terminal failure marker so subsequent commits can proceed. Once `.done` is published, a later metadata-save failure preserves the boundary.

### Scope

Supported through HTTP, `Session`/`SessionService`, and the OpenClaw plugin. No dedicated options are added to the Python/Go/TypeScript SDKs, Rust CLI, or Studio. Long-term memories and explicit history queries remain available. This fix relies on OpenClaw to manage turn lifecycles around the reset hook; it adds no revision/segment model or late-message routing.

### Validation

- Python regression command below: **14 passed**. Covers delayed completion of older jobs, repeated resets of empty sessions, summaries starting without pre-reset context, invalid parameters, and recovery from failed empty-archive writes.
- The same regression fails against unchanged main source: context still contains two old messages after reset. With the fix, it is empty.
- Plugin test command below: **101 passed**. TypeScript typecheck/build, lint of changed Python files, and diff checks passed.
- `node /tmp/ov-reset-live.mjs`: a temporary OV HTTP server ran from HEAD `d4d6c4528` using LocalFS, a local embedding stub, and a seeded old summary. The actual plugin `before_reset` → commit → next main assemble path retained the session ID, cleared the summary and live messages, and assembled only the new task. OpenAPI exposed `reset_context`.
- OpenClaw itself was not run; validation exercised plugin functions and the OV HTTP path.
- Independent local review of HEAD `d4d6c45285c37ce10a8eb31c94fbc3f39778a12b` found no remaining issues. No GitHub review was published.
- Remote openclaw-tests, plugin-tests, check-deps, and Docs passed. API & CLI Integration Tests are still running.

### 验证命令 / Validation commands

Repository root:

```bash
python -m pytest tests/server/test_api_session_reset.py tests/unit/session/test_session_commit_resume.py -q --no-cov --disable-warnings
ruff check openviking/session/session.py openviking/service/session_service.py openviking/server/routers/sessions.py tests/server/test_api_session_reset.py
git diff --check
```

From `examples/openclaw-plugin`:

```bash
vitest run tests/ut/context-engine-compact.test.ts tests/ut/context-engine-modules.test.ts tests/ut/client.test.ts tests/ut/plugin-modules.test.ts
tsc -p tsconfig.json
tsc -p tsconfig.build.json
```
