### PR TITLE
feat(studio): configure user memory policies

### DIFF
--- a/web-studio/src/i18n/locales/en.ts
+++ b/web-studio/src/i18n/locales/en.ts
@@ -1,3 +1,4 @@
+import memoryPolicy from './en/user-memory-policy'
 import workspace from './en/workspace'
 import resources from './en/resources'
 import activity from './en/activity'
@@ -6,6 +7,7 @@ const en = {
   ...workspace,
   ...resources,
   ...activity,
+  settings: { ...workspace.settings, memoryPolicy },
 } as const
 
 export default en

--- a/web-studio/src/i18n/locales/en/user-memory-policy.ts
+++ b/web-studio/src/i18n/locales/en/user-memory-policy.ts
@@ -28,6 +28,7 @@ export default {
   edit: 'Edit memory policy',
   editUser: 'Edit memory policy for {{user}}',
   saved: 'Memory policy updated',
+  saveFailed: 'Failed to save memory policy',
   retry: 'Failed to load · Retry',
   saveHint:
     'Selecting a policy saves it immediately. Existing memories are kept.',

--- a/web-studio/src/i18n/locales/en/user-memory-policy.ts
+++ b/web-studio/src/i18n/locales/en/user-memory-policy.ts
@@ -1,0 +1,115 @@
+export default {
+  simple: {
+    self: 'Current User memory',
+    selfHint: 'self.enabled · User information and Agent experience',
+    peer: 'Peer memory',
+    peerHint: 'peer.enabled · Separate memories per participant',
+    working_memory: 'Session summaries',
+    working_memoryHint: 'working_memory.enabled · Generate archive summaries',
+    typesHint:
+      'memory_types · Shared by User and Peer. Agent experience types are linked; Peer excludes cases. The server validates type availability.',
+    unlimited: 'No type restriction (omit memory_types)',
+    defaults: 'Select default types',
+    clear: 'Clear',
+  },
+  title: 'Memory policy',
+  choose: 'Choose a memory extraction policy',
+  back: 'Back',
+  change: 'Change',
+  select: 'Select',
+  selected: 'Selected',
+  enabled: 'Enabled',
+  disabled: 'Disabled',
+  userMemory: 'User memory extraction',
+  agentMemory: 'Agent memory extraction',
+  preview: 'User memory directory preview',
+  previewHint:
+    'Illustrative paths. Files are created when memories are extracted.',
+  edit: 'Edit memory policy',
+  editUser: 'Edit memory policy for {{user}}',
+  saved: 'Memory policy updated',
+  retry: 'Failed to load · Retry',
+  saveHint:
+    'Selecting a policy saves it immediately. Existing memories are kept.',
+  custom: {
+    userDescription:
+      'Choose user profiles, preferences, events and entities to remember.',
+    peerLabel: 'Peer memory extraction',
+    peerDescription:
+      'Keep separate memories for each participant using the same type selection as user memory and Agent experience above. Your app must identify participants using peer_id. Cases are excluded.',
+    advancedSettings: 'Advanced settings',
+    selfStorage: 'Save to the current User',
+    selfStorageHint:
+      'Controls whether selected user memories, Agent experience and other types accumulate under the current User. Peer memories can still be saved separately when enabled.',
+    otherTypes: 'Other memory types',
+    serverManaged:
+      'Uses types enabled on the server. Switch to Specific types to choose individual types.',
+
+    save: 'Save changes',
+    extraHint:
+      'Enter a type identifier already configured by your administrator. This adds it to the extraction scope; it does not create a new memory type.',
+    advanced: 'Advanced: reference extension types',
+    allHint:
+      'Use types enabled on the server now and in the future. No individual selection is needed.',
+    specified: 'Specific types',
+    typesTitle: 'Long-term memory types',
+    workingHint:
+      'Summarize the conversation when the session is committed and archived, making it easier to review later. Turning this off skips the summary; long-term memories can still be extracted according to the settings above.',
+    workingEnable: 'Generate session summaries',
+    peerHint:
+      'When one User serves multiple people, keep memories for each person, such as individual customer preferences. Your app must identify participants in messages using peer_id.',
+    selfHint:
+      'Accumulate memories across sessions, such as your preferences for a personal assistant or execution experience for a task agent.',
+    scopeTitle: 'Who to keep long-term memories for',
+    configurable: 'Configurable',
+    name: 'Custom policy',
+    edit: 'Customize memory policy',
+    self: 'Build memories for this User',
+    peer: 'Keep separate memories for each participant',
+    working_memory: 'Session summaries',
+    all: 'All enabled types',
+    availability:
+      'Built-in types are shown as a reference. The server validates availability when saving. Existing extension types are preserved; additional registered types can be entered below.',
+    defaultOff: 'Disabled by default',
+    linked:
+      'cases, trajectories and experiences are selected together. Peer extraction excludes cases.',
+    empty:
+      'No types selected: long-term memory extraction is disabled. Working memory uses the switch above.',
+    extra: 'Registered extension type name',
+    add: 'Add to selection',
+    apply: 'Use this policy',
+    description: 'Extract memories using custom scopes and types.',
+    examples: 'Configure current User, Peer and working memory independently.',
+  },
+  general: {
+    name: 'General policy',
+    description:
+      'Extract user memories and Agent experience. Each Session can override the extraction scope. Peer memory extraction is enabled.',
+    examples: 'Examples: personal coding assistants, group chat agents',
+  },
+  personal: {
+    name: 'Personal memory',
+    description:
+      'Accumulate a person’s profile, preferences, events and entities. Agent experience and Peer extraction are disabled.',
+    examples: 'Examples: personal assistants, long-term companions',
+  },
+  agent: {
+    name: 'Agent experience',
+    description:
+      'Accumulate reusable cases, trajectories and experiences across tasks. Personal and Peer memory extraction are disabled.',
+    examples: 'Examples: task execution agents, coding agents',
+  },
+  directories: {
+    identity: 'Agent identity',
+    soul: 'Agent values and boundaries',
+    skills: 'Skill usage memory',
+    tools: 'Tool usage memory',
+    profile: 'User profile',
+    preferences: 'Preferences and habits',
+    events: 'Past events',
+    entities: 'People, things and concepts',
+    cases: 'Training and evaluation cases',
+    trajectories: 'Execution steps and results',
+    experiences: 'Reusable Agent experience',
+  },
+} as const

--- a/web-studio/src/i18n/locales/zh-CN.ts
+++ b/web-studio/src/i18n/locales/zh-CN.ts
@@ -1,3 +1,4 @@
+import memoryPolicy from './zh-CN/user-memory-policy'
 import workspace from './zh-CN/workspace'
 import resources from './zh-CN/resources'
 import activity from './zh-CN/activity'
@@ -6,6 +7,7 @@ const zhCN = {
   ...workspace,
   ...resources,
   ...activity,
+  settings: { ...workspace.settings, memoryPolicy },
 } as const
 
 export default zhCN

--- a/web-studio/src/i18n/locales/zh-CN/user-memory-policy.ts
+++ b/web-studio/src/i18n/locales/zh-CN/user-memory-policy.ts
@@ -1,0 +1,108 @@
+export default {
+  simple: {
+    self: '当前 User 记忆',
+    selfHint: 'self.enabled · 包含用户信息和 Agent 经验',
+    peer: 'Peer 记忆',
+    peerHint: 'peer.enabled · 为参与者分别保存记忆',
+    working_memory: '会话摘要',
+    working_memoryHint: 'working_memory.enabled · 生成归档摘要',
+    typesHint:
+      'memory_types · 对 User 和 Peer 共用；Agent 经验三种类型联动，Peer 不抽取 cases。类型是否可用由服务端校验。',
+    unlimited: '不限类型（不传 memory_types）',
+    defaults: '选择默认类型',
+    clear: '清空',
+  },
+  title: '记忆策略',
+  choose: '选择记忆抽取策略',
+  back: '返回',
+  change: '更换',
+  select: '选择',
+  selected: '已选择',
+  enabled: '已开启',
+  disabled: '已关闭',
+  userMemory: '用户记忆抽取',
+  agentMemory: 'Agent 经验记忆抽取',
+  preview: 'User 记忆目录预览',
+  previewHint: '目录仅作示意，实际文件在记忆抽取后生成。',
+  edit: '修改记忆策略',
+  editUser: '修改 {{user}} 的记忆策略',
+  saved: '记忆策略已更新',
+  retry: '加载失败 · 重试',
+  saveHint: '选择后立即保存，已有记忆会保留。',
+  custom: {
+    userDescription: '选择要记住的用户画像、偏好、事件和实体。',
+    peerLabel: 'Peer 记忆抽取',
+    peerDescription:
+      '为不同参与者分别保存所选类型的记忆。与上面的用户记忆、Agent 经验记忆共用类型范围；需要应用标记参与者（peer_id），不抽取案例。',
+    advancedSettings: '高级设置',
+    selfStorage: '保存到当前 User',
+    selfStorageHint:
+      '控制所选用户记忆、Agent 经验等是否在当前 User 下积累。关闭后仍可按 Peer 开关分别保存参与者记忆。',
+    otherTypes: '其他记忆类型',
+    serverManaged: '按服务端已启用类型抽取；切换到“指定类型”可自行选择。',
+
+    save: '保存修改',
+    extraHint:
+      '填写管理员已在服务端配置的类型标识。这里只加入抽取范围，不会创建新的记忆类型。',
+    advanced: '高级：引用扩展类型',
+    allHint: '使用服务端当前及以后新增或启用的类型。无需逐项选择。',
+    specified: '指定类型',
+    typesTitle: '长期记忆类型',
+    workingHint:
+      '会话提交归档时，将这段对话整理成摘要，便于后续回顾。关闭后不生成这份摘要，仍可按上方设置抽取长期记忆。',
+    workingEnable: '生成会话摘要',
+    peerHint:
+      '同一个 User 服务多人时，为每个人分别积累记忆，例如客服分别记住各位客户的偏好。需要应用在消息中标记参与者（peer_id）。',
+    selfHint:
+      '在多次会话中积累这个 User 的记忆，例如个人助理记住你的偏好，或任务 Agent 积累执行经验。',
+    scopeTitle: '长期记忆保存给谁',
+    configurable: '可配置',
+    name: '自定义策略',
+    edit: '自定义记忆策略',
+    self: '为当前 User 积累记忆',
+    peer: '为不同参与者分别记忆',
+    working_memory: '会话摘要',
+    all: '全部已启用类型',
+    availability:
+      '以下为内置类型参考，当前服务端可用类型以保存时校验为准。已有扩展类型会保留，也可手动添加。',
+    defaultOff: '默认关闭',
+    linked: 'cases、trajectories、experiences 联动选择；Peer 不抽取 cases。',
+    empty: '未选择任何类型：不抽取长期记忆，工作记忆由上方开关控制。',
+    extra: '服务端已注册的扩展类型名称',
+    add: '加入选择',
+    apply: '使用此策略',
+    description: '按自定义范围和记忆类型抽取。',
+    examples: '可独立配置当前 User、Peer 和工作记忆。',
+  },
+  general: {
+    name: '通用策略',
+    description:
+      '同时抽取用户记忆和 Agent 执行经验，可按 Session 灵活调整抽取范围。开启 Peer 记忆抽取。',
+    examples: '示例 Agent：个人 Coding Agent、群聊 Agent',
+  },
+  personal: {
+    name: '用户个人记忆',
+    description:
+      '长期积累本人的画像、偏好、事件和实体，关闭 Agent 经验和 Peer 记忆抽取。',
+    examples: '示例 Agent：个人助理、长期陪伴助手',
+  },
+  agent: {
+    name: 'Agent 经验记忆',
+    description:
+      '积累跨任务可复用的案例、执行轨迹和经验，关闭用户个人记忆和 Peer 记忆抽取。',
+    examples: '示例 Agent：任务执行 Agent、Coding Agent',
+  },
+  directories: {
+    identity: 'Agent 身份',
+    soul: 'Agent 价值观与边界',
+    skills: '技能使用记忆',
+    tools: '工具使用记忆',
+    profile: 'User 画像',
+    preferences: '偏好与习惯',
+    events: '发生过的事',
+    entities: '常提到的人、事、物',
+    cases: '可训练或评估的案例样本',
+    trajectories: '执行过程与结果',
+    experiences: 'Agent 可复用经验',
+  },
+} as const

--- a/web-studio/src/i18n/locales/zh-CN/user-memory-policy.ts
+++ b/web-studio/src/i18n/locales/zh-CN/user-memory-policy.ts
@@ -27,6 +27,7 @@ export default {
   edit: '修改记忆策略',
   editUser: '修改 {{user}} 的记忆策略',
   saved: '记忆策略已更新',
+  saveFailed: '记忆策略保存失败',
   retry: '加载失败 · 重试',
   saveHint: '选择后立即保存，已有记忆会保留。',
   custom: {

--- a/web-studio/src/lib/admin.ts
+++ b/web-studio/src/lib/admin.ts
@@ -8,10 +8,11 @@ import {
   getAdminAccounts,
   getOvResult,
   postAdminAccountIdUserIdKey,
-  postAdminAccountIdUsers,
   postAdminAccounts,
   putAdminAccountIdUserIdRole,
 } from '#/lib/ov-client'
+
+import type { UserMemoryPolicy } from './user-memory-policy'
 
 export type AdminUserRole = 'admin' | 'root' | 'user'
 
@@ -42,6 +43,7 @@ export type CreateAccountInput = {
 }
 
 export type CreateUserInput = {
+  memoryPolicy?: UserMemoryPolicy
   accountId: string
   role: string
   userId: string
@@ -411,12 +413,16 @@ export async function createAdminUser(
   input: CreateUserInput,
 ): Promise<KeyResult> {
   const result = await getOvResult<unknown>(
-    postAdminAccountIdUsers({
+    createAdminClient(connection).post({
+      url: '/api/v1/admin/accounts/{account_id}/users',
+      headers: { 'Content-Type': 'application/json' },
       body: {
         role: input.role,
         user_id: input.userId,
+        ...(input.memoryPolicy
+          ? { user_config: { memory_policy: input.memoryPolicy } }
+          : {}),
       },
-      client: createAdminClient(connection),
       path: {
         account_id: input.accountId,
       },
@@ -476,6 +482,37 @@ export async function updateAdminUserRole(
         account_id: input.accountId,
         user_id: input.userId,
       },
+    }),
+  )
+}
+
+export type UserMemorySettings = { memory_policy: UserMemoryPolicy }
+
+export async function fetchUserMemorySettings(
+  connection: AdminConnection,
+  accountId: string,
+  userId: string,
+): Promise<UserMemorySettings> {
+  return getOvResult<UserMemorySettings>(
+    createAdminClient(connection).get({
+      url: '/api/v1/admin/accounts/{account_id}/users/{user_id}/settings',
+      path: { account_id: accountId, user_id: userId },
+    }),
+  )
+}
+
+export async function updateUserMemorySettings(
+  connection: AdminConnection,
+  accountId: string,
+  userId: string,
+  memoryPolicy: UserMemoryPolicy,
+): Promise<UserMemorySettings> {
+  return getOvResult<UserMemorySettings>(
+    createAdminClient(connection).patch({
+      url: '/api/v1/admin/accounts/{account_id}/users/{user_id}/settings',
+      path: { account_id: accountId, user_id: userId },
+      headers: { 'Content-Type': 'application/json' },
+      body: { memory_policy: memoryPolicy },
     }),
   )
 }

--- a/web-studio/src/lib/user-memory-policy.ts
+++ b/web-studio/src/lib/user-memory-policy.ts
@@ -1,0 +1,73 @@
+export type UserMemoryPolicy = {
+  self?: { enabled: boolean }
+  peer?: { enabled: boolean }
+  working_memory?: { enabled: boolean }
+  memory_types?: string[]
+}
+
+export const personalMemoryTypes = [
+  'profile',
+  'preferences',
+  'events',
+  'entities',
+]
+export const agentMemoryTypes = ['cases', 'trajectories', 'experiences']
+export const memoryPresets = ['general', 'personal', 'agent'] as const
+export type MemoryPreset = (typeof memoryPresets)[number]
+
+export function buildMemoryPolicy(preset: MemoryPreset): UserMemoryPolicy {
+  return {
+    self: { enabled: true },
+    peer: { enabled: preset === 'general' },
+    working_memory: { enabled: true },
+    ...(preset === 'general'
+      ? {}
+      : {
+          memory_types: [
+            ...(preset === 'personal' ? personalMemoryTypes : agentMemoryTypes),
+          ],
+        }),
+  }
+}
+
+export function identifyMemoryPreset(
+  policy: UserMemoryPolicy,
+): MemoryPreset | 'custom' {
+  return (
+    memoryPresets.find((preset) => {
+      const expected = buildMemoryPolicy(preset)
+      const types = policy.memory_types
+      const expectedTypes = expected.memory_types ?? defaultMemoryTypes
+      return (
+        policy.self?.enabled !== false &&
+        (policy.peer?.enabled !== false) === expected.peer?.enabled &&
+        policy.working_memory?.enabled !== false &&
+        (types
+          ? types.length === expectedTypes.length &&
+            expectedTypes.every((type) => types.includes(type))
+          : preset === 'general')
+      )
+    }) ?? 'custom'
+  )
+}
+
+export const defaultMemoryTypes = [
+  ...personalMemoryTypes,
+  ...agentMemoryTypes,
+  'identity',
+  'soul',
+]
+export const builtinMemoryTypes = [...defaultMemoryTypes, 'skills', 'tools']
+
+export function normalizeMemoryPolicy(
+  policy: UserMemoryPolicy,
+): UserMemoryPolicy {
+  if (!policy.memory_types) return policy
+  const types = new Set(policy.memory_types)
+  if (types.has('experiences'))
+    agentMemoryTypes.forEach((type) => types.add(type))
+  else agentMemoryTypes.forEach((type) => types.delete(type))
+  return { ...policy, memory_types: [...types] }
+}
+
+export const memoryScopeKeys = ['self', 'peer', 'working_memory'] as const

--- a/web-studio/src/routes/users/-components/add-user-dialog.tsx
+++ b/web-studio/src/routes/users/-components/add-user-dialog.tsx
@@ -19,6 +19,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from '#/components/ui/select'
+import {
+  MemoryDirectoryPreview,
+  MemoryPolicyPicker,
+  MemoryPolicySummary,
+} from './memory-policy-picker'
+import { buildMemoryPolicy } from '#/lib/user-memory-policy'
+import type { UserMemoryPolicy } from '#/lib/user-memory-policy'
 import type { CreateUserInput } from '#/lib/admin'
 import { PLAIN_INPUT_PROPS } from '#/lib/form-input'
 
@@ -36,6 +43,10 @@ export function AddUserDialog({
   open: boolean
 }) {
   const { t } = useTranslation('settings')
+  const [preset, setPreset] = React.useState<UserMemoryPolicy>(() =>
+    buildMemoryPolicy('general'),
+  )
+  const [choosing, setChoosing] = React.useState(false)
   const [draft, setDraft] = React.useState<CreateUserInput>({
     accountId,
     role: 'user',
@@ -44,80 +55,126 @@ export function AddUserDialog({
 
   React.useEffect(() => {
     if (open) {
+      setPreset(buildMemoryPolicy('general'))
+      setChoosing(false)
       setDraft({ accountId, role: 'user', userId: '' })
     }
   }, [accountId, open])
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <form
-          onSubmit={(event) => {
-            event.preventDefault()
-            onCreate(draft)
-          }}
-        >
-          <DialogHeader>
-            <DialogTitle>{t('dialogs.addUser.title')}</DialogTitle>
-            <DialogDescription>
-              {t('dialogs.addUser.currentAccountDescription', { accountId })}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="grid gap-4 py-5">
-            <label className="grid gap-2 text-sm font-medium">
-              {t('fields.user')}
-              <Input
-                required
-                value={draft.userId}
-                onChange={(event) =>
-                  setDraft((current) => ({
-                    ...current,
-                    userId: event.target.value,
-                  }))
-                }
-                placeholder={t('placeholders.user')}
-                {...PLAIN_INPUT_PROPS}
-              />
-            </label>
-            <label className="grid gap-2 text-sm font-medium">
-              {t('fields.role')}
-              <Select
-                value={draft.role}
-                onValueChange={(role) =>
-                  setDraft((current) => ({
-                    ...current,
-                    role: role || 'user',
-                  }))
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="user">{t('roles.user')}</SelectItem>
-                  <SelectItem value="admin">{t('roles.admin')}</SelectItem>
-                </SelectContent>
-              </Select>
-            </label>
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!isPending) onOpenChange(next)
+      }}
+    >
+      <DialogContent
+        className="gap-0 p-0 sm:max-w-5xl"
+        showCloseButton={!isPending}
+      >
+        {choosing ? (
+          <div className="p-6">
+            <DialogHeader className="mb-4">
+              <DialogTitle>{t('memoryPolicy.choose')}</DialogTitle>
+            </DialogHeader>
+            <MemoryPolicyPicker
+              value={preset}
+              onBack={() => setChoosing(false)}
+              onSelect={(value) => {
+                setPreset(value)
+                setChoosing(false)
+              }}
+            />
           </div>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
+        ) : (
+          <div className="grid lg:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)]">
+            <form
+              className="flex flex-col p-6 lg:p-8"
+              onSubmit={(event) => {
+                event.preventDefault()
+                if (!isPending)
+                  onCreate({
+                    ...draft,
+                    userId: draft.userId.trim(),
+                    memoryPolicy: preset,
+                  })
+              }}
             >
-              {t('actions.cancel')}
-            </Button>
-            <Button type="submit" disabled={isPending}>
-              {isPending ? (
-                <LoaderCircleIcon className="animate-spin" />
-              ) : (
-                <PlusIcon />
-              )}
-              {t('actions.addUser')}
-            </Button>
-          </DialogFooter>
-        </form>
+              <DialogHeader>
+                <DialogTitle>{t('dialogs.addUser.title')}</DialogTitle>
+                <DialogDescription>
+                  {t('dialogs.addUser.currentAccountDescription', {
+                    accountId,
+                  })}
+                </DialogDescription>
+              </DialogHeader>
+              <div className="grid gap-4 py-5">
+                <label className="grid gap-2 text-sm font-medium">
+                  {t('fields.user')}
+                  <Input
+                    required
+                    value={draft.userId}
+                    onChange={(event) =>
+                      setDraft((current) => ({
+                        ...current,
+                        userId: event.target.value,
+                      }))
+                    }
+                    placeholder={t('placeholders.user')}
+                    {...PLAIN_INPUT_PROPS}
+                  />
+                </label>
+                <label className="grid gap-2 text-sm font-medium">
+                  {t('fields.role')}
+                  <Select
+                    value={draft.role}
+                    onValueChange={(role) =>
+                      setDraft((current) => ({
+                        ...current,
+                        role: role || 'user',
+                      }))
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="user">{t('roles.user')}</SelectItem>
+                      <SelectItem value="admin">{t('roles.admin')}</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </label>
+              </div>
+              <MemoryPolicySummary
+                value={preset}
+                onChange={() => setChoosing(true)}
+                disabled={isPending}
+              />
+              <DialogFooter className="mt-8">
+                <Button
+                  type="button"
+                  disabled={isPending}
+                  variant="outline"
+                  onClick={() => onOpenChange(false)}
+                >
+                  {t('actions.cancel')}
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={isPending || !draft.userId.trim()}
+                >
+                  {isPending ? (
+                    <LoaderCircleIcon className="animate-spin" />
+                  ) : (
+                    <PlusIcon />
+                  )}
+                  {t('actions.addUser')}
+                </Button>
+              </DialogFooter>
+            </form>
+            <MemoryDirectoryPreview value={preset} userId={draft.userId} />
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   )

--- a/web-studio/src/routes/users/-components/custom-memory-policy.tsx
+++ b/web-studio/src/routes/users/-components/custom-memory-policy.tsx
@@ -1,0 +1,194 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '#/components/ui/button'
+import { Input } from '#/components/ui/input'
+import {
+  agentMemoryTypes,
+  builtinMemoryTypes,
+  defaultMemoryTypes,
+  memoryScopeKeys,
+  normalizeMemoryPolicy,
+} from '#/lib/user-memory-policy'
+import type { UserMemoryPolicy } from '#/lib/user-memory-policy'
+
+export function CustomMemoryPolicy({
+  policy,
+  disabled,
+  editing = false,
+  onSave,
+  onBack,
+}: {
+  policy: UserMemoryPolicy
+  editing?: boolean
+  disabled?: boolean
+  onSave: (policy: UserMemoryPolicy) => void
+  onBack: () => void
+}) {
+  const { t } = useTranslation('settings')
+  const [draft, setDraft] = useState(() =>
+    normalizeMemoryPolicy({
+      ...policy,
+      memory_types: policy.memory_types ?? [...defaultMemoryTypes],
+    }),
+  )
+  const [types, setTypes] = useState(
+    () => normalizeMemoryPolicy(policy).memory_types ?? [...defaultMemoryTypes],
+  )
+  const [extra, setExtra] = useState('')
+  const [extensions, setExtensions] = useState(() =>
+    (policy.memory_types ?? []).filter(
+      (type) => !builtinMemoryTypes.includes(type),
+    ),
+  )
+  const choices = [...new Set([...builtinMemoryTypes, ...extensions])].filter(
+    (type) => !['cases', 'trajectories'].includes(type),
+  )
+  function selectTypes(next: string[]) {
+    const normalized = normalizeMemoryPolicy({ ...draft, memory_types: next })
+    setTypes(normalized.memory_types ?? [])
+    setDraft(normalized)
+  }
+  function toggle(type: string, checked: boolean) {
+    const group = agentMemoryTypes.includes(type) ? agentMemoryTypes : [type]
+    selectTypes(
+      checked
+        ? [...new Set([...types, ...group])]
+        : types.filter((item) => !group.includes(item)),
+    )
+  }
+  return (
+    <div className="grid gap-5">
+      <fieldset disabled={disabled} className="grid gap-5">
+        <div className="grid gap-3 sm:grid-cols-3">
+          {memoryScopeKeys.map((key) => (
+            <label
+              key={key}
+              className="flex items-start gap-3 rounded-lg border p-3"
+            >
+              <input
+                className="mt-1"
+                type="checkbox"
+                checked={draft[key]?.enabled !== false}
+                onChange={(event) =>
+                  setDraft({
+                    ...draft,
+                    [key]: { enabled: event.target.checked },
+                  })
+                }
+              />
+              <span>
+                {t(`memoryPolicy.simple.${key}`)}
+                <span className="mt-1 block text-xs text-muted-foreground">
+                  {t(`memoryPolicy.simple.${key}Hint`)}
+                </span>
+              </span>
+            </label>
+          ))}
+        </div>
+        <section className="grid gap-3">
+          <h4 className="font-medium">{t('memoryPolicy.custom.typesTitle')}</h4>
+          <p className="text-sm text-muted-foreground">
+            {t('memoryPolicy.simple.typesHint')}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                selectTypes([...defaultMemoryTypes, ...extensions])
+              }
+            >
+              {t('memoryPolicy.simple.defaults')}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => selectTypes([])}
+            >
+              {t('memoryPolicy.simple.clear')}
+            </Button>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {choices.map((type) => (
+              <label
+                key={type}
+                className="flex items-center gap-2 rounded-lg border p-3 text-sm"
+              >
+                <input
+                  type="checkbox"
+                  checked={types.includes(type)}
+                  onChange={(event) => toggle(type, event.target.checked)}
+                />
+                <span>
+                  {t(`memoryPolicy.directories.${type}`, {
+                    defaultValue: type,
+                  })}
+                  <span className="mt-1 block text-xs text-muted-foreground">
+                    {agentMemoryTypes.includes(type)
+                      ? agentMemoryTypes.join(' / ')
+                      : type}
+                  </span>
+                  {['skills', 'tools'].includes(type) && (
+                    <span className="text-xs text-muted-foreground">
+                      {t('memoryPolicy.custom.defaultOff')}
+                    </span>
+                  )}
+                </span>
+              </label>
+            ))}
+          </div>
+          {types.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              {t('memoryPolicy.custom.empty')}
+            </p>
+          )}
+          <div className="flex gap-2">
+            <Input
+              aria-label={t('memoryPolicy.custom.extra')}
+              placeholder={t('memoryPolicy.custom.extra')}
+              value={extra}
+              onChange={(event) => setExtra(event.target.value)}
+            />
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={!extra.trim()}
+              onClick={() => {
+                const type = extra.trim()
+                setExtensions([...new Set([...extensions, type])])
+                toggle(type, true)
+                setExtra('')
+              }}
+            >
+              {t('memoryPolicy.custom.add')}
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {t('memoryPolicy.custom.extraHint')}
+          </p>
+        </section>
+      </fieldset>
+      <div className="flex justify-end gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          disabled={disabled}
+          onClick={onBack}
+        >
+          {t('actions.cancel')}
+        </Button>
+        <Button
+          type="button"
+          disabled={disabled}
+          onClick={() => onSave(normalizeMemoryPolicy(draft))}
+        >
+          {t(
+            editing ? 'memoryPolicy.custom.save' : 'memoryPolicy.custom.apply',
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/web-studio/src/routes/users/-components/memory-policy-picker.tsx
+++ b/web-studio/src/routes/users/-components/memory-policy-picker.tsx
@@ -1,0 +1,280 @@
+import { useState } from 'react'
+import { CustomMemoryPolicy } from './custom-memory-policy'
+import {
+  ArrowLeftIcon,
+  CheckIcon,
+  FileIcon,
+  FolderIcon,
+  ArrowLeftRightIcon,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '#/components/ui/button'
+import {
+  defaultMemoryTypes,
+  memoryScopeKeys,
+  buildMemoryPolicy,
+  identifyMemoryPreset,
+  personalMemoryTypes,
+  memoryPresets,
+} from '#/lib/user-memory-policy'
+import type { UserMemoryPolicy } from '#/lib/user-memory-policy'
+
+const policyChoices = [...memoryPresets, 'custom'] as const
+
+export function MemoryPolicyPicker({
+  value,
+  onSelect,
+  onBack,
+  disabled = false,
+  editing = false,
+}: {
+  value: UserMemoryPolicy
+  onSelect: (value: UserMemoryPolicy) => void
+  onBack: () => void
+  editing?: boolean
+  disabled?: boolean
+}) {
+  const { t } = useTranslation('settings')
+  const [custom, setCustom] = useState(false)
+  const selected = identifyMemoryPreset(value)
+  if (custom)
+    return (
+      <CustomMemoryPolicy
+        policy={value}
+        editing={editing}
+        disabled={disabled}
+        onSave={onSelect}
+        onBack={() => setCustom(false)}
+      />
+    )
+  return (
+    <div className="grid gap-5">
+      <div>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={onBack}
+          disabled={disabled}
+        >
+          <ArrowLeftIcon />
+          {t('memoryPolicy.back')}
+        </Button>
+      </div>
+      <div className="overflow-x-auto rounded-xl border">
+        <table className="w-full min-w-[540px] text-left text-sm">
+          <thead className="text-muted-foreground">
+            <tr>
+              <th className="p-4">{t('memoryPolicy.title')}</th>
+              <th className="p-4 text-center">
+                {t('memoryPolicy.userMemory')}
+              </th>
+              <th className="p-4 text-center">
+                {t('memoryPolicy.agentMemory')}
+              </th>
+              <th className="p-4">
+                <span className="sr-only">{t('memoryPolicy.select')}</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {policyChoices.map((preset) => (
+              <tr
+                key={preset}
+                className={selected === preset ? 'bg-primary/5' : ''}
+              >
+                <td className="p-5">
+                  <p className="font-medium">
+                    {t(`memoryPolicy.${preset}.name`)}
+                  </p>
+                  <p className="mt-2 max-w-lg text-muted-foreground">
+                    {t(`memoryPolicy.${preset}.description`)}
+                  </p>
+                </td>
+                {[preset !== 'agent', preset !== 'personal'].map(
+                  (enabled, index) => (
+                    <td key={index} className="p-4 text-center">
+                      {preset === 'custom' ? (
+                        <span className="text-muted-foreground">
+                          {t('memoryPolicy.custom.configurable')}
+                        </span>
+                      ) : enabled ? (
+                        <CheckIcon
+                          aria-label={t('memoryPolicy.enabled')}
+                          className="mx-auto size-5 text-primary"
+                        />
+                      ) : (
+                        <span aria-label={t('memoryPolicy.disabled')}>—</span>
+                      )}
+                    </td>
+                  ),
+                )}
+                <td className="p-4">
+                  <Button
+                    type="button"
+                    disabled={disabled}
+                    variant={selected === preset ? 'ghost' : 'secondary'}
+                    onClick={() => {
+                      if (preset === 'custom') setCustom(true)
+                      else onSelect(buildMemoryPolicy(preset))
+                    }}
+                  >
+                    {t(
+                      selected === preset
+                        ? 'memoryPolicy.selected'
+                        : 'memoryPolicy.select',
+                    )}
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+export function MemoryPolicySummary({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: UserMemoryPolicy
+  onChange: () => void
+  disabled?: boolean
+}) {
+  const { t } = useTranslation('settings')
+  const preset = identifyMemoryPreset(value)
+  return (
+    <section className="grid gap-3">
+      <h3 className="text-sm font-medium">{t('memoryPolicy.title')}</h3>
+      <div className="overflow-hidden rounded-xl border">
+        <div className="flex items-center justify-between gap-3 p-4">
+          <strong>{t(`memoryPolicy.${preset}.name`)}</strong>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onChange}
+            disabled={disabled}
+          >
+            <ArrowLeftRightIcon />
+            {t('memoryPolicy.change')}
+          </Button>
+        </div>
+        <div className="grid gap-3 bg-muted/30 p-4 text-sm text-muted-foreground">
+          <div className="flex flex-wrap gap-4">
+            {value.self?.enabled !== false &&
+              (value.memory_types ?? defaultMemoryTypes).some((type) =>
+                personalMemoryTypes.includes(type),
+              ) && (
+                <span className="flex items-center gap-2">
+                  <CheckIcon className="size-4" />
+                  {t('memoryPolicy.userMemory')}
+                </span>
+              )}
+            {value.self?.enabled !== false &&
+              (value.memory_types ?? defaultMemoryTypes).includes(
+                'experiences',
+              ) && (
+                <span className="flex items-center gap-2">
+                  <CheckIcon className="size-4" />
+                  {t('memoryPolicy.agentMemory')}
+                </span>
+              )}
+          </div>
+          <p>{t(`memoryPolicy.${preset}.description`)}</p>
+          <p>{t(`memoryPolicy.${preset}.examples`)}</p>
+          {preset === 'custom' && (
+            <div className="grid gap-2">
+              {memoryScopeKeys.map((key) => (
+                <p key={key}>
+                  {t(`memoryPolicy.custom.${key}`)}:{' '}
+                  {t(
+                    value[key]?.enabled === false
+                      ? 'memoryPolicy.disabled'
+                      : 'memoryPolicy.enabled',
+                  )}
+                </p>
+              ))}
+              <p className="break-words">
+                {value.memory_types === undefined
+                  ? t('memoryPolicy.custom.all')
+                  : value.memory_types.length
+                    ? value.memory_types.join(', ')
+                    : t('memoryPolicy.custom.empty')}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+/* eslint-disable i18next/no-literal-string -- Directory names and ID placeholders are literal storage paths. */
+export function MemoryDirectoryPreview({
+  value,
+  userId,
+}: {
+  value: UserMemoryPolicy
+  userId: string
+}) {
+  const { t } = useTranslation('settings')
+  const types = value.memory_types ?? defaultMemoryTypes
+  const nodes = (entries: string[]) =>
+    entries.map((type) => (
+      <li key={type} className="flex items-start gap-2 py-2">
+        {['profile', 'identity', 'soul'].includes(type) ? (
+          <FileIcon className="mt-0.5 size-4 shrink-0" />
+        ) : (
+          <FolderIcon className="mt-0.5 size-4 shrink-0" />
+        )}
+        <span>
+          {['profile', 'identity', 'soul'].includes(type) ? `${type}.md` : type}
+          <span className="ml-2 text-xs text-muted-foreground">
+            {t(`memoryPolicy.directories.${type}`, { defaultValue: '' })}
+          </span>
+        </span>
+      </li>
+    ))
+  return (
+    <aside className="max-h-[min(640px,calc(100dvh-4rem))] min-w-0 overflow-y-auto overscroll-contain rounded-xl bg-muted/30 p-5 lg:rounded-none lg:border-l lg:p-7">
+      <h3 className="mb-5 font-medium text-muted-foreground">
+        {t('memoryPolicy.preview')}
+      </h3>
+      <div className="flex items-center gap-2 font-medium">
+        <FolderIcon className="size-4 shrink-0" />
+        <span className="truncate">{userId.trim() || '<user_id>'}</span>
+      </div>
+      <div className="ml-2 mt-3 border-l pl-4">
+        <div className="flex items-center gap-2">
+          <FolderIcon className="size-4" />
+          memories
+        </div>
+        <ul className="ml-2 mt-2 border-l pl-4">
+          {nodes(value.self?.enabled === false ? [] : types)}
+        </ul>
+        {value.peer?.enabled !== false && (
+          <div className="mt-2">
+            <div className="flex items-center gap-2">
+              <FolderIcon className="size-4" />
+              peers
+            </div>
+            <div className="ml-2 mt-2 border-l pl-4">
+              {'<peer_id>'}
+              <div className="mt-2 border-l pl-4">
+                memories
+                <ul>{nodes(types.filter((type) => type !== 'cases'))}</ul>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+      <p className="mt-5 text-xs text-muted-foreground">
+        {t('memoryPolicy.previewHint')}
+      </p>
+    </aside>
+  )
+}
+
+/* eslint-enable i18next/no-literal-string */

--- a/web-studio/src/routes/users/-components/user-memory-policy-cell.test.tsx
+++ b/web-studio/src/routes/users/-components/user-memory-policy-cell.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { afterEach, expect, it, vi } from 'vitest'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { UserMemoryPolicyCell } from './user-memory-policy-cell'
+import type { UserMemoryPolicy } from '#/lib/user-memory-policy'
+
+const api = vi.hoisted(() => ({
+  fetch: vi.fn(),
+  update: vi.fn(),
+  error: vi.fn(),
+}))
+vi.mock('#/lib/admin', () => ({
+  fetchUserMemorySettings: api.fetch,
+  updateUserMemorySettings: api.update,
+}))
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: api.error } }))
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+vi.mock('#/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => children,
+  TooltipTrigger: ({ render: trigger }: { render: ReactNode }) => trigger,
+  TooltipContent: () => null,
+}))
+vi.mock('#/components/ui/dialog', () => {
+  const Container = ({ children }: { children: ReactNode }) => children
+  return {
+    Dialog: ({ open, children }: { open: boolean; children: ReactNode }) =>
+      open ? children : null,
+    DialogContent: Container,
+    DialogHeader: Container,
+    DialogTitle: Container,
+    DialogDescription: Container,
+  }
+})
+vi.mock('./memory-policy-picker', () => ({
+  MemoryPolicyPicker: ({
+    value,
+    onSelect,
+  }: {
+    value: UserMemoryPolicy
+    onSelect: (value: UserMemoryPolicy) => void
+  }) => (
+    <button onClick={() => onSelect(value)}>{JSON.stringify(value)}</button>
+  ),
+}))
+afterEach(() => {
+  cleanup()
+  vi.resetAllMocks()
+})
+const oldPolicy = { memory_types: ['profile'] }
+const newPolicy = { memory_types: ['preferences'] }
+function mount() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  render(
+    <QueryClientProvider client={client}>
+      <UserMemoryPolicyCell
+        connection={{
+          baseUrl: 'http://localhost',
+          apiKey: 'key',
+          accountId: 'a',
+          userId: 'admin',
+        }}
+        user={{ accountId: 'a', userId: 'u', role: 'user' }}
+      />
+    </QueryClientProvider>,
+  )
+  return client
+}
+it('reads the latest policy before editing and preserves save error details', async () => {
+  api.fetch
+    .mockResolvedValueOnce({ memory_policy: oldPolicy })
+    .mockResolvedValue({ memory_policy: newPolicy })
+  api.update.mockRejectedValue(new Error('server validation error'))
+  mount()
+  fireEvent.click(
+    await screen.findByRole('button', { name: 'memoryPolicy.editUser' }),
+  )
+  fireEvent.click(
+    await screen.findByRole('button', { name: JSON.stringify(newPolicy) }),
+  )
+  await waitFor(() =>
+    expect(api.update).toHaveBeenCalledWith(
+      expect.anything(),
+      'a',
+      'u',
+      newPolicy,
+    ),
+  )
+  await waitFor(() =>
+    expect(api.error).toHaveBeenCalledWith('memoryPolicy.saveFailed', {
+      description: 'server validation error',
+    }),
+  )
+})
+it('does not open stale data when refresh fails', async () => {
+  api.fetch
+    .mockResolvedValueOnce({ memory_policy: oldPolicy })
+    .mockRejectedValue(new Error('offline'))
+  mount()
+  fireEvent.click(
+    await screen.findByRole('button', { name: 'memoryPolicy.editUser' }),
+  )
+  await screen.findByRole('button', { name: 'memoryPolicy.retry' })
+  expect(
+    screen.queryByRole('button', { name: JSON.stringify(oldPolicy) }),
+  ).toBeNull()
+})
+it('refreshes mounted policies when the account prefix is invalidated', async () => {
+  api.fetch
+    .mockResolvedValueOnce({ memory_policy: oldPolicy })
+    .mockResolvedValue({ memory_policy: newPolicy })
+  const client = mount()
+  await screen.findByRole('button', { name: 'memoryPolicy.editUser' })
+  await client.invalidateQueries({
+    queryKey: ['user-memory-settings', 'http://localhost', 'key', 'a'],
+  })
+  expect(
+    client.getQueryData([
+      'user-memory-settings',
+      'http://localhost',
+      'key',
+      'a',
+      'u',
+    ]),
+  ).toEqual({ memory_policy: newPolicy })
+})

--- a/web-studio/src/routes/users/-components/user-memory-policy-cell.tsx
+++ b/web-studio/src/routes/users/-components/user-memory-policy-cell.tsx
@@ -54,7 +54,10 @@ export function UserMemoryPolicyCell({
       setOpen(false)
       toast.success(t('memoryPolicy.saved'))
     },
-    onError: (error) => toast.error(getErrorMessage(error)),
+    onError: (error) =>
+      toast.error(t('memoryPolicy.saveFailed'), {
+        description: getErrorMessage(error),
+      }),
   })
   if (query.isPending)
     return (
@@ -83,7 +86,11 @@ export function UserMemoryPolicyCell({
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => setOpen(true)}
+              disabled={query.isFetching}
+              onClick={async () => {
+                const result = await query.refetch()
+                if (result.isSuccess) setOpen(true)
+              }}
               aria-label={t('memoryPolicy.editUser', { user: user.userId })}
             />
           }

--- a/web-studio/src/routes/users/-components/user-memory-policy-cell.tsx
+++ b/web-studio/src/routes/users/-components/user-memory-policy-cell.tsx
@@ -1,0 +1,131 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { LoaderCircleIcon, PencilIcon } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { Button } from '#/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '#/components/ui/dialog'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '#/components/ui/tooltip'
+import { fetchUserMemorySettings, updateUserMemorySettings } from '#/lib/admin'
+import type { AdminConnection, AdminUser } from '#/lib/admin'
+import { identifyMemoryPreset } from '#/lib/user-memory-policy'
+import type { UserMemoryPolicy } from '#/lib/user-memory-policy'
+import { MemoryPolicyPicker } from './memory-policy-picker'
+import { getErrorMessage } from '../-lib/error'
+
+export function UserMemoryPolicyCell({
+  connection,
+  user,
+}: {
+  connection: AdminConnection
+  user: AdminUser
+}) {
+  const { t } = useTranslation('settings')
+  const [open, setOpen] = useState(false)
+  const queryClient = useQueryClient()
+  const queryKey = [
+    'user-memory-settings',
+    connection.baseUrl,
+    connection.apiKey,
+    user.accountId,
+    user.userId,
+  ]
+  const query = useQuery({
+    queryKey,
+    queryFn: () =>
+      fetchUserMemorySettings(connection, user.accountId, user.userId),
+    retry: false,
+  })
+  const update = useMutation({
+    mutationFn: (preset: UserMemoryPolicy) =>
+      updateUserMemorySettings(connection, user.accountId, user.userId, preset),
+    onSuccess: (result) => {
+      queryClient.setQueryData(queryKey, result)
+      setOpen(false)
+      toast.success(t('memoryPolicy.saved'))
+    },
+    onError: (error) => toast.error(getErrorMessage(error)),
+  })
+  if (query.isPending)
+    return (
+      <LoaderCircleIcon
+        aria-label={t('loading')}
+        className="size-4 animate-spin"
+      />
+    )
+  if (query.isError)
+    return (
+      <Button
+        variant="ghost"
+        size="sm"
+        title={getErrorMessage(query.error)}
+        onClick={() => void query.refetch()}
+      >
+        {t('memoryPolicy.retry')}
+      </Button>
+    )
+  const preset = identifyMemoryPreset(query.data.memory_policy)
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setOpen(true)}
+              aria-label={t('memoryPolicy.editUser', { user: user.userId })}
+            />
+          }
+        >
+          <span className="decoration-dotted underline-offset-4 underline">
+            {t(`memoryPolicy.${preset}.name`)}
+          </span>
+          <PencilIcon className="size-3.5 text-primary" />
+        </TooltipTrigger>
+        <TooltipContent>{t('memoryPolicy.edit')}</TooltipContent>
+      </Tooltip>
+      <Dialog
+        open={open}
+        onOpenChange={(next) => {
+          if (!update.isPending) setOpen(next)
+        }}
+      >
+        <DialogContent
+          className="sm:max-w-4xl"
+          showCloseButton={!update.isPending}
+        >
+          <DialogHeader>
+            <DialogTitle>{t('memoryPolicy.edit')}</DialogTitle>
+            <DialogDescription>
+              {user.userId} · {t('memoryPolicy.saveHint')}
+            </DialogDescription>
+          </DialogHeader>
+          <MemoryPolicyPicker
+            editing
+            value={query.data.memory_policy}
+            disabled={update.isPending}
+            onBack={() => setOpen(false)}
+            onSelect={(value) => update.mutate(value)}
+          />
+          {update.isPending && (
+            <LoaderCircleIcon
+              className="size-4 animate-spin"
+              aria-label={t('loading')}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/web-studio/src/routes/users/route.tsx
+++ b/web-studio/src/routes/users/route.tsx
@@ -337,7 +337,17 @@ function UserManagementRoute() {
           <Button
             type="button"
             variant="outline"
-            onClick={() => void usersQuery.refetch()}
+            onClick={() => {
+              void usersQuery.refetch()
+              void queryClient.invalidateQueries({
+                queryKey: [
+                  'user-memory-settings',
+                  adminConnection.baseUrl,
+                  adminConnection.apiKey,
+                  connection.accountId,
+                ],
+              })
+            }}
             disabled={usersQuery.isFetching}
           >
             <RefreshCwIcon

--- a/web-studio/src/routes/users/route.tsx
+++ b/web-studio/src/routes/users/route.tsx
@@ -74,6 +74,7 @@ import type {
 import { copyTextToClipboard } from '#/lib/clipboard'
 import { resolveStudioManagementCapabilities } from '#/lib/studio-permissions'
 
+import { UserMemoryPolicyCell } from './-components/user-memory-policy-cell'
 import { AddUserDialog } from './-components/add-user-dialog'
 import { DeleteAccountButton } from './-components/delete-account-button'
 import { getErrorMessage } from './-lib/error'
@@ -422,6 +423,7 @@ function UserManagementRoute() {
                   <TableRow className="bg-muted/20 hover:bg-muted/20">
                     <TableHead>{t('table.user')}</TableHead>
                     <TableHead>{t('table.role')}</TableHead>
+                    <TableHead>{t('memoryPolicy.title')}</TableHead>
                     <TableHead>{t('table.apiKey')}</TableHead>
                     <TableHead className="text-right">
                       {t('table.actions')}
@@ -518,6 +520,12 @@ function UserManagementRoute() {
                               })}
                             </Badge>
                           )}
+                        </TableCell>
+                        <TableCell>
+                          <UserMemoryPolicyCell
+                            connection={adminConnection}
+                            user={user}
+                          />
                         </TableCell>
                         <TableCell>
                           <div className="flex min-w-0 items-center gap-1">


### PR DESCRIPTION
## Description

Add memory policy configuration to Web Studio user creation and management. Users can choose a preset or configure extraction scopes and memory types before creating a user, then inspect and update the effective policy from the user list.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

None.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add general, personal, Agent experience, and custom policy choices to the create-user dialog, with a bounded, independently scrolling directory preview.
- Map custom controls to `self.enabled`, `peer.enabled`, `working_memory.enabled`, and `memory_types`; preserve extension types and link the Agent experience types consistently with server behavior.
- Read effective user policies through the existing settings endpoint and support updates with loading, retry, and save-error handling.
- Include English and Chinese labels. All changes are confined to `web-studio/`; no server changes.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation: production build, ESLint for changed behavior files, and `git diff --check`. Ran 28 existing tests covering connection handling, management permissions, and account deletion.

Used temporary Playwright checks with intercepted API responses to verify preset/custom selection, create and update payloads, extension-type preservation, linked Agent types, and independent preview scrolling. Checked desktop and mobile layouts. No live-server mutation or end-to-end server validation was performed.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Screenshots were reviewed locally for the policy picker, custom configuration, and directory preview.

## Additional Notes

The full TypeScript check is not clean: it reports errors in unchanged generated client, retrieval, and other existing files. Production build succeeds with bundle-size warnings.

Custom configuration saves an explicit type list; the general preset leaves types unrestricted. Built-in type choices are a reference, and the server validates their availability. This UI does not create or enable server-side memory schemas.
