### PR TITLE
fix(pi-plugin): preserve camelCase tool result messages

### DIFF
--- a/examples/pi-coding-agent-extension/lib/capture-adapter.mjs
+++ b/examples/pi-coding-agent-extension/lib/capture-adapter.mjs
@@ -10,7 +10,7 @@ function normalizeRole(role) {
   const value = String(role || "").toLowerCase();
   if (value === "user") return "user";
   if (value === "assistant") return "assistant";
-  if (value === "tool" || value === "tool_result") return "user";
+  if (value === "tool" || value === "tool_result" || value === "toolresult") return "user";
   if (value === "tool_call" || value === "toolcall") return "assistant";
   return "";
 }

--- a/examples/pi-coding-agent-extension/tests/capture-adapter.test.mjs
+++ b/examples/pi-coding-agent-extension/tests/capture-adapter.test.mjs
@@ -16,29 +16,54 @@ test("extractBranchCapturePayloads converts user text to message payload", () =>
   assert.equal(result.payloads[0].peer_id, "peer-a");
 });
 
-test("extractBranchCapturePayloads emits structured tool parts", () => {
-  const branch = [
-    {
-      type: "message",
-      message: {
-        role: "assistant",
-        content: [
-          { type: "text", text: "I will inspect it." },
-          { type: "tool_call", id: "call-1", name: "read", input: { path: "a.txt" } },
-        ],
-      },
-    },
-  ];
+for (const role of ["toolResult", "tool_result", "tool"]) {
+  for (const isError of [false, true]) {
+    test(`extractBranchCapturePayloads preserves ${role} ${isError ? "error" : "completed"} results`, () => {
+      const output = [{ type: "text", text: "OVTOOLMARKER98765\n" }];
+      const branch = [
+        { type: "message", message: { role: "user", content: "Run the command and report its output." } },
+        {
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [{
+              type: "toolCall",
+              id: "call-1",
+              name: "bash",
+              arguments: { command: "echo OVTOOLMARKER98765" },
+            }],
+          },
+        },
+        {
+          type: "message",
+          message: { role, toolCallId: "call-1", toolName: "bash", content: output, isError },
+        },
+      ];
+      const cfg = { captureAssistantTurns: true, captureToolMaxChars: 2000 };
+      const result = extractBranchCapturePayloads(branch, 0, cfg);
+      assert.deepEqual(result.payloads.map((payload) => payload.role), ["user", "assistant", "user"]);
+      assert.deepEqual(result.payloads[1].parts, [{
+        type: "tool",
+        tool_id: "call-1",
+        tool_name: "bash",
+        tool_status: "running",
+        tool_input: { command: "echo OVTOOLMARKER98765" },
+      }]);
+      assert.deepEqual(result.payloads[2].parts, [{
+        type: "tool",
+        tool_id: "call-1",
+        tool_name: "bash",
+        tool_status: isError ? "error" : "completed",
+        tool_output: JSON.stringify(output),
+      }]);
 
-  const result = extractBranchCapturePayloads(branch, 0, {
-    captureAssistantTurns: true,
-    captureToolMaxChars: 2000,
-  });
-  assert.equal(result.payloads.length, 1);
-  assert.equal(result.payloads[0].role, "assistant");
-  assert.ok(Array.isArray(result.payloads[0].parts));
-  assert.equal(result.payloads[0].parts.some((part) => part.type === "tool" && part.tool_name === "read"), true);
-});
+      const incremental = extractBranchCapturePayloads(branch, 2, cfg);
+      assert.deepEqual(incremental.payloads, [result.payloads[2]]);
+      assert.equal(incremental.nextEntryCount, 3);
+      assert.deepEqual(extractBranchCapturePayloads(branch, incremental.nextEntryCount, cfg).payloads, []);
+    });
+  }
+}
 
 test("extractBranchCapturePayloads resets watermark when branch shrinks", () => {
   const result = extractBranchCapturePayloads([


### PR DESCRIPTION
## Description

pi/omp session branches use `role: "toolResult"`. The pi capture adapter lowercases it to `toolresult`, but its role gate only accepted `tool` and `tool_result`. The result entry was skipped before the shared structured-part extractor could process it, and `SyncManager.syncBranch()` then advanced its watermark past the omitted entry.

Accept the native camelCase spelling at the pi adapter boundary. A user → assistant tool call → tool result branch now produces three session messages, with the result stored as a user-role tool part preserving the tool ID, name, output, and completed/error status.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4920

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Changes Made

- Add the missing `toolresult` spelling to the pi-specific role gate.
- Extend the existing structured-tool capture test to cover native `toolResult`, existing `tool_result`/`tool` roles, success/error results, call/result pairing, and incremental watermark behavior.

The current `lib/capture-adapter.mjs` is hand-written and pi-specific; `shared/capture-utils.mjs` already recognizes native tool-result payloads. No generated/shared files or server API changes are needed.

## Testing

- [x] I have added tests that prove my fix is effective
- [x] New and existing pi extension tests pass locally
- [x] Tested on Windows, Node.js v25.9.0

Reproduced through the production `extractBranchCapturePayloads()` entrypoint: both native `toolResult` cases fail before the source fix (9 pass, 2 fail) because the result message is missing; both pass after the fix.

Commands run:

```sh
node --preserve-symlinks --preserve-symlinks-main --test examples/pi-coding-agent-extension/tests/capture-adapter.test.mjs
node --preserve-symlinks --preserve-symlinks-main --test examples/pi-coding-agent-extension/tests/*.test.mjs
node --preserve-symlinks --preserve-symlinks-main --check examples/pi-coding-agent-extension/tests/capture-adapter.test.mjs
git -c core.autocrlf=false diff --check
```

Final full pi extension suite: **73 passed, 0 failed**. The Node path flags accommodate the local Windows workspace's parent-directory resolution restrictions. Remote file contents were checked against the tested local files.

## Checklist

- [x] My code follows the surrounding coding style
- [x] I have performed a self-review of the complete diff
- [x] My changes generate no new warnings in the executed checks
- [x] No dependent changes are required

## Additional Notes

Validation is offline with native-shaped session entries and the existing plugin suite. A live pi/omp harness with an OpenViking server and the full Python/Rust suites were not run; this change only affects the pi JavaScript capture boundary. No configuration or data migration is required.
