### PR TITLE
fix(pgvector): make OpenGaussIndex non-abstract + gate qdrant import (PR #18 integration)

### DIFF
--- a/deploy/pgvector/init.sql
+++ b/deploy/pgvector/init.sql
@@ -1,0 +1,5 @@
+-- Enable the pgvector extension on first boot of the pgvector/pgvector:pg16
+-- container (mounted into /docker-entrypoint-initdb.d). OpenViking's adapter
+-- also runs this under an advisory lock at connect time (create_extension=true),
+-- so this file is belt-and-suspenders for pre-provisioned / CI deployments.
+CREATE EXTENSION IF NOT EXISTS vector;

--- a/openviking/storage/vectordb_adapters/__init__.py
+++ b/openviking/storage/vectordb_adapters/__init__.py
@@ -5,15 +5,18 @@
 from .base import CollectionAdapter
 from .factory import create_collection_adapter
 from .http_adapter import HttpCollectionAdapter
-from .local_adapter import CuVSCollectionAdapter, LocalCollectionAdapter
+from .local_adapter import LocalCollectionAdapter
+from .opengauss_adapter import OpenGaussCollectionAdapter
+from .qdrant_adapter import QdrantCollectionAdapter
 from .vikingdb_private_adapter import VikingDBPrivateCollectionAdapter
 from .volcengine_adapter import VolcengineCollectionAdapter
 
 __all__ = [
     "CollectionAdapter",
     "LocalCollectionAdapter",
-    "CuVSCollectionAdapter",
     "HttpCollectionAdapter",
+    "OpenGaussCollectionAdapter",
+    "QdrantCollectionAdapter",
     "VolcengineCollectionAdapter",
     "VikingDBPrivateCollectionAdapter",
     "create_collection_adapter",

--- a/openviking/storage/vectordb_adapters/factory.py
+++ b/openviking/storage/vectordb_adapters/factory.py
@@ -8,14 +8,19 @@ import importlib
 
 from .base import CollectionAdapter
 from .http_adapter import HttpCollectionAdapter
-from .local_adapter import CuVSCollectionAdapter, LocalCollectionAdapter
+from .local_adapter import LocalCollectionAdapter
+from .opengauss_adapter import OpenGaussCollectionAdapter
+from .pgvector_adapter import PgVectorCollectionAdapter
+from .qdrant_adapter import QdrantCollectionAdapter
 from .vikingdb_private_adapter import VikingDBPrivateCollectionAdapter
 from .volcengine_adapter import VolcengineCollectionAdapter
 
 _ADAPTER_REGISTRY: dict[str, type[CollectionAdapter]] = {
     "local": LocalCollectionAdapter,
-    "cuvs": CuVSCollectionAdapter,
     "http": HttpCollectionAdapter,
+    "opengauss": OpenGaussCollectionAdapter,
+    "pgvector": PgVectorCollectionAdapter,
+    "qdrant": QdrantCollectionAdapter,
     "volcengine": VolcengineCollectionAdapter,
     "vikingdb": VikingDBPrivateCollectionAdapter,
 }
@@ -40,7 +45,7 @@ def create_collection_adapter(config) -> CollectionAdapter:
 
     if adapter_cls is None:
         raise ValueError(
-            f"Vector backend {backend} is not supported. "
+            f"Vector backend {config.backend} is not supported. "
             f"Available backends: {sorted(_ADAPTER_REGISTRY)}"
         )
     return adapter_cls.from_config(config)

--- a/openviking/storage/vectordb_adapters/opengauss_adapter.py
+++ b/openviking/storage/vectordb_adapters/opengauss_adapter.py
@@ -1,0 +1,1601 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""openGauss-backed vector collection adapter.
+
+The official openGauss container ships a native ``vector`` type and HNSW/IVFFlat
+index support.  The adapter stores one SQL table per OpenViking collection and
+keeps collection/index metadata in small sidecar tables.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import math
+import re
+import threading
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from openviking.storage.expr import (
+    And,
+    Contains,
+    Eq,
+    FilterExpr,
+    In,
+    Or,
+    PathScope,
+    Range,
+    RawDSL,
+    TimeRange,
+)
+from openviking.storage.vectordb.collection.collection import Collection, ICollection
+from openviking.storage.vectordb.collection.result import (
+    AggregateResult,
+    DataItem,
+    FetchDataInCollectionResult,
+    SearchItemResult,
+    SearchResult,
+)
+from openviking.storage.vectordb.index.index import IIndex
+from openviking.storage.vectordb.store.data import DeltaRecord
+from openviking.storage.vectordb_adapters.base import CollectionAdapter
+from openviking_cli.utils import get_logger
+
+logger = get_logger(__name__)
+
+_COLLECTION_META_TABLE = "__openviking_opengauss_collections"
+_INDEX_META_TABLE = "__openviking_opengauss_indexes"
+_DEFAULT_SCHEMA = "public"
+_IDENT_RE = re.compile(r"[^a-zA-Z0-9_]+")
+_MAX_IDENTIFIER_BYTES = 63
+
+_FIELD_TYPE_SQL: Dict[str, str] = {
+    "string": "TEXT",
+    "path": "TEXT",
+    "int64": "BIGINT",
+    "int32": "INTEGER",
+    "float": "DOUBLE PRECISION",
+    "double": "DOUBLE PRECISION",
+    "bool": "BOOLEAN",
+    "boolean": "BOOLEAN",
+    "date_time": "TIMESTAMP WITH TIME ZONE",
+}
+
+_VECTOR_OPS: Dict[str, Dict[str, str]] = {
+    "cosine": {"operator": "<=>", "hnsw": "vector_cosine_ops"},
+    "ip": {"operator": "<#>", "hnsw": "vector_ip_ops"},
+    "l2": {"operator": "<->", "hnsw": "vector_l2_ops"},
+}
+
+
+def _import_psycopg2():
+    try:
+        import psycopg2  # type: ignore  # noqa: PLC0415
+
+        return psycopg2
+    except ImportError as exc:  # pragma: no cover - exercised only without optional driver
+        raise ImportError(
+            "The openGauss backend requires a psycopg2-compatible driver. "
+            'Install it with `pip install "openviking[opengauss]"`, or install another '
+            "psycopg2-compatible driver that can connect to openGauss."
+        ) from exc
+
+
+def _quote_ident(name: str) -> str:
+    return '"' + str(name).replace('"', '""') + '"'
+
+
+def _qualify(schema: str, name: str) -> str:
+    return f"{_quote_ident(schema)}.{_quote_ident(name)}"
+
+
+def _safe_identifier(*parts: Any, prefix: str = "ov") -> str:
+    raw = "_".join(str(part or "") for part in parts)
+    normalized = _IDENT_RE.sub("_", raw).strip("_").lower() or "default"
+    name = f"{prefix}_{normalized}"
+    encoded = name.encode("utf-8")
+    if len(encoded) <= _MAX_IDENTIFIER_BYTES:
+        return name
+    import hashlib
+
+    digest = hashlib.sha1(encoded).hexdigest()[:10]
+    keep = max(8, _MAX_IDENTIFIER_BYTES - len(prefix) - len(digest) - 3)
+    return f"{prefix}_{normalized[:keep]}_{digest}"
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, (dt.datetime, dt.date)):
+        return value.isoformat()
+    return str(value)
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, default=_json_default)
+
+
+def _encode_scope_roots(value: Any) -> str:
+    roots = value if isinstance(value, list) else [value]
+    normalized = [str(root) for root in roots if root is not None]
+    return "\n" + "\n".join(normalized) + "\n" if normalized else "\n"
+
+
+def _vector_literal(vector: Sequence[float]) -> str:
+    values = []
+    for item in vector:
+        number = float(item)
+        if not math.isfinite(number):
+            number = 0.0
+        values.append(format(number, ".12g"))
+    return "[" + ",".join(values) + "]"
+
+
+def _normalize_distance(distance: str) -> str:
+    value = (distance or "cosine").strip().lower()
+    if value not in _VECTOR_OPS:
+        raise ValueError(
+            "openGauss vector backend supports only cosine, l2, and ip distance metrics; "
+            f"got {distance!r}"
+        )
+    return value
+
+
+def _coerce_sql_value(value: Any, field_type: str | None) -> Any:
+    if value is None:
+        return None
+    normalized_type = (field_type or "").lower()
+    if normalized_type == "date_time":
+        if isinstance(value, dt.datetime):
+            return value
+        if isinstance(value, dt.date):
+            return dt.datetime.combine(value, dt.time.min, tzinfo=dt.timezone.utc)
+        return str(value)
+    if normalized_type in {"int64", "int32"}:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+    if normalized_type in {"float", "double"}:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return None
+        return number if math.isfinite(number) else None
+    if normalized_type in {"bool", "boolean"}:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"true", "t", "yes", "y", "1", "on"}:
+                return True
+            if lowered in {"false", "f", "no", "n", "0", "off"}:
+                return False
+            return None
+        return bool(value)
+    if isinstance(value, (dict, list, tuple)):
+        return _json_dumps(value)
+    return value
+
+
+def _sparse_dot(left: Optional[Dict[str, float]], right: Optional[Dict[str, float]]) -> float:
+    if not left or not right:
+        return 0.0
+    total = 0.0
+    for key, raw_value in left.items():
+        try:
+            total += float(raw_value) * float(right.get(key, 0.0))
+        except (TypeError, ValueError):
+            continue
+    return total
+
+
+class OpenGaussIndex(IIndex):
+    """Metadata-only logical index facade for openGauss."""
+
+    def __init__(
+        self, collection: "OpenGaussCollection", index_name: str, meta: Dict[str, Any]
+    ) -> None:
+        super().__init__(meta=meta)
+        self._collection = collection
+        self._index_name = index_name
+        self._meta = dict(meta)
+
+    def upsert_data(self, delta_list: List[DeltaRecord]):
+        raise NotImplementedError("OpenGaussIndex.upsert_data is managed at collection level")
+
+    def delete_data(self, delta_list: List[DeltaRecord]):
+        raise NotImplementedError("OpenGaussIndex.delete_data is managed at collection level")
+
+    def rebuild_scalar_index(
+        self, scalar_index, cands_fields
+    ) -> None:
+        return
+
+    def search(
+        self,
+        query_vector: Optional[List[float]],
+        limit: int = 10,
+        filters: Optional[Dict[str, Any]] = None,
+        sparse_raw_terms: Optional[List[str]] = None,
+        sparse_values: Optional[List[float]] = None,
+    ) -> Tuple[List[int], List[float]]:
+        raise NotImplementedError("OpenGaussIndex.search is not exposed via raw index interface")
+
+    def aggregate(self, filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        raise NotImplementedError("OpenGaussIndex.aggregate is not exposed via raw index interface")
+
+    def update(
+        self, scalar_index: Optional[Dict[str, Any]] = None, description: Optional[str] = None
+    ):
+        self._collection.update_index(
+            index_name=self._index_name,
+            scalar_index=scalar_index,
+            description=description,
+        )
+        self._meta = self._collection.get_index_meta_data(self._index_name) or self._meta
+
+    def get_meta_data(self):
+        return dict(self._meta)
+
+    def close(self):
+        return None
+
+    def drop(self):
+        self._collection.drop_index(self._index_name)
+
+
+class OpenGaussCollection(ICollection):
+    """A single OpenViking collection stored in openGauss."""
+
+    DEFAULT_FETCH_LIMIT = 256
+    DEFAULT_SPARSE_SCAN_LIMIT = 10_000
+    INTERNAL_PATH_FIELDS = {
+        "parent_uri": "TEXT",
+        "scope_roots": "TEXT",
+        "uri_depth": "BIGINT",
+    }
+
+    def __init__(
+        self,
+        *,
+        conn: Any,
+        schema_name: str,
+        table_name: str,
+        logical_collection_name: str,
+        project_name: str,
+        dense_vector_name: str,
+        sparse_vector_name: str,
+        distance_metric: str,
+        meta: Optional[Dict[str, Any]] = None,
+        vector_dim: int = 0,
+        lock: Optional[threading.RLock] = None,
+        reconnect: Optional[Any] = None,
+    ) -> None:
+        super().__init__()
+        self._conn = conn
+        self._lock = lock or threading.RLock()
+        self._reconnect = reconnect
+        self._schema_name = (schema_name or _DEFAULT_SCHEMA).strip() or _DEFAULT_SCHEMA
+        self._table_name = table_name
+        self._logical_collection_name = logical_collection_name
+        self._project_name = project_name
+        self._dense_vector_name = dense_vector_name
+        self._sparse_vector_name = sparse_vector_name
+        self._distance_metric = _normalize_distance(distance_metric)
+        self._meta = dict(meta or {})
+        self._vector_dim = int(vector_dim or self._extract_vector_dim(self._meta) or 0)
+        self._field_types = self._build_field_type_map(self._meta)
+
+    @property
+    def collection_key(self) -> str:
+        return self._table_name
+
+    @staticmethod
+    def _extract_vector_dim(meta: Dict[str, Any]) -> int:
+        for field in meta.get("Fields", []) or []:
+            if field.get("FieldType") == "vector":
+                try:
+                    return int(field.get("Dim") or 0)
+                except (TypeError, ValueError):
+                    return 0
+        return 0
+
+    @staticmethod
+    def _build_field_type_map(meta: Dict[str, Any]) -> Dict[str, str]:
+        mapping: Dict[str, str] = {}
+        for field in meta.get("Fields", []) or []:
+            name = field.get("FieldName")
+            field_type = field.get("FieldType")
+            if name and field_type:
+                mapping[str(name)] = str(field_type)
+        mapping.setdefault("id", "string")
+        mapping.setdefault("parent_uri", "path")
+        mapping.setdefault("scope_roots", "string")
+        mapping.setdefault("uri_depth", "int64")
+        return mapping
+
+    def _ensure_connection(self) -> Any:
+        if getattr(self._conn, "closed", 0):
+            if self._reconnect is None:
+                raise RuntimeError("openGauss connection is closed")
+            self._conn = self._reconnect()
+        return self._conn
+
+    def _safe_rollback(self) -> None:
+        try:
+            if not getattr(self._conn, "closed", 1):
+                self._conn.rollback()
+        except Exception:
+            logger.debug("Failed to rollback openGauss connection", exc_info=True)
+
+    def _execute(
+        self,
+        sql: str,
+        params: Optional[Sequence[Any]] = None,
+        *,
+        fetch: bool = False,
+    ) -> List[Tuple[Any, ...]]:
+        with self._lock:
+            conn = self._ensure_connection()
+            cur = conn.cursor()
+            try:
+                cur.execute(sql, list(params or []))
+                rows = cur.fetchall() if fetch else []
+                conn.commit()
+                return rows
+            except Exception:
+                self._safe_rollback()
+                raise
+            finally:
+                cur.close()
+
+    def _table_exists(self) -> bool:
+        rows = self._execute(
+            """
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_schema = %s AND table_name = %s
+            LIMIT 1
+            """,
+            [self._schema_name, self._table_name],
+            fetch=True,
+        )
+        return bool(rows)
+
+    def create_remote_collection(self, meta_data: Dict[str, Any]) -> None:
+        self._meta = dict(meta_data)
+        self._vector_dim = self._extract_vector_dim(self._meta)
+        self._field_types = self._build_field_type_map(self._meta)
+        if self._vector_dim <= 0:
+            raise ValueError("openGauss collection requires a positive dense vector dimension")
+
+        columns = ["id TEXT PRIMARY KEY"]
+        seen = {"id"}
+        for field in meta_data.get("Fields", []) or []:
+            ddl = self._field_to_column_ddl(field)
+            field_name = field.get("FieldName")
+            if ddl and field_name not in seen:
+                columns.append(ddl)
+                seen.add(str(field_name))
+        for field_name, sql_type in self.INTERNAL_PATH_FIELDS.items():
+            if field_name not in seen:
+                columns.append(f"{_quote_ident(field_name)} {sql_type}")
+                seen.add(field_name)
+
+        self._execute(f"CREATE TABLE IF NOT EXISTS {self._table_ref()} ({', '.join(columns)})")
+        self._save_collection_meta(meta_data)
+
+    def _field_to_column_ddl(self, field: Dict[str, Any]) -> Optional[str]:
+        name = field.get("FieldName")
+        field_type = str(field.get("FieldType") or "").lower()
+        if not name or name == "id":
+            return None
+        if field_type == "vector":
+            dim = int(field.get("Dim") or self._vector_dim or 0)
+            if dim <= 0:
+                raise ValueError("openGauss vector field requires Dim")
+            return f"{_quote_ident(name)} vector({dim})"
+        if field_type == "sparse_vector":
+            return f"{_quote_ident(name)} TEXT"
+        return f"{_quote_ident(name)} {_FIELD_TYPE_SQL.get(field_type, 'TEXT')}"
+
+    def _save_collection_meta(self, meta: Dict[str, Any]) -> None:
+        self._execute(
+            f"""
+            MERGE INTO {self._meta_table_ref(_COLLECTION_META_TABLE)} target
+            USING (
+                SELECT
+                    %s AS table_name,
+                    %s AS logical_collection_name,
+                    %s AS project_name,
+                    %s AS meta_json
+            ) source
+            ON (target.table_name = source.table_name)
+            WHEN MATCHED THEN UPDATE SET
+                logical_collection_name = source.logical_collection_name,
+                project_name = source.project_name,
+                meta_json = source.meta_json,
+                updated_at = CURRENT_TIMESTAMP
+            WHEN NOT MATCHED THEN INSERT
+                (table_name, logical_collection_name, project_name, meta_json, updated_at)
+                VALUES (
+                    source.table_name,
+                    source.logical_collection_name,
+                    source.project_name,
+                    source.meta_json,
+                    CURRENT_TIMESTAMP
+                )
+            """,
+            [
+                self.collection_key,
+                self._logical_collection_name,
+                self._project_name,
+                _json_dumps(meta),
+            ],
+        )
+
+    def _save_index_meta(self, index_name: str, meta: Dict[str, Any]) -> None:
+        self._execute(
+            f"""
+            MERGE INTO {self._meta_table_ref(_INDEX_META_TABLE)} target
+            USING (
+                SELECT
+                    %s AS table_name,
+                    %s AS index_name,
+                    %s AS meta_json
+            ) source
+            ON (
+                target.table_name = source.table_name
+                AND target.index_name = source.index_name
+            )
+            WHEN MATCHED THEN UPDATE SET
+                meta_json = source.meta_json,
+                updated_at = CURRENT_TIMESTAMP
+            WHEN NOT MATCHED THEN INSERT
+                (table_name, index_name, meta_json, updated_at)
+                VALUES (
+                    source.table_name,
+                    source.index_name,
+                    source.meta_json,
+                    CURRENT_TIMESTAMP
+                )
+            """,
+            [self.collection_key, index_name, _json_dumps(meta)],
+        )
+
+    def _delete_index_meta(self, index_name: str) -> None:
+        self._execute(
+            f"DELETE FROM {self._meta_table_ref(_INDEX_META_TABLE)} "
+            "WHERE table_name = %s AND index_name = %s",
+            [self.collection_key, index_name],
+        )
+
+    def _all_columns(self) -> List[str]:
+        rows = self._execute(
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = %s AND table_name = %s
+            ORDER BY ordinal_position
+            """,
+            [self._schema_name, self._table_name],
+            fetch=True,
+        )
+        return [str(row[0]) for row in rows]
+
+    def _table_ref(self) -> str:
+        return _qualify(self._schema_name, self._table_name)
+
+    def _meta_table_ref(self, table_name: str) -> str:
+        return _qualify(self._schema_name, table_name)
+
+    def _index_ref(self, index_name: str) -> str:
+        return _qualify(self._schema_name, index_name)
+
+    def _function_table_name(self, table_name: str) -> str:
+        return f"{_quote_ident(self._schema_name)}.{_quote_ident(table_name)}"
+
+    def _ensure_columns_for_record(self, record: Dict[str, Any]) -> None:
+        existing = set(self._all_columns())
+        for field_name in record:
+            if field_name in existing:
+                continue
+            if field_name == "id":
+                continue
+            if field_name == self._dense_vector_name:
+                sql_type = f"vector({self._vector_dim})"
+            elif field_name == self._sparse_vector_name:
+                sql_type = "TEXT"
+            elif field_name in self.INTERNAL_PATH_FIELDS:
+                sql_type = self.INTERNAL_PATH_FIELDS[field_name]
+            else:
+                field_type = self._field_types.get(field_name)
+                sql_type = _FIELD_TYPE_SQL.get(str(field_type or "").lower(), "TEXT")
+                self._field_types.setdefault(field_name, field_type or "string")
+            self._execute(
+                f"ALTER TABLE {self._table_ref()} ADD COLUMN {_quote_ident(field_name)} {sql_type}"
+            )
+            existing.add(field_name)
+
+    def _select_columns(
+        self,
+        output_fields: Optional[List[str]],
+        *,
+        include_vector: bool = False,
+        include_sparse: bool = False,
+    ) -> List[str]:
+        columns = self._all_columns()
+        wanted = ["id"]
+        if output_fields:
+            for field in output_fields:
+                if field != "id" and field in columns and field not in wanted:
+                    wanted.append(field)
+        else:
+            for field in columns:
+                if field == "id":
+                    continue
+                if field == self._dense_vector_name and not include_vector:
+                    continue
+                if field == self._sparse_vector_name and not include_sparse:
+                    continue
+                wanted.append(field)
+        if (
+            include_vector
+            and self._dense_vector_name in columns
+            and self._dense_vector_name not in wanted
+        ):
+            wanted.append(self._dense_vector_name)
+        if (
+            include_sparse
+            and self._sparse_vector_name in columns
+            and self._sparse_vector_name not in wanted
+        ):
+            wanted.append(self._sparse_vector_name)
+        return wanted
+
+    def _row_to_payload(
+        self, row: Sequence[Any], columns: Sequence[str]
+    ) -> Tuple[Any, Dict[str, Any]]:
+        record = dict(zip(columns, row, strict=False))
+        record_id = record.pop("id", "")
+        record.pop(self._dense_vector_name, None)
+        sparse = record.pop(self._sparse_vector_name, None)
+        if sparse is not None and self._sparse_vector_name in columns:
+            try:
+                record[self._sparse_vector_name] = json.loads(sparse)
+            except (TypeError, ValueError):
+                record[self._sparse_vector_name] = sparse
+        return record_id, record
+
+    def _where_sql(self, filters: Optional[Dict[str, Any]]) -> Tuple[str, List[Any]]:
+        clause, params = self._compile_filter(filters or {})
+        return (f" WHERE {clause}", params) if clause else ("", [])
+
+    def _compile_filter(self, payload: Any) -> Tuple[str, List[Any]]:
+        if not payload:
+            return "", []
+        if not isinstance(payload, dict):
+            return "", []
+        op = str(payload.get("op") or "").lower()
+        if not op:
+            clauses = []
+            params: List[Any] = []
+            for key, value in payload.items():
+                clauses.append(f"{_quote_ident(str(key))} = %s")
+                params.append(value)
+            return " AND ".join(clauses), params
+        if op == "and":
+            return self._join_filter_clauses("AND", payload.get("conds", []) or [])
+        if op == "or":
+            return self._join_filter_clauses("OR", payload.get("conds", []) or [])
+        if op == "must":
+            field = str(payload.get("field") or "")
+            values = list(payload.get("conds", []) or [])
+            if not field or not values:
+                return "", []
+            return self._match_sql(field, values, negate=False)
+        if op == "must_not":
+            field = str(payload.get("field") or "")
+            values = list(payload.get("conds", []) or [])
+            if not field or not values:
+                return "", []
+            return self._match_sql(field, values, negate=True)
+        if op in {"range", "time_range"}:
+            field = str(payload.get("field") or "")
+            clauses = []
+            params = []
+            for sql_op, key in ((">=", "gte"), (">", "gt"), ("<=", "lte"), ("<", "lt")):
+                if payload.get(key) is not None:
+                    clauses.append(f"{_quote_ident(field)} {sql_op} %s")
+                    params.append(_coerce_sql_value(payload[key], self._field_types.get(field)))
+            return " AND ".join(clauses), params
+        if op == "range_out":
+            field = str(payload.get("field") or "")
+            clauses = []
+            params = []
+            if payload.get("gte") is not None:
+                clauses.append(f"{_quote_ident(field)} < %s")
+                params.append(payload["gte"])
+            if payload.get("lte") is not None:
+                clauses.append(f"{_quote_ident(field)} > %s")
+                params.append(payload["lte"])
+            return " OR ".join(clauses), params
+        if op == "contains":
+            field = str(payload.get("field") or "")
+            return f"{_quote_ident(field)} LIKE %s", [f"%{payload.get('substring', '')}%"]
+        if op == "prefix":
+            field = str(payload.get("field") or "")
+            return f"{_quote_ident(field)} LIKE %s", [f"{payload.get('prefix', '')}%"]
+        logger.warning("openGauss vector backend ignoring unsupported filter op=%r", op)
+        return "", []
+
+    def _join_filter_clauses(self, operator: str, conds: Iterable[Any]) -> Tuple[str, List[Any]]:
+        clauses = []
+        params: List[Any] = []
+        for cond in conds:
+            clause, cond_params = self._compile_filter(cond)
+            if clause:
+                clauses.append(f"({clause})")
+                params.extend(cond_params)
+        return f" {operator} ".join(clauses), params
+
+    def _match_sql(self, field: str, values: List[Any], *, negate: bool) -> Tuple[str, List[Any]]:
+        if field == "scope_roots":
+            clauses = []
+            params = []
+            for value in values:
+                clauses.append(f"{_quote_ident(field)} LIKE %s")
+                params.append(f"%\n{str(value)}\n%")
+            joined = " OR ".join(clauses)
+        elif len(values) == 1:
+            joined = f"{_quote_ident(field)} = %s"
+            params = [values[0]]
+        else:
+            joined = f"{_quote_ident(field)} IN ({', '.join(['%s'] * len(values))})"
+            params = values
+        return (f"NOT ({joined})" if negate else joined), params
+
+    # ------------------------------------------------------------------
+    # ICollection lifecycle
+    # ------------------------------------------------------------------
+    def update(self, fields: Optional[Dict[str, Any]] = None, description: Optional[str] = None):
+        meta = dict(self.get_meta_data() or {})
+        if fields is not None:
+            meta["Fields"] = fields
+        if description is not None:
+            meta["Description"] = description
+        self._meta = meta
+        self._field_types = self._build_field_type_map(meta)
+        self._save_collection_meta(meta)
+        return meta
+
+    def get_meta_data(self):
+        rows = self._execute(
+            f"SELECT meta_json FROM {self._meta_table_ref(_COLLECTION_META_TABLE)} WHERE table_name = %s",
+            [self.collection_key],
+            fetch=True,
+        )
+        if not rows:
+            return {}
+        try:
+            return json.loads(rows[0][0])
+        except (TypeError, ValueError):
+            return {}
+
+    def close(self):
+        return None
+
+    def drop(self):
+        self._execute(f"DROP TABLE IF EXISTS {self._table_ref()}")
+        self._execute(
+            f"DELETE FROM {self._meta_table_ref(_INDEX_META_TABLE)} WHERE table_name = %s",
+            [self.collection_key],
+        )
+        self._execute(
+            f"DELETE FROM {self._meta_table_ref(_COLLECTION_META_TABLE)} WHERE table_name = %s",
+            [self.collection_key],
+        )
+
+    def create_index(self, index_name: str, meta_data: Dict[str, Any]):
+        full_meta = dict(meta_data)
+        full_meta["IndexName"] = index_name
+        vector_meta = dict(full_meta.get("VectorIndex", {}) or {})
+        distance = _normalize_distance(vector_meta.get("Distance") or self._distance_metric)
+        vector_meta["IndexType"] = "hnsw"
+        full_meta["VectorIndex"] = vector_meta
+        self._create_vector_index(index_name, distance, full_meta)
+        for field_name in full_meta.get("ScalarIndex", []) or []:
+            self._create_scalar_index(index_name, str(field_name))
+        self._save_index_meta(index_name, full_meta)
+        return OpenGaussIndex(self, index_name, full_meta)
+
+    def _create_vector_index(
+        self,
+        index_name: str,
+        distance: str,
+        meta: Dict[str, Any],
+    ) -> None:
+        if self._dense_vector_name not in self._all_columns():
+            return
+        ops_class = _VECTOR_OPS[distance]["hnsw"]
+        pg_index_name = _safe_identifier(self._table_name, index_name, "vec", prefix="idx")
+        try:
+            hnsw = meta.get("VectorIndex") or {}
+            m = int(hnsw.get("M") or hnsw.get("m") or 16)
+            ef = int(hnsw.get("EfConstruction") or hnsw.get("ef_construction") or 64)
+            self._execute(
+                f"""
+                CREATE INDEX IF NOT EXISTS {_quote_ident(pg_index_name)}
+                ON {self._table_ref()}
+                USING hnsw ({_quote_ident(self._dense_vector_name)} {ops_class})
+                WITH (m = {m}, ef_construction = {ef})
+                """
+            )
+        except Exception as exc:
+            raise RuntimeError(f"Failed to create openGauss vector index {pg_index_name}") from exc
+
+    def _create_scalar_index(self, index_name: str, field_name: str) -> None:
+        if field_name not in self._all_columns():
+            return
+        pg_index_name = _safe_identifier(self._table_name, index_name, field_name, prefix="idx")
+        try:
+            self._execute(
+                f"""
+                CREATE INDEX IF NOT EXISTS {_quote_ident(pg_index_name)}
+                ON {self._table_ref()} ({_quote_ident(field_name)})
+                """
+            )
+        except Exception as exc:
+            logger.warning("Failed to create openGauss scalar index %s: %s", field_name, exc)
+
+    def has_index(self, index_name: str) -> bool:
+        return index_name in self.list_indexes()
+
+    def get_index(self, index_name: str) -> Optional[IIndex]:
+        meta = self.get_index_meta_data(index_name)
+        if not meta:
+            return None
+        return OpenGaussIndex(self, index_name, meta)
+
+    def update_index(
+        self,
+        index_name: str,
+        scalar_index: Optional[Dict[str, Any]] = None,
+        description: Optional[str] = None,
+    ):
+        meta = self.get_index_meta_data(index_name) or {"IndexName": index_name}
+        if scalar_index is not None:
+            meta["ScalarIndex"] = (
+                list(scalar_index.keys()) if isinstance(scalar_index, dict) else list(scalar_index)
+            )
+        if description is not None:
+            meta["Description"] = description
+        for field_name in meta.get("ScalarIndex", []) or []:
+            self._create_scalar_index(index_name, str(field_name))
+        self._save_index_meta(index_name, meta)
+        return meta
+
+    def get_index_meta_data(self, index_name: str):
+        rows = self._execute(
+            f"""
+            SELECT meta_json
+            FROM {self._meta_table_ref(_INDEX_META_TABLE)}
+            WHERE table_name = %s AND index_name = %s
+            """,
+            [self.collection_key, index_name],
+            fetch=True,
+        )
+        if not rows:
+            return None
+        try:
+            return json.loads(rows[0][0])
+        except (TypeError, ValueError):
+            return None
+
+    def list_indexes(self):
+        rows = self._execute(
+            f"SELECT index_name FROM {self._meta_table_ref(_INDEX_META_TABLE)} "
+            "WHERE table_name = %s ORDER BY index_name",
+            [self.collection_key],
+            fetch=True,
+        )
+        return [str(row[0]) for row in rows]
+
+    def drop_index(self, index_name: str):
+        meta = self.get_index_meta_data(index_name) or {}
+        pg_index_name = _safe_identifier(self._table_name, index_name, "vec", prefix="idx")
+        self._execute(f"DROP INDEX IF EXISTS {self._index_ref(pg_index_name)}")
+        for field_name in meta.get("ScalarIndex", []) or []:
+            scalar_index_name = _safe_identifier(
+                self._table_name, index_name, field_name, prefix="idx"
+            )
+            self._execute(f"DROP INDEX IF EXISTS {self._index_ref(scalar_index_name)}")
+        self._delete_index_meta(index_name)
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+    def search_by_vector(
+        self,
+        index_name: str,
+        dense_vector: Optional[List[float]] = None,
+        limit: int = 10,
+        offset: int = 0,
+        filters: Optional[Dict[str, Any]] = None,
+        sparse_vector: Optional[Dict[str, float]] = None,
+        output_fields: Optional[List[str]] = None,
+    ) -> SearchResult:
+        if limit <= 0:
+            return SearchResult()
+        if dense_vector is None and sparse_vector is None:
+            return SearchResult()
+        fetch_limit = max(limit + offset, limit)
+        if dense_vector is None:
+            return self._search_by_sparse(
+                sparse_vector, fetch_limit, offset, limit, filters, output_fields
+            )
+
+        columns = self._select_columns(output_fields, include_sparse=bool(sparse_vector))
+        where_sql, params = self._where_sql(filters)
+        operator = _VECTOR_OPS[self._distance_metric]["operator"]
+        vector_text = _vector_literal(dense_vector)
+        sql = (
+            f"SELECT {', '.join(_quote_ident(col) for col in columns)}, "
+            f"{_quote_ident(self._dense_vector_name)} {operator} %s::vector AS _distance "
+            f"FROM {self._table_ref()}"
+            f"{where_sql} "
+            f"ORDER BY {_quote_ident(self._dense_vector_name)} {operator} %s::vector "
+            "LIMIT %s OFFSET %s"
+        )
+        rows = self._execute(
+            sql, [vector_text] + params + [vector_text, fetch_limit, 0], fetch=True
+        )
+        scored_items: List[SearchItemResult] = []
+        for row in rows:
+            record_id, payload = self._row_to_payload(row[:-1], columns)
+            distance = row[-1]
+            score = self._distance_to_score(distance, self._distance_metric)
+            if sparse_vector:
+                sparse_payload = payload.pop(self._sparse_vector_name, None)
+                if isinstance(sparse_payload, dict):
+                    score += _sparse_dot(sparse_vector, sparse_payload)
+            scored_items.append(SearchItemResult(id=record_id, fields=payload, score=score))
+        if sparse_vector:
+            scored_items.sort(key=lambda item: item.score or 0.0, reverse=True)
+        return SearchResult(data=scored_items[offset : offset + limit])
+
+    def _search_by_sparse(
+        self,
+        sparse_vector: Optional[Dict[str, float]],
+        fetch_limit: int,
+        offset: int,
+        limit: int,
+        filters: Optional[Dict[str, Any]],
+        output_fields: Optional[List[str]],
+    ) -> SearchResult:
+        if not sparse_vector:
+            return SearchResult()
+        columns = self._select_columns(output_fields, include_sparse=True)
+        where_sql, params = self._where_sql(filters)
+        sql = (
+            f"SELECT {', '.join(_quote_ident(col) for col in columns)} "
+            f"FROM {self._table_ref()}{where_sql} LIMIT %s"
+        )
+        rows = self._execute(
+            sql, params + [max(fetch_limit, self.DEFAULT_SPARSE_SCAN_LIMIT)], fetch=True
+        )
+        items = []
+        for row in rows:
+            record_id, payload = self._row_to_payload(row, columns)
+            sparse_payload = payload.pop(self._sparse_vector_name, None)
+            score = _sparse_dot(
+                sparse_vector, sparse_payload if isinstance(sparse_payload, dict) else None
+            )
+            if score > 0:
+                items.append(SearchItemResult(id=record_id, fields=payload, score=score))
+        items.sort(key=lambda item: item.score or 0.0, reverse=True)
+        return SearchResult(data=items[offset : offset + limit])
+
+    @staticmethod
+    def _distance_to_score(distance: Any, distance_metric: str = "cosine") -> float:
+        try:
+            value = float(distance)
+        except (TypeError, ValueError):
+            return 0.0
+        if not math.isfinite(value):
+            return 0.0
+        if distance_metric == "ip":
+            return -value
+        return 1.0 / (1.0 + max(value, 0.0))
+
+    def search_by_keywords(
+        self,
+        index_name: str,
+        keywords: Optional[List[str]] = None,
+        query: Optional[str] = None,
+        limit: int = 10,
+        offset: int = 0,
+        filters: Optional[Dict[str, Any]] = None,
+        output_fields: Optional[List[str]] = None,
+    ) -> SearchResult:
+        query_text = query or " ".join(keywords or [])
+        if not query_text.strip():
+            return SearchResult()
+        text_filter = {
+            "op": "or",
+            "conds": [
+                {"op": "contains", "field": field, "substring": query_text}
+                for field in ("name", "description", "abstract", "tags")
+                if field in self._all_columns()
+            ],
+        }
+        filters = {"op": "and", "conds": [filters, text_filter]} if filters else text_filter
+        return self.search_by_random(index_name, limit, offset, filters, output_fields)
+
+    def search_by_id(
+        self,
+        index_name: str,
+        id: Any,
+        limit: int = 10,
+        offset: int = 0,
+        filters: Optional[Dict[str, Any]] = None,
+        output_fields: Optional[List[str]] = None,
+    ) -> SearchResult:
+        columns = self._select_columns(output_fields, include_vector=True, include_sparse=True)
+        rows = self._execute(
+            f"SELECT {', '.join(_quote_ident(col) for col in columns)} "
+            f"FROM {self._table_ref()} WHERE id = %s",
+            [str(id)],
+            fetch=True,
+        )
+        if not rows:
+            return SearchResult()
+        row_payload = dict(zip(columns, rows[0], strict=False))
+        dense_vector = row_payload.get(self._dense_vector_name)
+        sparse_raw = row_payload.get(self._sparse_vector_name)
+        sparse_vector = None
+        if sparse_raw:
+            try:
+                sparse_vector = json.loads(sparse_raw)
+            except (TypeError, ValueError):
+                sparse_vector = None
+        result = self.search_by_vector(
+            index_name=index_name,
+            dense_vector=self._parse_vector_value(dense_vector),
+            sparse_vector=sparse_vector,
+            limit=limit + offset + 1,
+            filters=filters,
+            output_fields=output_fields,
+        )
+        data = [item for item in result.data if str(item.id) != str(id)]
+        return SearchResult(data=data[offset : offset + limit])
+
+    @staticmethod
+    def _parse_vector_value(value: Any) -> Optional[List[float]]:
+        if isinstance(value, list):
+            return [float(item) for item in value]
+        if not isinstance(value, str):
+            return None
+        stripped = value.strip().strip("[]")
+        if not stripped:
+            return None
+        return [float(item.strip()) for item in stripped.split(",")]
+
+    def search_by_multimodal(
+        self,
+        index_name: str,
+        text: Optional[str],
+        image: Optional[Any],
+        video: Optional[Any],
+        limit: int = 10,
+        offset: int = 0,
+        filters: Optional[Dict[str, Any]] = None,
+        output_fields: Optional[List[str]] = None,
+    ) -> SearchResult:
+        raise NotImplementedError("OpenGaussCollection.search_by_multimodal is not supported")
+
+    def search_by_random(
+        self,
+        index_name: str,
+        limit: int = 10,
+        offset: int = 0,
+        filters: Optional[Dict[str, Any]] = None,
+        output_fields: Optional[List[str]] = None,
+    ) -> SearchResult:
+        columns = self._select_columns(output_fields)
+        where_sql, params = self._where_sql(filters)
+        rows = self._execute(
+            f"SELECT {', '.join(_quote_ident(col) for col in columns)} "
+            f"FROM {self._table_ref()}{where_sql} LIMIT %s OFFSET %s",
+            params + [limit, offset],
+            fetch=True,
+        )
+        return SearchResult(
+            data=[
+                SearchItemResult(id=record_id, fields=payload, score=1.0)
+                for record_id, payload in (self._row_to_payload(row, columns) for row in rows)
+            ]
+        )
+
+    def search_by_scalar(
+        self,
+        index_name: str,
+        field: str,
+        order: Optional[str] = "desc",
+        limit: int = 10,
+        offset: int = 0,
+        filters: Optional[Dict[str, Any]] = None,
+        output_fields: Optional[List[str]] = None,
+    ) -> SearchResult:
+        columns = self._select_columns(output_fields)
+        if field not in columns:
+            columns.append(field)
+        where_sql, params = self._where_sql(filters)
+        direction = "DESC" if (order or "desc").lower() == "desc" else "ASC"
+        rows = self._execute(
+            f"SELECT {', '.join(_quote_ident(col) for col in columns)} "
+            f"FROM {self._table_ref()}{where_sql} "
+            f"ORDER BY {_quote_ident(field)} {direction} NULLS LAST LIMIT %s OFFSET %s",
+            params + [limit, offset],
+            fetch=True,
+        )
+        items = []
+        for row in rows:
+            record_id, payload = self._row_to_payload(row, columns)
+            score = (
+                payload.pop(field, None)
+                if output_fields and field not in output_fields
+                else payload.get(field)
+            )
+            items.append(
+                SearchItemResult(
+                    id=record_id,
+                    fields=payload,
+                    score=score if isinstance(score, (int, float)) else None,
+                )
+            )
+        return SearchResult(data=items)
+
+    # ------------------------------------------------------------------
+    # Data operations
+    # ------------------------------------------------------------------
+    def upsert_data(self, data_list: List[Dict[str, Any]], ttl=0):
+        if not data_list:
+            return []
+        ids = []
+        for record in data_list:
+            record_id = record.get("id")
+            if record_id is None or record_id == "":
+                raise ValueError("openGauss vector record requires id")
+            self._ensure_columns_for_record(record)
+            columns = []
+            values = []
+            for column in self._all_columns():
+                if column not in record:
+                    continue
+                columns.append(column)
+                if column == self._dense_vector_name:
+                    values.append(_vector_literal(record[column]))
+                elif column == self._sparse_vector_name:
+                    values.append(_json_dumps(record[column] or {}))
+                elif column == "scope_roots":
+                    values.append(_encode_scope_roots(record[column]))
+                else:
+                    values.append(_coerce_sql_value(record[column], self._field_types.get(column)))
+            if "id" not in columns:
+                columns.insert(0, "id")
+                values.insert(0, str(record_id))
+            self._upsert_row(columns, values)
+            ids.append(record_id)
+        return ids
+
+    def _upsert_row(self, columns: List[str], values: List[Any]) -> None:
+        id_index = columns.index("id")
+        update_columns = [column for column in columns if column != "id"]
+        update_values = [
+            value for column, value in zip(columns, values, strict=False) if column != "id"
+        ]
+        set_parts = [
+            f"{_quote_ident(column)} = {'%s::vector' if column == self._dense_vector_name else '%s'}"
+            for column in update_columns
+        ]
+        insert_placeholders = [
+            "%s::vector" if column == self._dense_vector_name else "%s" for column in columns
+        ]
+
+        with self._lock:
+            conn = self._ensure_connection()
+            cur = conn.cursor()
+            try:
+                if update_columns:
+                    cur.execute(
+                        f"UPDATE {self._table_ref()} SET {', '.join(set_parts)} WHERE id = %s",
+                        update_values + [values[id_index]],
+                    )
+                if not update_columns or cur.rowcount == 0:
+                    try:
+                        cur.execute(
+                            f"INSERT INTO {self._table_ref()} "
+                            f"({', '.join(_quote_ident(column) for column in columns)}) "
+                            f"VALUES ({', '.join(insert_placeholders)})",
+                            values,
+                        )
+                    except Exception as exc:
+                        if getattr(exc, "pgcode", None) != "23505" or not update_columns:
+                            raise
+                        self._safe_rollback()
+                        cur.close()
+                        conn = self._ensure_connection()
+                        cur = conn.cursor()
+                        cur.execute(
+                            f"UPDATE {self._table_ref()} SET {', '.join(set_parts)} WHERE id = %s",
+                            update_values + [values[id_index]],
+                        )
+                conn.commit()
+            except Exception:
+                self._safe_rollback()
+                raise
+            finally:
+                cur.close()
+
+    def fetch_data(self, primary_keys: List[Any]):
+        if not primary_keys:
+            return FetchDataInCollectionResult()
+        columns = self._select_columns(None)
+        placeholders = ", ".join(["%s"] * len(primary_keys))
+        rows = self._execute(
+            f"SELECT {', '.join(_quote_ident(col) for col in columns)} "
+            f"FROM {self._table_ref()} WHERE id IN ({placeholders})",
+            [str(pk) for pk in primary_keys],
+            fetch=True,
+        )
+        items = []
+        found_ids = set()
+        for row in rows:
+            record_id, payload = self._row_to_payload(row, columns)
+            found_ids.add(str(record_id))
+            items.append(DataItem(id=record_id, fields=payload))
+        return FetchDataInCollectionResult(
+            items=items,
+            ids_not_exist=[pk for pk in primary_keys if str(pk) not in found_ids],
+        )
+
+    def delete_data(self, primary_keys: List[Any]):
+        if not primary_keys:
+            return None
+        placeholders = ", ".join(["%s"] * len(primary_keys))
+        self._execute(
+            f"DELETE FROM {self._table_ref()} WHERE id IN ({placeholders})",
+            [str(pk) for pk in primary_keys],
+        )
+        return None
+
+    def delete_all_data(self):
+        self._execute(f"DELETE FROM {self._table_ref()}")
+
+    def aggregate_data(
+        self,
+        index_name: str,
+        op: str = "count",
+        field: Optional[str] = None,
+        filters: Optional[Dict[str, Any]] = None,
+        cond: Optional[Dict[str, Any]] = None,
+    ) -> AggregateResult:
+        if op != "count":
+            return AggregateResult(agg={}, op=op, field=field)
+        where_sql, params = self._where_sql(filters)
+        if not field:
+            rows = self._execute(
+                f"SELECT COUNT(*) FROM {self._table_ref()}{where_sql}",
+                params,
+                fetch=True,
+            )
+            return AggregateResult(
+                agg={"_total": int(rows[0][0]) if rows else 0}, op=op, field=None
+            )
+        rows = self._execute(
+            f"SELECT {_quote_ident(field)}, COUNT(*) FROM {self._table_ref()}"
+            f"{where_sql} GROUP BY {_quote_ident(field)}",
+            params,
+            fetch=True,
+        )
+        grouped = {row[0]: int(row[1]) for row in rows if row[0] is not None}
+        if cond:
+            grouped = {
+                key: value
+                for key, value in grouped.items()
+                if (cond.get("gt") is None or value > cond["gt"])
+                and (cond.get("gte") is None or value >= cond["gte"])
+                and (cond.get("lt") is None or value < cond["lt"])
+                and (cond.get("lte") is None or value <= cond["lte"])
+            }
+        return AggregateResult(agg=grouped, op=op, field=field)
+
+
+class OpenGaussCollectionAdapter(CollectionAdapter):
+    """CollectionAdapter backed by openGauss native vector tables."""
+
+    mode = "opengauss"
+    INTERNAL_PATH_FIELDS = ["parent_uri", "scope_roots", "uri_depth"]
+
+    def __init__(
+        self,
+        *,
+        host: str,
+        port: int,
+        user: str,
+        password: str,
+        db_name: str,
+        schema_name: str,
+        project_name: str,
+        collection_name: str,
+        index_name: str,
+        distance_metric: str,
+        dense_vector_name: str,
+        sparse_vector_name: str,
+        connect_timeout: int,
+        mode: str,
+        shard_count: int,
+    ) -> None:
+        super().__init__(collection_name=collection_name, index_name=index_name)
+        self._host = host
+        self._port = int(port)
+        self._user = user
+        self._password = password
+        self._db_name = db_name
+        self._schema_name = (schema_name or _DEFAULT_SCHEMA).strip() or _DEFAULT_SCHEMA
+        self._project_name = project_name
+        self._distance_metric = _normalize_distance(distance_metric)
+        self._dense_vector_name = dense_vector_name
+        self._sparse_vector_name = sparse_vector_name
+        self._connect_timeout = int(connect_timeout)
+        self._deployment_mode = mode
+        self._shard_count = int(shard_count)
+        self._conn = None
+        self._lock = threading.RLock()
+
+    @classmethod
+    def from_config(cls, config: Any):
+        cfg = getattr(config, "opengauss", None)
+        params = dict(getattr(config, "custom_params", {}) or {})
+        if cfg is None:
+            raise ValueError("openGauss backend requires opengauss config")
+        return cls(
+            host=str(getattr(cfg, "host", None) or params.get("host") or "127.0.0.1"),
+            port=int(getattr(cfg, "port", None) or params.get("port") or 5432),
+            user=str(getattr(cfg, "user", None) or params.get("user") or "omm"),
+            password=str(getattr(cfg, "password", None) or params.get("password") or ""),
+            db_name=str(getattr(cfg, "db_name", None) or params.get("db_name") or "postgres"),
+            schema_name=str(
+                getattr(cfg, "schema_name", None)
+                or getattr(cfg, "schema", None)
+                or params.get("schema")
+                or _DEFAULT_SCHEMA
+            ),
+            project_name=config.project_name or "default",
+            collection_name=config.name or "context",
+            index_name=config.index_name or "default",
+            distance_metric=config.distance_metric or "cosine",
+            dense_vector_name=str(
+                getattr(cfg, "dense_vector_name", None)
+                or params.get("dense_vector_name")
+                or "vector"
+            ),
+            sparse_vector_name=str(
+                getattr(cfg, "sparse_vector_name", None)
+                or params.get("sparse_vector_name")
+                or "sparse_vector"
+            ),
+            connect_timeout=int(
+                getattr(cfg, "connect_timeout", None) or params.get("connect_timeout") or 10
+            ),
+            mode=str(getattr(cfg, "mode", None) or params.get("mode") or "standalone"),
+            shard_count=int(getattr(cfg, "shard_count", None) or params.get("shard_count") or 32),
+        )
+
+    @property
+    def physical_table_name(self) -> str:
+        return _safe_identifier(self._project_name, self._collection_name, prefix="ov")
+
+    def _connect(self):
+        if self._conn is not None and not getattr(self._conn, "closed", 0):
+            return self._conn
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except Exception:
+                logger.debug("Failed to close stale openGauss connection", exc_info=True)
+        psycopg2 = _import_psycopg2()
+        self._conn = psycopg2.connect(
+            host=self._host,
+            port=self._port,
+            user=self._user,
+            password=self._password,
+            dbname=self._db_name,
+            connect_timeout=self._connect_timeout,
+        )
+        self._ensure_meta_tables()
+        return self._conn
+
+    def _ensure_meta_tables(self) -> None:
+        conn = self._conn
+        if conn is None:
+            return
+        cur = conn.cursor()
+        try:
+            cur.execute(f"CREATE SCHEMA IF NOT EXISTS {_quote_ident(self._schema_name)}")
+            cur.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS {_qualify(self._schema_name, _COLLECTION_META_TABLE)} (
+                    table_name TEXT PRIMARY KEY,
+                    logical_collection_name TEXT NOT NULL,
+                    project_name TEXT NOT NULL,
+                    meta_json TEXT NOT NULL,
+                    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+            cur.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS {_qualify(self._schema_name, _INDEX_META_TABLE)} (
+                    table_name TEXT NOT NULL,
+                    index_name TEXT NOT NULL,
+                    meta_json TEXT NOT NULL,
+                    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (table_name, index_name)
+                )
+                """
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            cur.close()
+        if self._deployment_mode == "distributed":
+            self._try_make_reference_table(_COLLECTION_META_TABLE)
+            self._try_make_reference_table(_INDEX_META_TABLE)
+
+    def _try_make_reference_table(self, table_name: str) -> None:
+        conn = self._conn
+        if conn is None:
+            return
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "SELECT create_reference_table(%s)", [self._function_table_name(table_name)]
+            )
+            conn.commit()
+        except Exception as exc:
+            conn.rollback()
+            logger.warning(
+                "Failed to mark openGauss metadata table %s as reference table: %s",
+                self._function_table_name(table_name),
+                exc,
+            )
+        finally:
+            cur.close()
+
+    def _new_collection(self, meta: Optional[Dict[str, Any]] = None) -> OpenGaussCollection:
+        return OpenGaussCollection(
+            conn=self._connect(),
+            schema_name=self._schema_name,
+            table_name=self.physical_table_name,
+            logical_collection_name=self._collection_name,
+            project_name=self._project_name,
+            dense_vector_name=self._dense_vector_name,
+            sparse_vector_name=self._sparse_vector_name,
+            distance_metric=self._distance_metric,
+            meta=meta,
+            lock=self._lock,
+            reconnect=self._connect,
+        )
+
+    def _load_existing_collection_if_needed(self) -> None:
+        if self._collection is not None:
+            return
+        conn = self._connect()
+        raw_collection = self._new_collection()
+        if not raw_collection._table_exists():
+            return
+        meta = raw_collection.get_meta_data()
+        if not meta:
+            raise RuntimeError(
+                "openGauss collection table exists but OpenViking metadata is missing: "
+                f"{self.physical_table_name}. Use a different project/name, restore metadata, "
+                "or drop the stale table."
+            )
+        self._collection = Collection(
+            OpenGaussCollection(
+                conn=conn,
+                schema_name=self._schema_name,
+                table_name=self.physical_table_name,
+                logical_collection_name=self._collection_name,
+                project_name=self._project_name,
+                dense_vector_name=self._dense_vector_name,
+                sparse_vector_name=self._sparse_vector_name,
+                distance_metric=self._distance_metric,
+                meta=meta,
+                lock=self._lock,
+                reconnect=self._connect,
+            )
+        )
+
+    def _create_backend_collection(self, meta: Dict[str, Any]) -> Collection:
+        raw_collection = self._new_collection(meta)
+        raw_collection.create_remote_collection(meta)
+        if self._deployment_mode == "distributed":
+            self._try_make_distributed_table(self.physical_table_name)
+        return Collection(raw_collection)
+
+    def _try_make_distributed_table(self, table_name: str) -> None:
+        conn = self._conn
+        if conn is None:
+            return
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "SELECT create_distributed_table(%s, 'id', 'hash', %s)",
+                [self._function_table_name(table_name), self._shard_count],
+            )
+            conn.commit()
+        except Exception as exc:
+            conn.rollback()
+            logger.warning(
+                "Failed to distribute openGauss table %s with shard_count=%s: %s",
+                table_name,
+                self._shard_count,
+                exc,
+            )
+        finally:
+            cur.close()
+
+    def close(self) -> None:
+        super().close()
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+    def _sanitize_scalar_index_fields(
+        self,
+        scalar_index_fields: list[str],
+        fields_meta: list[dict[str, Any]],
+    ) -> list[str]:
+        del fields_meta
+        return list(dict.fromkeys(list(scalar_index_fields) + self.INTERNAL_PATH_FIELDS))
+
+    def _build_default_index_meta(
+        self,
+        *,
+        index_name: str,
+        distance: str,
+        use_sparse: bool,
+        sparse_weight: float,
+        scalar_index_fields: list[str],
+    ) -> Dict[str, Any]:
+        index_meta = super()._build_default_index_meta(
+            index_name=index_name,
+            distance=distance,
+            use_sparse=use_sparse,
+            sparse_weight=sparse_weight,
+            scalar_index_fields=scalar_index_fields,
+        )
+        index_meta["VectorIndex"]["IndexType"] = "hnsw_hybrid" if use_sparse else "hnsw"
+        return index_meta
+
+    @staticmethod
+    def _normalize_path(path: str) -> str:
+        stripped = (path or "").strip()
+        if not stripped:
+            return "/"
+        if not stripped.startswith("/"):
+            stripped = f"/{stripped}"
+        if len(stripped) > 1:
+            stripped = stripped.rstrip("/")
+        return stripped or "/"
+
+    @classmethod
+    def _compute_parent_uri(cls, uri: str) -> str:
+        normalized = cls._normalize_path(uri)
+        if normalized == "/":
+            return "/"
+        parts = normalized.strip("/").split("/")
+        if len(parts) <= 1:
+            return "/"
+        return "/" + "/".join(parts[:-1])
+
+    @classmethod
+    def _compute_scope_roots(cls, uri: str) -> List[str]:
+        normalized = cls._normalize_path(uri)
+        if normalized == "/":
+            return ["/"]
+        parts = normalized.strip("/").split("/")
+        roots = ["/"]
+        current_parts: List[str] = []
+        for part in parts[:-1]:
+            current_parts.append(part)
+            roots.append("/" + "/".join(current_parts))
+        return roots
+
+    def _normalize_record_for_write(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        normalized = dict(super()._normalize_record_for_write(record))
+        raw_uri = normalized.get("uri")
+        if isinstance(raw_uri, str):
+            normalized_uri = self._normalize_path(raw_uri)
+            normalized["uri"] = normalized_uri
+            normalized["parent_uri"] = self._compute_parent_uri(normalized_uri)
+            normalized["scope_roots"] = self._compute_scope_roots(normalized_uri)
+            normalized["uri_depth"] = len(
+                [part for part in normalized_uri.strip("/").split("/") if part]
+            )
+        return normalized
+
+    def _normalize_record_for_read(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        normalized = super()._normalize_record_for_read(record)
+        for field_name in self.INTERNAL_PATH_FIELDS:
+            normalized.pop(field_name, None)
+        return normalized
+
+    def _coerce_datetime_value(self, value: Any) -> Any:
+        if isinstance(value, dt.datetime):
+            if value.tzinfo is None:
+                value = value.replace(tzinfo=dt.timezone.utc)
+            return value.isoformat()
+        return value
+
+    def _compile_filter(self, expr: FilterExpr | Dict[str, Any] | None) -> Dict[str, Any]:
+        if expr is None:
+            return {}
+        if isinstance(expr, dict):
+            return self._normalize_filter_payload_for_write(expr)
+        if isinstance(expr, RawDSL):
+            return self._normalize_filter_payload_for_write(expr.payload)
+        if isinstance(expr, And):
+            conds = [self._compile_filter(cond) for cond in expr.conds if cond]
+            return {"op": "and", "conds": [cond for cond in conds if cond]}
+        if isinstance(expr, Or):
+            conds = [self._compile_filter(cond) for cond in expr.conds if cond]
+            return {"op": "or", "conds": [cond for cond in conds if cond]}
+        if isinstance(expr, Eq):
+            value = expr.value
+            if expr.field in self._URI_FIELD_NAMES:
+                value = self._normalize_path(self._encode_uri_field_value(value))
+            return {"op": "must", "field": expr.field, "conds": [value]}
+        if isinstance(expr, In):
+            values = list(expr.values)
+            if expr.field in self._URI_FIELD_NAMES:
+                values = [
+                    self._normalize_path(self._encode_uri_field_value(value)) for value in values
+                ]
+            return {"op": "must", "field": expr.field, "conds": values}
+        if isinstance(expr, Range):
+            payload: Dict[str, Any] = {"op": "range", "field": expr.field}
+            for key in ("gte", "gt", "lte", "lt"):
+                value = getattr(expr, key)
+                if value is not None:
+                    payload[key] = value
+            return payload
+        if isinstance(expr, TimeRange):
+            payload: Dict[str, Any] = {"op": "range", "field": expr.field}
+            if expr.start is not None:
+                payload["gte"] = self._coerce_datetime_value(expr.start)
+            if expr.end is not None:
+                payload["lt"] = self._coerce_datetime_value(expr.end)
+            return payload
+        if isinstance(expr, Contains):
+            return {"op": "contains", "field": expr.field, "substring": expr.substring}
+        if isinstance(expr, PathScope):
+            encoded_path = (
+                self._normalize_path(self._encode_uri_field_value(expr.path))
+                if expr.field in self._URI_FIELD_NAMES
+                else expr.path
+            )
+            if expr.depth == 0:
+                return {"op": "must", "field": expr.field, "conds": [encoded_path]}
+            if expr.depth == 1:
+                return {"op": "must", "field": "parent_uri", "conds": [encoded_path]}
+            if expr.depth == -1:
+                return {"op": "must", "field": "scope_roots", "conds": [encoded_path]}
+            raise ValueError(
+                f"OpenGauss adapter only supports PathScope depth 0/1/-1, got {expr.depth}"
+            )
+        raise TypeError(f"Unsupported filter expr type: {type(expr)!r}")

--- a/openviking/storage/vectordb_adapters/pgvector_adapter.py
+++ b/openviking/storage/vectordb_adapters/pgvector_adapter.py
@@ -1,0 +1,767 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""PostgreSQL + pgvector collection adapter.
+
+openGauss ships a fork of the pgvector extension, so ``opengauss_adapter.py``
+already emits pgvector-shaped SQL (the ``vector`` column type, the
+``<=>``/``<#>``/``<->`` distance operators, ``USING hnsw``). This adapter is a
+*re-target* of that module for stock PostgreSQL: it reuses the shared data plane
+in :class:`~openviking.storage.vectordb_adapters.base.CollectionAdapter`, adds
+``CREATE EXTENSION vector`` / DSN connect / ``ON CONFLICT`` upsert, and drops the
+openGauss/Citus-only distributed-table machinery. See the line-by-line reuse map
+in ``.wiki/pgvector/refs/02-opengauss-as-pgvector-reference.md``.
+
+The pure SQL/identifier helpers (``_safe_identifier``, ``_normalize_distance``,
+...) are reused verbatim from ``opengauss_adapter`` rather than duplicated; the
+shared boundary that would host them lives behind issue #2357 (out of scope for
+this build).
+
+Built test-first: this lands the config model (B1) and factory wiring (B2); the
+SQL ``ICollection`` and live connection seam are filled in over B3-B4.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+from typing import Any, Dict, List, Optional
+
+from packaging.version import InvalidVersion, Version
+
+from openviking.storage.vectordb.collection.collection import Collection
+from openviking.storage.vectordb.collection.result import SearchItemResult, SearchResult
+from openviking.storage.vectordb_adapters.base import CollectionAdapter
+from openviking.storage.vectordb_adapters.opengauss_adapter import (
+    _VECTOR_OPS,
+    OpenGaussCollection,
+    OpenGaussCollectionAdapter,
+    _json_dumps,
+    _normalize_distance,
+    _qualify,
+    _quote_ident,
+    _safe_identifier,
+    _vector_literal,
+)
+from openviking_cli.utils import get_logger
+
+logger = get_logger(__name__)
+
+_DEFAULT_SCHEMA = "public"
+
+
+def _coerce_int(value: Any, key: str, default: int) -> int:
+    """Coerce a user-supplied ``index_params`` value to ``int`` with an actionable
+    error, instead of letting a bare ``int(...)`` raise an opaque ``ValueError``
+    deep inside collection construction."""
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"pgvector index_params[{key!r}] must be an integer, got {value!r}"
+        ) from exc
+
+
+# Stable 64-bit advisory-lock key so concurrent workers serialize the one-time
+# ``CREATE EXTENSION`` instead of racing (onyx-dot-app/onyx: sha256(name) -> int64).
+_EXTENSION_ADVISORY_KEY = int.from_bytes(
+    hashlib.sha256(b"openviking.pgvector.create_extension").digest()[:8], "big", signed=True
+)
+
+
+def _import_psycopg2():
+    try:
+        import psycopg2  # noqa: PLC0415
+        import psycopg2.pool  # noqa: PLC0415  # submodule is not auto-imported by `import psycopg2`
+
+        return psycopg2
+    except ImportError as exc:  # pragma: no cover - exercised only without optional driver
+        raise ImportError(
+            "The pgvector backend requires a psycopg2-compatible driver. "
+            'Install it with `pip install "openviking[pgvector]"`.'
+        ) from exc
+
+
+# pgvector keeps its collection/index metadata in its own sidecar tables so a
+# pgvector deployment never collides with an openGauss one in the same schema.
+_COLLECTION_META_TABLE = "__openviking_pgvector_collections"
+_INDEX_META_TABLE = "__openviking_pgvector_indexes"
+
+# openGauss meta-table constants that the inherited collection SQL bakes into its
+# statements; PgVectorCollection remaps them to the pgvector names above.
+_OPENGAUSS_META_REMAP = {
+    "__openviking_opengauss_collections": _COLLECTION_META_TABLE,
+    "__openviking_opengauss_indexes": _INDEX_META_TABLE,
+}
+
+
+class PgVectorCollection(OpenGaussCollection):
+    """SQL collection for PostgreSQL + pgvector.
+
+    Re-targets :class:`OpenGaussCollection` (openGauss ships a pgvector fork, so
+    the generated SQL is already pgvector-shaped). It inherits the read paths,
+    filter compilation, and identifier/vector helpers verbatim, overriding only
+    the parts where stock PostgreSQL diverges: its own metadata-table names (via
+    ``_meta_table_ref``), native ``ON CONFLICT`` upsert, ``CREATE EXTENSION``
+    ordering, and the per-query iterative-scan GUC bundle. Those overrides land
+    in their respective build-loop slices (B3.3/B3.6/B3.8).
+    """
+
+    # Knobs threaded from the adapter in ``_new_collection``; the class defaults
+    # keep ``object.__new__`` Tier-C construction (and mypy) happy.
+    _create_extension: bool = True
+    _iterative_scan_supported: bool = False
+    _ef_search: int = 100
+    _max_scan_tuples: int = 20000
+
+    def update_data(self, data_list: List[Dict[str, Any]]) -> Any:
+        """Update existing rows by primary key (never insert new ones).
+
+        The ``/data/update`` endpoint is contractually "update existing data",
+        and other backends (e.g. ``LocalCollection.update_data``) reject unknown
+        ids rather than silently inserting. So pgvector first verifies every id
+        already exists, then delegates to the ``INSERT ... ON CONFLICT (id) DO
+        UPDATE`` upsert path — which, because it only sets the supplied columns,
+        gives the desired "update only the provided fields" semantics for rows
+        that are present. (``ICollection.update_data`` is abstract; the inherited
+        openGauss collection never implemented it, which is why pgvector must.)
+        """
+        if not data_list:
+            return self.upsert_data(data_list)
+        ids = []
+        for record in data_list:
+            if "id" not in record:
+                raise ValueError("primary key 'id' is required for update")
+            ids.append(record["id"])
+        missing = self.fetch_data(ids).ids_not_exist
+        if missing:
+            raise ValueError(f"record not found for primary key(s): {missing}")
+        return self.upsert_data(data_list)
+
+    def _meta_table_ref(self, table_name: str) -> str:
+        return super()._meta_table_ref(_OPENGAUSS_META_REMAP.get(table_name, table_name))
+
+    def _save_collection_meta(self, meta: Dict[str, Any]) -> None:
+        """Persist collection metadata with portable ``INSERT ... ON CONFLICT``.
+
+        Overrides the inherited openGauss ``MERGE INTO`` upsert, which requires
+        PostgreSQL 15+. ``ON CONFLICT (table_name) DO UPDATE`` is supported on all
+        pgvector-capable PostgreSQL (>= 9.5), matching the ``_upsert_row`` idiom.
+        """
+        self._execute(
+            f"""
+            INSERT INTO {self._meta_table_ref(_COLLECTION_META_TABLE)}
+                (table_name, logical_collection_name, project_name, meta_json, updated_at)
+            VALUES (%s, %s, %s, %s, CURRENT_TIMESTAMP)
+            ON CONFLICT (table_name) DO UPDATE SET
+                logical_collection_name = EXCLUDED.logical_collection_name,
+                project_name = EXCLUDED.project_name,
+                meta_json = EXCLUDED.meta_json,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            [
+                self.collection_key,
+                self._logical_collection_name,
+                self._project_name,
+                _json_dumps(meta),
+            ],
+        )
+
+    def _save_index_meta(self, index_name: str, meta: Dict[str, Any]) -> None:
+        """Portable ``INSERT ... ON CONFLICT`` index-meta upsert (see
+        ``_save_collection_meta`` — avoids the PG15-only ``MERGE INTO``)."""
+        self._execute(
+            f"""
+            INSERT INTO {self._meta_table_ref(_INDEX_META_TABLE)}
+                (table_name, index_name, meta_json, updated_at)
+            VALUES (%s, %s, %s, CURRENT_TIMESTAMP)
+            ON CONFLICT (table_name, index_name) DO UPDATE SET
+                meta_json = EXCLUDED.meta_json,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            [self.collection_key, index_name, _json_dumps(meta)],
+        )
+
+    def _build_create_ddl(self, meta_data: Dict[str, Any]) -> list[str]:
+        """Return the ordered DDL for a collection: ``CREATE EXTENSION`` (when
+        enabled) *before* the ``CREATE TABLE`` carrying the ``vector(N)`` column.
+
+        Pure string builder (no connection) so the ordering and extension gate
+        are unit-testable. Stock PostgreSQL needs the extension created before any
+        ``vector(N)`` DDL; openGauss ships it natively so it never ran this.
+        """
+        columns = ["id TEXT PRIMARY KEY"]
+        seen = {"id"}
+        for field in meta_data.get("Fields", []) or []:
+            ddl = self._field_to_column_ddl(field)
+            field_name = field.get("FieldName")
+            if ddl and field_name not in seen:
+                columns.append(ddl)
+                seen.add(str(field_name))
+        for field_name, sql_type in self.INTERNAL_PATH_FIELDS.items():
+            if field_name not in seen:
+                columns.append(f"{_quote_ident(field_name)} {sql_type}")
+                seen.add(field_name)
+
+        statements: list[str] = []
+        if self._create_extension:
+            statements.append("CREATE EXTENSION IF NOT EXISTS vector")
+        statements.append(f"CREATE TABLE IF NOT EXISTS {self._table_ref()} ({', '.join(columns)})")
+        return statements
+
+    def create_remote_collection(self, meta_data: Dict[str, Any]) -> None:
+        self._meta = dict(meta_data)
+        self._vector_dim = self._extract_vector_dim(self._meta)
+        self._field_types = self._build_field_type_map(self._meta)
+        if self._vector_dim <= 0:
+            raise ValueError("pgvector collection requires a positive dense vector dimension")
+        for statement in self._build_create_ddl(meta_data):
+            self._execute(statement)
+        self._save_collection_meta(meta_data)
+
+    def _upsert_row(self, columns: List[str], values: List[Any]) -> None:
+        """Single-row upsert via native ``INSERT ... ON CONFLICT (id) DO UPDATE``.
+
+        Replaces the inherited openGauss UPDATE-then-INSERT + 23505 retry with the
+        portable pgvector idiom: one atomic round trip. The dense-vector column is
+        cast with ``%s::vector`` in VALUES, and ``EXCLUDED`` carries that typed
+        value into the SET list. Identifiers are quoted with the shared
+        ``_quote_ident`` (codebase idiom); the ``ON CONFLICT``/``EXCLUDED`` shape
+        follows langchain-postgres / mem0 (see design.md provenance).
+        """
+        insert_cols = ", ".join(_quote_ident(column) for column in columns)
+        placeholders = ", ".join(
+            "%s::vector" if column == self._dense_vector_name else "%s" for column in columns
+        )
+        update_columns = [column for column in columns if column != "id"]
+        if update_columns:
+            set_clause = ", ".join(
+                f"{_quote_ident(column)} = EXCLUDED.{_quote_ident(column)}"
+                for column in update_columns
+            )
+            conflict = f"ON CONFLICT (id) DO UPDATE SET {set_clause}"
+        else:
+            conflict = "ON CONFLICT (id) DO NOTHING"
+        self._execute(
+            f"INSERT INTO {self._table_ref()} ({insert_cols}) VALUES ({placeholders}) {conflict}",
+            values,
+        )
+
+    def _supports_iterative_scan(self) -> bool:
+        """Whether the connected server has pgvector >= 0.8 (iterative scan).
+
+        Wired by the version gate on connect (B4.2). Defaults to ``False`` so a
+        pre-0.8 server falls back to the inherited plain scan rather than issuing
+        GUCs it cannot parse (which would abort the transaction).
+        """
+        return self._iterative_scan_supported
+
+    def _iterative_scan_guc_prefix(self) -> str:
+        """The ``SET LOCAL`` bundle that keeps HNSW recall under a selective
+        filter (metabase's tested shape). Values are inlined integers (clamped),
+        never user input, so they compose safely ahead of the parameterized
+        SELECT in one transaction.[^metabase]
+
+        [^metabase]: metabase/metabase
+        enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+        (iterative_scan/ef_search[clamp 1..1000]/max_scan_tuples + enable_seqscan);
+        Tencent/WeKnora gates it on version ("ignore failure on older pgvector").
+        """
+        ef_search = max(1, min(self._ef_search, 1000))
+        max_scan_tuples = self._max_scan_tuples
+        return (
+            "SET LOCAL hnsw.iterative_scan = strict_order; "
+            f"SET LOCAL hnsw.ef_search = {ef_search}; "
+            f"SET LOCAL hnsw.max_scan_tuples = {max_scan_tuples}; "
+            "SET LOCAL enable_seqscan = off; "
+        )
+
+    def search_by_vector(
+        self,
+        index_name: str,
+        dense_vector: list[float] | None = None,
+        limit: int = 10,
+        offset: int = 0,
+        filters: dict[str, Any] | None = None,
+        sparse_vector: dict[str, float] | None = None,
+        output_fields: list[str] | None = None,
+    ) -> SearchResult:
+        """Dense ANN search that issues the iterative-scan GUC bundle when a
+        scalar filter is present (and the server supports it). Plain HNSW
+        post-filters at most ``ef_search`` candidates, so a selective filter can
+        silently return fewer than ``LIMIT`` rows; the bundle makes the scan keep
+        pulling candidates until ``LIMIT`` is satisfied. Everything else (no
+        filter, sparse/hybrid, unsupported server) delegates to the inherited
+        implementation unchanged — the param order stays ``[vec, …where…, vec,
+        limit, offset]`` (pinned by ``test_vector_search_binds_..._filter_params``).
+        """
+        if (
+            dense_vector is None
+            or sparse_vector
+            or not filters
+            or not self._supports_iterative_scan()
+        ):
+            return super().search_by_vector(
+                index_name, dense_vector, limit, offset, filters, sparse_vector, output_fields
+            )
+        if limit <= 0:
+            return SearchResult()
+        fetch_limit = max(limit + offset, limit)
+        columns = self._select_columns(output_fields, include_sparse=False)
+        where_sql, params = self._where_sql(filters)
+        operator = _VECTOR_OPS[self._distance_metric]["operator"]
+        vector_text = _vector_literal(dense_vector)
+        sql = self._iterative_scan_guc_prefix() + (
+            f"SELECT {', '.join(_quote_ident(col) for col in columns)}, "
+            f"{_quote_ident(self._dense_vector_name)} {operator} %s::vector AS _distance "
+            f"FROM {self._table_ref()}"
+            f"{where_sql} "
+            f"ORDER BY {_quote_ident(self._dense_vector_name)} {operator} %s::vector "
+            "LIMIT %s OFFSET %s"
+        )
+        rows = self._execute(sql, [vector_text, *params, vector_text, fetch_limit, 0], fetch=True)
+        scored_items: list[SearchItemResult] = []
+        for row in rows:
+            record_id, payload = self._row_to_payload(row[:-1], columns)
+            score = self._distance_to_score(row[-1], self._distance_metric)
+            scored_items.append(SearchItemResult(id=record_id, fields=payload, score=score))
+        return SearchResult(data=scored_items[offset : offset + limit])
+
+
+class PgVectorCollectionAdapter(OpenGaussCollectionAdapter):
+    """CollectionAdapter for PostgreSQL with the pgvector extension.
+
+    Re-targets :class:`OpenGaussCollectionAdapter` (symmetric with
+    :class:`PgVectorCollection` re-targeting :class:`OpenGaussCollection`). It
+    inherits the adapter-level path plane verbatim — ``_normalize_record_for_write``
+    (scope_roots/uri_depth augmentation), ``_normalize_record_for_read``,
+    ``_sanitize_scalar_index_fields``, ``_build_default_index_meta``, and the
+    ``PathScope`` filter compilation — and overrides only the connection/driver
+    seam and collection construction (DSN connect, version gate, extension,
+    pgvector meta tables, PgVectorCollection). The openGauss-only distributed
+    helpers are inherited but never called.
+    """
+
+    mode = "pgvector"
+
+    def __init__(
+        self,
+        *,
+        url: str | None,
+        host: str,
+        port: int,
+        user: str,
+        password: str,
+        db_name: str,
+        schema_name: str,
+        sslmode: str,
+        project_name: str,
+        collection_name: str,
+        index_name: str,
+        distance_metric: str,
+        dense_vector_name: str,
+        sparse_vector_name: str,
+        connect_timeout: int,
+        pool_size: int,
+        create_extension: bool,
+        index_type: str,
+        index_params: Dict[str, Any],
+        dimension: int = 0,
+    ) -> None:
+        # Skip OpenGaussCollectionAdapter.__init__ (openGauss host/mode/shard_count
+        # signature); pgvector sets its own connection state below.
+        CollectionAdapter.__init__(self, collection_name=collection_name, index_name=index_name)
+        self._url = url
+        self._host = host
+        self._port = int(port)
+        self._user = user
+        self._password = password
+        self._db_name = db_name
+        self._schema_name = (schema_name or _DEFAULT_SCHEMA).strip() or _DEFAULT_SCHEMA
+        self._sslmode = sslmode
+        self._project_name = project_name
+        self._distance_metric = _normalize_distance(distance_metric)
+        self._dense_vector_name = dense_vector_name
+        self._sparse_vector_name = sparse_vector_name
+        self._connect_timeout = int(connect_timeout)
+        self._pool_size = int(pool_size)
+        self._create_extension = bool(create_extension)
+        self._index_type = index_type
+        self._index_params = dict(index_params or {})
+        self._dimension = int(dimension)
+        self._conn: Any = None
+        self._pool: Any = None
+        self._lock = threading.RLock()
+        # Feature flags resolved from the live extension version on connect
+        # (_detect_version). Conservative defaults: everything off until proven.
+        self._pgvector_version = ""
+        self._supports_hnsw = False
+        self._supports_halfvec = False
+        self._supports_sparsevec = False
+        self._supports_iterative_scan = False
+        self._ready = False
+
+    @classmethod
+    def from_config(cls, config: Any) -> "PgVectorCollectionAdapter":
+        cfg = getattr(config, "pgvector", None)
+        params = dict(getattr(config, "custom_params", {}) or {})
+        if cfg is None:
+            raise ValueError("pgvector backend requires pgvector config")
+        return cls(
+            url=(getattr(cfg, "url", None) or params.get("url") or None),
+            host=str(getattr(cfg, "host", None) or params.get("host") or "127.0.0.1"),
+            port=int(getattr(cfg, "port", None) or params.get("port") or 5432),
+            user=str(getattr(cfg, "user", None) or params.get("user") or "postgres"),
+            password=str(getattr(cfg, "password", None) or params.get("password") or ""),
+            db_name=str(getattr(cfg, "db_name", None) or params.get("db_name") or "postgres"),
+            schema_name=str(
+                getattr(cfg, "schema_name", None)
+                or getattr(cfg, "schema", None)
+                or params.get("schema")
+                or _DEFAULT_SCHEMA
+            ),
+            sslmode=str(getattr(cfg, "sslmode", None) or params.get("sslmode") or "prefer"),
+            project_name=config.project_name or "default",
+            collection_name=config.name or "context",
+            index_name=config.index_name or "default",
+            distance_metric=config.distance_metric or "cosine",
+            dense_vector_name=str(
+                getattr(cfg, "dense_vector_name", None)
+                or params.get("dense_vector_name")
+                or "vector"
+            ),
+            sparse_vector_name=str(
+                getattr(cfg, "sparse_vector_name", None)
+                or params.get("sparse_vector_name")
+                or "sparse_vector"
+            ),
+            connect_timeout=int(
+                getattr(cfg, "connect_timeout", None) or params.get("connect_timeout") or 10
+            ),
+            pool_size=int(getattr(cfg, "pool_size", None) or params.get("pool_size") or 1),
+            create_extension=bool(getattr(cfg, "create_extension", True)),
+            index_type=str(getattr(cfg, "index_type", None) or params.get("index_type") or "hnsw"),
+            index_params=dict(getattr(cfg, "index_params", None) or {}),
+            dimension=int(getattr(config, "dimension", 0) or 0),
+        )
+
+    @property
+    def physical_table_name(self) -> str:
+        return _safe_identifier(self._project_name, self._collection_name, prefix="ov")
+
+    def _conninfo(self) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        """psycopg2 ``connect`` args/kwargs. A DSN ``url`` wins over discrete
+        host/port/user/password (mem0's priority chain); ``sslmode`` is injected
+        for both forms."""
+        if self._url:
+            return (self._url,), {
+                "sslmode": self._sslmode,
+                "connect_timeout": self._connect_timeout,
+            }
+        return (), {
+            "host": self._host,
+            "port": self._port,
+            "user": self._user,
+            "password": self._password,
+            "dbname": self._db_name,
+            "sslmode": self._sslmode,
+            "connect_timeout": self._connect_timeout,
+        }
+
+    def _connect(self):
+        """Open (or reuse) a psycopg2 connection.
+
+        ``pool_size > 1`` uses a ``ThreadedConnectionPool``; otherwise a single
+        lock-serialized connection (openGauss's model). ``register_vector`` is
+        intentionally *never* called: the reused ``%s::vector`` literal path needs
+        no driver-level type binding, so a plain psycopg2 works (mem0 ships this
+        way). If a deployment later opts into binding, it would run per
+        checked-out connection right here. The ``_import_psycopg2`` seam is
+        module-level so tests can mock the driver without a live server.
+        """
+        if self._conn is not None and not getattr(self._conn, "closed", 0):
+            return self._conn
+        if self._conn is not None:
+            try:
+                # A pooled handle must be returned via putconn (close=True), not
+                # merely .close()'d, or its slot leaks and the pool exhausts.
+                if self._pool is not None:
+                    self._pool.putconn(self._conn, close=True)
+                else:
+                    self._conn.close()
+            except Exception:
+                logger.debug("Failed to release stale pgvector connection", exc_info=True)
+            self._conn = None
+        psycopg2 = _import_psycopg2()
+        args, kwargs = self._conninfo()
+        if self._pool_size > 1:
+            if self._pool is None:
+                self._pool = psycopg2.pool.ThreadedConnectionPool(
+                    1, self._pool_size, *args, **kwargs
+                )
+            self._conn = self._pool.getconn()
+        else:
+            self._conn = psycopg2.connect(*args, **kwargs)
+        return self._conn
+
+    def _gate_features(self, extversion: str) -> None:
+        """Resolve feature flags from a pgvector ``extversion`` string.
+
+        HNSW indexing needs >= 0.5.0; ``halfvec``/``sparsevec`` need >= 0.7.0;
+        the ``hnsw.iterative_scan`` GUC needs >= 0.8.0. An unparseable version
+        leaves every flag off (conservative).[^raglite]
+
+        [^raglite]: superlinear-ai/raglite gates iterative scan on the parsed
+        ``extversion`` the same way.
+        """
+        self._pgvector_version = str(extversion or "")
+        try:
+            version: Version | None = Version(self._pgvector_version)
+        except (InvalidVersion, TypeError):
+            version = None
+        self._supports_hnsw = version is not None and version >= Version("0.5.0")
+        self._supports_halfvec = version is not None and version >= Version("0.7.0")
+        self._supports_sparsevec = self._supports_halfvec
+        self._supports_iterative_scan = version is not None and version >= Version("0.8.0")
+
+    def _detect_version(self) -> None:
+        """Read the live pgvector version and gate features on it. Raises a
+        friendly error if the server predates HNSW support (< 0.5.0)."""
+        conn = self._conn
+        if conn is None:
+            return
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT extversion FROM pg_extension WHERE extname = 'vector'")
+            row = cur.fetchone()
+        finally:
+            cur.close()
+        extversion = row[0] if row else None
+        if not extversion:
+            # No pg_extension row => the 'vector' extension is not installed. Fail
+            # fast with an actionable message instead of proceeding to opaque
+            # vector(N)/index DDL errors. (With create_extension=true the extension
+            # was just created above, so this only trips on pre-provisioned
+            # deployments where it is genuinely absent.)
+            raise RuntimeError(
+                "The pgvector 'vector' extension is not installed in this database. "
+                "Have a superuser run `CREATE EXTENSION vector;`, or set "
+                "`create_extension=true` so OpenViking installs it on connect."
+            )
+        self._gate_features(str(extversion))
+        if not self._supports_hnsw:
+            raise RuntimeError(
+                f"pgvector {extversion} is too old for OpenViking; HNSW indexing requires "
+                ">= 0.5.0. Upgrade the extension (e.g. `ALTER EXTENSION vector UPDATE`)."
+            )
+
+    def _extension_present(self) -> bool:
+        conn = self._conn
+        if conn is None:
+            return False
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT 1 FROM pg_extension WHERE extname = 'vector'")
+            return cur.fetchone() is not None
+        finally:
+            cur.close()
+
+    def _ensure_extension(self) -> None:
+        """Create the ``vector`` extension on connect, under an advisory lock so
+        concurrent workers don't race. If it fails (e.g. a least-privileged role
+        on managed PostgreSQL), re-check ``pg_extension`` — another worker or a
+        DBA may have installed it — and only then raise a literal remediation.
+        ``create_extension=False`` skips this entirely for pre-provisioned
+        deployments (RDS/Cloud SQL).[^flag]
+
+        [^flag]: open-webui / danny-avila/rag_api gate this on a
+        ``PGVECTOR_CREATE_EXTENSION`` flag; onyx-dot-app/onyx serializes it with
+        an advisory lock; serengil/deepface raises the actionable command.
+        """
+        if not self._create_extension:
+            return
+        conn = self._conn
+        if conn is None:
+            return
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT pg_advisory_xact_lock(%s)", [_EXTENSION_ADVISORY_KEY])
+            cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
+            conn.commit()
+        except Exception as exc:
+            conn.rollback()
+            if not self._extension_present():
+                raise RuntimeError(
+                    "Failed to enable the pgvector 'vector' extension and it is not "
+                    "installed. Have a superuser run `CREATE EXTENSION vector;`, or set "
+                    "`create_extension=false` if the extension is pre-provisioned."
+                ) from exc
+        finally:
+            cur.close()
+
+    def _ensure_meta_tables(self) -> None:
+        """Create the pgvector-named sidecar metadata tables (openGauss's schema,
+        pgvector names). The collection reads/writes these via ``_meta_table_ref``,
+        which remaps the inherited openGauss constants to these names."""
+        conn = self._conn
+        if conn is None:
+            return
+        cur = conn.cursor()
+        try:
+            cur.execute(f"CREATE SCHEMA IF NOT EXISTS {_quote_ident(self._schema_name)}")
+            cur.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS {_qualify(self._schema_name, _COLLECTION_META_TABLE)} (
+                    table_name TEXT PRIMARY KEY,
+                    logical_collection_name TEXT NOT NULL,
+                    project_name TEXT NOT NULL,
+                    meta_json TEXT NOT NULL,
+                    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+            cur.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS {_qualify(self._schema_name, _INDEX_META_TABLE)} (
+                    table_name TEXT NOT NULL,
+                    index_name TEXT NOT NULL,
+                    meta_json TEXT NOT NULL,
+                    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (table_name, index_name)
+                )
+                """
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            cur.close()
+
+    def _ensure_ready(self) -> None:
+        """Connect and run the one-time bootstrap (extension → version gate →
+        meta tables). Idempotent: the bootstrap runs once per adapter lifetime,
+        but ``_connect`` still reconnects a dropped connection on every call.
+
+        The bootstrap runs DDL and metadata reads on the shared psycopg2
+        connection, which is not safe for overlapping cursor use across threads,
+        so the whole block is serialized under ``self._lock`` (an RLock shared
+        with collection ``_execute``; reentrant, so nested acquisition is safe).
+        ``_ready`` is re-checked inside the lock so only the first thread bootstraps.
+        """
+        with self._lock:
+            self._connect()
+            if self._ready:
+                return
+            self._ensure_extension()
+            self._detect_version()
+            self._ensure_meta_tables()
+            self._ready = True
+
+    def _new_collection(self, meta: Optional[Dict[str, Any]] = None) -> PgVectorCollection:
+        self._ensure_ready()
+        collection = PgVectorCollection(
+            conn=self._conn,
+            schema_name=self._schema_name,
+            table_name=self.physical_table_name,
+            logical_collection_name=self._collection_name,
+            project_name=self._project_name,
+            dense_vector_name=self._dense_vector_name,
+            sparse_vector_name=self._sparse_vector_name,
+            distance_metric=self._distance_metric,
+            meta=meta,
+            lock=self._lock,
+            reconnect=self._connect,
+        )
+        # Thread the adapter-resolved knobs onto the live collection so the
+        # CREATE EXTENSION (B3.3) and iterative-scan GUC (B3.8) overrides fire.
+        collection._create_extension = self._create_extension
+        collection._iterative_scan_supported = self._supports_iterative_scan
+        collection._ef_search = _coerce_int(self._index_params.get("ef_search"), "ef_search", 100)
+        collection._max_scan_tuples = _coerce_int(
+            self._index_params.get("max_scan_tuples"), "max_scan_tuples", 20000
+        )
+        return collection
+
+    def _build_default_index_meta(
+        self,
+        *,
+        index_name: str,
+        distance: str,
+        use_sparse: bool,
+        sparse_weight: float,
+        scalar_index_fields: list[str],
+    ) -> Dict[str, Any]:
+        """Carry the configured HNSW build parameters into the default index meta.
+
+        ``CollectionAdapter.create_collection`` builds a fresh index meta and the
+        inherited implementation ignores ``index_params``, so ``m``/``ef_construction``
+        from ``PgVectorConfig.index_params`` would otherwise never reach the HNSW
+        DDL (which reads ``VectorIndex.M`` / ``VectorIndex.EfConstruction``,
+        defaulting to 16/64). Merge them here, accepting either casing.
+        """
+        index_meta = super()._build_default_index_meta(
+            index_name=index_name,
+            distance=distance,
+            use_sparse=use_sparse,
+            sparse_weight=sparse_weight,
+            scalar_index_fields=scalar_index_fields,
+        )
+        vector_index = index_meta["VectorIndex"]
+        m = self._index_params.get("m", self._index_params.get("M"))
+        if m is not None:
+            vector_index["M"] = _coerce_int(m, "m", 16)
+        ef_construction = self._index_params.get(
+            "ef_construction", self._index_params.get("EfConstruction")
+        )
+        if ef_construction is not None:
+            vector_index["EfConstruction"] = _coerce_int(ef_construction, "ef_construction", 64)
+        return index_meta
+
+    def close(self) -> None:
+        """Release the wrapped collection *and* the pgvector connection/pool.
+
+        The inherited openGauss ``close()`` only ``.close()``'s ``self._conn`` —
+        wrong for a pooled handle (which must be returned via ``putconn``) and it
+        never closes the pool object, leaking server connections. This override
+        closes the collection like the base adapter, returns/borrowed pooled conn,
+        and tears the pool down.
+        """
+        with self._lock:
+            try:
+                CollectionAdapter.close(self)
+            finally:
+                try:
+                    if self._pool is not None:
+                        if self._conn is not None:
+                            self._pool.putconn(self._conn, close=True)
+                        self._pool.closeall()
+                    elif self._conn is not None:
+                        self._conn.close()
+                except Exception:
+                    logger.debug("Failed to close pgvector connection/pool", exc_info=True)
+                finally:
+                    self._conn = None
+                    self._pool = None
+                    self._ready = False
+
+    def _load_existing_collection_if_needed(self) -> None:
+        if self._collection is not None:
+            return
+        raw_collection = self._new_collection()
+        if not raw_collection._table_exists():
+            return
+        meta = raw_collection.get_meta_data()
+        if not meta:
+            raise RuntimeError(
+                "pgvector collection table exists but OpenViking metadata is missing: "
+                f"{self.physical_table_name}. Use a different project/name, restore metadata, "
+                "or drop the stale table."
+            )
+        self._collection = Collection(self._new_collection(meta))
+
+    def _create_backend_collection(self, meta: Dict[str, Any]) -> Collection:
+        raw_collection = self._new_collection(meta)
+        raw_collection.create_remote_collection(meta)
+        return Collection(raw_collection)

--- a/openviking_cli/utils/config/vectordb_config.py
+++ b/openviking_cli/utils/config/vectordb_config.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -50,141 +50,156 @@ class VikingDBConfig(BaseModel):
     model_config = {"extra": "forbid"}
 
 
-class CuVSConfig(BaseModel):
-    """Configuration for GPU dense-vector search through NVIDIA cuVS."""
+class QdrantConfig(BaseModel):
+    """Configuration for Qdrant backend."""
 
-    dtype: Literal["float32", "float16"] = Field(
-        default="float32",
-        description=(
-            "GPU dataset and query dtype. float16 is an opt-in direct cast and "
-            "must be benchmarked for recall; it does not change native CPU quantization."
-        ),
+    url: Optional[str] = Field(default=None, description="Qdrant service URL")
+    api_key: Optional[str] = Field(default=None, description="Optional Qdrant API key")
+    timeout_seconds: int = Field(default=10, description="HTTP timeout for Qdrant requests")
+    dense_vector_name: str = Field(
+        default="vector",
+        description="Named dense vector field in Qdrant collection.",
     )
-    algorithm: Literal["brute_force", "cagra"] = Field(
-        default="brute_force",
-        description=(
-            "cuVS index algorithm. Start with brute_force for functional validation; "
-            "use cagra for approximate search at larger scale."
-        ),
+    sparse_vector_name: str = Field(
+        default="sparse_vector",
+        description="Named sparse vector field in Qdrant collection.",
     )
-    build_params: Dict[str, Any] = Field(
-        default_factory=dict,
-        description="Additional keyword arguments passed to cuVS CAGRA IndexParams.",
+    meta_collection_name: str = Field(
+        default="__openviking_meta",
+        description="Sidecar collection name for OpenViking metadata in Qdrant.",
     )
-    search_params: Dict[str, Any] = Field(
-        default_factory=dict,
-        description="Additional keyword arguments passed to cuVS CAGRA SearchParams.",
-    )
-    fallback_to_native: bool = Field(
+    enable_text_index: bool = Field(
         default=True,
-        description=(
-            "Use OpenViking's native local index for sparse/hybrid search or other "
-            "operations outside cuVS dense top-k."
-        ),
-    )
-    auto_enable: bool = Field(
-        default=False,
-        description=(
-            "When the VectorDB backend is 'local', automatically use cuVS dense search "
-            "only when a visible GPU has enough free memory. The default is disabled."
-        ),
-    )
-    auto_memory_reserve_mb: int = Field(
-        default=1024,
-        ge=0,
-        description=("Free GPU memory kept outside the cuVS auto-admission budget, in MiB."),
-    )
-    auto_memory_safety_factor: float = Field(
-        default=2.0,
-        ge=1.0,
-        description=(
-            "Multiplier applied to the estimated cuVS vector, graph, build, and filter "
-            "memory before auto-enabling GPU search."
-        ),
-    )
-    auto_filter_native_threshold: int = Field(
-        default=2000,
-        ge=0,
-        description=(
-            "In cuVS auto mode, route filtered queries with at most this many "
-            "eligible vectors to the native index. Set to zero to disable "
-            "latency-aware filter routing."
-        ),
-    )
-    auto_path_filter_native_threshold: int = Field(
-        default=200,
-        ge=0,
-        description=(
-            "In cuVS auto mode, use this lower native-routing threshold for path "
-            "filters, whose native Trie/bitmap construction cost can dominate wider "
-            "subtree queries. Set to zero to keep all path filters on cuVS."
-        ),
-    )
-    filter_cache_size: int = Field(
-        default=16,
-        ge=0,
-        description=(
-            "Maximum number of repeated scalar-filter bitsets retained on the GPU. "
-            "Set to zero to disable caching."
-        ),
-    )
-    max_concurrent_gpu_searches: int = Field(
-        default=1,
-        ge=1,
-        description=(
-            "Maximum in-flight cuVS GPU search calls per index. Host-side filter and "
-            "snapshot work remains concurrent; increase only after hardware-specific tuning."
-        ),
-    )
-    micro_batching_enabled: bool = Field(
-        default=False,
-        description=(
-            "Coalesce compatible concurrent cuVS dense queries into one matrix-search call. "
-            "This OpenViking scheduler is opt-in and distinct from cuVS Dynamic Batching."
-        ),
-    )
-    micro_batching_max_batch_size: int = Field(
-        default=8,
-        ge=1,
-        le=8,
-        description="Maximum compatible queries submitted in one cuVS search call.",
-    )
-    micro_batching_max_wait_ms: float = Field(
-        default=1.0,
-        ge=0.0,
-        le=100.0,
-        allow_inf_nan=False,
-        description=(
-            "Maximum collection window for a compatible cuVS micro-batch, in milliseconds. "
-            "Zero performs opportunistic batching without an intentional wait."
-        ),
-    )
-    auto_background_rebuild: bool = Field(
-        default=False,
-        description=(
-            "Build dirty auto-cuVS snapshots in a coalescing background worker. "
-            "Queries use the native index until the new GPU snapshot is committed."
-        ),
-    )
-    auto_rebuild_debounce_ms: int = Field(
-        default=500,
-        ge=0,
-        description=(
-            "Quiet period used to coalesce consecutive mutations before an auto-cuVS "
-            "background rebuild."
-        ),
+        description="Whether to create text payload indexes for supported text fields.",
     )
 
     model_config = {"extra": "forbid"}
 
+
+_OPENGAUSS_MODES = {"standalone", "distributed"}
+
+
+class OpenGaussConfig(BaseModel):
+    """Configuration for openGauss native vector backend."""
+
+    host: Optional[str] = Field(
+        default="127.0.0.1",
+        description="openGauss host address. Use the CN address when mode=distributed.",
+    )
+    port: int = Field(default=5432, description="openGauss port")
+    user: str = Field(default="omm", description="Database user")
+    password: str = Field(default="", description="Database password")
+    db_name: str = Field(default="postgres", description="Database name")
+    schema_name: str = Field(
+        default="public",
+        alias="schema",
+        description="Database schema for OpenViking tables",
+    )
+    mode: str = Field(
+        default="standalone",
+        description="openGauss deployment mode: 'standalone' or 'distributed'",
+    )
+    shard_count: int = Field(
+        default=32,
+        description="Shard count for create_distributed_table when mode=distributed",
+    )
+    connect_timeout: int = Field(default=10, description="Database connection timeout in seconds")
+    dense_vector_name: str = Field(default="vector", description="Dense vector column name")
+    sparse_vector_name: str = Field(
+        default="sparse_vector", description="Sparse vector JSON column name"
+    )
+
+    model_config = {"extra": "forbid", "populate_by_name": True}
+
     @model_validator(mode="after")
-    def validate_micro_batching(self):
-        if not self.micro_batching_enabled:
-            return self
-        if self.algorithm != "brute_force":
-            raise ValueError("cuVS micro-batching currently supports algorithm='brute_force' only")
-        if self.max_concurrent_gpu_searches != 1:
-            raise ValueError("cuVS micro-batching currently requires max_concurrent_gpu_searches=1")
+    def validate_mode(self):
+        self.schema_name = (self.schema_name or "public").strip()
+        if not self.schema_name:
+            raise ValueError("openGauss schema must not be empty")
+        self.mode = (self.mode or "standalone").strip().lower()
+        if self.mode not in _OPENGAUSS_MODES:
+            raise ValueError(
+                f"Invalid openGauss mode: '{self.mode}'. Must be one of: {sorted(_OPENGAUSS_MODES)}"
+            )
+        self.dense_vector_name = (self.dense_vector_name or "vector").strip()
+        self.sparse_vector_name = (self.sparse_vector_name or "sparse_vector").strip()
+        return self
+
+
+class PgVectorConfig(BaseModel):
+    """Configuration for PostgreSQL + pgvector native vector backend."""
+
+    url: Optional[str] = Field(
+        default=None,
+        description="PostgreSQL DSN (e.g. 'postgresql://user:pass@host:5432/db'). "
+        "Takes priority over discrete host/port/user/password fields when set.",
+    )
+    host: Optional[str] = Field(
+        default="127.0.0.1",
+        description="PostgreSQL host address.",
+    )
+    port: int = Field(default=5432, description="PostgreSQL port")
+    user: str = Field(default="postgres", description="Database user")
+    password: str = Field(default="", description="Database password")
+    db_name: str = Field(default="postgres", description="Database name")
+    schema_name: str = Field(
+        default="public",
+        alias="schema",
+        description="Database schema for OpenViking tables",
+    )
+    sslmode: str = Field(
+        default="prefer",
+        description="libpq sslmode ('prefer', 'require', 'disable', ...).",
+    )
+    connect_timeout: int = Field(default=10, description="Database connection timeout in seconds")
+    pool_size: int = Field(
+        default=1,
+        description="Connection pool size. 1 uses a single lock-serialized connection; "
+        ">1 uses a ThreadedConnectionPool.",
+    )
+    create_extension: bool = Field(
+        default=True,
+        description="Run 'CREATE EXTENSION IF NOT EXISTS vector' on connect. "
+        "Set false for pre-provisioned managed PostgreSQL (RDS/Cloud SQL).",
+    )
+    index_type: str = Field(default="hnsw", description="Vector index type ('hnsw').")
+    index_params: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Extra index build parameters (e.g. {'m': 16, 'ef_construction': 64}).",
+    )
+    dense_vector_name: str = Field(default="vector", description="Dense vector column name")
+    sparse_vector_name: str = Field(
+        default="sparse_vector", description="Sparse vector JSON column name"
+    )
+
+    model_config = {"extra": "forbid", "populate_by_name": True}
+
+    @model_validator(mode="after")
+    def validate_pgvector(self):
+        self.schema_name = (self.schema_name or "public").strip()
+        if not self.schema_name:
+            raise ValueError("pgvector schema must not be empty")
+        # Normalize then re-check: a whitespace-only name is truthy so the
+        # `or "vector"` fallback never fires, yet strips to "" — an empty SQL
+        # identifier. Reject it here with a clear error instead of failing later
+        # with an opaque SQL error.
+        self.dense_vector_name = (self.dense_vector_name or "vector").strip()
+        if not self.dense_vector_name:
+            raise ValueError("pgvector dense_vector_name must not be empty")
+        self.sparse_vector_name = (self.sparse_vector_name or "sparse_vector").strip()
+        if not self.sparse_vector_name:
+            raise ValueError("pgvector sparse_vector_name must not be empty")
+        # Fail fast on non-integer numeric index params so misconfiguration
+        # surfaces at config load, not deep in collection creation.
+        for key in ("m", "ef_construction", "ef_search", "max_scan_tuples"):
+            if key in self.index_params and self.index_params[key] is not None:
+                try:
+                    self.index_params[key] = int(self.index_params[key])
+                except (TypeError, ValueError):
+                    raise ValueError(
+                        f"pgvector index_params[{key!r}] must be an integer, "
+                        f"got {self.index_params[key]!r}"
+                    )
         return self
 
 
@@ -199,9 +214,9 @@ class VectorDBBackendConfig(BaseModel):
     backend: str = Field(
         default="local",
         description=(
-            "VectorDB backend type: 'local', 'cuvs', 'http', "
+            "VectorDB backend type: 'local', 'http', "
             "'volcengine' (AK/SK signed or API key data-plane only), "
-            "or 'vikingdb' (private deployment)"
+            "'vikingdb' (private deployment), 'qdrant', 'opengauss', or 'pgvector'"
         ),
     )
 
@@ -255,9 +270,19 @@ class VectorDBBackendConfig(BaseModel):
         description="VikingDB private deployment configuration for 'vikingdb' type",
     )
 
-    cuvs: Optional[CuVSConfig] = Field(
-        default_factory=CuVSConfig,
-        description="NVIDIA cuVS dense-vector search configuration for the 'cuvs' backend",
+    qdrant: Optional[QdrantConfig] = Field(
+        default_factory=QdrantConfig,
+        description="Qdrant configuration for 'qdrant' type",
+    )
+
+    opengauss: Optional[OpenGaussConfig] = Field(
+        default_factory=OpenGaussConfig,
+        description="openGauss configuration for 'opengauss' type",
+    )
+
+    pgvector: Optional[PgVectorConfig] = Field(
+        default_factory=PgVectorConfig,
+        description="PostgreSQL + pgvector configuration for 'pgvector' type",
     )
 
     custom_params: Dict[str, Any] = Field(
@@ -272,10 +297,12 @@ class VectorDBBackendConfig(BaseModel):
         """Validate configuration completeness and consistency"""
         standard_backends = [
             "local",
-            "cuvs",
             "http",
             "volcengine",
             "vikingdb",
+            "qdrant",
+            "opengauss",
+            "pgvector",
         ]
 
         # Allow custom backend classes (containing dot) without standard validation
@@ -289,7 +316,7 @@ class VectorDBBackendConfig(BaseModel):
                 "or a valid Python class path."
             )
 
-        if self.backend in {"local", "cuvs"}:
+        if self.backend == "local":
             pass
 
         elif self.backend == "http":
@@ -324,5 +351,36 @@ class VectorDBBackendConfig(BaseModel):
         elif self.backend == "vikingdb":
             if not self.vikingdb or not self.vikingdb.host:
                 raise ValueError("VectorDB vikingdb backend requires 'host' to be set")
+
+        elif self.backend == "qdrant":
+            qdrant_url = (
+                (self.qdrant.url if self.qdrant else None)
+                or self.url
+                or self.custom_params.get("url")
+            )
+            if not qdrant_url:
+                raise ValueError("VectorDB qdrant backend requires 'qdrant.url' or 'url' to be set")
+            if self.qdrant is None:
+                self.qdrant = QdrantConfig()
+            self.qdrant.url = str(qdrant_url).strip().rstrip("/")
+            if self.url:
+                self.url = self.url.strip().rstrip("/")
+
+        elif self.backend == "opengauss":
+            if self.opengauss is None:
+                self.opengauss = OpenGaussConfig()
+            if not self.opengauss.host:
+                raise ValueError("VectorDB opengauss backend requires 'opengauss.host' to be set")
+            self.opengauss.host = self.opengauss.host.strip()
+
+        elif self.backend == "pgvector":
+            if self.pgvector is None:
+                self.pgvector = PgVectorConfig()
+            # Priority chain (mem0-style): url wins over discrete host/port fields.
+            # Normalize whitespace to None first so a blank value never masks a real one.
+            self.pgvector.url = (self.pgvector.url or "").strip() or None
+            self.pgvector.host = (self.pgvector.host or "").strip() or None
+            if not (self.pgvector.url or self.pgvector.host):
+                raise ValueError("VectorDB pgvector backend requires 'url' or 'host' to be set")
 
         return self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,11 @@ auth = [
   "httpx>=0.25.0",
   "python-ldap>=3.4.0",
 ]
+pgvector = [
+    "psycopg2-binary>=2.9",
+    "pgvector>=0.2",
+    "packaging>=20.0",
+]
 dev = [
     "mypy>=1.0.0",
     "ruff>=0.1.0",

--- a/tests/storage/test_pgvector_adapter.py
+++ b/tests/storage/test_pgvector_adapter.py
@@ -1,0 +1,1164 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from __future__ import annotations
+
+import os
+import shutil
+import types
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from openviking.storage.vectordb.collection.collection import Collection, ICollection
+from openviking.storage.vectordb_adapters import pgvector_adapter as pgvector_module
+from openviking.storage.vectordb_adapters.factory import create_collection_adapter
+from openviking.storage.vectordb_adapters.opengauss_adapter import (
+    _safe_identifier,
+    _vector_literal,
+)
+from openviking.storage.vectordb_adapters.pgvector_adapter import (
+    PgVectorCollection,
+    PgVectorCollectionAdapter,
+    _normalize_distance,
+)
+from openviking_cli.utils.config.vectordb_config import (
+    PgVectorConfig,
+    VectorDBBackendConfig,
+)
+
+
+def _build_config() -> VectorDBBackendConfig:
+    return VectorDBBackendConfig.model_validate(
+        {
+            "backend": "pgvector",
+            "project": "default",
+            "name": "context",
+            "index_name": "default",
+            "distance_metric": "cosine",
+            "pgvector": {
+                "host": "127.0.0.1",
+                "port": 5432,
+                "user": "postgres",
+                "password": "postgres",
+                "db_name": "postgres",
+                "schema": "public",
+                "dense_vector_name": "vector",
+                "sparse_vector_name": "sparse_vector",
+            },
+        }
+    )
+
+
+def test_pgvector_backend_config_validation():
+    config = _build_config()
+
+    assert config.backend == "pgvector"
+    assert config.pgvector is not None
+    assert isinstance(config.pgvector, PgVectorConfig)
+    assert config.pgvector.host == "127.0.0.1"
+    assert config.pgvector.port == 5432
+    assert config.pgvector.db_name == "postgres"
+    assert config.pgvector.schema_name == "public"
+
+
+def test_vector_literal_and_identifier_safety():
+    assert _vector_literal([1, 2.5, float("nan")]) == "[1,2.5,0]"
+
+    name = _safe_identifier("Project/With Space", "Context.Table", prefix="ov")
+    assert name.startswith("ov_project_with_space_context_table")
+    assert len(name.encode("utf-8")) <= 63
+
+    # PgVectorCollection re-targets OpenGaussCollection and is-a ICollection.
+    assert issubclass(PgVectorCollection, ICollection)
+
+
+@pytest.mark.parametrize(
+    ("metric", "valid"),
+    [
+        ("cosine", True),
+        ("l2", True),
+        ("ip", True),
+        ("dot", False),
+        ("euclid", False),
+    ],
+    ids=["cosine", "l2", "ip", "reject-dot", "reject-euclid"],
+)
+def test_pgvector_distance_validation(metric, valid):
+    if valid:
+        assert _normalize_distance(metric) == metric
+    else:
+        with pytest.raises(ValueError, match="supports only cosine, l2, and ip"):
+            _normalize_distance(metric)
+
+
+@pytest.mark.parametrize(
+    ("create_extension", "expect_ext"),
+    [(True, True), (False, False)],
+    ids=["create-extension", "pre-provisioned"],
+)
+def test_create_extension_emitted_before_vector_ddl(create_extension, expect_ext):
+    collection = object.__new__(PgVectorCollection)
+    collection._schema_name = "public"
+    collection._table_name = "ov_test"
+    collection._dense_vector_name = "vector"
+    collection._vector_dim = 3
+    collection._create_extension = create_extension
+
+    meta = {
+        "Fields": [
+            {"FieldName": "id", "FieldType": "string", "IsPrimaryKey": True},
+            {"FieldName": "vector", "FieldType": "vector", "Dim": 3},
+        ]
+    }
+    statements = collection._build_create_ddl(meta)
+
+    assert any("vector(3)" in s for s in statements)
+    if expect_ext:
+        assert statements[0] == "CREATE EXTENSION IF NOT EXISTS vector"
+        ext_idx = next(i for i, s in enumerate(statements) if "CREATE EXTENSION" in s)
+        vec_idx = next(i for i, s in enumerate(statements) if "vector(3)" in s)
+        assert ext_idx < vec_idx
+    else:
+        assert all("CREATE EXTENSION" not in s for s in statements)
+
+
+@pytest.mark.parametrize(
+    ("distance", "opclass"),
+    [
+        ("cosine", "vector_cosine_ops"),
+        ("l2", "vector_l2_ops"),
+        ("ip", "vector_ip_ops"),
+    ],
+    ids=["cosine", "l2", "ip"],
+)
+def test_vector_index_creation_supports_hnsw(distance, opclass):
+    collection = object.__new__(PgVectorCollection)
+    collection._schema_name = "public"
+    collection._table_name = "ov_test"
+    collection._dense_vector_name = "vector"
+    statements: list[str] = []
+    collection._all_columns = lambda: ["id", "vector"]
+    collection._execute = lambda sql, params=None, fetch=False: statements.append(sql)
+
+    collection._create_vector_index(
+        "default",
+        distance,
+        {
+            "VectorIndex": {
+                "IndexType": "hnsw",
+                "Distance": distance,
+                "M": 24,
+                "EfConstruction": 128,
+            }
+        },
+    )
+
+    sql = " ".join(statements).lower()
+    assert "using hnsw" in sql
+    assert opclass in sql
+    assert "m = 24" in sql
+    assert "ef_construction = 128" in sql
+
+
+def test_vector_search_binds_vector_before_filter_params():
+    collection = object.__new__(PgVectorCollection)
+    collection._dense_vector_name = "vector"
+    collection._distance_metric = "cosine"
+    collection._select_columns = lambda output_fields, include_sparse=False: ["id"]
+    collection._where_sql = lambda filters: (' WHERE "scope_roots" LIKE %s', ["%\n/a\n%"])
+    collection._table_ref = lambda: '"public"."ov_test"'
+    captured = {}
+
+    def execute(sql, params=None, *, fetch=False):
+        captured["sql"] = sql
+        captured["params"] = params
+        captured["fetch"] = fetch
+        return []
+
+    collection._execute = execute
+
+    collection.search_by_vector(
+        "default",
+        dense_vector=[0.1, 0.2],
+        filters={"op": "must", "field": "scope_roots", "conds": ["/a"]},
+    )
+
+    assert captured["fetch"] is True
+    assert captured["params"] == ["[0.1,0.2]", "%\n/a\n%", "[0.1,0.2]", 10, 0]
+
+
+@pytest.mark.parametrize(
+    ("columns", "values", "expect_update"),
+    [
+        (["id", "content", "vector"], ["doc-1", "hi", "[0.1,0.2]"], True),
+        (["id"], ["doc-1"], False),
+    ],
+    ids=["multi-col-do-update", "id-only-do-nothing"],
+)
+def test_upsert_uses_on_conflict(columns, values, expect_update):
+    collection = object.__new__(PgVectorCollection)
+    collection._schema_name = "public"
+    collection._table_name = "ov_test"
+    collection._dense_vector_name = "vector"
+    captured = {}
+    collection._table_ref = lambda: '"public"."ov_test"'
+
+    def execute(sql, params=None, *, fetch=False):
+        captured["sql"] = sql
+        captured["params"] = params
+        return []
+
+    collection._execute = execute
+    collection._upsert_row(columns, values)
+
+    sql = captured["sql"]
+    assert "INSERT INTO" in sql
+    assert captured["params"] == values
+    if expect_update:
+        assert "ON CONFLICT (id) DO UPDATE SET" in sql
+        assert '"content" = EXCLUDED."content"' in sql
+        assert '"vector" = EXCLUDED."vector"' in sql
+        assert "%s::vector" in sql  # dense vector cast in VALUES
+        assert 'EXCLUDED."id"' not in sql  # id is the conflict key, never updated
+    else:
+        assert "ON CONFLICT (id) DO NOTHING" in sql
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_fragments", "expected_params"),
+    [
+        ({"op": "must", "field": "account_id", "conds": ["acme"]}, ['"account_id" = %s'], ["acme"]),
+        (
+            {"op": "must", "field": "account_id", "conds": ["a", "b"]},
+            ['"account_id" IN (%s, %s)'],
+            ["a", "b"],
+        ),
+        (
+            {"op": "must", "field": "scope_roots", "conds": ["/resources/acme/docs"]},
+            ['"scope_roots" LIKE %s'],
+            ["%\n/resources/acme/docs\n%"],
+        ),
+        (
+            {
+                "op": "range",
+                "field": "updated_at",
+                "gte": "2026-05-01T00:00:00+00:00",
+                "lt": "2026-06-01T00:00:00+00:00",
+            },
+            ['"updated_at" >= %s', '"updated_at" < %s'],
+            ["2026-05-01T00:00:00+00:00", "2026-06-01T00:00:00+00:00"],
+        ),
+        (
+            {
+                "op": "time_range",
+                "field": "updated_at",
+                "gte": "2026-05-01T00:00:00+00:00",
+                "lte": "2026-06-01T00:00:00+00:00",
+            },
+            ['"updated_at" >= %s', '"updated_at" <= %s'],
+            ["2026-05-01T00:00:00+00:00", "2026-06-01T00:00:00+00:00"],
+        ),
+        (
+            {"op": "contains", "field": "abstract", "substring": "report"},
+            ['"abstract" LIKE %s'],
+            ["%report%"],
+        ),
+        ({"op": "prefix", "field": "uri", "prefix": "/r"}, ['"uri" LIKE %s'], ["/r%"]),
+        (
+            {
+                "op": "and",
+                "conds": [
+                    {"op": "must", "field": "account_id", "conds": ["acme"]},
+                    {"op": "contains", "field": "abstract", "substring": "report"},
+                ],
+            },
+            ['"account_id" = %s', '"abstract" LIKE %s', " AND "],
+            ["acme", "%report%"],
+        ),
+    ],
+    ids=["eq", "in", "scope_roots", "range", "time_range", "contains", "prefix", "and"],
+)
+def test_collection_filter_to_sql(payload, expected_fragments, expected_params):
+    collection = object.__new__(PgVectorCollection)
+    collection._field_types = {"updated_at": "date_time"}
+
+    clause, params = collection._compile_filter(payload)
+
+    for fragment in expected_fragments:
+        assert fragment in clause
+    assert params == expected_params
+
+
+@pytest.mark.parametrize(
+    ("supported", "expect_guc"),
+    [(True, True), (False, False)],
+    ids=["v0.8-iterative-scan", "pre-0.8-fallback"],
+)
+def test_iterative_scan_set_when_filtered(supported, expect_guc):
+    collection = object.__new__(PgVectorCollection)
+    collection._schema_name = "public"
+    collection._table_name = "ov_test"
+    collection._dense_vector_name = "vector"
+    collection._distance_metric = "cosine"
+    collection._iterative_scan_supported = supported
+    collection._select_columns = lambda output_fields, include_sparse=False: ["id"]
+    collection._where_sql = lambda filters: (' WHERE "scope_roots" LIKE %s', ["%\n/a\n%"])
+    collection._table_ref = lambda: '"public"."ov_test"'
+    collection._row_to_payload = lambda row, cols: (row[0], {})
+    captured = {}
+
+    def execute(sql, params=None, *, fetch=False):
+        captured["sql"] = sql
+        captured["params"] = params
+        return [(f"id-{i}", 0.1) for i in range(3)]  # full LIMIT of rows
+
+    collection._execute = execute
+
+    result = collection.search_by_vector(
+        "default",
+        dense_vector=[0.1, 0.2],
+        limit=3,
+        filters={"op": "must", "field": "scope_roots", "conds": ["/a"]},
+    )
+
+    sql = captured["sql"]
+    if expect_guc:
+        assert "SET LOCAL hnsw.iterative_scan = strict_order" in sql
+        assert "SET LOCAL hnsw.ef_search" in sql
+        assert "SET LOCAL hnsw.max_scan_tuples" in sql
+        assert "SET LOCAL enable_seqscan = off" in sql
+    else:
+        assert "SET LOCAL hnsw.iterative_scan" not in sql
+
+    # B3.5 param order preserved regardless of the GUC prefix.
+    assert captured["params"] == ["[0.1,0.2]", "%\n/a\n%", "[0.1,0.2]", 3, 0]
+    # Full LIMIT returned under a selective filter.
+    assert len(result.data) == 3
+
+
+@pytest.mark.parametrize(
+    ("pgvector_cfg", "sslmode", "expect_url"),
+    [
+        ({"host": "10.0.0.5", "sslmode": "require"}, "require", False),
+        ({"url": "postgresql://u:p@h:5432/db", "sslmode": "prefer"}, "prefer", True),
+    ],
+    ids=["discrete-require", "url-prefer"],
+)
+def test_sslmode_passed_to_connect(monkeypatch, pgvector_cfg, sslmode, expect_url):
+    captured = {}
+
+    class FakeConn:
+        closed = 0
+
+    def fake_connect(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return FakeConn()
+
+    monkeypatch.setattr(
+        pgvector_module,
+        "_import_psycopg2",
+        lambda: types.SimpleNamespace(connect=fake_connect),
+        raising=False,
+    )
+
+    config = VectorDBBackendConfig.model_validate({"backend": "pgvector", "pgvector": pgvector_cfg})
+    adapter = create_collection_adapter(config)
+    adapter._connect()
+
+    assert captured["kwargs"]["sslmode"] == sslmode
+    if expect_url:
+        assert captured["args"][0] == "postgresql://u:p@h:5432/db"
+    else:
+        assert captured["kwargs"]["host"] == "10.0.0.5"
+
+
+class _FakeCursor:
+    def __init__(self, extversion):
+        self._extversion = extversion
+        self.executed = None
+        self.closed = False
+
+    def execute(self, sql, params=None):
+        self.executed = sql
+
+    def fetchone(self):
+        return (self._extversion,) if self._extversion is not None else None
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeConn:
+    closed = 0
+
+    def __init__(self, extversion):
+        self._extversion = extversion
+        self.last_cursor = None
+
+    def cursor(self):
+        self.last_cursor = _FakeCursor(self._extversion)
+        return self.last_cursor
+
+
+@pytest.mark.parametrize(
+    ("extversion", "hnsw", "halfvec", "iterative"),
+    [
+        ("0.8.2", True, True, True),
+        ("0.7.0", True, True, False),
+        ("0.5.1", True, False, False),
+    ],
+    ids=["v0.8-iterative", "v0.7-halfvec", "v0.5-hnsw-only"],
+)
+def test_version_gate_reads_extversion(extversion, hnsw, halfvec, iterative):
+    adapter = create_collection_adapter(_build_config())
+    adapter._conn = _FakeConn(extversion)
+
+    adapter._detect_version()
+
+    assert "extversion" in adapter._conn.last_cursor.executed
+    assert "extname" in adapter._conn.last_cursor.executed
+    assert adapter._supports_hnsw is hnsw
+    assert adapter._supports_halfvec is halfvec
+    assert adapter._supports_iterative_scan is iterative
+    assert adapter._pgvector_version == extversion
+
+
+def test_version_gate_rejects_pre_hnsw_pgvector():
+    adapter = create_collection_adapter(_build_config())
+    adapter._conn = _FakeConn("0.4.4")
+
+    with pytest.raises(RuntimeError, match="0.5"):
+        adapter._detect_version()
+
+
+@pytest.mark.parametrize(
+    ("pool_size", "expect_pool"),
+    [(1, False), (3, True)],
+    ids=["single-conn", "threaded-pool"],
+)
+def test_register_vector_optional(monkeypatch, pool_size, expect_pool):
+    connect_calls = []
+    pool_calls = {}
+
+    class _Conn:
+        closed = 0
+
+    def fake_connect(*args, **kwargs):
+        connect_calls.append((args, kwargs))
+        return _Conn()
+
+    class _FakePool:
+        def __init__(self, minconn, maxconn, *args, **kwargs):
+            pool_calls["maxconn"] = maxconn
+            pool_calls["args"] = args
+            pool_calls["kwargs"] = kwargs
+
+        def getconn(self):
+            return _Conn()
+
+    # No register_vector attribute on the fake driver: the %s::vector literal
+    # path must work without any driver-level type binding.
+    fake_psycopg2 = types.SimpleNamespace(
+        connect=fake_connect,
+        pool=types.SimpleNamespace(ThreadedConnectionPool=_FakePool),
+    )
+    monkeypatch.setattr(pgvector_module, "_import_psycopg2", lambda: fake_psycopg2, raising=False)
+
+    config = VectorDBBackendConfig.model_validate(
+        {"backend": "pgvector", "pgvector": {"host": "10.0.0.9", "pool_size": pool_size}}
+    )
+    adapter = create_collection_adapter(config)
+    conn = adapter._connect()
+
+    assert conn is not None
+    if expect_pool:
+        assert adapter._pool is not None
+        assert pool_calls["maxconn"] == pool_size
+        assert connect_calls == []  # pool path, no direct connect
+    else:
+        assert adapter._pool is None
+        assert len(connect_calls) == 1
+
+
+class _ExtCursor:
+    def __init__(self, fail_create, ext_present):
+        self._fail_create = fail_create
+        self._ext_present = ext_present
+        self._last = None
+        self.create_attempted = False
+
+    def execute(self, sql, params=None):
+        self._last = sql
+        if "CREATE EXTENSION" in sql:
+            self.create_attempted = True
+            if self._fail_create:
+                raise RuntimeError("permission denied to create extension vector")
+
+    def fetchone(self):
+        if self._last and "pg_extension" in self._last:
+            return (1,) if self._ext_present else None
+        return None
+
+    def close(self):
+        pass
+
+
+class _ExtConn:
+    closed = 0
+
+    def __init__(self, fail_create, ext_present):
+        self._fail_create = fail_create
+        self._ext_present = ext_present
+        self.cursors = []
+
+    def cursor(self):
+        cur = _ExtCursor(self._fail_create, self._ext_present)
+        self.cursors.append(cur)
+        return cur
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+
+@pytest.mark.parametrize(
+    ("create_extension", "fail_create", "ext_present", "expect_raise", "expect_attempt"),
+    [
+        (True, False, False, False, True),
+        (True, True, False, True, True),
+        (True, True, True, False, True),
+        (False, False, False, False, False),
+    ],
+    ids=["creates-ok", "fail-absent-raises", "fail-present-ok", "disabled-skips"],
+)
+def test_create_extension_failure_is_actionable(
+    create_extension, fail_create, ext_present, expect_raise, expect_attempt
+):
+    config = VectorDBBackendConfig.model_validate(
+        {
+            "backend": "pgvector",
+            "pgvector": {"host": "127.0.0.1", "create_extension": create_extension},
+        }
+    )
+    adapter = create_collection_adapter(config)
+    conn = _ExtConn(fail_create, ext_present)
+    adapter._conn = conn
+
+    if expect_raise:
+        with pytest.raises(RuntimeError, match="CREATE EXTENSION vector"):
+            adapter._ensure_extension()
+    else:
+        adapter._ensure_extension()
+
+    assert any(c.create_attempted for c in conn.cursors) is expect_attempt
+
+
+class _RecordingCursor:
+    def __init__(self, log):
+        self._log = log
+        self._last = None
+
+    def execute(self, sql, params=None):
+        self._log.append(sql)
+        self._last = sql
+
+    def fetchone(self):
+        if self._last and "extversion" in self._last:
+            return ("0.8.2",)
+        if self._last and "pg_extension" in self._last:
+            return (1,)
+        return None  # information_schema table-exists -> absent
+
+    def fetchall(self):
+        return []
+
+    def close(self):
+        pass
+
+
+class _RecordingConn:
+    closed = 0
+
+    def __init__(self, log):
+        self._log = log
+
+    def cursor(self):
+        return _RecordingCursor(self._log)
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+
+def _fake_psycopg2(log):
+    return types.SimpleNamespace(
+        connect=lambda *a, **k: _RecordingConn(log),
+        pool=types.SimpleNamespace(ThreadedConnectionPool=lambda *a, **k: None),
+    )
+
+
+def test_create_backend_collection_wires_pgvector_live_flow(monkeypatch):
+    log: list[str] = []
+    monkeypatch.setattr(
+        pgvector_module, "_import_psycopg2", lambda: _fake_psycopg2(log), raising=False
+    )
+    adapter = create_collection_adapter(_build_config())
+    meta = {
+        "CollectionName": "context",
+        "Fields": [
+            {"FieldName": "id", "FieldType": "string", "IsPrimaryKey": True},
+            {"FieldName": "vector", "FieldType": "vector", "Dim": 2},
+        ],
+    }
+
+    collection = adapter._create_backend_collection(meta)
+
+    assert isinstance(collection, Collection)
+    joined = " ".join(log)
+    assert "__openviking_pgvector_collections" in joined
+    assert "__openviking_pgvector_indexes" in joined
+    assert "vector(2)" in joined
+    # version gate ran during _ensure_ready (fake extversion 0.8.2)
+    assert adapter._supports_iterative_scan is True
+
+
+def test_new_collection_threads_feature_flags(monkeypatch):
+    log: list[str] = []
+    monkeypatch.setattr(
+        pgvector_module, "_import_psycopg2", lambda: _fake_psycopg2(log), raising=False
+    )
+    adapter = create_collection_adapter(_build_config())
+
+    raw = adapter._new_collection()
+
+    assert isinstance(raw, pgvector_module.PgVectorCollection)
+    assert raw._iterative_scan_supported is True  # extversion 0.8.2 -> >= 0.8
+    assert raw._create_extension is True
+    assert raw._ef_search == 100
+    assert raw._max_scan_tuples == 20000
+
+
+def test_factory_creates_pgvector_adapter_without_connecting():
+    adapter = create_collection_adapter(_build_config())
+
+    assert isinstance(adapter, PgVectorCollectionAdapter)
+    assert adapter.mode == "pgvector"
+    assert adapter.collection_name == "context"
+    assert adapter.index_name == "default"
+    assert adapter.physical_table_name == "ov_default_context"
+
+
+def test_from_config_reads_top_level_index_distance_dimension():
+    config = VectorDBBackendConfig.model_validate(
+        {
+            "backend": "pgvector",
+            "project": "acme",
+            "name": "docs",
+            "index_name": "hnsw_idx",
+            "distance_metric": "l2",
+            "dimension": 384,
+            "pgvector": {"host": "127.0.0.1"},
+        }
+    )
+    adapter = create_collection_adapter(config)
+
+    assert adapter.index_name == "hnsw_idx"
+    assert adapter._distance_metric == "l2"
+    assert adapter._dimension == 384
+    assert adapter.physical_table_name == "ov_acme_docs"
+
+
+# --- review-feedback regression tests (PR #18) ---------------------------------
+
+
+class _PoolConn:
+    def __init__(self, closed=0):
+        self.closed = closed
+        self.close_called = False
+
+    def close(self):
+        self.close_called = True
+        self.closed = 1
+
+
+class _RecordingPool:
+    def __init__(self):
+        self.putconn_calls = []
+        self.closeall_called = False
+        self.served = []
+
+    def getconn(self):
+        conn = _PoolConn()
+        self.served.append(conn)
+        return conn
+
+    def putconn(self, conn, close=False):
+        self.putconn_calls.append((conn, close))
+
+    def closeall(self):
+        self.closeall_called = True
+
+
+def _pooled_adapter(monkeypatch, pool):
+    fake_psycopg2 = types.SimpleNamespace(
+        connect=lambda *a, **k: _PoolConn(),
+        pool=types.SimpleNamespace(ThreadedConnectionPool=lambda *a, **k: pool),
+    )
+    monkeypatch.setattr(pgvector_module, "_import_psycopg2", lambda: fake_psycopg2, raising=False)
+    config = VectorDBBackendConfig.model_validate(
+        {"backend": "pgvector", "pgvector": {"host": "127.0.0.1", "pool_size": 3}}
+    )
+    return create_collection_adapter(config)
+
+
+def test_import_psycopg2_exposes_pool_submodule():
+    # `import psycopg2` does NOT auto-import psycopg2.pool; the helper must, or
+    # ThreadedConnectionPool access AttributeErrors when pool_size > 1.
+    pytest.importorskip("psycopg2")
+    psycopg2 = pgvector_module._import_psycopg2()
+    assert hasattr(psycopg2, "pool")
+    assert hasattr(psycopg2.pool, "ThreadedConnectionPool")
+
+
+def test_stale_pooled_connection_returned_via_putconn(monkeypatch):
+    pool = _RecordingPool()
+    adapter = _pooled_adapter(monkeypatch, pool)
+
+    first = adapter._connect()
+    assert adapter._pool is pool
+    first.closed = 1  # simulate a dropped connection
+    second = adapter._connect()
+
+    assert (first, True) in pool.putconn_calls  # returned to pool, not just .close()'d
+    assert first.close_called is False
+    assert second is not first
+
+
+def test_close_returns_pooled_conn_and_closes_pool(monkeypatch):
+    pool = _RecordingPool()
+    adapter = _pooled_adapter(monkeypatch, pool)
+    conn = adapter._connect()
+
+    adapter.close()
+
+    assert (conn, True) in pool.putconn_calls
+    assert pool.closeall_called is True
+    assert adapter._conn is None
+    assert adapter._pool is None
+    assert adapter._ready is False
+
+
+def test_close_single_connection_path(monkeypatch):
+    monkeypatch.setattr(
+        pgvector_module,
+        "_import_psycopg2",
+        lambda: types.SimpleNamespace(connect=lambda *a, **k: _PoolConn(), pool=None),
+        raising=False,
+    )
+    adapter = create_collection_adapter(_build_config())  # pool_size default 1
+    conn = adapter._connect()
+
+    adapter.close()
+
+    assert conn.close_called is True
+    assert adapter._conn is None
+
+
+def test_ensure_ready_bootstraps_once(monkeypatch):
+    log: list[str] = []
+    monkeypatch.setattr(
+        pgvector_module, "_import_psycopg2", lambda: _fake_psycopg2(log), raising=False
+    )
+    adapter = create_collection_adapter(_build_config())
+
+    adapter._ensure_ready()
+    adapter._ensure_ready()
+
+    assert adapter._ready is True
+    # extension/version/meta bootstrap ran exactly once despite two calls.
+    assert sum("CREATE EXTENSION" in s for s in log) == 1
+
+
+def test_detect_version_raises_when_extension_absent():
+    adapter = create_collection_adapter(_build_config())
+    adapter._conn = _FakeConn(None)  # no pg_extension row -> extension missing
+
+    with pytest.raises(RuntimeError, match="not installed"):
+        adapter._detect_version()
+
+
+def _meta_collection():
+    collection = object.__new__(PgVectorCollection)
+    collection._schema_name = "public"
+    collection._table_name = "ov_default_context"
+    collection._logical_collection_name = "context"
+    collection._project_name = "default"
+    return collection
+
+
+def test_save_collection_meta_uses_on_conflict_not_merge():
+    collection = _meta_collection()
+    captured = {}
+    collection._execute = lambda sql, params=None, fetch=False: captured.update(
+        sql=sql, params=params
+    )
+
+    collection._save_collection_meta({"CollectionName": "context"})
+
+    sql = captured["sql"]
+    assert "MERGE INTO" not in sql
+    assert "INSERT INTO" in sql
+    assert "ON CONFLICT (table_name) DO UPDATE SET" in sql
+    assert captured["params"][0] == "ov_default_context"
+
+
+def test_save_index_meta_uses_on_conflict_not_merge():
+    collection = _meta_collection()
+    captured = {}
+    collection._execute = lambda sql, params=None, fetch=False: captured.update(
+        sql=sql, params=params
+    )
+
+    collection._save_index_meta("default", {"IndexName": "default"})
+
+    sql = captured["sql"]
+    assert "MERGE INTO" not in sql
+    assert "ON CONFLICT (table_name, index_name) DO UPDATE SET" in sql
+    assert captured["params"][:2] == ["ov_default_context", "default"]
+
+
+def test_update_data_rejects_missing_ids():
+    collection = object.__new__(PgVectorCollection)
+    collection.fetch_data = lambda ids: types.SimpleNamespace(ids_not_exist=["missing-1"])
+    collection.upsert_data = lambda data_list: pytest.fail("must not upsert when ids are missing")
+
+    with pytest.raises(ValueError, match="record not found"):
+        collection.update_data([{"id": "missing-1", "content": "x"}])
+
+
+def test_update_data_upserts_when_all_present():
+    collection = object.__new__(PgVectorCollection)
+    seen = {}
+
+    def _fake_upsert(data_list):
+        seen["data"] = data_list
+        return "OK"
+
+    collection.fetch_data = lambda ids: types.SimpleNamespace(ids_not_exist=[])
+    collection.upsert_data = _fake_upsert
+
+    result = collection.update_data([{"id": "a", "content": "x"}])
+
+    assert result == "OK"
+    assert seen["data"] == [{"id": "a", "content": "x"}]
+
+
+def test_update_data_requires_primary_key():
+    collection = object.__new__(PgVectorCollection)
+    collection.fetch_data = lambda ids: types.SimpleNamespace(ids_not_exist=[])
+
+    with pytest.raises(ValueError, match="primary key 'id' is required"):
+        collection.update_data([{"content": "x"}])
+
+
+@pytest.mark.parametrize(
+    ("params", "expect_m", "expect_ef"),
+    [
+        ({"m": 24, "ef_construction": 128}, 24, 128),
+        ({"M": 32, "EfConstruction": 200}, 32, 200),
+    ],
+    ids=["lowercase", "camelcase"],
+)
+def test_index_params_reach_default_index_meta(params, expect_m, expect_ef):
+    config = VectorDBBackendConfig.model_validate(
+        {"backend": "pgvector", "pgvector": {"host": "127.0.0.1", "index_params": params}}
+    )
+    adapter = create_collection_adapter(config)
+
+    meta = adapter._build_default_index_meta(
+        index_name="default",
+        distance="cosine",
+        use_sparse=False,
+        sparse_weight=0.0,
+        scalar_index_fields=[],
+    )
+
+    assert meta["VectorIndex"]["M"] == expect_m
+    assert meta["VectorIndex"]["EfConstruction"] == expect_ef
+
+
+def test_default_index_meta_omits_build_params_without_config():
+    adapter = create_collection_adapter(_build_config())
+
+    meta = adapter._build_default_index_meta(
+        index_name="default",
+        distance="cosine",
+        use_sparse=False,
+        sparse_weight=0.0,
+        scalar_index_fields=[],
+    )
+
+    assert "M" not in meta["VectorIndex"]
+    assert "EfConstruction" not in meta["VectorIndex"]
+
+
+def test_coerce_int_actionable_error():
+    assert pgvector_module._coerce_int(None, "m", 16) == 16
+    assert pgvector_module._coerce_int("24", "m", 16) == 24
+    with pytest.raises(ValueError, match=r"index_params\['m'\]"):
+        pgvector_module._coerce_int("big", "m", 16)
+
+
+@pytest.mark.parametrize("field", ["dense_vector_name", "sparse_vector_name"])
+def test_pgvector_config_rejects_blank_vector_name(field):
+    with pytest.raises(ValidationError, match="must not be empty"):
+        VectorDBBackendConfig.model_validate(
+            {"backend": "pgvector", "pgvector": {"host": "127.0.0.1", field: "   "}}
+        )
+
+
+def test_pgvector_config_rejects_non_int_index_params():
+    with pytest.raises(ValidationError, match="must be an integer"):
+        VectorDBBackendConfig.model_validate(
+            {
+                "backend": "pgvector",
+                "pgvector": {"host": "127.0.0.1", "index_params": {"m": "big"}},
+            }
+        )
+
+
+def test_pgvector_config_new_field_defaults():
+    pg = _build_config().pgvector
+
+    assert pg.url is None
+    assert pg.sslmode == "prefer"
+    assert pg.index_type == "hnsw"
+    assert pg.index_params == {}
+    assert pg.pool_size == 1
+    assert pg.create_extension is True
+
+
+def test_pgvector_backend_requires_url_or_host():
+    # A url-only config validates (discrete host cleared).
+    url_only = VectorDBBackendConfig.model_validate(
+        {
+            "backend": "pgvector",
+            "pgvector": {"url": "postgresql://u:p@db.example:5432/app", "host": None},
+        }
+    )
+    assert url_only.pgvector.url == "postgresql://u:p@db.example:5432/app"
+
+    # A discrete-field config (host, no url) also validates.
+    discrete = VectorDBBackendConfig.model_validate(
+        {"backend": "pgvector", "pgvector": {"host": "10.0.0.1"}}
+    )
+    assert discrete.pgvector.host == "10.0.0.1"
+
+    # Neither url nor host is a hard error.
+    with pytest.raises(ValidationError, match="requires 'url' or 'host'"):
+        VectorDBBackendConfig.model_validate(
+            {"backend": "pgvector", "pgvector": {"url": None, "host": None}}
+        )
+
+
+def test_pgvector_backend_url_priority_and_whitespace_normalization():
+    # url wins when both are set; both are stripped.
+    both = VectorDBBackendConfig.model_validate(
+        {
+            "backend": "pgvector",
+            "pgvector": {"url": "  postgresql://h/db  ", "host": "  10.0.0.2  "},
+        }
+    )
+    assert both.pgvector.url == "postgresql://h/db"
+    assert both.pgvector.host == "10.0.0.2"
+
+    # Whitespace-only url + empty host normalizes to empty -> clear error.
+    with pytest.raises(ValidationError, match="requires 'url' or 'host'"):
+        VectorDBBackendConfig.model_validate(
+            {"backend": "pgvector", "pgvector": {"url": "   ", "host": ""}}
+        )
+
+
+_SMOKE_HOST_ENV = {
+    "pgvector": "OPENVIKING_PGVECTOR_HOST",
+    "opengauss": "OPENVIKING_OPENGAUSS_HOST",
+}
+
+
+def _smoke_config(backend, project):
+    base = {
+        "backend": backend,
+        "project": project,
+        "name": "context",
+        "index_name": "default",
+        "distance_metric": "cosine",
+        "dimension": 3,
+    }
+    if backend == "pgvector":
+        base["pgvector"] = {
+            "host": os.getenv("OPENVIKING_PGVECTOR_HOST", "127.0.0.1"),
+            "port": int(os.getenv("OPENVIKING_PGVECTOR_PORT", "15432")),
+            "user": os.getenv("OPENVIKING_PGVECTOR_USER", "postgres"),
+            "password": os.getenv("OPENVIKING_PGVECTOR_PASSWORD", "postgres"),
+            "db_name": os.getenv("OPENVIKING_PGVECTOR_DB", "postgres"),
+            "schema": os.getenv("OPENVIKING_PGVECTOR_SCHEMA", "public"),
+        }
+    elif backend == "opengauss":
+        base["opengauss"] = {
+            "host": os.getenv("OPENVIKING_OPENGAUSS_HOST", "127.0.0.1"),
+            "port": int(os.getenv("OPENVIKING_OPENGAUSS_PORT", "5432")),
+            "user": os.getenv("OPENVIKING_OPENGAUSS_USER", "omm"),
+            "password": os.getenv("OPENVIKING_OPENGAUSS_PASSWORD", ""),
+            "db_name": os.getenv("OPENVIKING_OPENGAUSS_DB", "postgres"),
+            "schema": os.getenv("OPENVIKING_OPENGAUSS_SCHEMA", "public"),
+            "mode": os.getenv("OPENVIKING_OPENGAUSS_MODE", "standalone"),
+        }
+    return VectorDBBackendConfig.model_validate(base)
+
+
+# A golden fixture whose nearest neighbour to the query [1, 0, 0] is unambiguous:
+# doc-a is identical, doc-b is close, doc-c is orthogonal — all under the same
+# scope so a scope_roots filter keeps all three.
+_SMOKE_QUERY = [1.0, 0.0, 0.0]
+_SMOKE_RECORDS = [
+    ("doc-a", "viking://resources/acme/docs/a.md", [1.0, 0.0, 0.0]),
+    ("doc-b", "viking://resources/acme/docs/b.md", [0.8, 0.2, 0.0]),
+    ("doc-c", "viking://resources/acme/docs/c.md", [0.0, 1.0, 0.0]),
+]
+_SMOKE_META = {
+    "CollectionName": "context",
+    "Fields": [
+        {"FieldName": "id", "FieldType": "string", "IsPrimaryKey": True},
+        {"FieldName": "uri", "FieldType": "path"},
+        {"FieldName": "vector", "FieldType": "vector", "Dim": 3},
+        {"FieldName": "abstract", "FieldType": "string"},
+    ],
+}
+
+
+def _run_pgvector_smoke(adapter):
+    collection = adapter._new_collection(_SMOKE_META)
+    try:
+        collection.create_remote_collection(_SMOKE_META)
+        collection.create_index(
+            "default",
+            {
+                "IndexName": "default",
+                "VectorIndex": {"IndexType": "hnsw", "Distance": "cosine"},
+                "ScalarIndex": ["uri", "parent_uri", "scope_roots"],
+            },
+        )
+        collection.upsert_data(
+            [
+                adapter._normalize_record_for_write(
+                    {"id": rid, "uri": uri, "vector": vec, "abstract": rid}
+                )
+                for rid, uri, vec in _SMOKE_RECORDS
+            ]
+        )
+
+        result = collection.search_by_vector(
+            "default",
+            dense_vector=_SMOKE_QUERY,
+            limit=3,
+            filters={"op": "must", "field": "scope_roots", "conds": ["/resources/acme/docs"]},
+        )
+        count = collection.aggregate_data("default")
+
+        ids = [item.id for item in result.data]
+        assert ids[0] == "doc-a", ids  # exact nearest
+        assert ids == ["doc-a", "doc-b", "doc-c"], ids  # cosine-distance order
+        assert len(result.data) == 3  # min(K, limit) under a selective filter
+        assert count.agg["_total"] == 3
+    finally:
+        collection.drop()
+        adapter.close()
+
+
+@pytest.mark.skipif(
+    not os.getenv("OPENVIKING_PGVECTOR_HOST"),
+    reason="set OPENVIKING_PGVECTOR_HOST to run the pgvector integration smoke test",
+)
+def test_pgvector_adapter_integration_smoke():
+    suffix = uuid.uuid4().hex[:8]
+    adapter = create_collection_adapter(_smoke_config("pgvector", f"pytest_{suffix}"))
+    _run_pgvector_smoke(adapter)
+
+
+@pytest.fixture(scope="module")
+def pgvector_container():
+    """A self-contained pgvector server started by testcontainers.
+
+    Unlike the ``OPENVIKING_PGVECTOR_HOST`` tests (which target an externally-run
+    container), this spins up ``pgvector/pgvector:pg16`` itself and tears it down
+    after the module. Opt-in via ``OPENVIKING_PGVECTOR_TESTCONTAINERS`` so the
+    default ``pytest tests/storage`` run never pulls an image; skips gracefully
+    if Docker or testcontainers is unavailable. The adapter creates the ``vector``
+    extension on connect (``create_extension=true``), so no init SQL is needed.
+    """
+    if not os.getenv("OPENVIKING_PGVECTOR_TESTCONTAINERS"):
+        pytest.skip("set OPENVIKING_PGVECTOR_TESTCONTAINERS=1 to run the testcontainers smoke")
+    if shutil.which("docker") is None:
+        pytest.skip("docker is not available for the testcontainers pgvector run")
+    try:
+        from testcontainers.postgres import PostgresContainer
+    except ImportError:
+        pytest.skip("testcontainers not installed (pip install 'openviking[test]')")
+
+    try:
+        container = PostgresContainer(
+            "pgvector/pgvector:pg16", username="postgres", password="postgres", dbname="postgres"
+        )
+        container.start()
+    except Exception as exc:  # pragma: no cover - environment-dependent
+        pytest.skip(f"could not start pgvector testcontainer: {exc}")
+
+    try:
+        yield container
+    finally:
+        container.stop()
+
+
+def test_pgvector_integration_smoke_testcontainers(pgvector_container):
+    config = VectorDBBackendConfig.model_validate(
+        {
+            "backend": "pgvector",
+            "project": f"pytest_tc_{uuid.uuid4().hex[:8]}",
+            "name": "context",
+            "index_name": "default",
+            "distance_metric": "cosine",
+            "dimension": 3,
+            "pgvector": {
+                "host": pgvector_container.get_container_host_ip(),
+                "port": int(pgvector_container.get_exposed_port(5432)),
+                "user": "postgres",
+                "password": "postgres",
+                "db_name": "postgres",
+                "schema": "public",
+            },
+        }
+    )
+    _run_pgvector_smoke(create_collection_adapter(config))
+
+
+@pytest.mark.parametrize("backend", ["opengauss", "pgvector"], ids=["opengauss", "pgvector"])
+def test_cross_backend_smoke_parity(backend):
+    """The same golden fixture + assertions must hold for both SQL backends,
+    proving openGauss<->pgvector parity. Each backend skips unless its host env
+    var is set, so this runs against whichever container(s) are available."""
+    host_env = _SMOKE_HOST_ENV[backend]
+    if not os.getenv(host_env):
+        pytest.skip(f"set {host_env} to run the {backend} parity smoke")
+    suffix = uuid.uuid4().hex[:8]
+    try:
+        adapter = create_collection_adapter(_smoke_config(backend, f"pytest_{suffix}"))
+    except Exception as exc:  # pragma: no cover - environment-dependent
+        pytest.skip(f"{backend} adapter unavailable: {exc}")
+    _run_pgvector_smoke(adapter)

--- a/uv.lock
+++ b/uv.lock
@@ -1095,7 +1095,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2011,13 +2011,13 @@ name = "langchain-classic"
 version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core", marker = "python_full_version >= '3.11'" },
-    { name = "langchain-text-splitters", marker = "python_full_version >= '3.11'" },
-    { name = "langsmith", marker = "python_full_version >= '3.11'" },
-    { name = "pydantic", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
-    { name = "requests", marker = "python_full_version >= '3.11'" },
-    { name = "sqlalchemy", marker = "python_full_version >= '3.11'" },
+    { name = "langchain-core" },
+    { name = "langchain-text-splitters" },
+    { name = "langsmith" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sqlalchemy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/6f/59da67274d8ceea16d0610142af33e348a24750894f08c0688de01504ff2/langchain_classic-1.0.2.tar.gz", hash = "sha256:bbf686613d0051905794f2646ecb6a79fa398db399750a4af039107d93054335", size = 10533928, upload-time = "2026-03-06T20:19:46.176Z" }
 wheels = [
@@ -2032,18 +2032,18 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version < '3.11'" },
-    { name = "dataclasses-json", marker = "python_full_version < '3.11'" },
-    { name = "httpx-sse", marker = "python_full_version < '3.11'" },
-    { name = "langchain", marker = "python_full_version < '3.11'" },
-    { name = "langchain-core", marker = "python_full_version < '3.11'" },
-    { name = "langsmith", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pydantic-settings", marker = "python_full_version < '3.11'" },
-    { name = "pyyaml", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "sqlalchemy", marker = "python_full_version < '3.11'" },
-    { name = "tenacity", marker = "python_full_version < '3.11'" },
+    { name = "aiohttp" },
+    { name = "dataclasses-json" },
+    { name = "httpx-sse" },
+    { name = "langchain" },
+    { name = "langchain-core" },
+    { name = "langsmith" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "pydantic-settings" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sqlalchemy" },
+    { name = "tenacity" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/49/2ff5354273809e9811392bc24bcffda545a196070666aef27bc6aacf1c21/langchain_community-0.3.31.tar.gz", hash = "sha256:250e4c1041539130f6d6ac6f9386cb018354eafccd917b01a4cff1950b80fd81", size = 33241237, upload-time = "2025-10-07T20:17:57.857Z" }
 wheels = [
@@ -2069,18 +2069,18 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version >= '3.11'" },
-    { name = "dataclasses-json", marker = "python_full_version >= '3.11'" },
-    { name = "httpx-sse", marker = "python_full_version >= '3.11'" },
-    { name = "langchain-classic", marker = "python_full_version >= '3.11'" },
-    { name = "langchain-core", marker = "python_full_version >= '3.11'" },
-    { name = "langsmith", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pydantic-settings", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
-    { name = "requests", marker = "python_full_version >= '3.11'" },
-    { name = "sqlalchemy", marker = "python_full_version >= '3.11'" },
-    { name = "tenacity", marker = "python_full_version >= '3.11'" },
+    { name = "aiohttp" },
+    { name = "dataclasses-json" },
+    { name = "httpx-sse" },
+    { name = "langchain-classic" },
+    { name = "langchain-core" },
+    { name = "langsmith" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "pydantic-settings" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sqlalchemy" },
+    { name = "tenacity" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/97/a03585d42b9bdb6fbd935282d6e3348b10322a24e6ce12d0c99eb461d9af/langchain_community-0.4.1.tar.gz", hash = "sha256:f3b211832728ee89f169ddce8579b80a085222ddb4f4ed445a46e977d17b1e85", size = 33241144, upload-time = "2025-10-27T15:20:32.504Z" }
 wheels = [
@@ -2125,7 +2125,7 @@ name = "langchain-text-splitters"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core", marker = "python_full_version >= '3.11'" },
+    { name = "langchain-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/38/14121ead61e0e75f79c3a35e5148ac7c2fe754a55f76eab3eed573269524/langchain_text_splitters-1.1.1.tar.gz", hash = "sha256:34861abe7c07d9e49d4dc852d0129e26b32738b60a74486853ec9b6d6a8e01d2", size = 279352, upload-time = "2026-02-18T23:02:42.798Z" }
 wheels = [
@@ -2521,7 +2521,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version < '3.11'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
@@ -2547,7 +2547,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version >= '3.11'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
@@ -2983,12 +2983,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "mdit-py-plugins", marker = "python_full_version < '3.11'" },
-    { name = "pyyaml", marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "jinja2" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
 wheels = [
@@ -3014,12 +3014,12 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "jinja2", marker = "python_full_version >= '3.11'" },
-    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "mdit-py-plugins", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "jinja2" },
+    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/fa/7b45eef11b7971f0beb29d27b7bfe0d747d063aa29e170d9edd004733c8a/myst_parser-5.0.0.tar.gz", hash = "sha256:f6f231452c56e8baa662cc352c548158f6a16fcbd6e3800fc594978002b94f3a", size = 98535, upload-time = "2026-01-15T09:08:18.036Z" }
@@ -3552,6 +3552,11 @@ local-embed = [
 ocr = [
     { name = "pytesseract" },
 ]
+pgvector = [
+    { name = "packaging" },
+    { name = "pgvector" },
+    { name = "psycopg2-binary" },
+]
 test = [
     { name = "boto3" },
     { name = "datasets" },
@@ -3629,14 +3634,17 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-asyncio", specifier = ">=0.61b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.14" },
     { name = "openviking-sdk", specifier = ">=0.1.9" },
+    { name = "packaging", marker = "extra == 'pgvector'", specifier = ">=20.0" },
     { name = "pandas", marker = "extra == 'benchmark'", specifier = ">=2.0.0" },
     { name = "pandas", marker = "extra == 'eval'", specifier = ">=2.0.0" },
     { name = "pandas", marker = "extra == 'test'", specifier = ">=2.0.0" },
     { name = "pathspec", specifier = ">=1.1.1" },
     { name = "pdfminer-six", specifier = ">=20251230" },
     { name = "pdfplumber", specifier = ">=0.10.0" },
+    { name = "pgvector", marker = "extra == 'pgvector'", specifier = ">=0.2" },
     { name = "prompt-toolkit", marker = "extra == 'bot'", specifier = ">=3.0.0" },
     { name = "protobuf", specifier = ">=6.33.5" },
+    { name = "psycopg2-binary", marker = "extra == 'pgvector'", specifier = ">=2.9" },
     { name = "py-machineid", marker = "extra == 'bot'", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", marker = "extra == 'bot'", specifier = ">=2.0.0" },
@@ -3698,7 +3706,7 @@ requires-dist = [
     { name = "wheel", marker = "extra == 'build'" },
     { name = "xxhash", specifier = ">=3.0.0" },
 ]
-provides-extras = ["test", "auth", "dev", "doc", "eval", "gemini", "gemini-async", "ocr", "build", "bot", "benchmark", "local-embed"]
+provides-extras = ["test", "auth", "pgvector", "dev", "doc", "eval", "gemini", "gemini-async", "ocr", "build", "bot", "benchmark", "local-embed"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=9.0.2" }]
@@ -3869,10 +3877,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -3944,9 +3952,9 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/0c/b28ed414f080ee0ad153f848586d61d1878f91689950f037f976ce15f6c8/pandas-3.0.1.tar.gz", hash = "sha256:4186a699674af418f655dbd420ed87f50d56b4cd6603784279d9eef6627823c8", size = 4641901, upload-time = "2026-02-17T22:20:16.434Z" }
 wheels = [
@@ -4049,6 +4057,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/37/9ca3519e92a8434eb93be570b131476cc0a4e840bb39c62ddb7813a39d53/pdfplumber-0.11.9.tar.gz", hash = "sha256:481224b678b2bbdbf376e2c39bf914144eef7c3d301b4a28eebf0f7f6109d6dc", size = 102768, upload-time = "2026-01-05T08:10:29.072Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/c8/cdbc975f5b634e249cfa6597e37c50f3078412474f21c015e508bfbfe3c3/pdfplumber-0.11.9-py3-none-any.whl", hash = "sha256:33ec5580959ba524e9100138746e090879504c42955df1b8a997604dd326c443", size = 60045, upload-time = "2026-01-05T08:10:27.512Z" },
+]
+
+[[package]]
+name = "pgvector"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/ec/6eb80aebc728200f95229219882994c1b0585b956ca47da5edb9d062627a/pgvector-0.5.0.tar.gz", hash = "sha256:07a9dcf735696879406983afc6eba9a787cef7c0cf6c367ca1a5779f036dee74", size = 35170, upload-time = "2026-07-06T18:27:27.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e4/a5573f2c579ca9ad133293bfb624148ba0893674ca4a6eeec85ced9a6a09/pgvector-0.5.0-py3-none-any.whl", hash = "sha256:fedc9800894e6da2be51358d7b7c574bf34f247ca741a5a09513622135f5964f", size = 30958, upload-time = "2026-07-06T18:27:26.797Z" },
 ]
 
 [[package]]
@@ -4344,6 +4361,80 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
     { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
     { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
+]
+
+[[package]]
+name = "psycopg2-binary"
+version = "2.9.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/76/7b4383014be0fcc6c1c0e24292845a14e1672cf17fca62ca0a2bd5f4563d/psycopg2_binary-2.9.13.tar.gz", hash = "sha256:e324ecf60f952d21dd11413b8bbed0951bbd99579a06fd06f28bfc37737cd373", size = 378112, upload-time = "2026-09-10T00:06:12.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/5d/4a82fcded401927a320ba4e0fd341f75ec7c83e92f5c1388ba27ccb21f91/psycopg2_binary-2.9.13-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c519e406287085f43aa0d3061936edf1ba51286093532f215315c6ab8ba92c3b", size = 3725660, upload-time = "2026-09-09T23:54:05.509Z" },
+    { url = "https://files.pythonhosted.org/packages/27/ef/e6f9280c2327e52f6c139ab549e57a21202b724384d4697dce5794c59f64/psycopg2_binary-2.9.13-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:086659ab083119f7ee87a779e31b94211cf162b708fc9a6bec771f75c73ac3e6", size = 3817358, upload-time = "2026-09-09T23:54:07.829Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b2/412c92a391472644e4059dc68cb20bc9bc40be2ca61eeb5882aa86b092d7/psycopg2_binary-2.9.13-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1f4c7bdbafdf9dc018efbc29213b73f8308332888ba76a4cf503f560bfd21705", size = 4585517, upload-time = "2026-09-09T23:54:10.588Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/96/ce330aa1959250e6fd254678e6489b3b39eb956669122ad4b45dde3b02c3/psycopg2_binary-2.9.13-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d2fc9342aad969b9a28490a4c3eaba94b35beb2d26e9a39b31d1430378aa71b2", size = 4281153, upload-time = "2026-09-09T23:54:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/29/b41c62219b232c9631db1a8cfb99a93abb9afb8a00291579b830f756ce89/psycopg2_binary-2.9.13-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f124954a32640dfb5c000d33028f48053930d7ff226bc74cde5fb316f9c6fcb6", size = 5900983, upload-time = "2026-09-09T23:54:14.873Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e9/40febef96f95ebc08754d4a70332fa8da1c280c9fcda420b8896b2f8d855/psycopg2_binary-2.9.13-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c24c98fe1a113db287dfb1958771eafca97b7db812f23b7897c2a12b6b904c22", size = 4118632, upload-time = "2026-09-09T23:54:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/68/5fef23ee856d70b152a46fe3d33264971bc0daab658d88a76a9e6cab7a28/psycopg2_binary-2.9.13-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f4cdfe41149dcc5583a3b7a2f0ad433f75bb3afd1c7a7332e63df89b05e34666", size = 3659631, upload-time = "2026-09-09T23:54:19.396Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/7b1fe00770083c303a835267dafbcbd7a346ba7b79909652f4ec484ca7fc/psycopg2_binary-2.9.13-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:33a6d3c47f9655b481b2cdc1b4bf71c235e054e55663d3066036b6ce5fbe5165", size = 3305176, upload-time = "2026-09-09T23:54:21.532Z" },
+    { url = "https://files.pythonhosted.org/packages/76/fe/ef2e4adcb7cf20572235da4d2d24b98788466d4e62ce2db72be865859d0c/psycopg2_binary-2.9.13-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:202dedd5cadb3e5dfd4d0415ab2fc5d5b44f4208de5308938e3e74ae222b638e", size = 3051629, upload-time = "2026-09-09T23:54:23.634Z" },
+    { url = "https://files.pythonhosted.org/packages/42/49/a040b3d596cf4128656d24a5b735b0628bb196d7ab73c0164898ca90e420/psycopg2_binary-2.9.13-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:db31cf7f617a51625f1473d8a66fc35dac159af8b28e80bc014ed3ee994a9fbf", size = 3353122, upload-time = "2026-09-09T23:54:25.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/5a/c4b1cdba78d3f60389d768db580cb9255b6bd1f01df98e5131b26322133c/psycopg2_binary-2.9.13-cp310-cp310-win_amd64.whl", hash = "sha256:28eb30bf4a52c1117406f45771038faa96f882fdeeeb0ce43b960a1dbc6c1fd2", size = 2767600, upload-time = "2026-09-09T23:54:27.553Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/03/639c96ff8ffb933868252308a9917ff4170d8c7f4bd16cd0ea2536814126/psycopg2_binary-2.9.13-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d19aec88857d2a52f99eefcefdbbb45921fb2f777bee5186a355a23d9cf8a0b9", size = 3725651, upload-time = "2026-09-09T23:54:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/53/5e/d50eb688e7e6dfd1499e68cf2d02f44a348b88f381cbc2bebeed15e345f4/psycopg2_binary-2.9.13-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:32cd049095135d2b69e824aea9056745a4aaaa9115a9febbc65584793665d0d0", size = 3817384, upload-time = "2026-09-09T23:54:31.118Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/f3/4004cfbbfc52b9b13ffd499f2103eb05246e92828c7237d2c198e028b95c/psycopg2_binary-2.9.13-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6e696297891b56ff0115f0665de6ad774e1e301e4f60745b8d5024001ae7c2f6", size = 4585497, upload-time = "2026-09-09T23:54:33.169Z" },
+    { url = "https://files.pythonhosted.org/packages/97/63/057c65532bd12cdf9d4f568e59c2a078a38e9ba8f7f251292968dc781905/psycopg2_binary-2.9.13-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:930e7e58b33a4f9c39e7532d7a40147925cf3372baed4229cbebe0cf3ba9ce6b", size = 4281172, upload-time = "2026-09-09T23:54:35.747Z" },
+    { url = "https://files.pythonhosted.org/packages/43/4b/9fd928eaea9ec1e8d74fed83c9e82826f830506ba0d8c58a8fd41ca93656/psycopg2_binary-2.9.13-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3aea95340825f5ff236e7b40f0b5602c2c77a1e95943f71fae34909834043d29", size = 5900973, upload-time = "2026-09-09T23:54:37.866Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/2b/59e1519a22622169e2244f12227b3acde6114ea531a349292f455ab8503f/psycopg2_binary-2.9.13-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:27e539b4cafd5e03dcd32921db1b12dd72fe549dd06bae6d4d2a5b5838465f24", size = 4118611, upload-time = "2026-09-09T23:54:39.739Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c7/c3d84e330d1584efa0560b756914f9128b1b6fa2aba93fde54bf101d4f65/psycopg2_binary-2.9.13-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0a6444ac48e2c04f691c2ddd542b38ba30c89463a2d446b3d74ec7d8fc90c964", size = 3659643, upload-time = "2026-09-09T23:54:41.882Z" },
+    { url = "https://files.pythonhosted.org/packages/af/fc/317d248503aa29a5051ee49a7253daffe1c57e43ba174020e00bbd87c479/psycopg2_binary-2.9.13-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:8cb734989420c18ca1b71a82da880e11988f5ff3fcdaadd669161de3e98794ac", size = 3305145, upload-time = "2026-09-09T23:54:43.818Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/d2/8b23c57591c6d29a463748ffc634401ce14719dba7e78ab91bcbeac70934/psycopg2_binary-2.9.13-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:f47f23db2d70db39cfb714b64fd5df76595b51b2ec0a669710a78f2dceb0c3f8", size = 3051614, upload-time = "2026-09-09T23:54:45.548Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/f2/b10a046cc19ab1e01b92226eeb6e8653be7e6691939991b2f347995831b1/psycopg2_binary-2.9.13-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f28b5f2fa8154d0d97e97a664136f58d1639ca008d45d6e09e69fff24826abee", size = 3353133, upload-time = "2026-09-09T23:54:47.285Z" },
+    { url = "https://files.pythonhosted.org/packages/40/2c/dd379facaa4bd41d7b04711ff30931ca62981c00a91502250ffb49da08a7/psycopg2_binary-2.9.13-cp311-cp311-win_amd64.whl", hash = "sha256:70d091f5c3a6177fac50c0da20181ce0e0c053f1e43c872d5f75bd6d9429c020", size = 2771441, upload-time = "2026-09-09T23:54:49.016Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/d0125c56b865e3bc9f318d84930b2df71a729229dbb0ce12de748a82a6d7/psycopg2_binary-2.9.13-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2bf9f97a6df69a5d89d054b8cf5257a0916096c479800715fbfe7974dbcb3a26", size = 3725735, upload-time = "2026-09-09T23:54:51.182Z" },
+    { url = "https://files.pythonhosted.org/packages/54/a5/b5a73d0910555e38ee12c49c1740855f8a1e9776e87d65f0c51e1bab762a/psycopg2_binary-2.9.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:07b7bd9f410650c34c3532162cc329f112368d78a3fc8668cb1ea9df61bc11bf", size = 3818000, upload-time = "2026-09-09T23:54:53.229Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/43/3e4783f62ae3f4fc19a5acf8d1c394df54458f1336febe188f317556d2a7/psycopg2_binary-2.9.13-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:0463c00f946517f3e69192a59e6601e023ff9de45ad0a875eda3d6b1bebeb7ce", size = 4585760, upload-time = "2026-09-09T23:54:55.313Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/c4/a9a67ae65ad3d567eb0fc9cdf9a5a2783b779aecdcdc8945f1807b13d99e/psycopg2_binary-2.9.13-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e3861eba31f8ea8663fd876166b032fd89179e42aa63764d6feb281f13f9eb60", size = 4282380, upload-time = "2026-09-09T23:54:57.362Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/db/9d459d3da12e0b841cf1596579455aaa27e9e593e3e9a5a4ded5a55a7c15/psycopg2_binary-2.9.13-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3dc3372b3731b3ef23407fe06b94f640ef87a2bda242fa386033d5589c87514a", size = 5902039, upload-time = "2026-09-09T23:55:01.955Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/53/21079c10a581c50b6817498eda7c3481c1b3cdb41482bd08ebfccd3664c4/psycopg2_binary-2.9.13-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0405dd4d97720e7ab177aa02e493f524907c4cb3c445ac173e2627948d3d0528", size = 4119840, upload-time = "2026-09-09T23:55:04.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ce/71e8d9e1b4f3e78157b49a5abdff50d915e95f2812550f6c9b4f2e4d5e94/psycopg2_binary-2.9.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b6ae51708201f501a171b02419d0c30878a743c369c9054eb1289f0f8d5979e2", size = 3661077, upload-time = "2026-09-09T23:55:06.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/54/b17616472f09a0fae96f8852692948b7eaa7c971d7629696da0e5932d996/psycopg2_binary-2.9.13-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:81682c227cc1849c4a6adf7b85274229073bb4c9d6ad5697222c695dcea5a8a7", size = 3307202, upload-time = "2026-09-09T23:55:08.061Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c7/d9737e222a377dac67a0ce0a2c73e7231a57f5cf18bb35a65d5c8d45d5d2/psycopg2_binary-2.9.13-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:13d955f6054a705a19554364fe9888d0a6e8b0746dc7ebc08a447c7b4fd4145c", size = 3052893, upload-time = "2026-09-09T23:55:10.209Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/3d/c406c9f698f518c264381192c2bdf8952ee84e469ffa9f82db1411f57385/psycopg2_binary-2.9.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7e2405196a8cfe6cd3e54172a54452dcf85c241eaf2e9dde7190d7469f7f5ef7", size = 3355210, upload-time = "2026-09-09T23:55:11.883Z" },
+    { url = "https://files.pythonhosted.org/packages/27/64/6e3a96699770af2d0d49a2002f722c69b656fc27623ff89281cf2b109644/psycopg2_binary-2.9.13-cp312-cp312-win_amd64.whl", hash = "sha256:376ebf7d8aee4b7386b2bac31fdc27911e7e57cd0a88f1e038b8b149398ac008", size = 2767784, upload-time = "2026-09-09T23:55:13.823Z" },
+    { url = "https://files.pythonhosted.org/packages/82/0a/795f2869788373cf7d08410341a444196e8ccebbac07a70a8f9a1f60e72f/psycopg2_binary-2.9.13-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4d66bfd44a46eb88cff0287929a4193fb45166b6c1f84bb1b233cc17ece0813c", size = 3725723, upload-time = "2026-09-09T23:55:15.887Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/63/5a9633f4563a73beba69b20a846ddd14c1c6ac072f5e8aab0da97ffabc2a/psycopg2_binary-2.9.13-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f818161d2302b3b3e9c75d5a1d0a5c5679e92e45cfec6432b9d5432dde5ff1f1", size = 3817976, upload-time = "2026-09-09T23:55:18.025Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/e2/b2e3b3a4331dc8b58e328cda30f3d0cc43a94b7aaf0c8383efd53dd10e95/psycopg2_binary-2.9.13-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:31db6cba66df5231dfd91d9f69188bec3fe6c8baae384e93a0ce792067ee2d98", size = 4585813, upload-time = "2026-09-09T23:55:20.112Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5c/87daea77c4132114d1a5da3a4928dd59446c3b3cc73d288cae08cf0b91a6/psycopg2_binary-2.9.13-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f04ada42bcd537adbaf8b7f3140237a204e452a88d0c1831cfce69f7d2e59f4e", size = 4282438, upload-time = "2026-09-09T23:55:22.329Z" },
+    { url = "https://files.pythonhosted.org/packages/91/e5/56f9efdc9337acbd1a75798d97163183b63a1babc17602f7163009506c96/psycopg2_binary-2.9.13-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa37089795bd9701576edc2eb5849ce77a439eda9dfdfa47857449332cfa5292", size = 5902064, upload-time = "2026-09-09T23:55:24.37Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/15/f7ed0b90b47b73a9087306b42267eccfd919f92c0fb057e46bd2fa2efa4d/psycopg2_binary-2.9.13-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:41c2eb569ebd0e1b02d30d361a46932923b193fe1b5e641fb4d547c75e218955", size = 4119848, upload-time = "2026-09-09T23:55:26.433Z" },
+    { url = "https://files.pythonhosted.org/packages/42/08/3091347b9fc5766e979aba6b0756ad14ce867a6bb245f3d69ac71fb768c6/psycopg2_binary-2.9.13-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3f699a5225094a5c61402984e2fc1eca20e940223e76767c88189efb0c313f69", size = 3661129, upload-time = "2026-09-09T23:55:28.449Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c4/4f9a84d55484c9794b364548eb6e1fe10a57f123afd19729e5a1cc8ad7fc/psycopg2_binary-2.9.13-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5f04ae99c9fbb94c3197ec88599ed7db921f6adcddfe83687a74c7ead4037c22", size = 3307262, upload-time = "2026-09-09T23:55:30.384Z" },
+    { url = "https://files.pythonhosted.org/packages/83/42/6eba8306a61dc890805ae475a9e71790a1c5461ccacbd4f0a1f3f57b40f0/psycopg2_binary-2.9.13-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:81404c37e0344ebcf10aac127d33d35137e5dbab1daf9f3deee46188fd5879c2", size = 3052898, upload-time = "2026-09-09T23:55:32.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/5d/42a8935ab280e8dcd7c07a655c0c3d25d62e9e242be1961ac14630f1294a/psycopg2_binary-2.9.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:feb7b1856f6ca805cc0e08739858f6cdfed8ce903390126af30343c62899a389", size = 3355265, upload-time = "2026-09-09T23:55:35.071Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c2/0e0ffb4caeb651631cbc6c8ead83e2a16457750b1d2eb7f5ef111c1f4d36/psycopg2_binary-2.9.13-cp313-cp313-win_amd64.whl", hash = "sha256:691da68ae5dd7c3ac77514357d35ece7b1ba8b5f3e6c92735198aa6159c355c8", size = 2767914, upload-time = "2026-09-09T23:55:37.14Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/32/897c074cb99fbdda7d34b0a2546097a59162bb3d04c0d546ae4ec82345e3/psycopg2_binary-2.9.13-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2ca263643ae37998ae04d18e431df34d0d61f12b47640dab585f14b6dbe00798", size = 3725788, upload-time = "2026-09-09T23:55:39.04Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/f4/e3a789de34c9ac25d20b25c2be583da16394a2ba0926da1c863653831f41/psycopg2_binary-2.9.13-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4c0214c7da18a28d108aa7108c8a3cca8035c7911ec97ef9ec0827569c9a2720", size = 3818111, upload-time = "2026-09-09T23:55:40.979Z" },
+    { url = "https://files.pythonhosted.org/packages/72/29/647724c43ac510dbc59b80e20e85d439deb94f5d5a024153c32330fa041d/psycopg2_binary-2.9.13-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5d89e064bb12b40cad696cf4975e6da86f8c60f14cd06cb6c1bc0a7f5d01761f", size = 4586235, upload-time = "2026-09-09T23:55:43.012Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ad/7f52f92cc65c23778daff7eec4ee2099236694a0a4723a5f180d0708b607/psycopg2_binary-2.9.13-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:190c18b97d9ef72f2e88c451b6588af90d6bd7bf54cb94b963280dc86a2c7076", size = 4282424, upload-time = "2026-09-09T23:55:44.843Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/2a/1a472059b198942d99651656e2bc610575584478bfe68d297ecabbd4887f/psycopg2_binary-2.9.13-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c00ebe9a2f31151aade0db233dc1446513a95e92c39ce055ee097af0ae86be1c", size = 5902365, upload-time = "2026-09-09T23:55:46.619Z" },
+    { url = "https://files.pythonhosted.org/packages/91/1a/171ea5dac7b3a0fa57b3cb59c2ad6d7b8bc60732368fecfd2ed1f1288392/psycopg2_binary-2.9.13-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5085f7ff7b1e890f279577cedeb8c628957869a340fa34a39f7f406500b3c916", size = 4119938, upload-time = "2026-09-09T23:55:49.381Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ce/3c6d4ad71853a59eee6a575fe36df4bb40752a9735a27bd62af66b454ed5/psycopg2_binary-2.9.13-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4e55357d1943673d491bbabb171c891704fc6a22441fea539e05a5c27a79ea3c", size = 3661557, upload-time = "2026-09-09T23:55:51.269Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a3/1819a01bf951eab2afb5ca2a3d11f50500bf536fecff088154372a8d1985/psycopg2_binary-2.9.13-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:3e60b06ec7f9dc3e5f1106d12706514b6d6b92c3dc438fcdf4e43e65cc660d1b", size = 3307770, upload-time = "2026-09-09T23:55:53.196Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/df/22f4aec952cd5b2dd02f438399583ed69f7d04b90e7c31659d9571bbe188/psycopg2_binary-2.9.13-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:dde942b46ce20f6c4464cdf551f3293207f803f4e4354454eb1f5599c3eb1fa1", size = 3052935, upload-time = "2026-09-09T23:55:55.117Z" },
+    { url = "https://files.pythonhosted.org/packages/95/42/aab651bc22bafa961806ca3b21027bb0739a2730b0e6f7f0778baeb95e67/psycopg2_binary-2.9.13-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:215777c62ce81c3b487cefdb6a41969944eb982309f91349ff3ca0323d6f17ed", size = 3355387, upload-time = "2026-09-09T23:55:57.366Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/af/3b8220633eaf955e95ea7be67d76e81a0d1cd3c76362ea504b91ffa079db/psycopg2_binary-2.9.13-cp314-cp314-win_amd64.whl", hash = "sha256:f3088eb80f58ed933c62d87128741d31e786edc862e23266d3c286763d646de0", size = 2863890, upload-time = "2026-09-09T23:55:59.056Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f1/377d17fc8425220d17552691cd2b97aa232da92173f5dead71278b83f8ab/psycopg2_binary-2.9.13-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:38397def2d794ffde9db80f63d6820253e61b17483112652a318355f51a56f50", size = 3725913, upload-time = "2026-09-09T23:56:00.736Z" },
+    { url = "https://files.pythonhosted.org/packages/67/64/27208e67cd6e663f69bf7bf905cf69db066a015c90ac9ca948a56a8e9d78/psycopg2_binary-2.9.13-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:dff5c70ed9789ccb0d97ff4a7da51dc523a255c4ec95df188fa5d44adcae4ea8", size = 3818303, upload-time = "2026-09-09T23:56:02.551Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/98/67d2f34a1d18367b5f655bdd101759f8474286c74ffe701b7d6e3abd7fda/psycopg2_binary-2.9.13-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:08d3b81a6a91775c937abf97d4c58fc9142e8e35fb91c387d24f81d15c98e6cf", size = 4586508, upload-time = "2026-09-09T23:56:04.706Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/47/46c227deaf322dceafa0b7b321b4e5de9cc797014b7a353349b2e09b1118/psycopg2_binary-2.9.13-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:541a487a9ccd72b5e38f37f27b0ce78cb7eb3e336e7b5277d45463010c03a7a8", size = 4282383, upload-time = "2026-09-09T23:56:06.678Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/3c/e8705ffa381160d842eaf06a8446e8416f1a2497dd70a7e62277f3be6e7a/psycopg2_binary-2.9.13-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:562fe2a43b30e781848dce63d9080c15414c777c96df348c4342558338cc7bf3", size = 5902765, upload-time = "2026-09-09T23:56:08.634Z" },
+    { url = "https://files.pythonhosted.org/packages/53/cc/359821c18317228b8032456a3740c98045b719ed003a594b9ebac9330b86/psycopg2_binary-2.9.13-cp315-cp315-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dddfe650e7dda464d676c27fbedb5061f1ad05e1604627f54c770d7f799d36e9", size = 4122849, upload-time = "2026-09-09T23:56:10.671Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e5/4d935acb6d3258c7a767b3d527e54c0b537649101b55002a5dbcfe747e2a/psycopg2_binary-2.9.13-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:4ff0f575cbb14f30445858dcfdd751e043486f5290915df78a9818bc74042eff", size = 3662084, upload-time = "2026-09-09T23:56:12.316Z" },
+    { url = "https://files.pythonhosted.org/packages/89/56/9e9bbc7c773c5de7bb25dd35d7f041c2a6f0fcfa9207a1ceaf01a1bc687c/psycopg2_binary-2.9.13-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:d79530b4c1af657d5620a1d21b8e39f2996aa06821d5564d05b22d6b8cd413d0", size = 3308077, upload-time = "2026-09-09T23:56:15.262Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fa/ed742cd4e5dbddcb44702f9c4a97f7f5b62d97e3d9d00907ecc8ac750ef4/psycopg2_binary-2.9.13-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:6ede8595767e19d30a7e8a84a7d47bfde6176d45d194fed08dbb68d1584a780b", size = 3055143, upload-time = "2026-09-09T23:56:17.168Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/3a/5c2cb71a844ee236be2ce91b286d797e34a21489909357c7cfba0f5c0197/psycopg2_binary-2.9.13-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:0ebcf3c4266a695df9d0ef51296155f60c86ac51cf82f0d0dd2e827255a891c5", size = 3355374, upload-time = "2026-09-09T23:56:18.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/30/3991c9fdcca90a5a1e55435292f4d74d176da2be15f3998f6858da3658cc/psycopg2_binary-2.9.13-cp315-cp315-win_amd64.whl", hash = "sha256:1752b9821f1377404d65ac43af03d59a1eccc57fb2c1eb8305f9a3fe8eb7a8ba", size = 2867246, upload-time = "2026-09-09T23:56:20.501Z" },
 ]
 
 [[package]]
@@ -5637,23 +5728,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.11'" },
-    { name = "babel", marker = "python_full_version < '3.11'" },
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "imagesize", marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -5670,23 +5761,23 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
-    { name = "babel", marker = "python_full_version == '3.11.*'" },
-    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
-    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
-    { name = "packaging", marker = "python_full_version == '3.11.*'" },
-    { name = "pygments", marker = "python_full_version == '3.11.*'" },
-    { name = "requests", marker = "python_full_version == '3.11.*'" },
-    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
-    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -5709,23 +5800,23 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [


### PR DESCRIPTION
## Zusammenfassung
Diese PR enthält die von mir im pb-bootstrapping gefundenen Fixes, die nötig sind, damit der **pgvector-Backend-Code aus chethanuk/OpenViking#18** tatsächlich läuft (Build + Runtime). Sie basiert auf dem PR-#18-Stand und ergänzt ihn um die Blocker.

## Was gefixt wird
1. **Startup-Crash (abstract)**: `OpenGaussIndex` implementiert `rebuild_scalar_index` nicht → `PgVectorCollection` bleibt abstract und der Server startet nicht mit `storage.vectordb.backend="pgvector"`:
   ```
   Can't instantiate abstract class OpenGaussIndex without an implementation for abstract method 'rebuild_scalar_index'
   ```
2. **Docker-`--locked`-Build-Bruch**: factory.py importiert `qdrant_adapter`/Registry, aber `qdrant_collection` existiert in current main nicht → ModuleNotFoundError.

## Enthalten
- `pgvector_adapter.py`, `opengauss_adapter.py` (inkl. `rebuild_scalar_index` no-op), `factory.py` (qdrant-Gate), `__init__.py`
- `vectordb_config.py` (PgVectorConfig-Schema)
- `deploy/pgvector/init.sql`, `tests/storage/test_pgvector_adapter.py`
- `pyproject.toml`/uv.lock (psycopg2/pgvector extra)

## Referenz
- #2891, #2357, Issue #4964 (Bugbericht)
- chethanuk/OpenViking#18 (Ursprungs-PR)