### PR TITLE
fix(docker): keep relative workspaces inside the persistent mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ripgrep \
  && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
+# Resolve relative storage paths inside the persistent mount.
+WORKDIR /app/.openviking
 
 COPY --from=py-builder /app/.venv /app/.venv
 # Fail the image build if VikingBot and the separately released SDK drift apart.
@@ -128,7 +129,7 @@ EXPOSE 1933
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
     CMD ["openviking-entrypoint", "--healthcheck"]
 
-# All persistent state (ov.conf, ovcli.conf, workspace data) lives under
+# Default persistent state (ov.conf, ovcli.conf, workspace data) lives under
 # /app/.openviking, which mirrors the host's ~/.openviking layout. Mount one
 # volume there to persist everything across container restarts:
 #   docker run -v ~/.openviking:/app/.openviking <image>

--- a/docs/en/guides/03-deployment.md
+++ b/docs/en/guides/03-deployment.md
@@ -184,7 +184,7 @@ curl http://localhost:1933/api/v1/fs/ls?uri=viking:// \
 
 ### Docker
 
-OpenViking provides pre-built Docker images published to GitHub Container Registry. All persistent state — `ov.conf`, `ovcli.conf`, and the workspace data — lives under `/app/.openviking` inside the container, so a single mount is enough:
+OpenViking provides pre-built Docker images published to GitHub Container Registry. The runtime working directory is `/app/.openviking`, so the default `storage.workspace` (`./data`) resolves to `/app/.openviking/data`. The default workspace, `ov.conf`, and `ovcli.conf` therefore share one persistent mount. If you configure an absolute workspace outside this directory, mount that path separately:
 
 ```bash
 docker run -d \
@@ -210,6 +210,8 @@ Since the server binds to `0.0.0.0` inside the container (required for Docker po
 ```
 
 The server will refuse to start without it. You can override the bind address via the `OPENVIKING_SERVER_HOST` environment variable if needed.
+
+**Upgrading from an older image:** images that started in `/app` resolved `./data` to `/app/data`, outside the default mount. Before removing the old container, stop it and back up its configured workspace (for example, `docker cp openviking:/app/data ./openviking-data-backup`). Restore that backup into the mounted host workspace, normally `~/.openviking/data`, before starting the replacement. Do not overwrite an existing workspace without checking which data to retain. Absolute workspace paths are unchanged; other relative paths now resolve from `/app/.openviking`.
 
 Upgrade the container:
 ```bash

--- a/docs/zh/guides/03-deployment.md
+++ b/docs/zh/guides/03-deployment.md
@@ -182,7 +182,7 @@ curl http://localhost:1933/api/v1/fs/ls?uri=viking:// \
 
 ### Docker
 
-OpenViking 提供预构建的 Docker 镜像，发布在 GitHub Container Registry。容器内所有持久化状态（`ov.conf`、`ovcli.conf` 以及工作区数据）都放在 `/app/.openviking` 下，挂载一个目录即可：
+OpenViking 提供预构建的 Docker 镜像，发布在 GitHub Container Registry。运行目录为 `/app/.openviking`，因此默认的 `storage.workspace`（`./data`）解析为 `/app/.openviking/data`。默认工作区、`ov.conf` 和 `ovcli.conf` 共用一个持久卷。若将工作区配置为此目录以外的绝对路径，需要另外挂载该路径：
 
 ```bash
 docker run -d \
@@ -208,6 +208,8 @@ Docker 镜像默认会同时启动：
 ```
 
 未设置时服务将拒绝启动。如需自定义绑定地址，可通过环境变量 `OPENVIKING_SERVER_HOST` 覆盖。
+
+**从旧镜像升级：** 运行目录为 `/app` 的旧镜像会把 `./data` 解析为默认挂载之外的 `/app/data`。删除旧容器前，先停止容器并备份其实际工作区（例如 `docker cp openviking:/app/data ./openviking-data-backup`）。启动替换容器前，将备份恢复到挂载的宿主机工作区，通常为 `~/.openviking/data`。若目标工作区已存在，先确认要保留的数据，不要直接覆盖。绝对工作区路径不变；其他相对路径现在以 `/app/.openviking` 为基准。
 
 升级容器的方式
 ```bash

--- a/tests/misc/test_root_docker_image_packaging.py
+++ b/tests/misc/test_root_docker_image_packaging.py
@@ -1,6 +1,9 @@
 import re
 from pathlib import Path
 
+import pytest
+import yaml
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -122,3 +125,22 @@ def test_rust_crates_declare_the_repo_minimum_rust_version():
     ):
         cargo_toml = _read_text(relative_path)
         assert f'rust-version = "{min_rust_version}"' in cargo_toml
+
+
+@pytest.mark.parametrize("storage", [{}, {"workspace": "./data"}, {"workspace": "./custom"}])
+def test_docker_relative_workspace_is_inside_persistent_mount(tmp_path, monkeypatch, storage):
+    from openviking_cli.utils.config.storage_config import StorageConfig
+
+    runtime = _read_text("Dockerfile").rsplit("\nFROM ", maxsplit=1)[1]
+    workdir = re.findall(r"^WORKDIR (.+)$", runtime, re.MULTILINE)[-1]
+    compose = yaml.safe_load(_read_text("docker-compose.yml"))
+    mount_target = compose["services"]["openviking"]["volumes"][0].split(":")[1]
+    container_cwd = tmp_path / workdir.lstrip("/")
+    container_cwd.mkdir(parents=True)
+    monkeypatch.chdir(container_cwd)
+
+    config = StorageConfig(**storage)
+
+    assert Path(config.workspace).is_relative_to(tmp_path / mount_target.lstrip("/"))
+    assert config.agfs.path == config.workspace
+    assert config.vectordb.path == config.workspace


### PR DESCRIPTION
## Description

The official Compose file mounts host `~/.openviking` at `/app/.openviking`, but the current image starts in `/app`. With the default or explicitly configured `storage.workspace: "./data"`, data is therefore written to `/app/data`, outside that mount. Restarting the same container preserves this data; removing and recreating the container does not. Config files survive in the mounted directory while the unmounted workspace is lost.

This PR changes the runtime `WORKDIR` from `/app` to `/app/.openviking`, placing the default workspace inside the existing mount. It does not change the `storage.workspace` default value (`./data`). Relative workspaces are resolved against the process working directory, not the directory containing `ov.conf`. Build-stage directories and installed package paths are unchanged.

## Breaking Change and Data Location

This changes the base directory for all paths resolved relative to the runtime working directory, including explicitly configured relative workspaces. It is not limited to users who omitted `storage.workspace`. For deployments using the image's default working directory:

| `storage.workspace` | Before | After |
| --- | --- | --- |
| Omitted or `./data` | `/app/data` | `/app/.openviking/data` |
| `./custom` | `/app/custom` | `/app/.openviking/custom` |
| `./.openviking/data` | `/app/.openviking/data` | `/app/.openviking/.openviking/data` |
| `/app/data` | `/app/data` | `/app/data` |
| `/app/.openviking/data` | `/app/.openviking/data` | `/app/.openviking/data` |

Existing deployments that already persist `/app/data` with a separate mount, but still configure `./data`, are also affected: the old data remains in that mount, while the new image reads a different location. The same applies to relative paths that previously resolved inside the official mount.

There is no automatic workspace migration or fallback to the old location. Without an explicit data switch, the replacement may start with an empty workspace. Absolute workspace paths keep their meaning, but their contents survive container recreation only if the relevant directory is persisted.

## Upgrade and Data Switch

1. Determine the old container's actual workspace and its mounts. Stop the service and back up the complete workspace before removing or recreating the old container. For an unmounted default workspace, copy `/app/data` out of the stopped container, for example `docker cp openviking:/app/data ./openviking-data-backup`, using a new backup destination. The host `~/.openviking` directory alone does not contain this unmounted data.
2. Choose the target explicitly:
   - **Keep the existing location:** set `storage.workspace` to the previous absolute container path, such as `/app/data`, and retain the existing mount there. If it was not mounted, restore the backup to a host directory and mount that directory at the same container path before starting the replacement.
   - **Move into the official mount:** restore the complete workspace into the host directory mapped to `/app/.openviking/data` (normally `~/.openviking/data`), and set `storage.workspace` to `/app/.openviking/data`. The default `./data` also resolves there in the new image, but the absolute value makes the intended location explicit.
3. Complete the restore while the service is stopped. If the destination already contains a workspace, determine which data to retain; do not overwrite or merge workspaces blindly. Start the replacement with the matching configuration and mount, verify that existing data is visible, and retain the backup until verification is complete.

The English and Chinese deployment guides add the backup and restore requirement before their container-removal instructions. Other configured relative paths must also be checked against the new working directory.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4954.

## Type of Change

- [x] Bug fix
- [x] Breaking change — runtime working directory changes; existing relative-path data needs migration
- [x] Documentation update
- [x] Test update

## Changes Made

- Change only the runtime Docker working directory.
- Extend the existing packaging contract test: resolve the image's runtime directory and Compose mount, then instantiate the real `StorageConfig` for omitted/default/custom relative workspaces and verify workspace/AGFS/VectorDB stay under the mount.
- Document the migration before the container-removal instructions.

## Testing

On macOS, CPython 3.13.15:

- `python -m pytest --noconftest -o addopts= tests/misc/test_root_docker_image_packaging.py -k relative_workspace -q`: **3 passed**. All three fail against the old Dockerfile because the effective workspace is outside the mount.
- The complete packaging file: **11 passed, 2 failed**. The existing console-static-assets and maturin `--features` assertions also fail against unmodified base `0f77ab5625a5e2ead4f286d4e58ea77e05fcfdee`; neither packaging input is changed here.
- `ruff check` and `ruff format --check` for the changed test; `git diff --check`: passed.

`--noconftest` avoids unrelated native-server fixtures for this configuration/packaging test. This is a real storage-path reproduction using the Docker/Compose configuration, not a complete image build or running-service/container-recreation test. No production data was touched.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have added regression coverage for the affected behavior
