### PR TITLE
docs: fix table striping, community heading case, add contributor graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Build your own integration with the [Python](sdk/python/README.md), [Go](sdk/go/
 Connect your agent to OpenViking for cross-session memory. Choose a native integration for automatic recall and session capture, or use MCP to give your agent memory and context tools.
 
 <table>
+<tbody>
 <tr>
 <td align="center" valign="bottom" width="16%">
 <a href="https://docs.openviking.ai/en/agent-integrations/02-claude-code"><img src="docs/images/integrations/logos/claude-code.png" width="32" height="32" alt=""><br><strong>Claude</strong></a><br>
@@ -171,6 +172,8 @@ Connect your agent to OpenViking for cross-session memory. Choose a native integ
 <sub>Built-in</sub>
 </td>
 </tr>
+</tbody>
+<tbody>
 <tr>
 <td align="center" valign="bottom" width="16%">
 <a href="https://docs.openviking.ai/en/agent-integrations/10-opencode"><img src="docs/images/integrations/logos/opencode.png" width="32" height="32" alt=""><br><strong>OpenCode</strong></a><br>
@@ -197,6 +200,7 @@ Connect your agent to OpenViking for cross-session memory. Choose a native integ
 <sub>Tools&nbsp;+&nbsp;store</sub>
 </td>
 </tr>
+</tbody>
 </table>
 
 **General integrations**

--- a/README.md
+++ b/README.md
@@ -301,13 +301,17 @@ The server supports [accounts and user isolation](https://docs.openviking.ai/en/
 
 To propose a partnership, [open an issue](https://github.com/volcengine/OpenViking/issues).
 
-## Community & contributing
+## Community & Contributing
 
 - **Docs**: [docs.openviking.ai](https://docs.openviking.ai/) · [FAQ](https://docs.openviking.ai/en/faq/faq)
 - **Blog**: [blog.openviking.ai](https://blog.openviking.ai/)
 - **Team**: [About us](https://docs.openviking.ai/en/about/01-about-us)
 - **Chat**: 📱 [Lark Group](https://docs.openviking.ai/en/about/01-about-us#lark-group) · 💬 [WeChat](https://docs.openviking.ai/en/about/01-about-us#wechat-group) · 🎮 [Discord](https://discord.com/invite/eHvx8E9XF3) · 🐦 [X](https://x.com/openvikingai)
 - **Contribute**: bug fixes and new features are both welcome — see [CONTRIBUTING.md](CONTRIBUTING.md)
+
+<a href="https://github.com/volcengine/OpenViking/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=volcengine/OpenViking" alt="OpenViking contributors" />
+</a>
 
 ## Security and privacy
 

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ To propose a partnership, [open an issue](https://github.com/volcengine/OpenViki
 - **Contribute**: bug fixes and new features are both welcome — see [CONTRIBUTING.md](CONTRIBUTING.md)
 
 <a href="https://github.com/volcengine/OpenViking/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=volcengine/OpenViking" alt="OpenViking contributors" />
+  <img src="https://contrib.rocks/image?repo=volcengine/OpenViking&amp;columns=15&amp;max=120" alt="OpenViking contributors" />
 </a>
 
 ## Security and privacy

--- a/README_CN.md
+++ b/README_CN.md
@@ -309,6 +309,10 @@ ov chat   # 在另一个终端运行
 - **交流**：📱 [飞书群](https://docs.openviking.ai/zh/about/01-about-us#飞书群) · 💬 [微信群](https://docs.openviking.ai/zh/about/01-about-us#微信群) · 🎮 [Discord](https://discord.com/invite/eHvx8E9XF3) · 🐦 [X](https://x.com/openvikingai)
 - **贡献**：修 bug、加新功能都欢迎——见 [CONTRIBUTING_CN.md](CONTRIBUTING_CN.md)
 
+<a href="https://github.com/volcengine/OpenViking/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=volcengine/OpenViking" alt="OpenViking contributors" />
+</a>
+
 ## 安全与隐私
 
 漏洞报告方式和受支持的版本，见 [SECURITY.md](SECURITY.md)

--- a/README_CN.md
+++ b/README_CN.md
@@ -145,6 +145,7 @@ ov grep "openviking" --uri viking://resources/volcengine/OpenViking/docs/zh
 将 Agent 接入 OpenViking，跨会话保留记忆。原生集成支持自动召回与会话采集；也可通过 MCP 提供记忆和上下文工具。
 
 <table>
+<tbody>
 <tr>
 <td align="center" valign="bottom" width="16%">
 <a href="https://docs.openviking.ai/zh/agent-integrations/02-claude-code"><img src="docs/images/integrations/logos/claude-code.png" width="32" height="32" alt=""><br><strong>Claude</strong></a><br>
@@ -171,6 +172,8 @@ ov grep "openviking" --uri viking://resources/volcengine/OpenViking/docs/zh
 <sub>内置记忆</sub>
 </td>
 </tr>
+</tbody>
+<tbody>
 <tr>
 <td align="center" valign="bottom" width="16%">
 <a href="https://docs.openviking.ai/zh/agent-integrations/10-opencode"><img src="docs/images/integrations/logos/opencode.png" width="32" height="32" alt=""><br><strong>OpenCode</strong></a><br>
@@ -197,6 +200,7 @@ ov grep "openviking" --uri viking://resources/volcengine/OpenViking/docs/zh
 <sub>工具&nbsp;+&nbsp;存储</sub>
 </td>
 </tr>
+</tbody>
 </table>
 
 **通用接入**

--- a/README_CN.md
+++ b/README_CN.md
@@ -310,7 +310,7 @@ ov chat   # 在另一个终端运行
 - **贡献**：修 bug、加新功能都欢迎——见 [CONTRIBUTING_CN.md](CONTRIBUTING_CN.md)
 
 <a href="https://github.com/volcengine/OpenViking/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=volcengine/OpenViking" alt="OpenViking contributors" />
+  <img src="https://contrib.rocks/image?repo=volcengine/OpenViking&amp;columns=15&amp;max=120" alt="OpenViking contributors" />
 </a>
 
 ## 安全与隐私

--- a/README_JA.md
+++ b/README_JA.md
@@ -309,6 +309,10 @@ ov chat   # 別のターミナルで実行
 - **チャット**: 📱 [Larkグループ](https://docs.openviking.ai/en/about/01-about-us#lark-group) · 💬 [WeChat](https://docs.openviking.ai/en/about/01-about-us#wechat-group) · 🎮 [Discord](https://discord.com/invite/eHvx8E9XF3) · 🐦 [X](https://x.com/openvikingai)
 - **コントリビュート**: バグ修正も新機能も歓迎します — [CONTRIBUTING_JA.md](CONTRIBUTING_JA.md) を参照してください
 
+<a href="https://github.com/volcengine/OpenViking/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=volcengine/OpenViking" alt="OpenViking contributors" />
+</a>
+
 ## セキュリティとプライバシー
 
 脆弱性の報告方法とサポート対象バージョンについては、[SECURITY.md](SECURITY.md) を参照してください

--- a/README_JA.md
+++ b/README_JA.md
@@ -310,7 +310,7 @@ ov chat   # 別のターミナルで実行
 - **コントリビュート**: バグ修正も新機能も歓迎します — [CONTRIBUTING_JA.md](CONTRIBUTING_JA.md) を参照してください
 
 <a href="https://github.com/volcengine/OpenViking/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=volcengine/OpenViking" alt="OpenViking contributors" />
+  <img src="https://contrib.rocks/image?repo=volcengine/OpenViking&amp;columns=15&amp;max=120" alt="OpenViking contributors" />
 </a>
 
 ## セキュリティとプライバシー

--- a/README_JA.md
+++ b/README_JA.md
@@ -145,6 +145,7 @@ ov grep "openviking" --uri viking://resources/volcengine/OpenViking/docs/en
 OpenViking を接続して、セッションをまたいで記憶を引き継ぎます。ネイティブ統合で自動想起とセッション収集を使うか、MCP で記憶とコンテキストのツールを提供できます。
 
 <table>
+<tbody>
 <tr>
 <td align="center" valign="bottom" width="16%">
 <a href="https://docs.openviking.ai/en/agent-integrations/02-claude-code"><img src="docs/images/integrations/logos/claude-code.png" width="32" height="32" alt=""><br><strong>Claude</strong></a><br>
@@ -171,6 +172,8 @@ OpenViking を接続して、セッションをまたいで記憶を引き継ぎ
 <sub>内蔵メモリ</sub>
 </td>
 </tr>
+</tbody>
+<tbody>
 <tr>
 <td align="center" valign="bottom" width="16%">
 <a href="https://docs.openviking.ai/en/agent-integrations/10-opencode"><img src="docs/images/integrations/logos/opencode.png" width="32" height="32" alt=""><br><strong>OpenCode</strong></a><br>
@@ -197,6 +200,7 @@ OpenViking を接続して、セッションをまたいで記憶を引き継ぎ
 <sub>ツール&nbsp;+&nbsp;ストア</sub>
 </td>
 </tr>
+</tbody>
 </table>
 
 **汎用接続**


### PR DESCRIPTION
三处 README 微调，只动三份 README：

1. **集成表第二行背景偏深** — 是 GitHub 自带的斑马纹 `.markdown-body tr:nth-child(2n)`，两行的表第二行正好命中。把两行各自包进独立的 `<tbody>`，每个 `<tr>` 在自己父节点里都是第一个子元素，选择器不再命中。GitHub sanitizer 保留多个 tbody（用其 markdown API 验过）。
2. `Community & contributing` → `Community & Contributing`（仅英文版，中日文标题本来就是本地化的）。
3. 社区章节末尾加上 contrib.rocks 贡献者图，链到 contributors 页。三份都加了。