### PR TITLE
feat(bot): make the Feishu channel domain configurable for Lark

### DIFF
--- a/bot/docs/en/concepts/05-channel.md
+++ b/bot/docs/en/concepts/05-channel.md
@@ -232,6 +232,7 @@ Feishu uses a persistent **WebSocket** connection, so no public IP address is re
 ```
 
 > In long-connection mode, `encryptKey` and `verificationToken` are optional.
+> `domain`: the open-platform domain. Defaults to `https://open.feishu.cn` (Feishu). For **Lark international**, set it to `https://open.larksuite.com`; both the HTTP calls and the WebSocket long connection follow it.
 > `allowFrom`: leave it empty to allow every user, or add `["ou_xxx"]` to restrict access.
 > `botName`: replaces `@<open_id>` mentions with the bot name in group-chat context sent to the model, and labels messages sent by the bot itself. When empty, it falls back to `"Bot"`.
 > `threadRequireMention`: controls whether group messages must mention the bot. The default is `true`, meaning every message in regular groups and topic groups requires an `@` mention. When set to `false`, regular groups do not require a mention, and only the first message in a topic group can omit it; later replies still require an `@` mention outside `DEBUG` mode.

--- a/bot/docs/zh/concepts/05-channel.md
+++ b/bot/docs/zh/concepts/05-channel.md
@@ -228,6 +228,7 @@ vikingbot gateway
 ```
 
 > 长连接模式下，`encryptKey` 和 `verificationToken` 是可选的。
+> `domain`：开放平台域名，默认 `https://open.feishu.cn`（飞书）。对接 **Lark 国际版**时填 `https://open.larksuite.com`，HTTP 调用和 WebSocket 长连接都会走这个域名。
 > `allowFrom`：留空以允许所有用户，或添加 `["ou_xxx"]` 以限制访问。
 > `botName`：用于在传给模型的群聊上下文中把 `@<open_id>` 提及替换为机器人名称，以及标注机器人自身发出的消息；留空则回退为 `"Bot"`。
 > `threadRequireMention`：群聊是否需要 `@` 机器人才响应。默认 `true` —— 普通群和话题群的所有消息都需要 `@`；设为 `false` 时，普通群无需 `@`，话题群仅首条消息无需 `@`，非 `DEBUG` 模式下后续回复仍需 `@`。

--- a/bot/vikingbot/channels/feishu.py
+++ b/bot/vikingbot/channels/feishu.py
@@ -138,7 +138,7 @@ class FeishuChannel(BaseChannel):
         ):  # Refresh 1 min before expire
             return self._tenant_access_token
 
-        url = "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal"
+        url = f"{self.config.domain}/open-apis/auth/v3/tenant_access_token/internal"
         payload = {"app_id": self.config.app_id, "app_secret": self.config.app_secret}
 
         async with httpx.AsyncClient(timeout=30.0) as client:
@@ -161,7 +161,7 @@ class FeishuChannel(BaseChannel):
             raise ValueError("Feishu image upload requires a non-empty image")
 
         token = await self._get_tenant_access_token()
-        url = "https://open.feishu.cn/open-apis/im/v1/images"
+        url = f"{self.config.domain}/open-apis/im/v1/images"
 
         headers = {"Authorization": f"Bearer {token}"}
         data = {"image_type": "message"}
@@ -327,6 +327,7 @@ class FeishuChannel(BaseChannel):
             lark.Client.builder()
             .app_id(self.config.app_id)
             .app_secret(self.config.app_secret)
+            .domain(self.config.domain)
             .log_level(lark.LogLevel.INFO)
             .build()
         )
@@ -346,6 +347,7 @@ class FeishuChannel(BaseChannel):
             self.config.app_id,
             self.config.app_secret,
             event_handler=event_handler,
+            domain=self.config.domain,
             log_level=lark.LogLevel.INFO,
         )
 

--- a/bot/vikingbot/config/schema.py
+++ b/bot/vikingbot/config/schema.py
@@ -126,6 +126,10 @@ class FeishuChannelConfig(BaseChannelConfig):
     app_secret: str = ""
     encrypt_key: str = ""
     verification_token: str = ""
+    domain: str = Field(
+        default="https://open.feishu.cn",
+        description="开放平台域名：飞书用 https://open.feishu.cn，Lark 国际版用 https://open.larksuite.com",
+    )
     allow_from: list[str] = Field(default_factory=list)
     allow_cmd_from: list[str] = Field(default_factory=list)  ## 允许执行命令的Feishu用户ID列表
     thread_require_mention: bool = Field(


### PR DESCRIPTION
对接 Lark 国际版（`open.larksuite.com`）时，vikingbot 的 feishu channel 连不上：域名写死在 `open.feishu.cn`，lark-oapi SDK 也没拿到自定义 domain。

## 改了什么

`FeishuChannelConfig` 加一个 `domain` 字段，默认 `https://open.feishu.cn`，feishu.py 里四处用上它：

- `_get_tenant_access_token` 的 token 接口
- `_upload_image_to_feishu` 的图片上传接口
- `lark.Client.builder().domain(...)`
- `lark.ws.Client(..., domain=...)`

已核对 lark-oapi 1.7.3：`ClientBuilder.domain()` 存在，`ws.Client.__init__` 也有 `domain: str = FEISHU_DOMAIN` 参数，SDK 内置常量 `LARK_DOMAIN = "https://open.larksuite.com"`。中英文 channel 文档各补一行说明。

对接 Lark 时配置：

```json
{ "type": "feishu", "appId": "cli_xxx", "appSecret": "xxx", "domain": "https://open.larksuite.com" }
```

默认值不变，存量飞书配置零影响。

## add-resource 侧不用改

顺带查了一遍 `open.feishu.cn` 的其他出现位置，资源导入这条链路已经是 domain 可配的：

- `openviking_cli/utils/config/parser_config.py` 已有 `domain` 字段（默认飞书域名）
- `openviking/parse/accessors/feishu_accessor.py` 建 client 时读 `config.domain`
- `openviking/resource/feishu_watch_auth.py` 同样读 `config.domain`

唯一残留是 `feishu_accessor._build_feishu_doc_url` 的兜底展示链接写死了飞书域名，但它只在 `plan.source_url` 为空时才走到；正常从一个 larksuite URL 导入时，`_import_doc_url` 会沿用原 URL 的 netloc。影响面很小，这个 PR 不动，避免把改动摊开。