### PR TITLE
fix(acl): use stable pagination for subtree updates

### DIFF
--- a/openviking/storage/acl.py
+++ b/openviking/storage/acl.py
@@ -320,19 +320,50 @@ class AclManager:
         output_fields: list[str],
         ctx: RequestContext,
     ) -> list[dict[str, Any]]:
+        expected_count = await self._context_store._strict_transfer_count(ctx, filter_expr)
+        requested_fields = list(dict.fromkeys([*output_fields, "id"]))
         records: list[dict[str, Any]] = []
         cursor: str | None = None
+        seen_cursors: set[str] = set()
+        seen_ids: set[str] = set()
         while True:
-            page, cursor = await self._context_store.scroll(
-                filter=filter_expr,
+            page, next_cursor = await self._context_store._strict_transfer_page(
+                ctx,
+                filter_expr,
                 limit=500,
                 cursor=cursor,
-                output_fields=output_fields,
-                ctx=ctx,
+                output_fields=requested_fields,
             )
+            if not page and len(records) < expected_count:
+                raise RuntimeError(
+                    f"ACL vector scan ended after {len(records)} of {expected_count} records"
+                )
+            for record in page:
+                record_id = record.get("id")
+                if not record_id:
+                    raise RuntimeError("ACL vector scan returned a record without an ID")
+                normalized_id = str(record_id)
+                if normalized_id in seen_ids:
+                    raise RuntimeError(
+                        f"ACL vector scan returned duplicate vector record {normalized_id}"
+                    )
+                seen_ids.add(normalized_id)
             records.extend(page)
-            if cursor is None:
+            if len(records) == expected_count:
                 return records
+            if len(records) > expected_count:
+                raise RuntimeError(
+                    f"ACL vector scan returned {len(records)} records but count was "
+                    f"{expected_count}"
+                )
+            if next_cursor is None:
+                raise RuntimeError(
+                    f"ACL vector scan cursor ended after {len(records)} of {expected_count} records"
+                )
+            if next_cursor in seen_cursors:
+                raise RuntimeError(f"ACL vector scroll cursor repeated: {next_cursor}")
+            seen_cursors.add(next_cursor)
+            cursor = next_cursor
 
     async def _subtree_records(self, uri: str, ctx: RequestContext) -> list[dict[str, Any]]:
         refs = await self._scroll_all(PathScope("uri", uri, depth=-1), ["id"], ctx)

--- a/tests/storage/test_viking_vector_scope_filter.py
+++ b/tests/storage/test_viking_vector_scope_filter.py
@@ -1,10 +1,12 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import cast
+
 import pytest
 
 from openviking.server.identity import RequestContext, Role
-from openviking.storage.acl import AclManager
+from openviking.storage.acl import AclManager, AclMode
 from openviking.storage.collection_schemas import CollectionSchemas
 from openviking.storage.expr import And, Eq, In, Or, PathScope
 from openviking.storage.viking_vector_index_backend import VikingVectorIndexBackend
@@ -43,6 +45,125 @@ def _tenant_filter(ctx: RequestContext):
     backend = object.__new__(VikingVectorIndexBackend)
     backend.acl_manager = None
     return backend._tenant_filter(ctx)
+
+
+class _AclScanStore:
+    def __init__(self, records, pages, expected_count):
+        self.records = records
+        self.pages = list(pages)
+        self.expected_count = expected_count
+        self.upserted = []
+
+    async def scroll(self, **kwargs):
+        raise AssertionError(f"unstable scroll used: {kwargs}")
+
+    async def _strict_transfer_count(self, ctx, filter):
+        del ctx
+        return self.expected_count if isinstance(filter, PathScope) else 0
+
+    async def _strict_transfer_page(self, ctx, filter, **kwargs):
+        del ctx, kwargs
+        if not isinstance(filter, PathScope):
+            return [], None
+        return self.pages.pop(0)
+
+    async def get_strict(self, ids, *, ctx):
+        del ctx
+        return [dict(self.records[record_id]) for record_id in ids]
+
+    async def _upsert_many_raw(self, records, *, ctx):
+        del ctx
+        ids = [str(record["id"]) for record in records]
+        if len(ids) != len(set(ids)):
+            raise ValueError("duplicate record id")
+        self.upserted = list(records)
+        return ids
+
+
+@pytest.mark.asyncio
+async def test_set_acl_updates_every_record_beyond_first_page():
+    ctx = _ctx()
+    root = "viking://resources/large-tree"
+    refs = [{"id": f"record-{index:03d}"} for index in range(501)]
+    records = {
+        ref["id"]: {
+            "id": ref["id"],
+            "uri": root if index == 0 else f"{root}/file-{index:03d}.md",
+        }
+        for index, ref in enumerate(refs)
+    }
+    pages = [
+        (refs[:500], "500"),
+        (refs[500:], None),
+    ]
+    store = _AclScanStore(records, pages, len(refs))
+
+    manager = AclManager(cast(VikingVectorIndexBackend, store))
+
+    result = await manager.set_acl(root, [], ctx, acl_mode=AclMode.RESTRICTED)
+
+    assert result.mode == AclMode.RESTRICTED
+    assert [record["id"] for record in store.upserted] == [ref["id"] for ref in refs]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("expected_count", "pages", "error"),
+    [
+        pytest.param(
+            501,
+            [
+                ([{"id": f"record-{index:03d}"} for index in range(500)], "500"),
+                ([{"id": "record-499"}, {"id": "record-500"}], None),
+            ],
+            "duplicate vector record record-499",
+            id="duplicate-id",
+        ),
+        pytest.param(
+            501,
+            [([{"id": f"record-{index:03d}"} for index in range(500)], None)],
+            "cursor ended after 500 of 501 records",
+            id="early-cursor-end",
+        ),
+        pytest.param(
+            1,
+            [([], None)],
+            "scan ended after 0 of 1 records",
+            id="empty-page",
+        ),
+        pytest.param(
+            501,
+            [
+                ([{"id": f"record-{index:03d}"} for index in range(250)], "250"),
+                ([{"id": f"record-{index:03d}"} for index in range(250, 500)], "250"),
+            ],
+            "scroll cursor repeated: 250",
+            id="repeated-cursor",
+        ),
+        pytest.param(
+            1,
+            [([{"uri": "viking://resources/large-tree/file.md"}], None)],
+            "record without an ID",
+            id="missing-id",
+        ),
+        pytest.param(
+            1,
+            [([{"id": "record-000"}, {"id": "record-001"}], None)],
+            "returned 2 records but count was 1",
+            id="more-records-than-count",
+        ),
+    ],
+)
+async def test_set_acl_rejects_incomplete_subtree_pagination(expected_count, pages, error):
+    ctx = _ctx()
+    root = "viking://resources/large-tree"
+    store = _AclScanStore({}, pages, expected_count)
+    manager = AclManager(cast(VikingVectorIndexBackend, store))
+
+    with pytest.raises(RuntimeError, match=error):
+        await manager.set_acl(root, [], ctx, acl_mode=AclMode.RESTRICTED)
+
+    assert store.upserted == []
 
 
 def test_descendant_target_elides_only_visible_root_path_filter():


### PR DESCRIPTION
## Description

Fix ACL updates for resource subtrees containing more than 500 context records.

ACL subtree scans previously used offset pagination over an unordered vector query. Subsequent pages could return duplicate records or omit records, causing bulk ACL updates to fail with `duplicate record id at index 500`.

The updated scan uses stable pagination and validates record counts, IDs, and cursor progression before applying any ACL changes.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4917

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Use stable ordered pagination when scanning context records for ACL resolution and subtree updates.
- Validate expected record counts, unique record IDs, non-empty pages, and cursor progression before writing ACL changes.
- Add regression coverage for subtrees spanning multiple 500-record pages and malformed pagination results.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing relevant unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation performed:

- ACL regression tests: 15 passed
- Related storage and transfer tests: 91 passed, 1 skipped
- Ruff formatting and lint checks passed
- Git whitespace checks passed

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Some native integration tests could not run locally because the development environment does not include the `PersistStore` and `ragfs_python` native libraries. The focused ACL and related storage regression suites pass.