### PR TITLE
fix(parser): render math blocks inside AnyDoc table cells

### DIFF
--- a/openviking/parse/parsers/anydoc_renderer.py
+++ b/openviking/parse/parsers/anydoc_renderer.py
@@ -472,6 +472,10 @@ class _AnyDocMarkdownRenderer:
                     fence = self._backtick_fence(text, 1)
                     pad = " " if text.startswith("`") or text.endswith("`") else ""
                     parts.append(f"{fence}{pad}{text}{pad}{fence}")
+            elif kind == "math":
+                source = self._escape_math_source(block.text or "", context="table_cell")
+                if source:
+                    parts.append(f"${source}$")
             elif kind != "rule":
                 raise RuntimeError(f"Unsupported AnyDoc table-cell block kind: {kind}")
         return "<br>".join(line.strip() for line in "<br>".join(parts).splitlines() if line.strip())


### PR DESCRIPTION
## Description

A DOCX table cell containing a block-level OMML formula (`m:oMathPara`) crashes the
AnyDoc parser and fails the entire document ingest. `_render_cell` handles six of the
eight AnyDoc block kinds and deliberately skips `rule`, which leaves `math` as the only
kind that can still raise inside a cell.

This renders cell math through the escaping helper that already understands cells, so
one unsupported cell no longer loses the whole upload.

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

The code was written by an AI agent working under human direction, and a human reviewed
the change and this description before submission. See **Additional Notes**.

## Related Issue

Fixes #4967

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- `openviking/parse/parsers/anydoc_renderer.py` — handle `kind == "math"` in
  `_render_cell`, rendering it as inline `$...$` via
  `_escape_math_source(context="table_cell")`. **+4 / −0 lines, one file.**

Two deliberate choices:

- **Reuse the existing owner of the escaping rule.** `_escape_math_source` already
  supports `context="table_cell"`: it collapses newlines to spaces and escapes
  unescaped `|`. That branch existed for cells but `_render_cell` never called it, so no
  new escaping mechanism was added.
- **Inline `$...$`, not display `$$...$$`.** Cell parts are joined with `<br>`
  (`anydoc_renderer.py:476`), so a display block would split the Markdown row. This also
  matches how inline math already renders inside cells (`_render_inline`).

`rule` is left silently skipped, exactly as before. It is the pre-existing intended
behaviour for cells, and changing it is not needed to fix this crash.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Both unchecked boxes are deliberate and explained below rather than left ambiguous.

### Reproduced through the real entrypoint, not inferred from code

A minimal 1090-byte DOCX (hand-written OOXML) with a 2×2 table whose second cell holds
`<m:oMathPara><m:oMath>E = mc^2`. `anydoc.to_document` confirms the cell really produces
a block-level math node:

```text
cell[0][0] block kinds: ['paragraph']
cell[0][1] block kinds: ['paragraph']
cell[1][0] block kinds: ['paragraph']
cell[1][1] block kinds: ['math']
```

**Before** — `AnyDocConverter().convert(docx, resource_name=..., storage=None)`:

```text
RuntimeError: Unsupported AnyDoc table-cell block kind: math
```

**After** — the same call on the same file returns the complete document:

```markdown
| Quantity | Definition |
| --- | --- |
| Energy | $E = mc\char`^2$ |

Tail paragraph proves the whole parse completed.
```

### Negative control

Reverting only `anydoc_renderer.py` (`git stash push -- <file>`) makes the same script
raise the original `RuntimeError` again; restoring it converts successfully. The
reproduction is therefore not vacuous.

### Edge cases

Rendering cell math directly, to confirm the `table_cell` context is doing real work:

| input | rendered | raw pipes | newlines |
|---|---|---|---|
| `E = mc^2` | `$E = mc^2$` | 0 | 0 |
| `|x| + |y|` | `$\|x\| + \|y\|$` | 0 | 0 |
| `\|x\|` (already escaped) | `$\|x\|$` (not double-escaped) | 0 | 0 |
| `a $ b` | `$a \$ b$` | 0 | 0 |
| `a = 1\nb = 2` | `$a = 1 b = 2$` | 0 | 0 |
| whitespace only | `` (nothing emitted) | 0 | 0 |

Zero raw pipes means a formula cannot corrupt the row; zero newlines means the cell
stays on one Markdown row.

### Exact commands run

```bash
uv sync --frozen --extra test        # with OV_SKIP_CPP_BUILD/OV_SKIP_OV_BUILD/OV_SKIP_RAGFS_BUILD/OV_SKIP_STUDIO_BUILD=1
uv run --no-sync ruff check openviking/parse/parsers/anydoc_renderer.py
uv run --no-sync ruff format --check openviking/parse/parsers/anydoc_renderer.py
uv run --no-sync mypy openviking/parse/parsers/anydoc_renderer.py
uv run pytest tests/parse -q -o addopts=''
```

Results:

- `ruff check` — **All checks passed.**
- `ruff format --check` — reports this file as unformatted, **identically before and
  after my change** (the same 7 hunks, at lines 101, 176, 191, 320, 444, 492, 625, 637).
  None of them is in the code I added. The file is already unformatted on `main`, so I
  did **not** run `ruff format`; doing so would add ~30 lines of unrelated reflow. Happy
  to include it, or to land it separately, if you would prefer.
- `mypy` — **1535 errors in 201 files both with and without this change**, and **0 inside
  `anydoc_renderer.py`** either way. Pre-existing and untouched.
- `pytest tests/parse` — **55 failed, 598 passed, 31 skipped**, and the baseline with my
  change stashed is **identical: 55 failed, 598 passed, 31 skipped**. I diffed the
  failure sets by node id: **no new failures, none disappeared.**

### Why two boxes are unchecked

- **No test added.** CONTRIBUTING says not to add a new unit test or test file by
  default and to prefer updating an existing high-value contract test. I looked for one:
  there is no existing contract test over AnyDoc renderer output — the only test that
  touches the converter is `tests/parse/test_document_parser_threading.py`, which
  monkeypatches `AnyDocConverter.convert` for a threading assertion, so extending it
  would not exercise rendering. Rather than introduce a new file against your stated
  policy, I validated through the real entrypoint above. **If you would like a
  regression test, say the word and I will add one** — a small case over
  `_render_cell`, or a fixture-based one through `AnyDocConverter`, whichever fits your
  intent.
- **Pre-existing suite failures.** I cannot honestly claim the suite is green: the 55
  failures above are in the feishu, markdown-link-rewrite, and directory-ingest groups
  and reproduce on clean `main` on this machine. They are almost certainly environmental
  — I built without the RAGFS Rust binding (see below) — so I am reporting them as
  skipped/failed-for-environment rather than attributing them to this change.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

No documentation change: this restores expected parsing behaviour and adds no public
API, configuration, or output contract. The added branch is four lines that mirror the
adjacent `code_block` branch, so it needed no explanatory comment.

## Additional Notes

**Affected entrypoint and owner module.** Entrypoint is `AnyDocConverter.convert`
(`openviking/parse/parsers/anydoc_converter.py:59`), reached from
`openviking/parse/parsers/anydoc.py`; the failure surfaces to callers through
`ResourceProcessor.process_resource`. Owner module is `openviking/parse`
(cc @zihengli-bytedance, @KCHENPENGFEI per the CONTRIBUTING routing map).

**Compatibility.** No breaking change. Documents that parsed before produce
byte-identical Markdown, because the new branch is only reachable for a block kind that
previously raised. Cells that used to abort the whole ingest now render their formula.

**Environment limitation, disclosed.** I developed on Windows with Python 3.12.13 and
built with `OV_SKIP_CPP_BUILD=1 OV_SKIP_OV_BUILD=1 OV_SKIP_RAGFS_BUILD=1
OV_SKIP_STUDIO_BUILD=1`, since this machine has no Rust/CMake/MinGW toolchain. That is
sufficient for this change — `anydoc_renderer.py` is pure Python and the guarded
`openviking.pyagfs` import degrades gracefully — but it does mean I did not exercise the
native RAGFS path, and it is the likely cause of the pre-existing failures above. Not
tested on Linux or macOS.

**AI involvement.** Implemented by an AI agent under human direction and review. Every
number, command, and log excerpt above was produced by actually running it on this
machine; nothing is estimated or assumed.
