### PR TITLE
docs(helm): preserve release values in upgrade examples

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -19,19 +19,23 @@ helm install openviking ./deploy/helm/openviking \
   --set-string config.vlm.api_key="YOUR_VOLCENGINE_API_KEY"
 ```
 
-The chart deploys `ghcr.io/volcengine/openviking:latest` by default. To choose
-a different image tag:
+The chart deploys `ghcr.io/volcengine/openviking:latest` by default. To change only
+the image tag of the existing release installed above, use `--reuse-values` to
+retain its API keys and other settings:
 
 ```bash
 # newest image from the main branch
-helm upgrade --install openviking ./deploy/helm/openviking --set image.tag=main
+helm upgrade openviking ./deploy/helm/openviking --reuse-values --set image.tag=main
 
 # pinned release image
-helm upgrade --install openviking ./deploy/helm/openviking --set image.tag=v0.3.17
+helm upgrade openviking ./deploy/helm/openviking --reuse-values --set image.tag=v0.3.17
 
 # use the default latest image
-helm upgrade --install openviking ./deploy/helm/openviking --set image.tag=
+helm upgrade openviking ./deploy/helm/openviking --reuse-values --set image.tag=
 ```
+
+For a first-time installation, add `--set image.tag=...` to the install command
+above, alongside the API key settings.
 
 ### Install with Custom Values
 

--- a/deploy/helm/openviking/templates/NOTES.txt
+++ b/deploy/helm/openviking/templates/NOTES.txt
@@ -34,8 +34,8 @@ WARNING: config.server.root_api_key is not set. When the server binds to 0.0.0.0
 (the default), a root_api_key is REQUIRED for security. The server will refuse to
 start without it.
 
-Set it via:
+Set it while retaining the release's other settings via:
 
-  helm upgrade {{ .Release.Name }} <chart> --set config.server.root_api_key="YOUR_SECRET_KEY"
+  helm upgrade {{ .Release.Name }} <chart> --reuse-values --set config.server.root_api_key="YOUR_SECRET_KEY"
 
 {{- end }}


### PR DESCRIPTION
## Description

After following the Helm quick start, running an image-tag upgrade example replaces the release's configured values with the new image override and chart defaults, losing the root and model API keys. Add `--reuse-values` to the three existing-release image examples and the post-install root-key example so unrelated settings are retained. Separate first-time image selection from upgrading an existing release.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

No linked issue. No matching open Helm fix was found during the duplicate search.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Preserve existing release values when changing only the image tag in the Helm README; direct new installations to the install command with credentials.
- Preserve other settings when following the root-key command in rendered installation notes.
- Scope: `deploy/helm/README.md` and `deploy/helm/openviking/templates/NOTES.txt`, 11 additions and 7 deletions. These files have no corresponding translated documents.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Reproduced with Helm 3.19.0 on macOS arm64 using its real `action.Install.Run` and `action.Upgrade.Run` entrypoints, the OpenViking chart, in-memory release storage, and Helm's fake Kubernetes client. Only fake credentials were used. The temporary harness is under `test_scripts/helm_upgrade_values/` and is excluded from the proposed patch.

For each image override (`main`, `v0.3.17`, and empty/default), the original upgrade lost all three configured keys in the rendered `ov.conf`. With `ReuseValues=true`, the keys were retained and the requested image was rendered. The root-key example likewise lost both model keys without reuse and retained them with reuse. All eight cases passed; each upgrade was recorded as deployed revision 2 in memory. The harness also verified that the corrected root-key command appears in rendered installation notes.

Commands run from the repository root (workspace-local tools):

```bash
../toolchain/darwin-arm64/helm lint deploy/helm/openviking
../toolchain/darwin-arm64/helm template openviking deploy/helm/openviking > test_scripts/helm_upgrade_values/updated.yaml
cmp test_scripts/helm_upgrade_values/original.yaml test_scripts/helm_upgrade_values/updated.yaml
git diff --check
```

Command run from `test_scripts/helm_upgrade_values/`:

```bash
GOPATH="$PWD/../../../toolchain/gopath" GOCACHE="$PWD/../../../toolchain/gocache" ../../../toolchain/go/bin/go run .
```

Helm lint passed. Its icon recommendation also occurs on the original chart. Original and updated Kubernetes manifests were byte-for-byte identical. All seven README Bash blocks passed `bash -n`; the complete diff passed whitespace checks and was reviewed.

Revalidated on September 17, 2026 after merging the base above: all eight Helm action-API cases passed with `GOPROXY=off`; `helm lint` passed; all seven README Bash blocks passed `bash -n`; `git diff origin/main --check` passed; and `helm template` output was byte-for-byte identical to a chart extracted from the current `origin/main` with `git archive`. These are local checks; GitHub Actions still requires maintainer approval.

Limitations: a direct `helm install --dry-run=client` attempt could not complete because no Kubernetes cluster was available. The successful reproduction covers Helm's value merging, chart rendering, and release storage through its action API, with Kubernetes operations replaced by the fake client. No real Pod startup, network access to model providers, or live-cluster upgrade was tested. The full application suite and documentation-site build were not run because the change affects only Helm usage text and installation notes. No permanent test was added for Helm framework behavior.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Code comments are not applicable to this documentation change. There are no dependent changes.

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Base: `1825d704b45af5a5162099c9d4ceb8a93948bcda` from upstream `main`.

The README retains both the first-time installation guidance and upstream's registry-mirror guidance. The PR remains limited to the same two files (11 additions, 7 deletions).

Configuration overrides originate in the documented Helm commands, are combined with release values by Helm, and are rendered through `deploy/helm/openviking/templates/configmap.yaml` into `ov.conf`. This change corrects example commands and installation guidance; it does not modify chart defaults, configuration semantics, or resource templates. No migration is required. The existing values-file chart-upgrade example is unchanged.


