### PR TITLE
fix(storage): 启动时初始化完整 agent 目录

### DIFF
--- a/openviking/core/directories.py
+++ b/openviking/core/directories.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Sequence
 
 from openviking.core.context import Context, Vectorize
 from openviking.core.namespace import (
+    AGENT_SHARED_ROOTS,
     canonical_user_root,
     context_type_for_uri,
     is_session_uri,
@@ -49,7 +50,7 @@ class _DirectoryTarget:
     ctx: RequestContext
 
 
-# Preset directory tree - each scope has a root DirectoryDefinition
+# Preset directory trees, keyed by their namespace path.
 PRESET_DIRECTORIES: Dict[str, DirectoryDefinition] = {
     "user": DirectoryDefinition(
         path="",
@@ -152,6 +153,13 @@ PRESET_DIRECTORIES: Dict[str, DirectoryDefinition] = {
         overview="Globally shared resource storage, organized by project/topic. "
         "No preset subdirectory structure, users create project directories as needed.",
     ),
+    "agent/skills": DirectoryDefinition(
+        path="",
+        abstract="Shared skill registry. Stores callable skill definitions available across the account.",
+        overview="Use this directory for skills shared by users in the same account. "
+        "Each skill is stored in its own directory using the SKILL.md format. "
+        "User-private skills remain under viking://user/{user_id}/skills.",
+    ),
 }
 
 
@@ -175,13 +183,12 @@ class DirectoryInitializer:
 
     async def initialize_account_workspace(self, ctx: RequestContext) -> tuple[int, int]:
         """Initialize account and first-user preset directories as one batch."""
-        account_target = self._account_directory_target(ctx)
+        account_targets = self._account_directory_targets(ctx)
         user_root, user_children = self._user_directory_targets(ctx)
 
-        root_targets = (account_target, user_root)
+        root_targets = (*account_targets, user_root)
         root_results = await asyncio.gather(
-            self._ensure_agfs_directory(account_target),
-            self._ensure_agfs_directory(user_root),
+            *(self._ensure_agfs_directory(target) for target in root_targets),
             return_exceptions=True,
         )
         created_targets, root_error = self._partition_directory_results(root_targets, root_results)
@@ -200,8 +207,9 @@ class DirectoryInitializer:
         await self._ensure_directory_l0_l1_vectors(created_targets)
         if child_error is not None:
             raise child_error
-        return int(root_results[0] is True), int(root_results[1] is True) + sum(
-            result is True for result in child_results
+        return (
+            sum(result is True for result in root_results[:-1]),
+            int(root_results[-1] is True) + sum(result is True for result in child_results),
         )
 
     async def initialize_account_directories(self, ctx: RequestContext) -> int:
@@ -210,11 +218,20 @@ class DirectoryInitializer:
         ``viking://user`` is the container of user spaces, not a space itself.
         Its concrete metadata belongs to ``viking://user/{user_id}`` and is
         created by ``initialize_user_directories``.
+
+        Likewise, ``viking://agent`` remains a container, created implicitly
+        when its shared skills directory is initialized.
         """
-        target = self._account_directory_target(ctx)
-        created = await self._ensure_agfs_directory(target)
-        await self._ensure_directory_l0_l1_vectors([target] if created else [])
-        return int(created)
+        targets = self._account_directory_targets(ctx)
+        results = await asyncio.gather(
+            *(self._ensure_agfs_directory(target) for target in targets),
+            return_exceptions=True,
+        )
+        created_targets, error = self._partition_directory_results(targets, results)
+        await self._ensure_directory_l0_l1_vectors(created_targets)
+        if error is not None:
+            raise error
+        return len(created_targets)
 
     async def initialize_user_directories(self, ctx: RequestContext) -> int:
         """Initialize the current user's root and first-level entry directories.
@@ -242,14 +259,21 @@ class DirectoryInitializer:
         return int(root_created) + sum(result is True for result in child_results)
 
     @staticmethod
-    def _account_directory_target(ctx: RequestContext) -> _DirectoryTarget:
-        return _DirectoryTarget(
-            uri="viking://resources",
-            parent_uri=None,
-            definition=PRESET_DIRECTORIES["resources"],
-            scope="resources",
-            ctx=ctx,
-        )
+    def _account_directory_targets(ctx: RequestContext) -> list[_DirectoryTarget]:
+        targets = []
+        for uri in ("viking://resources", *AGENT_SHARED_ROOTS):
+            namespace_path = uri.removeprefix("viking://")
+            parent_path, _, _ = namespace_path.rpartition("/")
+            targets.append(
+                _DirectoryTarget(
+                    uri=uri,
+                    parent_uri=f"viking://{parent_path}" if parent_path else None,
+                    definition=PRESET_DIRECTORIES[namespace_path],
+                    scope=namespace_path.split("/", 1)[0],
+                    ctx=ctx,
+                )
+            )
+        return targets
 
     @staticmethod
     def _user_directory_targets(

--- a/tests/unit/test_directory_initializer.py
+++ b/tests/unit/test_directory_initializer.py
@@ -59,12 +59,15 @@ async def test_initialize_account_workspace_batches_preset_directories(monkeypat
         user_root,
         *(f"{user_root}/{child.path}" for child in PRESET_DIRECTORIES["user"].children),
     }
-    expected_uris = {"viking://resources", *expected_user_uris}
-    assert account_count == 1
+    expected_uris = {"viking://resources", "viking://agent/skills", *expected_user_uris}
+    assert account_count == 2
     assert user_count == len(expected_user_uris)
     assert set(viking_fs.contexts) == expected_uris
     assert f"{user_root}/memories/preferences" not in viking_fs.contexts
     assert len(vikingdb.get_calls) == 1
+
+    assert await initializer.initialize_account_directories(ctx) == 0
+    assert set(viking_fs.contexts) == expected_uris
     vectorized_uris = {uri for uri in expected_uris if not is_session_uri(uri)}
     assert len(vikingdb.get_calls[0][0]) == 2 * len(vectorized_uris)
     assert len(vikingdb.embedding_messages) == 2 * len(vectorized_uris)


### PR DESCRIPTION
## Description

服务启动时，`viking://agent` 与 `viking://resources` 使用同一套预设目录初始化流程，自动创建 agent 根目录及 `skills`、`endpoints`、`tools`、`payments` 四个子目录，并生成摘要、概述及对应向量。已有目录只补缺失的元信息，不覆盖已有内容，重复初始化不重复写入。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

无。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 将完整 agent 预设目录树纳入现有启动初始化和批量向量化流程。
- 允许 agent 根目录及其摘要、概述文件写入，保留旧 agent ID 路径的写入限制和根目录删除限制。
- 通过读取实际元信息文件判断是否需要初始化，保留已有内容。
- 更新现有初始化契约测试的目录与元信息断言。

## Testing

Ruff 静态检查、格式检查、Python 语法检查及 diff 检查通过。本次未运行单元测试或服务启动验证。

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

无。
