### PR TITLE
fix(pathlock): atomically replace stale tokens during takeover

### DIFF
--- a/crates/ragfs/src/lock/manager.rs
+++ b/crates/ragfs/src/lock/manager.rs
@@ -866,7 +866,7 @@ impl PathLockManager {
             first_attempt = false;
             let acquired_lock_paths = match self.try_acquire_batch_once(&sorted, &owner_id).await {
                 Ok(acquired) => acquired,
-                Err((err, pre_conflict)) => {
+                Err(err) => {
                     drop(owner_registry);
                     if !Self::is_retryable_error(&err) {
                         break Err(err);
@@ -898,37 +898,6 @@ impl PathLockManager {
                         break Err(PathLockError::Timeout {
                             elapsed_ms: start.elapsed().as_millis() as u64,
                         });
-                    }
-
-                    if pre_conflict {
-                        if let PathLockError::Conflict { ref lock_path, .. } = &err {
-                            let token = match self.provider.read_token(lock_path).await {
-                                Ok(token) => token,
-                                Err(error) => break Err(error),
-                            };
-                            if let Some(token) = token {
-                                let now_ns = Self::now_ns();
-                                if self.is_stale(&token, now_ns) {
-                                    if start.elapsed() >= timeout {
-                                        break Err(PathLockError::Timeout {
-                                            elapsed_ms: start.elapsed().as_millis() as u64,
-                                        });
-                                    }
-                                    let removed = match self
-                                        .provider
-                                        .remove_token(lock_path, &token.owner_id, true)
-                                        .await
-                                    {
-                                        Ok(removed) => removed,
-                                        Err(error) => break Err(error),
-                                    };
-                                    if removed {
-                                        info!(lock_path = %lock_path, stale_owner = %token.owner_id, token_kind = ?token.lock_type, age_ms = ((now_ns.saturating_sub(token.time_ns)) / 1_000_000) as u64, "removed stale pathlock token during acquire retry");
-                                        self.metrics.write().await.stale_tokens_removed += 1;
-                                    }
-                                }
-                            }
-                        }
                     }
 
                     let remaining = timeout.saturating_sub(start.elapsed());
@@ -998,7 +967,7 @@ impl PathLockManager {
         &self,
         requests: &[PathLockRequest],
         owner_id: &str,
-    ) -> Result<Vec<(String, AcquisitionChange)>, (PathLockError, bool)> {
+    ) -> PathLockResult<Vec<(String, AcquisitionChange)>> {
         let mut acquired = Vec::new();
         let mut exact_resolutions: HashMap<String, ResolvedExactPaths> = HashMap::new();
         let acquisition: PathLockResult<()> = async {
@@ -1045,9 +1014,9 @@ impl PathLockManager {
         .await;
         if let Err(error) = acquisition {
             if let Err(rollback_error) = self.rollback_acquisitions(&acquired, owner_id).await {
-                return Err((Self::rollback_error(error, rollback_error), false));
+                return Err(Self::rollback_error(error, rollback_error));
             }
-            return Err((error, true));
+            return Err(error);
         }
 
         let verification: PathLockResult<()> = async {
@@ -1082,9 +1051,9 @@ impl PathLockManager {
         .await;
         if let Err(error) = verification {
             if let Err(rollback_error) = self.rollback_acquisitions(&acquired, owner_id).await {
-                return Err((Self::rollback_error(error, rollback_error), false));
+                return Err(Self::rollback_error(error, rollback_error));
             }
-            return Err((error, false));
+            return Err(error);
         }
         Ok(acquired)
     }
@@ -1169,17 +1138,23 @@ impl PathLockManager {
                 debug!(lock_path = %lock_path, owner_id = %owner_id, kind = ?existing.lock_type, "reused existing pathlock token for same owner");
                 return Ok(AcquisitionChange::Reentrant);
             }
-            if !self.is_stale(&existing, now_ns) {
-                return Err(PathLockError::Conflict {
-                    lock_path: lock_path.to_string(),
-                    owner: existing.owner_id,
-                    kind: existing.lock_type,
-                });
+            // Replace only the stale snapshot we observed. A concurrent heartbeat
+            // or takeover must not be erased by a separate remove/create sequence.
+            if self.is_stale(&existing, now_ns)
+                && self
+                    .provider
+                    .compare_and_write_token(lock_path, &existing, &token)
+                    .await?
+            {
+                info!(lock_path = %lock_path, stale_owner = %existing.owner_id, owner_id = %owner_id, "replaced stale pathlock token during acquire");
+                self.metrics.write().await.stale_tokens_removed += 1;
+                return Ok(AcquisitionChange::Created);
             }
-            // Stale — remove it before attempting to create our own token.
-            self.provider
-                .remove_token(lock_path, &existing.owner_id, true)
-                .await?;
+            return Err(PathLockError::Conflict {
+                lock_path: lock_path.to_string(),
+                owner: existing.owner_id,
+                kind: existing.lock_type,
+            });
         }
 
         self.provider.try_create_token(lock_path, &token).await?;
@@ -2150,9 +2125,10 @@ mod tests {
         fail_next_read: AtomicBool,
         fail_next_remove: AtomicBool,
         return_false_next_remove: AtomicBool,
-        busy_next_remove: AtomicBool,
-        busy_remove_count: AtomicUsize,
+        busy_next_takeover: AtomicBool,
+        busy_takeover_count: AtomicUsize,
         reject_compare: bool,
+        refresh_on_takeover: bool,
     }
 
     impl FailNextRemoveProvider {
@@ -2163,22 +2139,24 @@ mod tests {
                 fail_next_read: AtomicBool::new(true),
                 fail_next_remove: AtomicBool::new(false),
                 return_false_next_remove: AtomicBool::new(false),
-                busy_next_remove: AtomicBool::new(false),
-                busy_remove_count: AtomicUsize::new(0),
+                busy_next_takeover: AtomicBool::new(false),
+                busy_takeover_count: AtomicUsize::new(0),
                 reject_compare: false,
+                refresh_on_takeover: false,
             }
         }
 
-        /// Build a memory provider whose next remove reports a retryable busy error.
-        fn with_busy_remove() -> Self {
+        /// Build a memory provider whose next takeover reports a retryable busy error.
+        fn with_busy_takeover() -> Self {
             Self {
                 inner: crate::lock::provider::MemoryPathLockProvider::new(),
                 fail_next_read: AtomicBool::new(false),
                 fail_next_remove: AtomicBool::new(false),
                 return_false_next_remove: AtomicBool::new(false),
-                busy_next_remove: AtomicBool::new(true),
-                busy_remove_count: AtomicUsize::new(0),
+                busy_next_takeover: AtomicBool::new(true),
+                busy_takeover_count: AtomicUsize::new(0),
                 reject_compare: false,
+                refresh_on_takeover: false,
             }
         }
 
@@ -2189,9 +2167,10 @@ mod tests {
                 fail_next_read: AtomicBool::new(false),
                 fail_next_remove: AtomicBool::new(false),
                 return_false_next_remove: AtomicBool::new(false),
-                busy_next_remove: AtomicBool::new(false),
-                busy_remove_count: AtomicUsize::new(0),
+                busy_next_takeover: AtomicBool::new(false),
+                busy_takeover_count: AtomicUsize::new(0),
                 reject_compare: true,
+                refresh_on_takeover: false,
             }
         }
     }
@@ -2219,8 +2198,20 @@ mod tests {
             expected: &LockToken,
             replacement: &LockToken,
         ) -> PathLockResult<bool> {
+            if self.busy_next_takeover.swap(false, Ordering::SeqCst) {
+                self.busy_takeover_count.fetch_add(1, Ordering::SeqCst);
+                return Err(PathLockError::Busy {
+                    lock_path: lock_path.to_string(),
+                    operation: "compare_and_write".to_string(),
+                });
+            }
             if self.reject_compare {
                 return Ok(false);
+            }
+            if self.refresh_on_takeover {
+                self.inner
+                    .refresh_token(lock_path, &expected.owner_id, PathLockManager::now_ns())
+                    .await?;
             }
             self.inner
                 .compare_and_write_token(lock_path, expected, replacement)
@@ -2242,18 +2233,16 @@ mod tests {
             owner_id: &str,
             force: bool,
         ) -> PathLockResult<bool> {
-            if self.busy_next_remove.swap(false, Ordering::SeqCst) {
-                self.busy_remove_count.fetch_add(1, Ordering::SeqCst);
-                return Err(PathLockError::Busy {
-                    lock_path: lock_path.to_string(),
-                    operation: "remove".to_string(),
-                });
-            }
             if self.return_false_next_remove.swap(false, Ordering::SeqCst) {
                 return Ok(false);
             }
             if self.fail_next_remove.swap(false, Ordering::SeqCst) {
                 return Err(PathLockError::Io("injected remove failure".to_string()));
+            }
+            if self.refresh_on_takeover {
+                self.inner
+                    .refresh_token(lock_path, owner_id, PathLockManager::now_ns())
+                    .await?;
             }
             self.inner.remove_token(lock_path, owner_id, force).await
         }
@@ -2833,10 +2822,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn busy_cleanup_is_retried() {
+    async fn busy_stale_takeover_is_retried() {
         let fs = Arc::new(MemFileSystem::new());
         fs.mkdir("/data", 0o755).await.unwrap();
-        let provider = Arc::new(FailNextRemoveProvider::with_busy_remove());
+        let provider = Arc::new(FailNextRemoveProvider::with_busy_takeover());
         provider
             .inner
             .try_create_token(
@@ -2863,13 +2852,59 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(provider.busy_remove_count.load(Ordering::SeqCst), 1);
+        assert_eq!(provider.busy_takeover_count.load(Ordering::SeqCst), 1);
         mgr.release(&lease).await.unwrap();
         let error = PathLockManager::rollback_error(
             PathLockError::Io("commit".into()),
             PathLockError::Io("rollback".into()),
         );
         assert!(!PathLockManager::is_retryable_error(&error));
+    }
+
+    #[tokio::test]
+    async fn stale_takeover_preserves_a_concurrent_refresh() {
+        for (refresh, timeout) in [
+            (false, Duration::ZERO),
+            (true, Duration::ZERO),
+            (true, Duration::from_millis(200)),
+        ] {
+            let fs = Arc::new(MemFileSystem::new());
+            fs.mkdir("/data", 0o755).await.unwrap();
+            let provider = Arc::new(FailNextRemoveProvider {
+                reject_compare: false,
+                refresh_on_takeover: refresh,
+                ..FailNextRemoveProvider::with_compare_miss()
+            });
+            let lock_path = "/data/.path.ovlock";
+            provider
+                .inner
+                .try_create_token(
+                    lock_path,
+                    &LockToken {
+                        owner_id: "original-owner".to_string(),
+                        time_ns: 1,
+                        lock_type: PathLockKind::Tree,
+                    },
+                )
+                .await
+                .unwrap();
+            let mgr = PathLockManager::new(fs, provider.clone(), PathLockConfig::default());
+
+            let result = mgr.acquire_tree("/data", timeout, None).await;
+            let token = provider.inner.read_token(lock_path).await.unwrap().unwrap();
+            assert!(token.time_ns > 1);
+            if refresh {
+                // The heartbeat wins after the stale read but before takeover.
+                // Both the renewed token and its ownership must survive.
+                assert!(matches!(result, Err(PathLockError::Timeout { .. })));
+                assert_eq!(token.owner_id, "original-owner");
+            } else {
+                // A genuinely stale token remains reclaimable without waiting.
+                let lease = result.unwrap();
+                assert_eq!(token.owner_id, lease.lease.owner_id);
+                mgr.release(&lease).await.unwrap();
+            }
+        }
     }
 
     /// Verify a downgrade CAS miss returns without dropping local lease state.


### PR DESCRIPTION
## Description

`PathLockManager::acquire_tree` can acquire a path after the previous owner's heartbeat has already renewed its token: stale takeover reads an expired snapshot, then removes by owner ID without checking that the snapshot is still current. The same owner with a newer timestamp is therefore deleted.

Replace the expired snapshot atomically with the contender's token using the existing provider CAS. If a heartbeat or another contender changes it first, acquisition follows the existing conflict/retry/timeout path. Unchanged expired tokens remain immediately reclaimable.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4943

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Use `compare_and_write_token` in `try_acquire_one` for stale takeover; record a successful replacement as a created acquisition so existing batch rollback removes the contender's token.
- Remove the acquire-retry loop's second stale-read/force-remove path and its now-unused pre-conflict flag. Ancestor/descendant/conflict checks already ignore stale tokens; same-path takeover now has one owner.
- Add a deterministic regression through the public manager entrypoint: inject a heartbeat after stale observation and before mutation, and verify that ownership survives with both zero and nonzero timeouts. Also verify zero-timeout recovery without a competing heartbeat, and update the existing Busy recovery test for atomic takeover.

## Testing

Windows / MSVC, rustc 1.98.1:

- Before the production fix, the concurrent-refresh regression **failed** on `4f430f65fe2710e159cd2e195b11bbfb8bd4e85b`: acquisition unexpectedly succeeded. The original 32 lock tests passed on that baseline.
- `cargo test -p ragfs --lib --locked --offline` — **433 passed**, including all 33 lock tests and the new regression.
- `cargo clippy -p ragfs --lib --tests --locked --offline` — exit 0; repository warnings remain, with no diagnostics in the changed file.
- `rustfmt --edition 2021 --check crates/ragfs/src/lock/manager.rs` — passed.
- `git diff --check` — passed.

- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (not applicable)
- [x] My changes generate no new compiler warnings (the library test build reports the same 89 warnings as the baseline)
- [x] Any dependent changes have been merged and published (no dependencies)

## Additional Notes

Area: Storage / RAGFS PathLock. One file, 169 changed lines. No changes to public APIs, persisted token encoding, or configuration; no migration required. The reproduction uses a controlled provider-level interleaving, not a production outage. Python end-to-end, optional Redis/S3 integration, and local Linux/macOS checks were not run; this change is confined to the Rust lock manager, and the available host is Windows.
