### PR TITLE
fix(storage): stop deletion snapshots from recreating the deleted path

### DIFF
--- a/openviking/storage/viking_fs/_snapshot.py
+++ b/openviking/storage/viking_fs/_snapshot.py
@@ -267,9 +267,14 @@ class _SnapshotMixin:
 
         from openviking.storage.errors import LockAcquisitionError, ResourceBusyError
 
+        lock_targets = set()
+        for uri in paths:
+            lock_targets.add(
+                await self._existing_lock_target(self._uri_to_path(uri, ctx=real_ctx))
+            )
         lock_paths: List[str] = []
         for path in sorted(
-            {self._uri_to_path(uri, ctx=real_ctx) for uri in paths},
+            lock_targets,
             key=lambda value: (value.count("/"), value),
         ):
             if not any(path == root or path.startswith(f"{root.rstrip('/')}/") for root in lock_paths):
@@ -287,6 +292,28 @@ class _SnapshotMixin:
             return await self._async_agfs.run("git_commit", **kwargs)
         finally:
             await self._async_agfs.pathlock_release(lease)
+
+    async def _existing_lock_target(self, path: str) -> str:
+        """Return the nearest existing path to tree-lock for ``path``.
+
+        A tree lock stores its token at ``{path}/.path.ovlock``, so locking a
+        path that no longer exists materializes it as an empty directory.
+        Deletion snapshots legitimately name already-deleted files, so walk up
+        to the closest surviving ancestor instead. The commit itself still
+        receives the original paths, keeping the deletion in history.
+        """
+        current = path.rstrip("/") or "/"
+        while current and current != "/":
+            try:
+                await self._async_agfs.stat(current)
+            except Exception as exc:
+                if not is_not_found_error(exc):
+                    raise
+                parent = current.rsplit("/", 1)[0]
+                current = parent or "/"
+                continue
+            return current
+        return current or "/"
 
     async def restore(
         self,

--- a/tests/storage/test_viking_fs_git.py
+++ b/tests/storage/test_viking_fs_git.py
@@ -348,3 +348,131 @@ async def test_diff_does_not_treat_missing_storage_object_as_absent():
             to_ref="to",
             ctx=_request_context(),
         )
+
+
+async def test_commit_locks_nearest_existing_ancestor_for_deleted_paths():
+    """A deletion snapshot must not tree-lock the deleted path itself.
+
+    Tree locks live at ``{path}/.path.ovlock``, so locking a path that was just
+    deleted recreates it as an empty directory. Lock the closest surviving
+    ancestor instead; the commit still records the original path.
+    """
+
+    class RecordingAGFS:
+        def __init__(self, existing):
+            self.existing = existing
+            self.locked = None
+            self.commits = []
+            self.released = []
+
+        async def stat(self, path):
+            if path not in self.existing:
+                raise AGFSPathNotFoundError(path)
+            return {"path": path, "is_dir": True}
+
+        async def pathlock_acquire_tree_batch(self, paths):
+            self.locked = list(paths)
+            return "lease-1"
+
+        async def pathlock_release(self, lease):
+            self.released.append(lease)
+
+        async def run(self, operation, **kwargs):
+            self.commits.append((operation, kwargs))
+            return {"result": "created", "commit_oid": "b" * 40}
+
+    class CommitVikingFS:
+        _DEFAULT_GIT_AUTHOR_NAME = "bot"
+        _DEFAULT_GIT_AUTHOR_EMAIL = "bot@example.com"
+
+        def __init__(self, existing):
+            self._async_agfs = RecordingAGFS(existing)
+
+        def _ctx_or_default(self, ctx):
+            return ctx
+
+        def _uri_to_tree_path(self, uri, *, ctx):
+            return uri.removeprefix("viking://")
+
+        def _uri_to_path(self, uri, *, ctx):
+            return "/acct/" + uri.removeprefix("viking://")
+
+        async def _snapshot_scope_uris(self, paths, ctx):
+            return list(paths)
+
+        async def _ensure_access_many(self, uris, ctx, *, action):
+            return None
+
+    deleted = "viking://user/alice/memories/experiences/example.md"
+    vfs = CommitVikingFS({"/acct/user/alice/memories/experiences"})
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="account", user_id="alice"),
+        role=Role.USER,
+    )
+
+    result = await VikingFS.commit(vfs, message="record deletion", paths=[deleted], ctx=ctx)
+
+    assert result["result"] == "created"
+    # Locked the surviving parent, never the deleted file path.
+    assert vfs._async_agfs.locked == ["/acct/user/alice/memories/experiences"]
+    # The deletion itself is still part of the commit.
+    assert vfs._async_agfs.commits[0][1]["paths"] == [
+        "user/alice/memories/experiences/example.md"
+    ]
+    assert vfs._async_agfs.released == ["lease-1"]
+
+
+async def test_commit_locks_the_path_itself_when_it_still_exists():
+    class RecordingAGFS:
+        def __init__(self, existing):
+            self.existing = existing
+            self.locked = None
+
+        async def stat(self, path):
+            if path not in self.existing:
+                raise AGFSPathNotFoundError(path)
+            return {"path": path, "is_dir": False}
+
+        async def pathlock_acquire_tree_batch(self, paths):
+            self.locked = list(paths)
+            return "lease-1"
+
+        async def pathlock_release(self, lease):
+            return None
+
+        async def run(self, operation, **kwargs):
+            return {"result": "created", "commit_oid": "c" * 40}
+
+    class CommitVikingFS:
+        _DEFAULT_GIT_AUTHOR_NAME = "bot"
+        _DEFAULT_GIT_AUTHOR_EMAIL = "bot@example.com"
+
+        def __init__(self, existing):
+            self._async_agfs = RecordingAGFS(existing)
+
+        def _ctx_or_default(self, ctx):
+            return ctx
+
+        def _uri_to_tree_path(self, uri, *, ctx):
+            return uri.removeprefix("viking://")
+
+        def _uri_to_path(self, uri, *, ctx):
+            return "/acct/" + uri.removeprefix("viking://")
+
+        async def _snapshot_scope_uris(self, paths, ctx):
+            return list(paths)
+
+        async def _ensure_access_many(self, uris, ctx, *, action):
+            return None
+
+    uri = "viking://user/alice/memories/experiences/example.md"
+    path = "/acct/user/alice/memories/experiences/example.md"
+    vfs = CommitVikingFS({path})
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="account", user_id="alice"),
+        role=Role.USER,
+    )
+
+    await VikingFS.commit(vfs, message="create", paths=[uri], ctx=ctx)
+
+    assert vfs._async_agfs.locked == [path]


### PR DESCRIPTION
Fixes #4966.

## 根因

树锁的 token 存在 `{path}/.path.ovlock`。`resolve_tree_lock_path` 对**不存在**的路径就解析成这个形式，`ensure_lock_dir` 再把缺失的父目录逐级建出来——于是被锁的那个已删除文件路径，本身就被 mkdir 成了一个空目录。释放租约只删 token 文件，空目录留在原地。ROOT 走的是 `commit` 里的免锁分支，所以复现脚本里只有 `Role.USER` 中招。

Studio 里看到的 `*.md` 变成空文件夹、读它报错，就是这么来的。

## 改法（最小）

`VikingFS.commit` 在给显式 snapshot 路径申请树锁之前，先 stat 一下：路径还在就照旧锁它自己；已经被删掉了，就往上找最近一个还存在的祖先来锁。

- 传给 `git_commit` 的 `paths` **一个字没改**，删除照样进快照，历史不丢
- ACL 仍然按原 URI 走 `_snapshot_scope_uris` + `_ensure_access_many`，覆盖面不变
- 并发保护不降级：祖先上的树锁范围比原路径更大，原来能挡住的现在一样挡得住
- 祖先目录自己也被删了的情况，循环会继续往上走，不会在上一层重新制造同样的问题

这个「stat 不到就退到父路径」的写法，和同文件 `_authorize_restore_writes` 里已有的处理是同一套。

## 没有动 Rust 那一层

`resolve_tree_lock_path` 把缺失路径解析成 `{path}/.path.ovlock`、`ensure_lock_dir` 建目录，这个组合对「即将被创建的目录」是有意为之的；真要改，要么让缺失路径退回父 sidecar（但 `check_ancestor_tree_locks` 只读 `.path.ovlock`，后代就扫不到这把锁了，会丢覆盖），要么把 acquire 时创建的目录记进租约、release 时回收（要改 registry 结构）。两条都不算 minimal，本 PR 先按 issue 里的定性——「问题出在把它用在已删除的 snapshot 目标上」——在调用侧收口。

## 测试

`tests/storage/test_viking_fs_git.py` 加两个用例：删除的路径锁到幸存父目录且 commit 仍带原路径、路径还在时锁它自己。

本机没装 openviking 和 Rust binding，这两个用例没跑过，靠 CI。issue 里的复现脚本也没在本机跑。