### PR TITLE
fix(ragfs): reclaim lock-created directories so deletion snapshots leave no empty dirs

### DIFF
--- a/crates/ragfs-python/src/lib.rs
+++ b/crates/ragfs-python/src/lib.rs
@@ -1251,6 +1251,7 @@ fn handoff_ref_to_py_dict(py: Python<'_>, handoff: &PathLockHandoffRef) -> PyRes
         covered.append(item)?;
     }
     dict.set_item("covered_paths", covered)?;
+    dict.set_item("created_dirs", &handoff.created_dirs)?;
     Ok(dict.into())
 }
 
@@ -2718,11 +2719,17 @@ impl RAGFSBindingClient {
             .map(|v| v.extract(py))
             .transpose()?
             .filter(|s: &String| !s.is_empty());
+        let created_dirs: Vec<String> = handoff_ref
+            .get("created_dirs")
+            .map(|v| v.extract(py))
+            .transpose()?
+            .unwrap_or_default();
         let handoff = PathLockHandoffRef {
             lease_ref,
             owner_id,
             lock_paths,
             covered_paths,
+            created_dirs,
         };
         let lease = self
             .run_scoped(py, fs_ctx, move || {

--- a/crates/ragfs/src/core/filesystem.rs
+++ b/crates/ragfs/src/core/filesystem.rs
@@ -213,14 +213,16 @@ pub trait FileSystem: Send + Sync + Any {
     /// * `Error::NotFound` - If the parent directory doesn't exist
     async fn mkdir(&self, path: &str, mode: u32) -> Result<()>;
 
-    /// Remove a file at the specified path
+    /// Remove a file — or, on backends that support it (localfs, memfs), an
+    /// empty directory — at the specified path
     ///
     /// # Arguments
     /// * `path` - The path of the file to remove
     ///
     /// # Errors
     /// * `Error::NotFound` - If the file doesn't exist
-    /// * `Error::IsADirectory` - If the path points to a directory
+    /// * `Error::IsADirectory` - If the path points to a non-empty directory
+    ///   (or any directory, on backends without empty-directory removal)
     async fn remove(&self, path: &str) -> Result<()>;
 
     /// Recursively remove a file or directory

--- a/crates/ragfs/src/lock/manager.rs
+++ b/crates/ragfs/src/lock/manager.rs
@@ -514,6 +514,7 @@ impl PathLockManager {
         // Spawn a background task that refreshes active owned leases.
         let refresh_registry = registry.clone();
         let refresh_provider = provider.clone();
+        let refresh_fs = fs.clone();
         let refresh_config = config.clone();
         let refresh_metrics = metrics.clone();
         let refresh_interval = Duration::from_secs_f64(config.lock_expire_secs / 3.0);
@@ -558,6 +559,7 @@ impl PathLockManager {
                 for (lease_ref, owner) in stale_candidates {
                     match Self::release_lease_paths_with(
                         &refresh_provider,
+                        &refresh_fs,
                         &refresh_registry,
                         owner,
                         &lease_ref,
@@ -864,7 +866,10 @@ impl PathLockManager {
                 }
             }
             first_attempt = false;
-            let acquired_lock_paths = match self.try_acquire_batch_once(&sorted, &owner_id).await {
+            let (acquired_lock_paths, created_dirs) = match self
+                .try_acquire_batch_once(&sorted, &owner_id)
+                .await
+            {
                 Ok(acquired) => acquired,
                 Err((err, pre_conflict)) => {
                     drop(owner_registry);
@@ -946,6 +951,7 @@ impl PathLockManager {
                     .map(|(lock_path, _)| lock_path.clone())
                     .collect(),
                 covered_paths: sorted.clone(),
+                created_dirs,
             };
             let ownership_ref = Self::new_owner_id();
             let lock_kinds: Vec<_> = sorted.iter().map(|request| request.kind).collect();
@@ -955,6 +961,7 @@ impl PathLockManager {
                 let rollback = self
                     .rollback_acquisitions(&acquired_lock_paths, &owner_id)
                     .await;
+                Self::cleanup_created_dirs(&self.resolver.fs, &lease.created_dirs).await;
                 break match rollback {
                     Ok(()) => Err(error),
                     Err(rollback_error) => Err(Self::rollback_error(error, rollback_error)),
@@ -968,6 +975,7 @@ impl PathLockManager {
                 let rollback = self
                     .rollback_acquisitions(&acquired_lock_paths, &owner_id)
                     .await;
+                Self::cleanup_created_dirs(&self.resolver.fs, &lease.created_dirs).await;
                 break match rollback {
                     Ok(()) => Err(error),
                     Err(rollback_error) => Err(Self::rollback_error(error, rollback_error)),
@@ -998,8 +1006,9 @@ impl PathLockManager {
         &self,
         requests: &[PathLockRequest],
         owner_id: &str,
-    ) -> Result<Vec<(String, AcquisitionChange)>, (PathLockError, bool)> {
+    ) -> Result<(Vec<(String, AcquisitionChange)>, Vec<String>), (PathLockError, bool)> {
         let mut acquired = Vec::new();
+        let mut created_dirs: Vec<String> = Vec::new();
         let mut exact_resolutions: HashMap<String, ResolvedExactPaths> = HashMap::new();
         let acquisition: PathLockResult<()> = async {
             for request in requests {
@@ -1012,11 +1021,13 @@ impl PathLockManager {
                             .await?;
                         let lock_path = resolved.acquire_lock_path.clone();
                         exact_resolutions.insert(request.path.clone(), resolved);
-                        self.ensure_lock_dir(&lock_path).await.map_err(|error| {
-                            PathLockError::Io(format!("failed to create lock dir: {error}"))
-                        })?;
                         let change = self
-                            .try_acquire_one(&lock_path, owner_id, PathLockKind::Exact)
+                            .acquire_token_ensuring_dir(
+                                &lock_path,
+                                owner_id,
+                                PathLockKind::Exact,
+                                &mut created_dirs,
+                            )
                             .await?;
                         acquired.push((lock_path, change));
                     }
@@ -1030,11 +1041,13 @@ impl PathLockManager {
                             .await?;
                         self.check_lock_paths(&exact_candidates, owner_id).await?;
                         self.check_descendant_locks(&request.path, owner_id).await?;
-                        self.ensure_lock_dir(&lock_path).await.map_err(|error| {
-                            PathLockError::Io(format!("failed to create lock dir: {error}"))
-                        })?;
                         let change = self
-                            .try_acquire_one(&lock_path, owner_id, PathLockKind::Tree)
+                            .acquire_token_ensuring_dir(
+                                &lock_path,
+                                owner_id,
+                                PathLockKind::Tree,
+                                &mut created_dirs,
+                            )
                             .await?;
                         acquired.push((lock_path, change));
                     }
@@ -1044,7 +1057,9 @@ impl PathLockManager {
         }
         .await;
         if let Err(error) = acquisition {
-            if let Err(rollback_error) = self.rollback_acquisitions(&acquired, owner_id).await {
+            let rollback = self.rollback_acquisitions(&acquired, owner_id).await;
+            Self::cleanup_created_dirs(&self.resolver.fs, &created_dirs).await;
+            if let Err(rollback_error) = rollback {
                 return Err((Self::rollback_error(error, rollback_error), false));
             }
             return Err((error, true));
@@ -1081,12 +1096,14 @@ impl PathLockManager {
         }
         .await;
         if let Err(error) = verification {
-            if let Err(rollback_error) = self.rollback_acquisitions(&acquired, owner_id).await {
+            let rollback = self.rollback_acquisitions(&acquired, owner_id).await;
+            Self::cleanup_created_dirs(&self.resolver.fs, &created_dirs).await;
+            if let Err(rollback_error) = rollback {
                 return Err((Self::rollback_error(error, rollback_error), false));
             }
             return Err((error, false));
         }
-        Ok(acquired)
+        Ok((acquired, created_dirs))
     }
 
     /// Roll back token changes made by one incomplete batch acquisition.
@@ -1268,11 +1285,14 @@ impl PathLockManager {
     }
 
     /// Ensure the parent directory of a lock path exists.
-    async fn ensure_lock_dir(&self, lock_path: &str) -> PathLockResult<()> {
+    ///
+    /// Returns every directory this call materialized (creation order,
+    /// shallowest first) so the lease can reclaim still-empty ones on release.
+    async fn ensure_lock_dir(&self, lock_path: &str) -> PathLockResult<Vec<String>> {
         if let Some(parent_end) = lock_path.rfind('/') {
             let parent = &lock_path[..parent_end];
             if parent.is_empty() || parent == "/" {
-                return Ok(());
+                return Ok(Vec::new());
             }
             // Walk up creating missing ancestors.
             let mut missing: Vec<String> = Vec::new();
@@ -1306,8 +1326,69 @@ impl PathLockManager {
             if !created_dirs.is_empty() {
                 debug!(lock_path = %lock_path, created_dirs = ?created_dirs, "ensured pathlock parent directories");
             }
+            return Ok(created_dirs);
         }
-        Ok(())
+        Ok(Vec::new())
+    }
+
+    /// Create the lock token for one resolved lock path, materializing missing
+    /// lock directories and recording them in `created_dirs`.
+    ///
+    /// A concurrent final release may reclaim an empty lock directory between
+    /// `ensure_lock_dir` and token creation; when token creation fails for a
+    /// non-conflict reason and the directory turns out to be missing again,
+    /// re-create it and retry once before giving up.
+    async fn acquire_token_ensuring_dir(
+        &self,
+        lock_path: &str,
+        owner_id: &str,
+        kind: PathLockKind,
+        created_dirs: &mut Vec<String>,
+    ) -> PathLockResult<AcquisitionChange> {
+        created_dirs.extend(
+            self.ensure_lock_dir(lock_path).await.map_err(|error| {
+                PathLockError::Io(format!("failed to create lock dir: {error}"))
+            })?,
+        );
+        match self.try_acquire_one(lock_path, owner_id, kind).await {
+            Ok(change) => Ok(change),
+            Err(error) if Self::is_retryable_error(&error) => Err(error),
+            Err(error) => {
+                let recreated = match self.ensure_lock_dir(lock_path).await {
+                    Ok(recreated) => recreated,
+                    Err(_) => return Err(error),
+                };
+                if recreated.is_empty() {
+                    return Err(error);
+                }
+                created_dirs.extend(recreated);
+                self.try_acquire_one(lock_path, owner_id, kind).await
+            }
+        }
+    }
+
+    /// Best-effort removal of directories materialized during lock acquisition.
+    ///
+    /// Directories are removed deepest-first and only while still empty:
+    /// `FileSystem::remove` refuses non-empty directories, so content written
+    /// under a reserved path while the lock was held is never touched.
+    /// Failures are logged and ignored — leaking an empty directory is the
+    /// pre-existing behavior this reclamation improves on.
+    async fn cleanup_created_dirs(fs: &Arc<dyn FileSystem>, created_dirs: &[String]) {
+        for dir in created_dirs.iter().rev() {
+            match fs.stat(dir).await {
+                Ok(info) if info.is_dir => {}
+                _ => continue,
+            }
+            match fs.remove(dir).await {
+                Ok(()) => {
+                    debug!(dir = %dir, "reclaimed pathlock-created directory");
+                }
+                Err(error) => {
+                    debug!(dir = %dir, error = %error, "left pathlock-created directory in place");
+                }
+            }
+        }
     }
 
     /// Refresh an owned lease. Returns "refreshed", "lost", or "failed".
@@ -1382,6 +1463,7 @@ impl PathLockManager {
             })?;
         let result = Self::release_lease_paths_with(
             &self.provider,
+            &self.resolver.fs,
             &self.lease_registry,
             owner,
             &lease.lease.lease_ref,
@@ -1422,6 +1504,7 @@ impl PathLockManager {
             })?;
         let result = Self::release_lease_paths_with(
             &self.provider,
+            &self.resolver.fs,
             &self.lease_registry,
             owner,
             &lease.lease.lease_ref,
@@ -1437,8 +1520,10 @@ impl PathLockManager {
     }
 
     /// Release selected paths while serializing all state and provider work for one owner.
+    #[allow(clippy::too_many_arguments)]
     async fn release_lease_paths_with(
         provider: &Arc<dyn PathLockProvider>,
+        fs: &Arc<dyn FileSystem>,
         lease_registry: &Arc<LeaseRegistry>,
         owner: Arc<OwnerState>,
         lease_ref: &str,
@@ -1465,6 +1550,7 @@ impl PathLockManager {
         if stale_cutoff.is_some_and(|cutoff| entry.last_active_at > cutoff) {
             return Ok(false);
         }
+        let created_dirs = entry.lease.created_dirs.clone();
         let selected: Option<HashSet<&str>> =
             selected_paths.map(|paths| paths.iter().map(String::as_str).collect());
         let mut seen = HashSet::new();
@@ -1562,6 +1648,36 @@ impl PathLockManager {
         }
 
         let removed = !owner_registry.entries.contains_key(lease_ref);
+        if removed && !created_dirs.is_empty() {
+            // Final release: reclaim still-empty directories this lease
+            // materialized while acquiring lock tokens, so locking a missing
+            // path leaves nothing behind. Non-empty directories (reservations
+            // that received content, or tokens that failed to release) are
+            // kept.
+            Self::cleanup_created_dirs(fs, &created_dirs).await;
+            // A directory can survive cleanup because another same-owner
+            // lease still keeps a token inside it (reentrant coverage).
+            // Donate it to a surviving lease holding a lock path under it so
+            // the final release can reclaim it; cleanup only ever removes
+            // empty directories, so donating is always safe.
+            for dir in &created_dirs {
+                if !fs.stat(dir).await.is_ok_and(|info| info.is_dir) {
+                    continue;
+                }
+                let prefix = format!("{}/", dir.trim_end_matches('/'));
+                if let Some(entry) = owner_registry.entries.values_mut().find(|entry| {
+                    entry
+                        .lease
+                        .lock_paths
+                        .iter()
+                        .any(|lock_path| lock_path.starts_with(&prefix))
+                }) {
+                    if !entry.lease.created_dirs.contains(dir) {
+                        entry.lease.created_dirs.push(dir.clone());
+                    }
+                }
+            }
+        }
         if let Some(error) = first_error {
             if ownership_ref.is_some() || !removed {
                 return Err(error);
@@ -1652,6 +1768,7 @@ impl PathLockManager {
             owner_id: lease.lease.owner_id.clone(),
             lock_paths: lease.lease.lock_paths.clone(),
             covered_paths: lease.lease.covered_paths.clone(),
+            created_dirs: lease.lease.created_dirs.clone(),
         }
     }
 
@@ -1849,6 +1966,7 @@ impl PathLockManager {
             owner_id: handoff.owner_id.clone(),
             lock_paths: handoff.lock_paths.clone(),
             covered_paths: handoff.covered_paths.clone(),
+            created_dirs: handoff.created_dirs.clone(),
         };
         let ownership_ref = Self::new_owner_id();
         owner_registry.insert(
@@ -2441,6 +2559,248 @@ mod tests {
         assert_eq!(mgr.metrics_snapshot().await.active_lock_count, 0);
     }
 
+    /// Build a manager + filesystem provider over one shared memfs with `/data`.
+    fn reclaim_test_manager() -> (Arc<MemFileSystem>, PathLockManager) {
+        let fs = Arc::new(MemFileSystem::new());
+        let provider = Arc::new(crate::lock::provider::FilesystemPathLockProvider::new(
+            fs.clone(),
+            PathLockConfig::default().lock_expire_secs,
+        ));
+        let mgr = PathLockManager::new(fs.clone(), provider, PathLockConfig::default());
+        (fs, mgr)
+    }
+
+    #[tokio::test]
+    async fn tree_lock_on_missing_path_reclaims_reserved_directory_on_release() {
+        let (fs, mgr) = reclaim_test_manager();
+        fs.mkdir("/data", 0o755).await.unwrap();
+
+        // Regression for volcengine/OpenViking#4966: tree-locking an
+        // already-deleted file path (deletion snapshot) must not leave an
+        // empty directory behind once the lease is released.
+        let lease = mgr
+            .acquire_tree("/data/deleted.md", Duration::ZERO, None)
+            .await
+            .unwrap();
+
+        // While held, the reservation directory and its token exist.
+        assert!(fs.stat("/data/deleted.md").await.unwrap().is_dir);
+        assert!(fs.stat("/data/deleted.md/.path.ovlock").await.is_ok());
+
+        mgr.release(&lease).await.unwrap();
+
+        assert!(
+            fs.stat("/data/deleted.md").await.is_err(),
+            "releasing a tree lock on a missing path must not leave a directory behind"
+        );
+        assert!(fs.stat("/data").await.unwrap().is_dir);
+    }
+
+    #[tokio::test]
+    async fn tree_lock_on_missing_nested_path_reclaims_all_created_directories() {
+        let (fs, mgr) = reclaim_test_manager();
+        fs.mkdir("/data", 0o755).await.unwrap();
+
+        let lease = mgr
+            .acquire_tree("/data/a/b/c", Duration::ZERO, None)
+            .await
+            .unwrap();
+        assert!(fs.stat("/data/a/b/c").await.unwrap().is_dir);
+
+        mgr.release(&lease).await.unwrap();
+
+        assert!(fs.stat("/data/a/b/c").await.is_err());
+        assert!(fs.stat("/data/a/b").await.is_err());
+        assert!(fs.stat("/data/a").await.is_err());
+        assert!(fs.stat("/data").await.unwrap().is_dir);
+    }
+
+    #[tokio::test]
+    async fn tree_lock_reservation_keeps_directory_once_content_is_written() {
+        let (fs, mgr) = reclaim_test_manager();
+        fs.mkdir("/data", 0o755).await.unwrap();
+
+        let lease = mgr
+            .acquire_tree("/data/new", Duration::ZERO, None)
+            .await
+            .unwrap();
+        fs.write("/data/new/file.txt", b"payload", 0, WriteFlag::Create)
+            .await
+            .unwrap();
+
+        mgr.release(&lease).await.unwrap();
+
+        assert!(fs.stat("/data/new").await.unwrap().is_dir);
+        assert!(!fs.stat("/data/new/file.txt").await.unwrap().is_dir);
+        assert!(fs.stat("/data/new/.path.ovlock").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn tree_lock_release_keeps_preexisting_directory() {
+        let (fs, mgr) = reclaim_test_manager();
+        fs.mkdir("/data", 0o755).await.unwrap();
+        fs.mkdir("/data/existing", 0o755).await.unwrap();
+
+        let lease = mgr
+            .acquire_tree("/data/existing", Duration::ZERO, None)
+            .await
+            .unwrap();
+        mgr.release(&lease).await.unwrap();
+
+        assert!(fs.stat("/data/existing").await.unwrap().is_dir);
+    }
+
+    #[tokio::test]
+    async fn exact_lock_on_missing_nested_path_reclaims_created_directories() {
+        let (fs, mgr) = reclaim_test_manager();
+        fs.mkdir("/data", 0o755).await.unwrap();
+
+        // Exact sidecar lives in the parent, so /data/x/y is materialized.
+        let lease = mgr
+            .acquire_exact("/data/x/y/file.txt", Duration::ZERO, None)
+            .await
+            .unwrap();
+        assert!(fs.stat("/data/x/y").await.unwrap().is_dir);
+
+        mgr.release(&lease).await.unwrap();
+
+        assert!(fs.stat("/data/x/y").await.is_err());
+        assert!(fs.stat("/data/x").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn failed_batch_acquire_reclaims_directories_created_before_the_conflict() {
+        let (fs, mgr) = reclaim_test_manager();
+        fs.mkdir("/data", 0o755).await.unwrap();
+        fs.write("/data/held.txt", b"", 0, WriteFlag::Create)
+            .await
+            .unwrap();
+
+        let holder = PathLockManager::new(
+            fs.clone(),
+            Arc::new(crate::lock::provider::FilesystemPathLockProvider::new(
+                fs.clone(),
+                PathLockConfig::default().lock_expire_secs,
+            )),
+            PathLockConfig::default(),
+        );
+        let _held = holder
+            .acquire_exact("/data/held.txt", Duration::ZERO, None)
+            .await
+            .unwrap();
+
+        // "/data/new" sorts before "/data/held.txt", so its reservation
+        // directory is created before the batch hits the conflict.
+        let result = mgr
+            .acquire_batch(
+                &[
+                    PathLockRequest {
+                        path: "/data/new".to_string(),
+                        kind: PathLockKind::Tree,
+                    },
+                    PathLockRequest {
+                        path: "/data/held.txt".to_string(),
+                        kind: PathLockKind::Exact,
+                    },
+                ],
+                Duration::ZERO,
+                None,
+            )
+            .await;
+        assert!(result.is_err());
+
+        assert!(
+            fs.stat("/data/new").await.is_err(),
+            "a failed batch acquire must reclaim reservation directories it created"
+        );
+    }
+
+    #[tokio::test]
+    async fn adopted_handoff_reclaims_created_directories_on_final_release() {
+        let fs = Arc::new(MemFileSystem::new());
+        fs.mkdir("/data", 0o755).await.unwrap();
+        let provider = Arc::new(crate::lock::provider::FilesystemPathLockProvider::new(
+            fs.clone(),
+            PathLockConfig::default().lock_expire_secs,
+        ));
+        let producer =
+            PathLockManager::new(fs.clone(), provider.clone(), PathLockConfig::default());
+        let consumer = PathLockManager::new(fs.clone(), provider, PathLockConfig::default());
+
+        let lease = producer
+            .acquire_tree("/data/reserved", Duration::ZERO, None)
+            .await
+            .unwrap();
+        assert!(fs.stat("/data/reserved").await.unwrap().is_dir);
+        let handoff = producer.to_handoff(&lease);
+        assert_eq!(handoff.created_dirs, vec!["/data/reserved".to_string()]);
+        producer.handoff(&lease).await.unwrap();
+
+        let adopted = consumer.adopt(&handoff).await.unwrap();
+        consumer.release(&adopted).await.unwrap();
+
+        assert!(
+            fs.stat("/data/reserved").await.is_err(),
+            "the adopter inherits reclamation of acquisition-created directories"
+        );
+    }
+
+    #[tokio::test]
+    async fn reentrant_lease_inherits_reclamation_when_creating_lease_releases_first() {
+        let (fs, mgr) = reclaim_test_manager();
+        fs.mkdir("/data", 0o755).await.unwrap();
+
+        let first = mgr
+            .acquire_tree("/data/reserved", Duration::ZERO, None)
+            .await
+            .unwrap();
+        let second = mgr
+            .acquire_tree(
+                "/data/reserved",
+                Duration::ZERO,
+                Some((&first.lease.lease_ref, &first.ownership_ref)),
+            )
+            .await
+            .unwrap();
+
+        // The creating lease goes away first; the shared token keeps the
+        // directory alive, so reclamation duty transfers to the survivor.
+        mgr.release(&first).await.unwrap();
+        assert!(fs.stat("/data/reserved").await.unwrap().is_dir);
+
+        mgr.release(&second).await.unwrap();
+        assert!(fs.stat("/data/reserved").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn tree_lock_on_missing_path_reclaims_directory_on_localfs() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let fs: Arc<dyn FileSystem> = Arc::new(
+            crate::plugins::localfs::LocalFileSystem::new(tempdir.path().to_str().unwrap())
+                .unwrap(),
+        );
+        let provider = Arc::new(crate::lock::provider::FilesystemPathLockProvider::new(
+            fs.clone(),
+            PathLockConfig::default().lock_expire_secs,
+        ));
+        let mgr = PathLockManager::new(fs.clone(), provider, PathLockConfig::default());
+        fs.mkdir("/data", 0o755).await.unwrap();
+
+        let lease = mgr
+            .acquire_tree("/data/deleted.md", Duration::ZERO, None)
+            .await
+            .unwrap();
+        assert!(tempdir.path().join("data/deleted.md").is_dir());
+
+        mgr.release(&lease).await.unwrap();
+
+        assert!(
+            !tempdir.path().join("data/deleted.md").exists(),
+            "localfs release must remove the reservation directory"
+        );
+        assert!(tempdir.path().join("data").is_dir());
+    }
+
     #[tokio::test]
     async fn acquire_exact_reentrant_requires_local_owned_capability() {
         let mgr = make_manager().await;
@@ -2715,6 +3075,7 @@ mod tests {
         // Historic payload: no lease_ref, no covered_paths.
         let legacy = PathLockHandoffRef {
             lease_ref: None,
+            created_dirs: Vec::new(),
             owner_id: lease.lease.owner_id.clone(),
             lock_paths: lease.lease.lock_paths.clone(),
             covered_paths: Vec::new(),

--- a/crates/ragfs/src/lock/types.rs
+++ b/crates/ragfs/src/lock/types.rs
@@ -52,6 +52,10 @@ pub struct PathLockLease {
     pub lock_paths: Vec<String>,
     /// Original path coverage granted by the lease.
     pub covered_paths: Vec<PathLockRequest>,
+    /// Directories materialized by `ensure_lock_dir` while acquiring this
+    /// lease (creation order, shallowest first). Reclaimed on final release
+    /// when still empty so locking a missing path leaves no residue behind.
+    pub created_dirs: Vec<String>,
 }
 
 /// Owned lease — caller controls refresh/release/handoff lifecycle.
@@ -84,6 +88,11 @@ pub struct PathLockHandoffRef {
     /// Original path coverage granted by the handed-off lease.
     #[serde(default)]
     pub covered_paths: Vec<PathLockRequest>,
+    /// Directories materialized while acquiring the handed-off lease
+    /// (creation order, shallowest first). The adopter inherits the duty to
+    /// reclaim them on final release when they are still empty.
+    #[serde(default)]
+    pub created_dirs: Vec<String>,
 }
 
 /// A single lock request for batch acquire.

--- a/crates/ragfs/src/plugins/memfs/mod.rs
+++ b/crates/ragfs/src/plugins/memfs/mod.rs
@@ -207,13 +207,18 @@ impl FileSystem for MemFileSystem {
         // Check if exists
         match entries.get(&normalized) {
             Some(entry) if entry.is_dir => {
-                return Err(Error::IsADirectory(normalized));
+                // Match localfs: an empty directory may be removed, a
+                // non-empty one may not.
+                let prefix = format!("{}/", normalized);
+                if entries.keys().any(|p| p.starts_with(&prefix)) {
+                    return Err(Error::IsADirectory(normalized));
+                }
             }
             Some(_) => {}
             None => return Err(Error::not_found(&normalized)),
         }
 
-        // Remove file
+        // Remove file or empty directory
         entries.remove(&normalized);
         Ok(())
     }
@@ -622,6 +627,25 @@ MemFS has no configuration parameters.
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn remove_deletes_empty_directory_but_not_populated_one() {
+        let fs = MemFileSystem::new();
+        fs.mkdir("/empty", 0o755).await.unwrap();
+        fs.mkdir("/full", 0o755).await.unwrap();
+        fs.write("/full/file.txt", b"x", 0, crate::core::WriteFlag::Create)
+            .await
+            .unwrap();
+
+        fs.remove("/empty").await.unwrap();
+        assert!(fs.stat("/empty").await.is_err());
+
+        assert!(matches!(
+            fs.remove("/full").await,
+            Err(Error::IsADirectory(_))
+        ));
+        assert!(fs.stat("/full").await.unwrap().is_dir);
+    }
 
     #[tokio::test]
     async fn test_create_and_read_file() {


### PR DESCRIPTION
Fixes #4966。锁层的系统性修复，取代 #4970 的调用侧绕过。

## 根因

树锁 token 存在 `{path}/.path.ovlock`。`resolve_tree_lock_path` 对不存在的路径也解析成这个形式，`ensure_lock_dir` 逐级 mkdir 缺失祖先——被锁的已删除文件路径因此被 mkdir 成目录。释放租约只删 token 文件，空目录永久留在原地。ROOT 在 `VikingFS.commit` 里免锁，所以只有非 ROOT 复现。

关键前提：**「锁不存在的路径会建出目录」不是意外，是文档化的预留（reservation）协议**。`docs/*/concepts/09-transaction.md` 明确写了 TreeLock 不存在的 final_uri 时"create final_uri and write final_uri/.path.ovlock as a T lock"，DAG 之后往这个已存在的目录里同步内容，ResourceProcessor 的自动命名也靠它占位。所以 bug 不是"加锁建了目录"，而是**租约结束后没有回收空预留**。

## 改法：租约记账 + 释放时回收空目录

- `ensure_lock_dir` 返回本次实际创建的目录（浅→深），记入 `PathLockLease.created_dirs`。
- 租约**完全释放**时（`release` / `release_selected` 释放完最后一个 path / 后台 stale 清扫），先删 token，再从深到浅对 created_dirs 做 `fs.remove`——`remove` 只删空目录（localfs 原生如此；memfs 本 PR 对齐），预留期间写入的内容绝不会被碰。
- batch 获取中途失败（冲突/验证失败/registry 失败）走同样的回收，失败的 acquire 不留残渣。
- handoff：`created_dirs` 随 `PathLockHandoffRef` 传给 adopter（`#[serde(default)]`，旧 payload 兼容；Python dict 往返同步透传），DAG 失败释放时空预留一样被回收。
- 同 owner 重入租约:创建方先释放而共享 token 还在时，目录回收职责"捐赠"给幸存租约，最终释放时回收。
- 新竞态收口:并发 release 可能在 `ensure_lock_dir` 和写 token 之间回收掉空锁目录，token 创建失败后重建目录再试一次（仅当重建确实创建了东西）。

## 备选方案及否决理由

**(a) 缺失路径的树锁改放父目录 sidecar（`.exact.ovlock.*`），完全不建目录。** 语义上最"干净"，但二连败：其一，`check_ancestor_tree_locks` 只扫祖先的 `.path.ovlock`，后代路径的加锁将看不到这把树锁，除非把祖先扫描改成每层读两个 token（所有 acquire 热路径读放大 2x）；其二，也是决定性的——它直接违反 09-transaction.md 的预留协议：final_uri 必须在锁定时存在，DAG/自动命名依赖这一点。改表示法等于重设计预留机制，血面积横跨 Rust 锁层 + Python resource pipeline。

**(b) 调用侧绕过（#4970 现状）：`VikingFS.commit` stat 不到就锁最近幸存祖先。** 能治 commit 这一处症状,但锁层病根还在——任何其他调用方树锁一个已删除路径都会继续复活它;且祖先树锁范围比原路径大,并发上是过度加锁。repo owner 已明确要求修在锁层。

**(c) 只在真正写 token 时才 lazily mkdir。** 和现状等价——树锁 token 就在 `{path}/` 里面,写 token 必然要建目录,没有可延迟的窗口。

选定的记账+回收方案不改任何锁解析/冲突判定逻辑,预留协议原样保留,是三者中语义正确且最小的。

## 锁语义血面积

- 锁的解析、冲突检测（ancestor/descendant/exact 候选）、token 格式、重入/升级/降级、handoff 校验:**零改动**。
- 新增行为仅在:租约完全释放、batch 失败回滚两个时刻,多了"删除仍为空的自建目录"这一步。删除用的 `remove` 在 localfs 落到 `std::fs::remove_dir`（内核级 ENOTEMPTY 原子拒绝非空）,memfs 在写锁内检查,不存在删掉他人内容的窗口。
- `remove` 语义变化仅 memfs:空目录可删（对齐 localfs 既有行为）,非空仍报 `IsADirectory`;trait 文档同步更新。s3fs/kvfs/sqlfs 等不支持删目录的后端,回收自动退化为 no-op（保持现状的泄漏,不会出错）。
- 已知残余:跨 owner 的兄弟路径共享自建祖先时,后释放的一方可能留下一个空祖先目录（需要跨租约引用计数才能彻底,不值得）;对象存储后端不回收。都严格不差于现状。
- `release_tree_lease_succeeds_after_locked_directory_is_deleted` 等全部既有用例不动、全绿——"目录被删后释放成功"的既有语义保持。

## 测试

新增 8 个 Rust 单测。其中 6 个回收用例在未修复的 main 上全部失败（在 main + 仅测试的树上实跑验证过）,修复后全绿;另 2 个（预留写入内容后保留、既有目录保留）编码的是必须保持的语义,修复前后都过。

```
test lock::manager::tests::tree_lock_on_missing_nested_path_reclaims_all_created_directories ... ok
test lock::manager::tests::exact_lock_on_missing_nested_path_reclaims_created_directories ... ok
test lock::manager::tests::failed_batch_acquire_reclaims_directories_created_before_the_conflict ... ok
test lock::manager::tests::tree_lock_on_missing_path_reclaims_reserved_directory_on_release ... ok
test lock::manager::tests::adopted_handoff_reclaims_created_directories_on_final_release ... ok
test lock::manager::tests::tree_lock_on_missing_path_reclaims_directory_on_localfs ... ok
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 439 filtered out; finished in 0.00s
```

ragfs 全量:

```
test result: ok. 445 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 10.11s
```

未修复 main + 同批测试:

```
test result: FAILED. 0 passed; 6 failed; 0 ignored; 0 measured; 438 filtered out; finished in 0.00s
```

`cargo check -p ragfs-python` 通过;改动区域 rustfmt 干净,clippy 无新告警（`release_lease_paths_with` 第 8 参加了 `#[allow(clippy::too_many_arguments)]`）。**本机没装 openviking Python 包和 Rust binding,issue 里的 Python 端到端复现脚本和 `tests/` 下的 Python 用例没有跑,依赖 CI。**
