### PR TITLE
perf(skill): 导入时直接使用技能正文作为 L1

### DIFF
--- a/openviking/utils/skill_processor.py
+++ b/openviking/utils/skill_processor.py
@@ -36,7 +36,6 @@ from openviking.utils.path_safety import safe_join_viking_uri
 from openviking.utils.zip_safe import safe_extract_zip
 from openviking_cli.exceptions import InvalidArgumentError
 from openviking_cli.utils import get_logger
-from openviking_cli.utils.config import get_openviking_config
 
 logger = get_logger(__name__)
 
@@ -94,7 +93,7 @@ class SkillProcessor:
 
     Workflow:
     1. Parse skill data (directory, file, string, or dict)
-    2. Generate L1 overview using VLM
+    2. Use skill metadata as L0 and skill instructions as L1
     3. Write skill content to VikingFS
     4. Write auxiliary files
     5. Index to vector store
@@ -167,7 +166,6 @@ class SkillProcessor:
         privacy_change_reason: str = "auto-extracted from add_skill",
         target_uri: Optional[str] = None,
     ) -> Dict[str, Any]:
-        config = get_openviking_config()
         cleanup_path = preparation.cleanup_path
         skill_dict = preparation.skill_dict
         auxiliary_files = preparation.auxiliary_files
@@ -204,13 +202,6 @@ class SkillProcessor:
             )
             context.set_vectorize(Vectorize(text=context.abstract))
 
-            overview_start = time.perf_counter()
-            overview = await self._generate_overview(skill_dict, config)
-            telemetry.set(
-                "skill.overview.duration_ms",
-                round((time.perf_counter() - overview_start) * 1000, 3),
-            )
-
             skill_dir_uri = context.uri
 
             write_start = time.perf_counter()
@@ -219,7 +210,7 @@ class SkillProcessor:
                 skill_dict=skill_dict,
                 skill_dir_uri=skill_dir_uri,
                 abstract=skill_abstract,
-                overview=overview,
+                overview=skill_dict.get("content", ""),
                 ctx=ctx,
             )
 

--- a/tests/unit/test_skill_processor_none.py
+++ b/tests/unit/test_skill_processor_none.py
@@ -152,14 +152,7 @@ class TestParseSkillNoneData:
 
 
 @pytest.mark.asyncio
-async def test_process_skill_preserves_hyphenated_allowed_tools_in_meta(monkeypatch):
-    config = MagicMock()
-    config.vlm.get_completion_async = AsyncMock(return_value="overview")
-    monkeypatch.setattr(
-        "openviking.utils.skill_processor.get_openviking_config",
-        lambda: config,
-    )
-
+async def test_process_skill_preserves_hyphenated_allowed_tools_in_meta():
     vikingdb = MagicMock()
     vikingdb.enqueue_embedding_msg = AsyncMock(return_value=False)
     viking_fs = MagicMock()


### PR DESCRIPTION
## Description

添加技能时，原流程会在隐私处理后额外调用一次 VLM 生成 L1，增加导入等待。现在直接使用处理后的 `SKILL.md` 正文作为 L1，L0 继续取自技能元数据。

例如，同一个技能的元数据为 `name: demo`、`description: 示例技能`，正文为 `先执行 A，再执行 B。`：

| 产物 | 修改前 | 修改后 |
| --- | --- | --- |
| L0 | 技能名称和描述 | 技能名称和描述 |
| L1 | 模型生成的摘要，内容不固定 | `先执行 A，再执行 B。` |
| SKILL.md | 技能定义和正文 | 技能定义和正文 |

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

无。

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made

- 导入处理直接将技能正文传给 L1 写入逻辑，删除该阶段的模型调用和计时。
- 删除不再使用的配置读取及 import，清理现有测试中过时的模型配置 Mock。

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

现有处理器契约测试通过：`tests/unit/test_skill_processor_none.py::test_process_skill_preserves_hyphenated_allowed_tools_in_meta`。

本地同一配置、同一 Wiki 技能导入前后对比：两条 CLI 入口各测 3 次，中位耗时分别由 18.51 秒降至 5.12 秒、19.66 秒降至 3.66 秒。逐次验证 L1 与技能正文一致，`SKILL.md` 内容哈希与修改前一致，向量任务完成。HTTP API 直接导入也已验证通过。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

本 PR 只调整技能导入阶段。隐私处理、读取展示、重建索引和 `wait` 行为保留原有实现。
