### PR TITLE
fix(studio): make task-center re-queue actually retry failed session commits

### DIFF
--- a/openviking/server/routers/sessions.py
+++ b/openviking/server/routers/sessions.py
@@ -664,6 +664,19 @@ class CommitRequest(BaseModel):
         return self
 
 
+class CommitRetryRequest(BaseModel):
+    """Retry request body for failed session commit archives."""
+
+    archive_uri: Optional[str] = Field(
+        default=None,
+        description=(
+            "Retry one specific failed archive. Omit to sweep every failed "
+            "archive of the session."
+        ),
+    )
+    telemetry: TelemetryRequest = False
+
+
 @router.post("/{session_id}/commit")
 async def commit_session(
     session_id: str = Path(..., description="Session ID"),
@@ -699,6 +712,37 @@ async def commit_session(
             session_id,
             _ctx,
             **commit_kwargs,
+        ),
+    )
+    return Response(
+        status="ok",
+        result=execution.result,
+        telemetry=execution.telemetry,
+    ).model_dump(exclude_none=True)
+
+
+@router.post("/{session_id}/commits/retry")
+async def retry_failed_session_commits(
+    session_id: str = Path(..., description="Session ID"),
+    body: CommitRetryRequest = Body(default_factory=CommitRetryRequest),
+    _ctx: RequestContext = Depends(get_session_request_context),
+):
+    """Re-enqueue memory extraction for failed session commit archives.
+
+    The task-center "re-queue" action must use this endpoint for
+    ``session_commit`` tasks: calling commit again is a silent no-op for an
+    already-archived session, while a failed archive is terminal until its
+    ``.failed.json`` marker is cleared and the persisted Phase 2 work is
+    re-enqueued under a fresh task ID.
+    """
+    service = get_service()
+    execution = await run_operation(
+        operation="session.retry_failed_commits",
+        telemetry=body.telemetry,
+        fn=lambda: service.sessions.retry_failed_commits(
+            session_id,
+            _ctx,
+            archive_uri=body.archive_uri,
         ),
     )
     return Response(

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -32,6 +32,7 @@ from openviking.session import Session
 from openviking.session.auto_commit_policy import AutoCommitPolicy
 from openviking.session.memory.memory_type_registry import MemoryTypeRegistry
 from openviking.session.memory_policy import MemoryPolicy
+from openviking.session.session import _SESSION_PHASE1_LOCK_TIMEOUT_SECONDS
 from openviking.storage.viking_fs import VikingFS
 from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking.utils.tags import normalize_search_tags
@@ -481,6 +482,50 @@ class SessionService:
         )
         self._record_lifecycle_metric("extract", "ok")
         return memories
+
+    async def retry_failed_commits(
+        self,
+        session_id: str,
+        ctx: RequestContext,
+        *,
+        archive_uri: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Re-enqueue memory extraction for failed session commit archives.
+
+        A failed Phase 2 (memory extraction) archive is terminal: re-calling
+        commit is a no-op because the session has no live messages, and the
+        queue consumer treats the persisted ``.failed.json`` marker as final.
+        This is the real retry path used by the Studio task center.
+
+        Args:
+            session_id: Session ID whose failed commits should be retried
+            ctx: Request context of the caller
+            archive_uri: Retry one specific archive; ``None`` sweeps all
+                failed archives of the session
+
+        Returns:
+            Dict with ``retried`` / ``skipped`` / ``failed`` lists, plus a
+            convenience ``task_ids`` list of newly enqueued Phase 2 tasks.
+        """
+        self._ensure_initialized()
+        session = await self.get(session_id, ctx)
+        if not await session.exists():
+            self._record_lifecycle_metric("retry_commit", "error")
+            raise NotFoundError(session_id, "session")
+
+        session_path = self._viking_fs._uri_to_path(session.uri, ctx=ctx)
+        lease = await self._viking_fs._async_agfs.pathlock_acquire_exact(
+            session_path, timeout_secs=_SESSION_PHASE1_LOCK_TIMEOUT_SECONDS
+        )
+        try:
+            await session.load()
+            result = await session.retry_failed_commit(archive_uri=archive_uri)
+        finally:
+            await self._viking_fs._async_agfs.pathlock_release(lease)
+
+        result["task_ids"] = [entry.get("task_id") for entry in result.get("retried", [])]
+        self._record_lifecycle_metric("retry_commit", "ok")
+        return result
 
     @staticmethod
     def effective_auto_commit_policy(session: Session) -> Optional[Dict[str, Any]]:

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -2300,6 +2300,137 @@ class Session:
             error="session commit cancelled",
         )
 
+    async def retry_failed_commit(self, archive_uri: Optional[str] = None) -> Dict[str, Any]:
+        """Re-enqueue memory extraction for failed Phase 2 archives.
+
+        The Studio "re-queue" action cannot go through :meth:`commit_async`
+        again: an already-archived session has no live messages, so the commit
+        returns ``skipped/no_messages`` and never reaches Phase 2. The queue
+        consumer also treats an existing ``.failed.json`` marker as terminal.
+        This method is the real retry path: it clears the terminal marker and
+        re-enqueues the persisted Phase 1 queue message under a fresh task ID.
+
+        Args:
+            archive_uri: One specific failed archive to retry. ``None`` retries
+                every failed archive of this session.
+
+        Returns:
+            Dict with ``retried`` / ``skipped`` / ``failed`` entries.
+        """
+        from openviking.service.task_tracker import get_task_tracker
+        from openviking.storage.queuefs import QueueManager, get_queue_manager
+
+        retried: List[Dict[str, Any]] = []
+        skipped: List[Dict[str, Any]] = []
+        failures: List[Dict[str, Any]] = []
+
+        if archive_uri:
+            targets = [archive_uri]
+        else:
+            refs = await self._list_archive_refs()
+            targets = [ref["archive_uri"] for ref in refs]
+
+        for target_uri in targets:
+            try:
+                state = await self._archive_terminal_state(target_uri)
+            except Exception as exc:
+                failures.append({"archive_uri": target_uri, "error": str(exc)})
+                continue
+            if state != "failed":
+                skipped.append(
+                    {"archive_uri": target_uri, "reason": f"archive_state_{state}"}
+                )
+                continue
+
+            try:
+                entry = await self._requeue_failed_archive(target_uri)
+            except ValueError as exc:
+                skipped.append({"archive_uri": target_uri, "reason": str(exc)})
+                continue
+            except Exception as exc:
+                failures.append({"archive_uri": target_uri, "error": str(exc)})
+                continue
+            retried.append(entry)
+            logger.info(
+                "Re-enqueued failed session commit: session=%s archive=%s task=%s",
+                self.session_id,
+                target_uri,
+                entry.get("task_id"),
+            )
+
+        if not archive_uri:
+            # Full sweep: failed terminal markers of skipped entries that
+            # cannot be requeued would block later archives, so surface them
+            # to the caller instead of silently keeping the session stuck.
+            logger.info(
+                "Session commit retry sweep: session=%s retried=%d skipped=%d failed=%d",
+                self.session_id,
+                len(retried),
+                len(skipped),
+                len(failures),
+            )
+        return {"retried": retried, "skipped": skipped, "failed": failures}
+
+    async def _requeue_failed_archive(self, archive_uri: str) -> Dict[str, Any]:
+        """Clear one failed marker and re-enqueue its persisted Phase 2 work.
+
+        Must be called while holding the session path lock so the marker
+        removal and queue enqueue are atomic with respect to the queue
+        consumer (which bails out on any existing ``.failed.json``).
+        """
+        from openviking.service.task_tracker import get_task_tracker
+        from openviking.storage.queuefs import QueueManager, get_queue_manager
+        from openviking.storage.queuefs.session_commit_msg import SessionCommitMsg
+
+        try:
+            failed = json.loads(
+                await self._viking_fs.read_file(f"{archive_uri}/.failed.json", ctx=self.ctx)
+            )
+        except Exception as exc:
+            if _is_storage_not_found(exc):
+                raise ValueError("missing_failed_marker") from exc
+            raise
+
+        phase1 = await self._read_phase1_meta(archive_uri)
+        queue_message = phase1.get("queue_message")
+        if not isinstance(queue_message, dict) or not queue_message:
+            raise ValueError("missing_phase1_queue_message")
+
+        try:
+            archive_messages = await self._read_archive_messages(archive_uri)
+        except Exception:
+            archive_messages = []
+        if not archive_messages:
+            raise ValueError("archive_has_no_messages")
+
+        msg = SessionCommitMsg.from_dict(queue_message)
+        msg.task_id = str(uuid4())
+        await self._viking_fs.rm(f"{archive_uri}/.failed.json", ctx=self.ctx)
+        try:
+            await get_queue_manager().enqueue(QueueManager.SESSION_COMMIT, msg.to_dict())
+        except Exception:
+            # Restore the terminal marker: without it this archive would read
+            # as pending forever and block all later archives of the session.
+            await self._write_failed_marker(
+                archive_uri,
+                stage=str(failed.get("stage") or "memory_extraction"),
+                error=str(failed.get("error") or "session commit failed"),
+                completed_memory_steps=failed.get("completed_memory_steps"),
+            )
+            raise
+        await get_task_tracker().create(
+            "session_commit",
+            resource_id=self.session_id,
+            account_id=self.ctx.account_id,
+            user_id=self.ctx.user.user_id,
+            task_id=msg.task_id,
+        )
+        return {
+            "archive_uri": archive_uri,
+            "task_id": msg.task_id,
+            "previous_error": str(failed.get("error") or ""),
+        }
+
     async def resume_queued_commit(self, msg: "SessionCommitMsg") -> bool:
         """Run one durable Phase 2 job from its archived messages."""
         from openviking.service.task_tracker import get_task_tracker

--- a/tests/unit/session/test_session_commit_retry.py
+++ b/tests/unit/session/test_session_commit_retry.py
@@ -1,0 +1,283 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Tests for retrying failed session commit (Phase 2) archives."""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from openviking.message import Message, TextPart
+from openviking.service.task_tracker import TaskTracker, set_task_tracker
+from openviking.session.session import Session
+from openviking.storage.queuefs.session_commit_msg import SessionCommitMsg
+
+
+class _TaskStore:
+    def __init__(self):
+        self.tasks = {}
+
+    async def create(self, task):
+        self.tasks[task.task_id] = task
+
+    async def update(self, task):
+        self.tasks[task.task_id] = task
+
+    async def get(self, task_id, *, account_id=None, user_id=None):
+        return None
+
+    async def list(self, account_id, *, user_id=None):
+        return []
+
+    async def delete(self, task_id, *, account_id, user_id=None):
+        self.tasks.pop(task_id, None)
+
+
+class _MemoryVikingFS:
+    def __init__(self, files):
+        self.files = files
+        self._async_agfs = AsyncMock()
+
+    def _uri_to_path(self, uri, ctx=None):
+        return "/local/session-1"
+
+    async def read_file(self, uri, ctx=None):
+        if uri not in self.files:
+            raise FileNotFoundError(uri)
+        return self.files[uri]
+
+    async def write_file(self, uri, content, ctx=None, lease_ref=None):
+        self.files[uri] = content
+
+    async def exists(self, uri, ctx=None):
+        return uri in self.files
+
+    async def rm(self, uri, recursive=False, ctx=None, lease_ref=None, auto_pathlock=True):
+        self.files.pop(uri, None)
+
+    async def ls(self, uri, ctx=None, **kwargs):
+        prefix = uri.rstrip("/") + "/"
+        names = []
+        for path in self.files:
+            if path.startswith(prefix):
+                remainder = path[len(prefix) :]
+                head = remainder.split("/", 1)[0]
+                if head and head not in names:
+                    names.append(head)
+        return [{"name": name, "isDir": True} for name in names]
+
+
+def _write_session_scaffold(files, session_uri, archive_uri, *, failed_stage="memory_extraction"):
+    """Build the minimal on-disk state of one failed Phase 2 archive."""
+    archived = Message(id="archived", role="user", parts=[TextPart("old")])
+    retained = Message(id="retained", role="assistant", parts=[TextPart("new")])
+    original_task_id = "task-old"
+    queue_message = SessionCommitMsg(
+        task_id=original_task_id,
+        session_id="session-1",
+        session_uri=session_uri,
+        archive_uri=archive_uri,
+        user={"account_id": "default", "user_id": "default"},
+        memory_policy={"memory_types": []},
+    )
+    files[f"{session_uri}/messages.jsonl"] = f"{retained.to_jsonl()}\n"
+    files[f"{session_uri}/.meta.json"] = json.dumps(
+        {"session_id": "session-1", "message_count": 1, "commit_count": 1}
+    )
+    files[f"{archive_uri}/messages.jsonl"] = f"{archived.to_jsonl()}\n"
+    files[f"{archive_uri}/.failed.json"] = json.dumps(
+        {
+            "stage": failed_stage,
+            "error": "APITimeoutError",
+            "failed_at": "2026-09-11T20:47:40",
+            "skipped": True,
+            "completed_memory_steps": {},
+        }
+    )
+    files[f"{archive_uri}/.meta.json"] = json.dumps(
+        {"phase1": {"status": "ready", "queue_message": queue_message.to_dict()}}
+    )
+    return queue_message
+
+
+def _new_session(viking_fs, session_uri="viking://user/default/sessions/session-1"):
+    return Session(viking_fs=viking_fs, session_id="session-1", session_uri=session_uri)
+
+
+class _QueueManagerStub:
+    SESSION_COMMIT = "SessionCommit"
+
+    def __init__(self):
+        self.enqueued = []
+
+    async def enqueue(self, queue_name, payload):
+        self.enqueued.append((queue_name, payload))
+
+
+@pytest.fixture
+def queue_stub(monkeypatch):
+    stub = _QueueManagerStub()
+
+    def _fake_get_queue_manager():
+        return stub
+
+    import openviking.storage.queuefs as queuefs_pkg
+
+    monkeypatch.setattr(queuefs_pkg, "get_queue_manager", _fake_get_queue_manager)
+    monkeypatch.setattr(queuefs_pkg, "QueueManager", stub)
+    return stub
+
+
+@pytest.mark.asyncio
+async def test_retry_failed_commit_reenqueues_with_fresh_task_id(queue_stub, monkeypatch):
+    session_uri = "viking://user/default/sessions/session-1"
+    archive_uri = f"{session_uri}/history/archive_001"
+    files = {}
+    _write_session_scaffold(files, session_uri, archive_uri)
+    viking_fs = _MemoryVikingFS(files)
+    session = _new_session(viking_fs)
+    tracker = TaskTracker(_TaskStore())
+    set_task_tracker(tracker)
+    monkeypatch.setattr(session, "_run_memory_extraction", AsyncMock())
+
+    try:
+        result = await session.retry_failed_commit()
+        assert len(result["retried"]) == 1
+        new_task_id = result["retried"][0]["task_id"]
+        assert new_task_id != "task-old"
+        assert result["retried"][0]["archive_uri"] == archive_uri
+        assert result["skipped"] == []
+        assert result["failed"] == []
+
+        # Terminal marker cleared, queue message re-enqueued with fresh ID.
+        assert f"{archive_uri}/.failed.json" not in viking_fs.files
+        assert len(queue_stub.enqueued) == 1
+        queue_name, payload = queue_stub.enqueued[0]
+        assert queue_name == "SessionCommit"
+        assert payload["task_id"] == new_task_id
+        assert payload["session_id"] == "session-1"
+        assert payload["archive_uri"] == archive_uri
+
+        # A new tracker task exists for polling.
+        task = await tracker.get(new_task_id)
+        assert task is not None
+    finally:
+        set_task_tracker(None)
+
+
+@pytest.mark.asyncio
+async def test_retry_skips_completed_and_pending_archives(queue_stub, monkeypatch):
+    session_uri = "viking://user/default/sessions/session-1"
+    failed_uri = f"{session_uri}/history/archive_001"
+    done_uri = f"{session_uri}/history/archive_002"
+    pending_uri = f"{session_uri}/history/archive_003"
+    files = {}
+    _write_session_scaffold(files, session_uri, failed_uri)
+    done = Message(id="done", role="user", parts=[TextPart("done")])
+    pending = Message(id="pending", role="user", parts=[TextPart("pending")])
+    files[f"{done_uri}/messages.jsonl"] = f"{done.to_jsonl()}\n"
+    files[f"{done_uri}/.done"] = json.dumps({"starting_message_id": "done"})
+    files[f"{done_uri}/.meta.json"] = json.dumps(
+        {"phase1": {"status": "ready", "queue_message": {}}}
+    )
+    files[f"{pending_uri}/messages.jsonl"] = f"{pending.to_jsonl()}\n"
+    files[f"{pending_uri}/.meta.json"] = json.dumps(
+        {"phase1": {"status": "ready", "queue_message": {}}}
+    )
+    viking_fs = _MemoryVikingFS(files)
+    session = _new_session(viking_fs)
+    tracker = TaskTracker(_TaskStore())
+    set_task_tracker(tracker)
+    monkeypatch.setattr(session, "_run_memory_extraction", AsyncMock())
+
+    try:
+        result = await session.retry_failed_commit()
+        assert [entry["archive_uri"] for entry in result["retried"]] == [failed_uri]
+        skipped = {entry["archive_uri"]: entry["reason"] for entry in result["skipped"]}
+        assert skipped[done_uri] == "archive_state_completed"
+        assert skipped[pending_uri] == "archive_state_pending"
+    finally:
+        set_task_tracker(None)
+
+
+@pytest.mark.asyncio
+async def test_retry_without_phase1_queue_message_is_skipped(queue_stub, monkeypatch):
+    session_uri = "viking://user/default/sessions/session-1"
+    archive_uri = f"{session_uri}/history/archive_001"
+    files = {}
+    _write_session_scaffold(files, session_uri, archive_uri)
+    # Legacy archives have no Phase 1 snapshot to rebuild the queue message from.
+    files[f"{archive_uri}/.meta.json"] = json.dumps({})
+    viking_fs = _MemoryVikingFS(files)
+    session = _new_session(viking_fs)
+    tracker = TaskTracker(_TaskStore())
+    set_task_tracker(tracker)
+
+    try:
+        result = await session.retry_failed_commit()
+        assert result["retried"] == []
+        assert result["skipped"] == [
+            {"archive_uri": archive_uri, "reason": "missing_phase1_queue_message"}
+        ]
+        # The failed marker must remain intact so the archive stays terminal.
+        assert f"{archive_uri}/.failed.json" in viking_fs.files
+        assert queue_stub.enqueued == []
+    finally:
+        set_task_tracker(None)
+
+
+@pytest.mark.asyncio
+async def test_retry_restores_failed_marker_when_enqueue_fails(queue_stub, monkeypatch):
+    session_uri = "viking://user/default/sessions/session-1"
+    archive_uri = f"{session_uri}/history/archive_001"
+    files = {}
+    _write_session_scaffold(files, session_uri, archive_uri)
+    viking_fs = _MemoryVikingFS(files)
+    session = _new_session(viking_fs)
+    tracker = TaskTracker(_TaskStore())
+    set_task_tracker(tracker)
+
+    async def _failing_enqueue(queue_name, payload):
+        raise RuntimeError("queue down")
+
+    queue_stub.enqueue = _failing_enqueue
+
+    try:
+        result = await session.retry_failed_commit()
+        assert result["retried"] == []
+        assert len(result["failed"]) == 1
+        assert result["failed"][0]["archive_uri"] == archive_uri
+        # The marker is restored so the archive does not read as pending.
+        marker = json.loads(viking_fs.files[f"{archive_uri}/.failed.json"])
+        assert marker["stage"] == "memory_extraction"
+        assert marker["error"] == "APITimeoutError"
+    finally:
+        set_task_tracker(None)
+
+
+@pytest.mark.asyncio
+async def test_retry_specific_archive_uri_only(queue_stub, monkeypatch):
+    session_uri = "viking://user/default/sessions/session-1"
+    first_uri = f"{session_uri}/history/archive_001"
+    second_uri = f"{session_uri}/history/archive_002"
+    files = {}
+    _write_session_scaffold(files, session_uri, first_uri)
+    _write_session_scaffold(files, session_uri, second_uri)
+    files[f"{second_uri}/.failed.json"] = json.dumps(
+        {"stage": "memory_extraction", "error": "second", "skipped": True}
+    )
+    viking_fs = _MemoryVikingFS(files)
+    session = _new_session(viking_fs)
+    tracker = TaskTracker(_TaskStore())
+    set_task_tracker(tracker)
+
+    try:
+        result = await session.retry_failed_commit(archive_uri=second_uri)
+        assert [entry["archive_uri"] for entry in result["retried"]] == [second_uri]
+        assert f"{second_uri}/.failed.json" not in viking_fs.files
+        # The other failed archive is untouched without an explicit sweep.
+        assert f"{first_uri}/.failed.json" in viking_fs.files
+        assert len(queue_stub.enqueued) == 1
+    finally:
+        set_task_tracker(None)

--- a/web-studio/src/lib/sessions/api.ts
+++ b/web-studio/src/lib/sessions/api.ts
@@ -288,6 +288,62 @@ export async function extractSession(sessionId: string): Promise<unknown> {
   )
 }
 
+export interface RetryFailedCommitsEntry {
+  archive_uri?: string
+  task_id?: string
+  reason?: string
+  error?: string
+}
+
+export interface RetryFailedCommitsResult {
+  retried: RetryFailedCommitsEntry[]
+  skipped: RetryFailedCommitsEntry[]
+  failed: RetryFailedCommitsEntry[]
+  task_ids: Array<string | undefined>
+}
+
+/**
+ * Re-enqueue memory extraction for failed session commit archives.
+ *
+ * Unlike `commitSession` — which silently no-ops (`skipped/no_messages`) for
+ * an already-archived session — this targets the failed Phase 2 archives
+ * directly: the server clears each `.failed.json` marker and re-enqueues the
+ * persisted Phase 2 work under a fresh task ID.
+ */
+export async function retryFailedCommits(
+  sessionId: string,
+  archiveUri?: string,
+): Promise<RetryFailedCommitsResult> {
+  const resp = await ovClient.instance.post(
+    `/api/v1/sessions/${encodeURIComponent(sessionId)}/commits/retry`,
+    archiveUri === undefined ? {} : { archive_uri: archiveUri },
+  )
+  // The endpoint is not part of the generated client schema yet; parse the
+  // envelope defensively like the reindex calls in the tasks route do.
+  const payload: any = resp.data
+  if (payload?.status === 'error' || payload?.error) {
+    throw normalizeOvClientError(
+      new Error(
+        (typeof payload.error === 'object' && payload.error?.message) ||
+          payload.message ||
+          'Re-queue failed',
+      ),
+    )
+  }
+  const result: any = payload?.result ?? payload
+  const toEntries = (value: unknown): RetryFailedCommitsEntry[] =>
+    Array.isArray(value) ? (value as RetryFailedCommitsEntry[]) : []
+  return {
+    retried: toEntries(result?.retried),
+    skipped: toEntries(result?.skipped),
+    failed: toEntries(result?.failed),
+    task_ids: toEntries(result?.task_ids).map((entry) => {
+      const value: unknown = entry
+      return typeof value === 'string' ? value : undefined
+    }),
+  }
+}
+
 export async function recordSessionUsed(
   sessionId: string,
   body: UsedRequest,

--- a/web-studio/src/routes/tasks/route.tsx
+++ b/web-studio/src/routes/tasks/route.tsx
@@ -45,7 +45,7 @@ import {
 import { useAppConnection } from '#/hooks/use-app-connection'
 import { ovClient } from '#/lib/ov-client'
 import { postResources } from '#/gen/ov-client'
-import { commitSession } from '#/lib/sessions/api'
+import { retryFailedCommits } from '#/lib/sessions/api'
 import { cn } from '#/lib/utils'
 import { QueueStatusCard } from '#/routes/monitoring/-components/queue-status-card'
 import { TaskDetailSheet } from '#/routes/tasks/-components/task-detail-sheet'
@@ -132,16 +132,32 @@ function TasksRoute() {
 
       // ── 1. task_type 精确匹配优先（不受 URI 前缀干扰）──────────────────────
       if (task.task_type === 'session_commit') {
-        const res = await commitSession(task.resource_id)
+        // An archived session has no live messages, so re-calling commit is a
+        // silent no-op (`skipped/no_messages`). Failed Phase 2 work must be
+        // retried through the dedicated endpoint instead.
+        const res = await retryFailedCommits(task.resource_id)
         const resAny = res as any
-        if (resAny?.result?.reason === 'no_messages' || resAny?.reason === 'no_messages') {
-          toast.info(
-            i18n.language.startsWith('zh')
-              ? '该会话无未提交消息，已无需重复入队'
-              : 'Session has no pending uncommitted messages',
+        const retried = Array.isArray(resAny?.retried) ? resAny.retried : []
+        if (retried.length > 0) {
+          // Fresh Phase 2 task IDs were enqueued; the task list picks them up.
+          return { res, task }
+        }
+        const failed = Array.isArray(resAny?.failed) ? resAny.failed : []
+        if (failed.length > 0) {
+          throw new Error(
+            String(
+              failed[0]?.error ||
+                (i18n.language.startsWith('zh')
+                  ? '重新入队失败'
+                  : 'Re-queue failed'),
+            ),
           )
         }
-        return { res, task }
+        throw new Error(
+          i18n.language.startsWith('zh')
+            ? '该会话没有可重试的失败归档'
+            : 'No retryable failed archive for this session',
+        )
       }
       const resourceUri = task.resource_id || ''
 


### PR DESCRIPTION
## Summary

The Web Studio task center "re-queue" action for a failed `session_commit` task shows a success toast, but the backend silently does nothing: failed memory extraction (Phase 2) could never actually be retried. This PR adds the missing retry path.

### The bug

Reproduced against a real deployment (OpenViking 0.4.19): a session's Phase 2 memory extraction failed with `APITimeoutError` after 600s, and the archive got a terminal `.failed.json` marker (`{"stage": "memory_extraction", "skipped": true, ...}`). Clicking **Re-queue** in the task center:

1. The frontend called `POST /sessions/{id}/commit`. Because the session was already archived, its live `messages.jsonl` is empty, so `commit_async()` hit the `if not self._messages:` branch and returned `{status: "skipped", task_id: None, reason: "no_messages"}` — the `session_commit` queue message was never created.
2. Even if the queue message had been re-delivered, the queue consumer (`resume_queued_commit`) reads the archive's `.failed.json` marker and immediately `tracker.fail()`s the task without re-running extraction — the marker is terminal.
3. The UI then showed **"Re-queue request submitted successfully!"** unconditionally in `onSuccess`, despite `task_id` being `None` and nothing being enqueued. Four independent checks confirmed the ghost success: queue DB empty after checkpoint, `.failed.json` mtime unchanged, zero new server log lines, zero new inference requests.

So a failed extraction was permanently unrecoverable from the user's perspective.

### The fix

**Backend — a real retry path:**

- `Session.retry_failed_commit(archive_uri=None)`: for each failed archive (or one specific archive), verify its terminal state is `failed`, rebuild the `SessionCommitMsg` from the persisted `phase1.queue_message` snapshot in archive meta, clear the `.failed.json` marker, and enqueue the message under a **fresh task ID**. `archive_has_no_messages` / `missing_phase1_queue_message` are reported as skipped rather than half-processed.
- Safety properties:
  - Marker removal + enqueue happen under the session path lock, so the queue consumer can never observe a half-cleared state.
  - If enqueue fails, the `.failed.json` marker is **restored** (stage/error/`completed_memory_steps` preserved) so the archive never reads as pending and blocks later archives.
  - `completed_memory_steps` progress is preserved, so the resumed extraction skips already-completed memory steps (existing resume semantics).
  - Enqueue-failure rollback is covered by a unit test.
- `SessionService.retry_failed_commits()`: owner-checked service entry point; loads the session under the session path lock; passing no `archive_uri` sweeps every failed archive of the session.
- `POST /api/v1/sessions/{session_id}/commits/retry`: exposes the above. Returns `{retried: [...], skipped: [...], failed: [...], task_ids: [...]}`.

**Frontend — accurate outcomes instead of a ghost success:**

- The tasks route re-queue mutation now calls the new endpoint for `session_commit` tasks.
- Three distinct outcomes are surfaced: success (fresh task IDs enqueued, the task list picks them up), nothing to retry ("No retryable failed archive for this session"), or the underlying failure reason — replacing the unconditional success toast.

### Notes

- The old frontend behavior even showed two contradictory toasts (an info "no pending messages" + a success "request submitted") for the same click; both are gone.
- The generated OpenAPI client (`src/gen/ov-client`) is not regenerated in this PR; the adapter-level call parses the response envelope defensively, consistent with the existing `content/reindex` calls in the same route. Happy to regenerate if maintainers prefer.

## Test plan

- [x] New unit tests (`tests/unit/session/test_session_commit_retry.py`):
  - failed archive is re-enqueued with a fresh task ID, marker cleared, tracker task created
  - completed/pending archives are skipped during a sweep
  - archive without a `phase1.queue_message` snapshot (legacy) is skipped and stays terminal
  - enqueue failure restores the `.failed.json` marker
  - targeting one specific `archive_uri` leaves other failed archives untouched
- [x] Existing session/unit tests: no regressions (263 passed; 4 pre-existing failures on `main` unrelated to this change)
- [x] Web Studio: `npm run test` 320/320, ESLint and `tsc --noEmit` baseline unchanged