### PR TITLE
fix(parse): 保留 Understanding 上传的原始文件名

### DIFF
--- a/docs/design/resource-ingestion-routing.md
+++ b/docs/design/resource-ingestion-routing.md
@@ -177,9 +177,11 @@ Accessor 路径中的文档图片和 Base 附件字段图片使用同一条素�
 `UnifiedResourceProcessor.prepare` 随后冻结两个字段：
 
 - `resolved_extension`：本次 Parser 路由唯一使用的扩展名。
-- `resolved_name`：用于展示和默认资源命名，不参与 HTTP 资源的类型覆盖。
+- `resolved_name`：用于展示、默认资源命名和 Understanding 上传文件名，不参与 HTTP 资源的类型覆盖。
 
 HTTP 资源以 HTTPAccessor 检出的 `meta.extension` 为准；本地文件或上传的临时文件可优先使用显式 `source_name` 的扩展名。这样既不会拿随机临时文件名选 Parser，也不会让用户提供的 URL 名称覆盖实际下载内容类型。
+
+本地文件进入 Understanding 时，ParserRouter 将冻结的 `resolved_name` 作为 `source_name` 传给上传层；普通上传和分片上传都使用这个名称的 basename，本地路径只用于读取文件。同步解析、提前提交解析和仅上传获取 `file_id` 使用相同规则。`resource_name` 只控制外层资源目录，例如 `README.md` 下载为 `/tmp/tmpABC.md` 后，上传文件名仍为 `README.md`。
 
 ## 无后缀 URL 怎么判断类型
 

--- a/openviking/parse/parser_router.py
+++ b/openviking/parse/parser_router.py
@@ -135,6 +135,8 @@ class ParserRouter:
             )
 
         if use_understanding:
+            if isinstance(source, LocalResource):
+                kwargs["source_name"] = source.meta["resolved_name"]
             display = source_path
             if isinstance(source_path, str) and source_path.startswith(("http://", "https://")):
                 display = "<url>"
@@ -156,7 +158,14 @@ class ParserRouter:
     async def submit(self, source: Union[str, Path, LocalResource], **kwargs) -> str:
         source_path = self._extract_source_path(source)
         if Path(source_path).is_file():
-            return await self._get_understanding_api().submit_file(source_path)
+            source_name = (
+                source.meta["resolved_name"]
+                if isinstance(source, LocalResource)
+                else kwargs.get("source_name")
+            )
+            return await self._get_understanding_api().submit_file(
+                source_path, source_name=source_name
+            )
         if not self.should_use_understanding_api(str(source_path)):
             raise ValueError("source is not routed to UnderstandingAPI")
         return await self._get_understanding_api().submit_url(str(source_path), **kwargs)
@@ -164,7 +173,8 @@ class ParserRouter:
     async def upload_file(self, source: Union[str, Path, LocalResource]) -> str:
         """Upload a local source file and return only the external Files API file_id."""
         source_path = self._extract_source_path(source)
-        return await self._get_understanding_api().upload_file(source_path)
+        source_name = source.meta["resolved_name"] if isinstance(source, LocalResource) else None
+        return await self._get_understanding_api().upload_file(source_path, source_name=source_name)
 
     def _extract_source_path(self, source: Union[str, Path, LocalResource]) -> Union[str, Path]:
         """Extract a filesystem path from the source."""

--- a/openviking/parse/understanding_api.py
+++ b/openviking/parse/understanding_api.py
@@ -180,7 +180,7 @@ class UnderstandingAPI(BaseParser):
                 task_meta["file_id"] = prepared_file_id
                 response_obj = await self._create_response_for_file(file_id=prepared_file_id)
             elif url is None and local_path is not None:
-                file_obj = await self._create_file(local_path=local_path)
+                file_obj = await self._create_file(local_path=local_path, source_name=source_name)
                 file_id_value = file_obj.get("id")
                 if not file_id_value:
                     raise RuntimeError(
@@ -279,21 +279,25 @@ class UnderstandingAPI(BaseParser):
         logger.info("[UnderstandingAPI] done")
         return result
 
-    async def upload_file(self, source: Union[str, Path]) -> str:
+    async def upload_file(
+        self, source: Union[str, Path], *, source_name: Optional[str] = None
+    ) -> str:
         """Upload a local file and return a durable Files API file_id."""
         local_path = Path(source)
         if not local_path.is_file():
             raise ValueError("UnderstandingAPI file upload requires an existing local file")
 
-        file_obj = await self._create_file(local_path=local_path)
+        file_obj = await self._create_file(local_path=local_path, source_name=source_name)
         file_id = file_obj.get("id")
         if not file_id:
             raise RuntimeError(f"files api missing file_id: {self._safe_error_summary(file_obj)}")
         return str(file_id)
 
-    async def submit_file(self, source: Union[str, Path]) -> str:
+    async def submit_file(
+        self, source: Union[str, Path], *, source_name: Optional[str] = None
+    ) -> str:
         """Upload a local file and submit it without retaining the local artifact."""
-        file_id = await self.upload_file(source)
+        file_id = await self.upload_file(source, source_name=source_name)
         response_obj = await self._create_response_for_file(file_id=str(file_id))
         response_id = response_obj.get("id")
         if not response_id:
@@ -438,10 +442,14 @@ class UnderstandingAPI(BaseParser):
         self._raise_if_error(body, context=context)
         return body
 
-    async def _create_file(self, *, local_path: Path) -> Dict[str, Any]:
+    async def _create_file(
+        self, *, local_path: Path, source_name: Optional[str] = None
+    ) -> Dict[str, Any]:
         file_size = local_path.stat().st_size
         if file_size == 0:
             raise InvalidArgumentError("Understanding parser does not support empty files.")
+        # The local path locates bytes; its temporary basename is not the source identity.
+        file_name = Path(source_name).name if source_name else local_path.name
         if file_size > self._upload_simple_max_bytes:
             if not self._enable_resumable_upload:
                 raise ValueError(
@@ -449,13 +457,13 @@ class UnderstandingAPI(BaseParser):
                     f"upload_simple_max_bytes={self._upload_simple_max_bytes}; "
                     "enable parser_api.enable_resumable_upload to continue"
                 )
-            return await self._multipart_create_file(local_path)
+            return await self._multipart_create_file(local_path, file_name=file_name)
 
         data: Dict[str, Any] = {"purpose": "user_data"}
 
         content_type = mimetypes.guess_type(str(local_path))[0] or "application/octet-stream"
         with open(local_path, "rb") as f:
-            files = {"file": (local_path.name, f, content_type)}
+            files = {"file": (file_name, f, content_type)}
             async with httpx.AsyncClient(timeout=1200.0, follow_redirects=True) as client:
                 rsp = await client.post(
                     f"{self._api_base}/files",
@@ -616,9 +624,9 @@ class UnderstandingAPI(BaseParser):
                     return str(zip_obj["url"])
         return None
 
-    async def _uploads_init(self, *, file_path: Path) -> Dict[str, Any]:
+    async def _uploads_init(self, *, file_path: Path, file_name: str) -> Dict[str, Any]:
         payload = {
-            "file_name": file_path.name,
+            "file_name": file_name,
             "file_size": file_path.stat().st_size,
             "content_type": mimetypes.guess_type(str(file_path))[0] or "application/octet-stream",
             "part_size": int(self._upload_part_size_bytes),
@@ -663,8 +671,8 @@ class UnderstandingAPI(BaseParser):
             )
         return self._read_api_response(rsp, context="uploads complete error")
 
-    async def _multipart_create_file(self, file_path: Path) -> Dict[str, Any]:
-        init_obj = await self._uploads_init(file_path=file_path)
+    async def _multipart_create_file(self, file_path: Path, *, file_name: str) -> Dict[str, Any]:
+        init_obj = await self._uploads_init(file_path=file_path, file_name=file_name)
         upload_id = init_obj.get("upload_id") or init_obj.get("uploadId")
         object_key = init_obj.get("object_key") or init_obj.get("objectKey")
         part_size = int(

--- a/tests/parse/test_feishu_parser_api.py
+++ b/tests/parse/test_feishu_parser_api.py
@@ -358,7 +358,7 @@ async def test_legacy_accessor_output_does_not_enable_lark_protocol(tmp_path: Pa
         feishu_access_token="u-test",
     )
 
-    api._create_file.assert_awaited_once_with(local_path=markdown_path)
+    api._create_file.assert_awaited_once_with(local_path=markdown_path, source_name=None)
     api._create_response_for_file.assert_awaited_once_with(file_id="file-1")
     api._create_response_for_url.assert_not_awaited()
 

--- a/tests/parse/test_understanding_api.py
+++ b/tests/parse/test_understanding_api.py
@@ -1,18 +1,24 @@
-from pathlib import Path
+import json
+from email.parser import BytesParser
+from email.policy import default
 from unittest.mock import AsyncMock, Mock
 
 import httpx
 import pytest
 
+from openviking.parse.accessors.base import LocalResource, SourceType
+from openviking.parse.parser_router import ParserRouter
 from openviking.parse.understanding_api import (
     PREPARED_FILE_ID_ARG,
     UnderstandingAPI,
     UnderstandingAPIError,
 )
+from openviking.utils.media_processor import UnifiedResourceProcessor
 from openviking_cli.exceptions import InvalidArgumentError
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("entry_point", ["parse", "submit", "upload_file"])
 @pytest.mark.parametrize(
     "filename,content,original_source,resolved_extension,source_format",
     [
@@ -22,35 +28,58 @@ from openviking_cli.exceptions import InvalidArgumentError
     ],
 )
 async def test_parse_uses_downloaded_file_and_resolved_extension(
-    monkeypatch, tmp_path, filename, content, original_source, resolved_extension, source_format
+    monkeypatch,
+    tmp_path,
+    entry_point,
+    filename,
+    content,
+    original_source,
+    resolved_extension,
+    source_format,
 ):
-    downloaded = tmp_path / filename
-    downloaded.write_bytes(content)
+    source_name = f"original.{source_format}"
+    uploaded_names = []
+    uploaded_content = []
+
+    def handler(request):
+        if request.url.path.endswith("/files"):
+            if request.url.query == b"uploads":
+                uploaded_names.append(json.loads(request.content)["file_name"])
+                return httpx.Response(200, json={"upload_id": "upload-1", "object_key": "obj-1"})
+            if request.method == "GET":
+                return httpx.Response(200, json={"parts": []})
+            if request.method == "PUT":
+                uploaded_content.append(request.content)
+                return httpx.Response(200, json={"etag": "part-1"})
+            if not request.url.query:
+                message = BytesParser(policy=default).parsebytes(
+                    f"Content-Type: {request.headers['content-type']}\r\n\r\n".encode()
+                    + request.content
+                )
+                part = next(part for part in message.iter_parts() if part.get_filename())
+                uploaded_names.append(part.get_filename())
+                uploaded_content.append(part.get_payload(decode=True))
+            return httpx.Response(200, json={"id": "file-1", "status": "active"})
+        if request.method == "POST" and request.url.path.endswith("/responses"):
+            assert json.loads(request.content)["input"][0]["content"] == [
+                {"type": "file", "file": {"file_id": "file-1"}}
+            ]
+            return httpx.Response(200, json={"id": "response-1"})
+        assert request.url.path.endswith("/responses/response-1")
+        return httpx.Response(
+            200,
+            json={"status": "completed", "result": {"zip_url": "https://example.com/result.zip"}},
+        )
+
+    api = _api_with_transport(monkeypatch, handler)
+    api._enable_resumable_upload = True
+    # Exercise both upload protocols through every ingestion entry point.
+    api._upload_simple_max_bytes = 1 if source_format == "pdf" else 1024
+    router = ParserRouter(parser_registry=object())
+    router._understanding_api = api
+    processor = UnifiedResourceProcessor(vlm_processor=object())
+    processor._parser_router = router
     zip_path = tmp_path / "result.zip"
-    zip_path.write_bytes(b"zip")
-    uploaded: list[Path] = []
-
-    api = UnderstandingAPI.__new__(UnderstandingAPI)
-    api._video_exts = {"mp4"}
-    api._audio_exts = {"mp3"}
-    api._image_exts = {"png"}
-
-    async def create_file(*, local_path):
-        uploaded.append(local_path)
-        return {"id": "file-1"}
-
-    async def create_response_for_file(*, file_id):
-        assert file_id == "file-1"
-        return {"id": "response-1"}
-
-    async def poll_response(*, response_id):
-        assert response_id == "response-1"
-        return {"status": "completed"}
-
-    monkeypatch.setattr(api, "_create_file", create_file)
-    monkeypatch.setattr(api, "_create_response_for_file", create_response_for_file)
-    monkeypatch.setattr(api, "_poll_response", poll_response)
-    monkeypatch.setattr(api, "_extract_zip_url", lambda _: "https://example.com/result.zip")
     monkeypatch.setattr(api, "_download_zip", lambda _: _return(zip_path))
     monkeypatch.setattr(
         api,
@@ -58,21 +87,39 @@ async def test_parse_uses_downloaded_file_and_resolved_extension(
         lambda **_: _return("viking://temp/result"),
     )
 
-    result = await api.parse(
-        downloaded,
-        original_source=original_source,
-        resource_name="report",
-        resolved_extension=resolved_extension,
-    )
+    for prefix in ("tmpABC", "tmpXYZ"):
+        downloaded = tmp_path / f"{prefix}-{filename}"
+        downloaded.write_bytes(content)
+        resource = LocalResource(
+            path=downloaded,
+            source_type=SourceType.HTTP,
+            original_source=original_source,
+            meta={"original_filename": source_name, "extension": resolved_extension},
+        )
+        processor._set_resolved_identity(resource, source_name=None)
+        if entry_point == "parse":
+            zip_path.write_bytes(b"zip")
+            result = await processor.process(
+                original_source,
+                prepared_resource=resource,
+                resource_name="report",
+                source_name=None,
+                parser_backend="understanding",
+            )
+            assert result.source_path == original_source
+            assert result.source_format == source_format
+            assert result.root.title == "report"
+        elif entry_point == "submit":
+            assert await processor.submit_understanding(resource) == "response-1"
+        else:
+            assert await processor.upload_understanding_file(resource) == "file-1"
 
-    assert uploaded == [downloaded]
-    assert result.source_path == original_source
-    assert result.source_format == source_format
-    assert result.root.title == "report"
+    assert uploaded_names == [source_name, source_name]
+    assert uploaded_content == [content, content]
 
 
 @pytest.mark.asyncio
-async def test_upload_file_validates_input_and_returns_file_id(tmp_path):
+async def test_upload_file_validates_input_and_returns_file_id(monkeypatch, tmp_path):
     empty_source = tmp_path / "empty.pdf"
     empty_source.touch()
     api = UnderstandingAPI.__new__(UnderstandingAPI)
@@ -87,12 +134,17 @@ async def test_upload_file_validates_input_and_returns_file_id(tmp_path):
 
     source = tmp_path / "download.pdf"
     source.write_bytes(b"%PDF-1.7")
-    api._create_file = AsyncMock(return_value={"id": "file-1"})
+
+    def handler(request):
+        assert b'filename="download.pdf"' in request.content
+        assert source.read_bytes() in request.content
+        return httpx.Response(200, json={"id": "file-1"})
+
+    api = _api_with_transport(monkeypatch, handler)
 
     file_id = await api.upload_file(source)
 
     assert file_id == "file-1"
-    api._create_file.assert_awaited_once_with(local_path=source)
 
 
 @pytest.mark.asyncio
@@ -143,21 +195,6 @@ async def test_file_above_simple_limit_requires_resumable_upload(tmp_path):
 
     with pytest.raises(ValueError, match="size=9, upload_simple_max_bytes=8"):
         await api._create_file(local_path=source)
-
-
-@pytest.mark.asyncio
-async def test_file_above_simple_limit_uses_multipart_when_enabled(tmp_path):
-    source = tmp_path / "large.pdf"
-    source.write_bytes(b"123456789")
-    api = UnderstandingAPI.__new__(UnderstandingAPI)
-    api._upload_simple_max_bytes = 8
-    api._enable_resumable_upload = True
-    api._multipart_create_file = AsyncMock(return_value={"id": "file-1"})
-
-    result = await api._create_file(local_path=source)
-
-    assert result == {"id": "file-1"}
-    api._multipart_create_file.assert_awaited_once_with(source)
 
 
 @pytest.mark.asyncio
@@ -325,7 +362,7 @@ async def test_http_errors_preserve_business_message(monkeypatch, tmp_path, meth
         "_create_response_for_file": {"file_id": "file-1"},
         "_create_response_for_url": {"url": "https://example.test/a.pdf", "doc_type": "pdf"},
         "_poll_response": {"response_id": "response-1"},
-        "_uploads_init": {"file_path": source},
+        "_uploads_init": {"file_path": source, "file_name": source.name},
         "_uploads_status": {"upload_id": "upload-1", "object_key": "object-1"},
         "_uploads_put_part": {
             "upload_id": "upload-1",


### PR DESCRIPTION
## Description

修复 OV 将 HTTP 下载临时文件名传给 Understanding，导致同一资源重复解析时产物名称和图片 URI 随临时文件名变化的问题。

以同一份 `README.md` 两次下载为例：

| 场景 | 本地文件 | 修复前上传文件名 | 修复后上传文件名 |
| --- | --- | --- | --- |
| 第一次解析 | `/tmp/tmpABC.md` | `tmpABC.md` | `README.md` |
| 再次解析 | `/tmp/tmpXYZ.md` | `tmpXYZ.md` | `README.md` |

准备阶段已经保存了原始名称；本次将该名称传到 Understanding 上传边界，消除由 OV 临时路径引入的命名差异。`resource_name` 仍只控制外层资源目录。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

无关联 GitHub issue。相关历史：#3295、#2614。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- ParserRouter 复用准备阶段冻结的 `resolved_name`，在同步解析、提前提交解析、仅上传获取 `file_id` 三条路径中传递 `source_name`。
- Understanding 普通上传和分片上传使用原始名称的 basename；本地路径继续用于读取文件。直接上传本地文件、未提供来源名称时，保留其本地文件名。
- 改写现有契约测试，检查实际 HTTP 请求中的文件名和内容，验证不同临时路径上传同一内容时名称一致；删除被覆盖的分片上传 Mock 分支测试，没有新增测试文件或测试函数。
- 补充解析路由文档中的上传命名规则。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

- 改写后的契约测试在修复前复现：上传名称分别为 `tmpABC-download`、`tmpXYZ-download`；修复后均为 `original.pdf`。
- `test_understanding_api.py`、`test_parser_router.py`、`test_feishu_parser_api.py`、`test_understanding_api_artifact_images.py`、`test_directory_understanding_routing.py`：163 passed。使用内容为 `{}` 的隔离 `OPENVIKING_CONFIG_FILE`，通过 MockTransport 验证请求，不依赖真实远端服务。
- `test_resource_service_understanding_routing.py`：1 passed、4 failed。四处既有响应断言未包含 `source_path`；在隔离进程中将本 PR 两个生产模块恢复为基线 `b1c0bef43` 后，同样四处失败。
- Ruff check、Ruff format check、`git diff --check` 通过。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

历史归因：直接取本地文件名上传的实现始于 2026-06-15 的 #2614（`63a035073`）。HTTP 下载文件优先于原 URL 的触发路径写于 2026-07-16（`2779e14af`），随 #3295 于 2026-07-27 合入 main（`2be4bb487`）。对 #3295 合并前后的真实 `parse` 函数做局部 A/B，确认同一输入从提交原 URL 变为上传临时文件。

这里确认的是该 HTTP 路径进入 main 的时间，不宣称已经完成所有历史路径的首次故障二分。未重跑真实 Understanding 服务的完整远端解析；本次修复上传命名，不追溯改名已有产物。
