### PR TITLE
refactor(cli): reuse shared HTTP client in post_with_timeout

### DIFF
--- a/crates/ov_cli/src/base_client.rs
+++ b/crates/ov_cli/src/base_client.rs
@@ -700,6 +700,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn post_with_timeout_overrides_client_timeout() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _connection = listener.accept().await.unwrap();
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        });
+
+        let client = BaseClient::new(
+            format!("http://{address}"),
+            None,
+            None,
+            None,
+            None,
+            5.0,
+            false,
+            None,
+        );
+        let started = std::time::Instant::now();
+        let error = client
+            .post_with_timeout::<_, Value>("/slow", &json!({}), Duration::from_millis(20))
+            .await
+            .expect_err("slow response should time out");
+
+        assert!(matches!(error, Error::Timeout(_)));
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "request-level timeout should fire before the 5s client timeout"
+        );
+    }
+
+    #[tokio::test]
     async fn plain_text_http_error_preserves_status() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();

--- a/crates/ov_cli/src/base_client.rs
+++ b/crates/ov_cli/src/base_client.rs
@@ -467,16 +467,6 @@ impl BaseClient {
         })
     }
 
-    pub(crate) fn create_client_with_timeout(
-        &self,
-        timeout: std::time::Duration,
-    ) -> Result<ReqwestClient> {
-        ReqwestClient::builder()
-            .timeout(timeout)
-            .build()
-            .map_err(|e| Error::from_reqwest("Failed to build HTTP client", e))
-    }
-
     pub(crate) fn create_client_with_connect_timeout(
         &self,
         connect_timeout: std::time::Duration,
@@ -534,9 +524,13 @@ impl BaseClient {
         timeout: std::time::Duration,
     ) -> Result<T> {
         let url = format!("{}{}", self.base_url, path);
-        let client = self.create_client_with_timeout(timeout)?;
 
-        let request = client.post(&url).headers(self.build_headers()).json(body);
+        let request = self
+            .http
+            .post(&url)
+            .headers(self.build_headers())
+            .timeout(timeout)
+            .json(body);
         let request = if self.profile_enabled {
             request.query(&[("profile", "1")])
         } else {


### PR DESCRIPTION

## Description
Apply the per-request timeout on self.http instead of building a one-off ReqwestClient for each call, and drop the unused create_client_with_timeout helper.
<!-- Provide a brief description of the changes in this PR -->

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->
No issues related
## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- reuse shared HTTP client in post_with_timeout

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

@zhoujh01 @t0saki @ehz0ah