### PR TITLE
fix(cli): 统一 add-skill 与 skills add 的导入流程

### DIFF
--- a/crates/ov_cli/src/client.rs
+++ b/crates/ov_cli/src/client.rs
@@ -1000,7 +1000,6 @@ impl HttpClient {
         &self,
         data: &str,
         wait: bool,
-        timeout: Option<f64>,
         show_progress: bool,
         verbose: bool,
         source_metadata: Option<Value>,
@@ -1025,7 +1024,6 @@ impl HttpClient {
                 let mut body = serde_json::json!({
                     "temp_file_id": temp_file_id,
                     "wait": wait,
-                    "timeout": timeout,
                 });
                 if let Some(source_metadata) = source_metadata.clone() {
                     body["source_metadata"] = source_metadata;
@@ -1049,7 +1047,6 @@ impl HttpClient {
                 let mut body = serde_json::json!({
                     "temp_file_id": temp_file_id,
                     "wait": wait,
-                    "timeout": timeout,
                 });
                 if let Some(source_metadata) = source_metadata.clone() {
                     body["source_metadata"] = source_metadata;
@@ -1066,7 +1063,6 @@ impl HttpClient {
                 let mut body = serde_json::json!({
                     "data": data,
                     "wait": wait,
-                    "timeout": timeout,
                 });
                 if let Some(source_metadata) = source_metadata.clone() {
                     body["source_metadata"] = source_metadata;
@@ -1080,7 +1076,6 @@ impl HttpClient {
             let mut body = serde_json::json!({
                 "data": data,
                 "wait": wait,
-                "timeout": timeout,
             });
             if let Some(source_metadata) = source_metadata {
                 body["source_metadata"] = source_metadata;

--- a/crates/ov_cli/src/commands/resources.rs
+++ b/crates/ov_cli/src/commands/resources.rs
@@ -65,29 +65,3 @@ pub async fn add_resource(
     output_success(&result, format, compact);
     Ok(())
 }
-
-pub async fn add_skill(
-    client: &HttpClient,
-    data: &str,
-    wait: bool,
-    timeout: Option<f64>,
-    parent: Option<&str>,
-    show_progress: bool,
-    verbose: bool,
-    format: OutputFormat,
-    compact: bool,
-) -> Result<()> {
-    let result = client
-        .add_skill(data, wait, timeout, show_progress, verbose, None, parent)
-        .await?;
-
-    if !wait && matches!(format, OutputFormat::Table) {
-        eprintln!("Note: Skill is being processed in the background.");
-        eprintln!(
-            "Use 'ov task status <task_id>' to check progress, or 'ov task list' to see all tasks."
-        );
-    }
-
-    output_success(&result, format, compact);
-    Ok(())
-}

--- a/crates/ov_cli/src/commands/skills.rs
+++ b/crates/ov_cli/src/commands/skills.rs
@@ -122,7 +122,6 @@ pub async fn add(
             .add_skill(
                 &target.data,
                 wait,
-                None,
                 show_progress,
                 verbose,
                 source_metadata,

--- a/crates/ov_cli/src/handlers.rs
+++ b/crates/ov_cli/src/handlers.rs
@@ -1,4 +1,3 @@
-use crate::CliContext;
 use crate::PrivacyCommands;
 use crate::client;
 use crate::commands;
@@ -10,6 +9,7 @@ use crate::terminal_ui::{
 };
 use crate::theme;
 use crate::tui;
+use crate::{CliContext, SkillAddArgs, UploadCliOptions};
 use colored::Colorize;
 use serde_json::{Map, Value};
 
@@ -320,23 +320,27 @@ mod add_resource_args_tests {
 }
 
 pub async fn handle_add_skill(
-    data: String,
-    wait: bool,
-    timeout: Option<f64>,
-    parent: Option<String>,
+    args: SkillAddArgs,
+    legacy_upload_options: UploadCliOptions,
     ctx: CliContext,
 ) -> Result<()> {
+    let ctx = ctx.with_upload_options(
+        args.upload_options
+            .merged_with_legacy(legacy_upload_options),
+    );
     let client = ctx.get_client();
-    commands::resources::add_skill(
+    commands::skills::add(
         &client,
-        &data,
-        wait,
-        timeout,
-        parent.as_deref(),
+        &args.source,
+        args.skills,
+        args.list,
+        args.wait,
+        args.yes,
         ctx.should_show_progress(),
         ctx.is_verbose(),
         ctx.output_format,
         ctx.compact,
+        args.parent.as_deref(),
     )
     .await
 }

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -466,33 +466,8 @@ enum Commands {
         #[command(flatten)]
         upload_options: UploadCliOptions,
     },
-    /// [Data] Add a skill into OpenViking
-    AddSkill {
-        /// Skill directory, SKILL.md, or raw content
-        #[arg(value_name = "skill-path-or-content")]
-        data: String,
-        /// Wait until processing is complete
-        #[arg(long, help_heading = "Common options")]
-        wait: bool,
-        /// Wait timeout in seconds
-        #[arg(
-            long,
-            value_parser = config::parse_positive_timeout,
-            value_name = "seconds",
-            help_heading = "Common options"
-        )]
-        timeout: Option<f64>,
-        /// Parent skill root URI (e.g. viking://agent/skills); defaults to user-private skills
-        #[arg(
-            short = 'p',
-            long = "parent-auto-create",
-            value_name = "uri",
-            help_heading = "Skill options"
-        )]
-        parent: Option<String>,
-        #[command(flatten)]
-        upload_options: UploadCliOptions,
-    },
+    /// [Data] Add skills from a source (same as `skills add`)
+    AddSkill(SkillAddArgs),
     /// [Data] Manage installed skills
     Skills {
         #[command(subcommand)]
@@ -1299,7 +1274,14 @@ impl Commands {
     }
 
     fn supports_upload_options(&self) -> bool {
-        matches!(self, Self::AddResource { .. } | Self::AddSkill { .. })
+        matches!(
+            self,
+            Self::AddResource { .. }
+                | Self::AddSkill(_)
+                | Self::Skills {
+                    action: SkillCommands::Add(_)
+                }
+        )
     }
 }
 
@@ -1309,7 +1291,7 @@ fn legacy_upload_option_error(
 ) -> Option<&'static str> {
     if options.is_set() && !command.supports_upload_options() {
         Some(
-            "--progress, --no-progress, and --verbose are only supported for add-resource and add-skill.",
+            "--progress, --no-progress, and --verbose are only supported for add-resource, add-skill, and skills add.",
         )
     } else {
         None
@@ -1644,29 +1626,34 @@ enum SessionConfigCommands {
     },
 }
 
+#[derive(Args)]
+struct SkillAddArgs {
+    /// Local skill file/directory, Git repository or GitHub tree URL, or raw content
+    #[arg(value_name = "source")]
+    source: String,
+    /// Install only the named skill(s); use '*' to install all skills in a source
+    #[arg(short = 's', long = "skill", value_name = "NAME", num_args = 1.., value_delimiter = ',')]
+    skills: Vec<String>,
+    /// List available skills in the source without installing
+    #[arg(short = 'l', long = "list")]
+    list: bool,
+    /// Wait until processing is complete
+    #[arg(short = 'w', long)]
+    wait: bool,
+    /// Skip confirmation prompt
+    #[arg(short = 'y', long = "yes")]
+    yes: bool,
+    /// Parent skill root URI (e.g. viking://agent/skills); defaults to user-private skills
+    #[arg(short = 'p', long = "parent-auto-create", value_name = "uri")]
+    parent: Option<String>,
+    #[command(flatten)]
+    upload_options: UploadCliOptions,
+}
+
 #[derive(Subcommand)]
 enum SkillCommands {
     /// Add skills from a source
-    Add {
-        /// Skill source
-        #[arg(value_name = "source")]
-        source: String,
-        /// Install only the named skill(s); use '*' to install all skills in a source
-        #[arg(short = 's', long = "skill", value_name = "NAME", num_args = 1.., value_delimiter = ',')]
-        skills: Vec<String>,
-        /// List available skills in the source without installing
-        #[arg(short = 'l', long = "list")]
-        list: bool,
-        /// Wait until processing is complete
-        #[arg(short = 'w', long)]
-        wait: bool,
-        /// Skip confirmation prompt
-        #[arg(short = 'y', long = "yes")]
-        yes: bool,
-        /// Parent skill root URI (e.g. viking://agent/skills); defaults to user-private skills
-        #[arg(short = 'p', long = "parent-auto-create", value_name = "uri")]
-        parent: Option<String>,
-    },
+    Add(SkillAddArgs),
     /// List installed agent skills
     #[command(alias = "ls")]
     List {
@@ -3297,41 +3284,12 @@ async fn main() {
                 ))
             }
         }
-        Commands::AddSkill {
-            data,
-            wait,
-            timeout,
-            parent,
-            upload_options,
-        } => {
-            let ctx =
-                ctx.with_upload_options(upload_options.merged_with_legacy(legacy_upload_options));
-            handlers::handle_add_skill(data, wait, timeout, parent, ctx).await
+        Commands::AddSkill(args) => {
+            handlers::handle_add_skill(args, legacy_upload_options, ctx).await
         }
         Commands::Skills { action } => match action {
-            SkillCommands::Add {
-                source,
-                skills,
-                list,
-                wait,
-                yes,
-                parent,
-            } => {
-                let client = ctx.get_client();
-                commands::skills::add(
-                    &client,
-                    &source,
-                    skills,
-                    list,
-                    wait,
-                    yes,
-                    ctx.should_show_progress(),
-                    ctx.is_verbose(),
-                    ctx.output_format,
-                    ctx.compact,
-                    parent.as_deref(),
-                )
-                .await
+            SkillCommands::Add(args) => {
+                handlers::handle_add_skill(args, legacy_upload_options, ctx).await
             }
             SkillCommands::List { node_limit, parent } => {
                 let client = ctx.get_client();
@@ -4649,13 +4607,13 @@ mod tests {
         let add_skill = Cli::try_parse_from(["ov", "add-skill", "./skill", "--no-progress"])
             .expect("add-skill upload flags should parse");
         match add_skill.command {
-            Commands::AddSkill { upload_options, .. } => {
-                assert!(upload_options.no_progress);
+            Commands::AddSkill(args) => {
+                assert!(args.upload_options.no_progress);
             }
             _ => panic!("expected add-skill command"),
         }
 
-        assert!(Cli::try_parse_from(["ov", "skills", "add", "./skill", "--progress"]).is_err());
+        assert!(Cli::try_parse_from(["ov", "skills", "add", "./skill", "--progress"]).is_ok());
         assert!(Cli::try_parse_from(["ov", "skills", "update", "--progress"]).is_err());
     }
 
@@ -4792,35 +4750,35 @@ mod tests {
             _ => panic!("expected skills update"),
         }
 
-        let add_selected = Cli::try_parse_from([
-            "ov",
-            "skills",
-            "add",
-            "https://github.com/acme/skills.git",
-            "--skill",
-            "foo",
-            "bar",
-            "--list",
-            "--yes",
-        ])
-        .expect("skills add RFC flags should parse");
-        match add_selected.command {
-            Commands::Skills {
-                action:
-                    SkillCommands::Add {
-                        source,
-                        skills,
-                        list,
-                        yes,
-                        ..
-                    },
-            } => {
-                assert_eq!(source, "https://github.com/acme/skills.git");
-                assert_eq!(skills, vec!["foo", "bar"]);
-                assert!(list);
-                assert!(yes);
-            }
-            _ => panic!("expected skills add"),
+        for mut argv in [vec!["ov", "add-skill"], vec!["ov", "skills", "add"]] {
+            argv.extend([
+                "https://github.com/acme/skills.git",
+                "--skill",
+                "foo",
+                "bar",
+                "--list",
+                "--yes",
+                "--wait",
+                "--parent-auto-create",
+                "viking://agent/skills",
+                "--no-progress",
+            ]);
+            let add_selected = Cli::try_parse_from(argv)
+                .expect("both skill add commands should accept the same options");
+            let args = match add_selected.command {
+                Commands::AddSkill(args)
+                | Commands::Skills {
+                    action: SkillCommands::Add(args),
+                } => args,
+                _ => panic!("expected skill add command"),
+            };
+            assert_eq!(args.source, "https://github.com/acme/skills.git");
+            assert_eq!(args.skills, vec!["foo", "bar"]);
+            assert!(args.list);
+            assert!(args.yes);
+            assert!(args.wait);
+            assert_eq!(args.parent.as_deref(), Some("viking://agent/skills"));
+            assert!(args.upload_options.no_progress);
         }
 
         let show = Cli::try_parse_from([
@@ -4918,7 +4876,7 @@ mod tests {
         assert_eq!(
             legacy_upload_option_error(upload_options, &tree.command),
             Some(
-                "--progress, --no-progress, and --verbose are only supported for add-resource and add-skill."
+                "--progress, --no-progress, and --verbose are only supported for add-resource, add-skill, and skills add."
             )
         );
 
@@ -4928,12 +4886,7 @@ mod tests {
 
         let skills_add = Cli::try_parse_from(["ov", "--progress", "skills", "add", "./skill"])
             .expect("hidden legacy flag still parses before runtime validation");
-        assert_eq!(
-            legacy_upload_option_error(upload_options, &skills_add.command),
-            Some(
-                "--progress, --no-progress, and --verbose are only supported for add-resource and add-skill."
-            )
-        );
+        assert!(legacy_upload_option_error(upload_options, &skills_add.command).is_none());
     }
 
     #[test]
@@ -5015,7 +4968,6 @@ mod tests {
     fn all_timeout_options_require_positive_finite_seconds() {
         let command_prefixes = [
             vec!["ov", "add-resource", "https://example.com", "--timeout"],
-            vec!["ov", "add-skill", "skill", "--timeout"],
             vec!["ov", "rm", "viking://resources/item", "--timeout"],
             vec![
                 "ov",

--- a/docs/en/api/04-skills.md
+++ b/docs/en/api/04-skills.md
@@ -341,8 +341,24 @@ fmt.Println(result["task_id"])
 
 **CLI**
 
+`ov add-skill` and `ov skills add` share the same options and import flow. The CLI
+clones Git repositories or GitHub `tree` directories locally, then packages and
+uploads the selected skills. The server API still receives inline content or
+temporary uploads. Supporting files such as `references/` and `scripts/` are included.
+Use `--list` to inspect a collection and `--skill` to select skills. Batch imports
+require confirmation unless `--yes` is set. By default, the command waits for downloading,
+uploading, server-side parsing, overview generation, and file writes, but not vectorization.
+`--wait` additionally waits for vectorization.
+
 ```bash
-# Add skill (from file or directory
+# Import one skill from the standalone skills branch; ov skills add also works
+ov add-skill https://github.com/volcengine/OpenViking/tree/skills/llm-wiki --wait
+
+# Inspect a local collection, then select skills to import
+ov add-skill ./examples/compile/ov-compile-skills --list
+ov add-skill ./examples/compile/ov-compile-skills --skill llm-wiki daily-report --yes
+
+# Add a skill from a local file or directory
 ov add-skill ./skills/my-skill.json
 ov add-skill ./skills/search-web/SKILL.md
 ov add-skill ./skills/code-runner/
@@ -377,7 +393,7 @@ ov add-skill ./skills/my-skill/ -o json
 
 **CLI response (default table format)**:
 ```
-Note: Skill is being processed in the background.
+Note: Skill processing may continue in the background.
 Use 'ov task status <task_id>' to check progress, or 'ov task list' to see all tasks.
 status          success
 root_uri        viking://user/alice/skills/my-skill

--- a/docs/zh/api/04-skills.md
+++ b/docs/zh/api/04-skills.md
@@ -340,7 +340,21 @@ fmt.Println(result["task_id"])
 
 **CLI**：
 
+`ov add-skill` 与 `ov skills add` 使用同一套参数和导入流程。Git 仓库或
+GitHub `tree` 目录由 CLI 克隆到本地，再将选中的技能打包上传；服务端 API
+仍接收内联内容或临时上传文件。目录中的 `references/`、`scripts/` 等附件一并上传。
+技能集合可以用 `--list` 查看、`--skill` 选择；批量导入需要确认，或使用 `--yes`。
+默认不等待向量化完成，但仍需完成下载、上传，以及服务端的解析、overview 生成和文件写入。
+`--wait` 额外等待向量化完成。
+
 ```bash
+# 从独立 skills 分支导入一个技能；也可以写成 ov skills add
+ov add-skill https://github.com/volcengine/OpenViking/tree/skills/llm-wiki --wait
+
+# 查看本地技能集合，再选择导入
+ov add-skill ./examples/compile/ov-compile-skills --list
+ov add-skill ./examples/compile/ov-compile-skills --skill llm-wiki daily-report --yes
+
 # 添加技能（从文件或目录）
 ov add-skill ./skills/my-skill.json
 ov add-skill ./skills/search-web/SKILL.md
@@ -376,7 +390,7 @@ ov add-skill ./skills/my-skill/ -o json
 
 **CLI 响应（默认表格格式）**：
 ```
-Note: Skill is being processed in the background.
+Note: Skill processing may continue in the background.
 Use 'ov task status <task_id>' to check progress, or 'ov task list' to see all tasks.
 status          success
 root_uri        viking://user/alice/skills/my-skill


### PR DESCRIPTION
## Description

统一 `ov add-skill` 和 `ov skills add` 的参数与导入流程，让 `add-skill` 直接复用已有的 Git 下载、技能发现、选择和打包上传能力。

以 [llm-wiki 技能目录](https://github.com/volcengine/OpenViking/tree/skills/llm-wiki) 为 `SOURCE`，执行同一条命令 `ov add-skill "$SOURCE" --wait`：

- 修改前：CLI 直接将链接提交给服务端，返回 `PERMISSION_DENIED`；使用 `ov skills add` 才能完成 Git 下载和导入。
- 修改后：两个入口都由 CLI 克隆仓库、定位技能目录并上传，再调用同一个技能 API，导入 `llm-wiki`。技能附带的 `references/`、`scripts/` 等文件一起上传。

CLI 不再接受技能导入的 `--timeout`，保留 `--wait`。服务端行为保持原样：默认完成解析、overview 生成和文件写入后返回，`task_id` 跟踪剩余向量化；`--wait` 额外等待向量化完成。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

无。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 两个入口共用 `SkillAddArgs` 和 handler，删除旧的独立转发路径；统一支持 `--list`、`--skill`、`--yes` 和上传选项。
- 移除 CLI 技能导入的 timeout 参数及请求字段；HTTP API 和 SDK 的现有 timeout 契约不变。
- 修改现有参数契约测试，补充中英文文档中的 Git 目录和技能集合示例。

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

复用并修改现有测试，没有新增测试文件。相关 Rust CLI 测试共 70 项通过；release 编译安装成功。使用真实本地服务验证两个 CLI 入口均可导入上述 GitHub 技能目录，并确认内容、overview、来源信息和检索结果；直接 API 的内联内容及带 reference 的 ZIP 导入也通过。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

兼容性变化仅涉及 CLI：原先使用 `ov add-skill --timeout ...` 的脚本需要移除该选项。
